### PR TITLE
chore: 更新版本至 0.5.5-beta.2，修复初始位置调整导致位置交互错位的问题，修复 Vue2 部分属性不生效的问题

### DIFF
--- a/src/frontend/ai-blueking/package.json
+++ b/src/frontend/ai-blueking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/ai-blueking",
-  "version": "0.5.5-beta.1",
+  "version": "0.5.5-beta.2",
   "description": "AI 小鲸",
   "license": "MIT",
   "author": "Tencent BlueKing",

--- a/src/frontend/ai-blueking/src/composables/use-resizable-container.ts
+++ b/src/frontend/ai-blueking/src/composables/use-resizable-container.ts
@@ -68,8 +68,8 @@ export function useResizableContainer(options: ResizableContainerOptions = {}) {
   const top = ref(options.defaultTop !== undefined ? options.defaultTop : 0);
   const left = ref(options.defaultLeft !== undefined ? options.defaultLeft : initialX.value);
   const width = ref(initWidth);
-  const height = ref(options.defaultHeight !== undefined ? options.defaultHeight : window.innerHeight);
-  const maxWidth = ref(window.innerWidth * (maxWidthPercent / 100));
+  const height = ref(options.defaultHeight !== undefined ? options.defaultHeight : window.innerHeight - top.value);
+  const maxWidth = ref((window.innerWidth - left.value) * (maxWidthPercent / 100));
   const isCompressionHeight = ref(false);
   const leftDiff = ref(0);
 

--- a/src/frontend/web/docs/changelog.md
+++ b/src/frontend/web/docs/changelog.md
@@ -8,6 +8,14 @@ export default {
     return {
       changelogData: [
         {
+          version: "0.5.5-beta.2",
+          date: "2025-05-09",
+          fixed: [
+            "修复 初始位置调整导致位置交互错位的问题"
+            "修复 Vue2 部分属性不生效的问题"
+          ]
+        }
+        {
           version: "v0.5.4",
           date: "2025-04-28",
           features: [

--- a/src/frontend/web/package.json
+++ b/src/frontend/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-blueking-docs",
-  "version": "0.5.4",
+  "version": "0.5.5-beta.2",
   "description": "AI 小鲸智能对话组件文档",
   "scripts": {
     "dev": "vitepress dev docs --host",
@@ -9,7 +9,7 @@
     "server": "node ./server.cjs"
   },
   "dependencies": {
-    "@blueking/ai-blueking": "0.5.4",
+    "@blueking/ai-blueking": "0.5.5-beta.2",
     "vue": "^3.3.4",
     "express": "^5.1.0",
     "bkui-vue": "^2.0.1-beta.114"


### PR DESCRIPTION
chore: 更新版本至 0.5.5-beta.2，修复初始位置调整导致位置交互错位的问题，修复 Vue2 部分属性不生效的问题