### PR TITLE
feat: 更新版本至 1.1.0-multi-session.beta.6，新增历史和新聊天图标属性，优化标题显示逻辑

### DIFF
--- a/src/frontend/ai-blueking/package.json
+++ b/src/frontend/ai-blueking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/ai-blueking",
-  "version": "1.1.0-multi-session.beta.5",
+  "version": "1.1.0-multi-session.beta.6",
   "description": "AI 小鲸",
   "license": "MIT",
   "author": "Tencent BlueKing",

--- a/src/frontend/ai-blueking/playground/dynamic-demo.vue
+++ b/src/frontend/ai-blueking/playground/dynamic-demo.vue
@@ -55,7 +55,6 @@
       <div>
         <AIBlueking
       ref="aiBlueking"
-      title="aaa"
       hello-text="bbb"
       :request-options="{
         data: requestData,

--- a/src/frontend/ai-blueking/src/ai-blueking-new.vue
+++ b/src/frontend/ai-blueking/src/ai-blueking-new.vue
@@ -29,6 +29,8 @@
             :title="props.title"
             :is-compression-height="isCompressionHeight"
             :draggable="props.draggable"
+            :show-history-icon="props.showHistoryIcon"
+            :show-new-chat-icon="props.showNewChatIcon"
             @close="handleClose"
             @toggle-compression="toggleCompression"
             @new-chat="handleNewChat"
@@ -172,6 +174,8 @@ interface Props {
   hideHeader?: boolean
   disabledInput?: boolean
   nimbusSize?: "small" | "normal" | "large"
+  showHistoryIcon?: boolean
+  showNewChatIcon?: boolean
 }
 
 // Props 定义
@@ -194,6 +198,8 @@ const props = withDefaults(defineProps<Props>(), {
   hideHeader: false,
   disabledInput: false,
   nimbusSize: "normal",
+  showHistoryIcon: true,
+  showNewChatIcon: true,
 })
 
 // Emits 定义

--- a/src/frontend/ai-blueking/src/components/ai-header.vue
+++ b/src/frontend/ai-blueking/src/components/ai-header.vue
@@ -11,15 +11,17 @@
           alt="logo"
         />
       </div>
-      <div class="title">{{ title }}</div>
+      <div class="title">{{ displayTitle }}</div>
     </div>
     <div class="right-section">
       <i
+        v-if="props.showNewChatIcon"
         class="bkai-icon bkai-xinzengliaotian"
         v-bk-tooltips="{ content: t('新增聊天'), boundary: 'parent' }"
         @click="handleNewChat"
       ></i>
       <i
+        v-if="props.showHistoryIcon"
         ref="historyIconRef"
         class="bkai-icon bkai-history"
         v-bk-tooltips="{ content: t('历史会话'), boundary: 'parent' }"
@@ -56,10 +58,14 @@
     title: string;
     isCompressionHeight: boolean;
     draggable: boolean;
+    showHistoryIcon: boolean;
+    showNewChatIcon?: boolean;
   }>(), {
     title: t('AI 小鲸'),
     isCompressionHeight: false,
     draggable: true,
+    showHistoryIcon: true,
+    showNewChatIcon: true,
   });
 
   const emit = defineEmits<(e: 'close' | 'toggleCompression' | 'newChat') => void>();
@@ -78,6 +84,10 @@
       offset: [0, 8],
       appendTo: () => document.querySelector('.ai-blueking-container-wrapper') as HTMLElement || document.body,
     }
+  });
+
+  const displayTitle = computed(() => {
+    return sessionStore.currentSession.value?.sessionName || props.title;
   });
 
   const compressionIcon = computed(() => {
@@ -161,6 +171,8 @@
       display: flex;
       gap: 4px;
       align-items: center;
+      flex: 1;
+      min-width: 0;
 
       .logo {
         width: 32px;
@@ -178,6 +190,10 @@
         font-weight: 600;
         line-height: 20px;
         color: #4d4f56;
+        max-width: calc(100% - 60px);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
       }
     }
 

--- a/src/frontend/publish-template/package.json
+++ b/src/frontend/publish-template/package.json
@@ -1,6 +1,6 @@
 {
   "name": "frontend",
-  "version": "1.0.1-beta.5",
+  "version": "1.0.1-beta.6",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@blueking/ai-blueking": "1.1.0-multi-session.beta.5",
+    "@blueking/ai-blueking": "1.1.0-multi-session.beta.6",
     "@blueking/ai-ui-sdk": "0.0.15-beta.30",
     "@blueking/cli-service": "0.1.0-beta.9",
     "bkui-vue": "2.0.1",

--- a/src/frontend/web/package.json
+++ b/src/frontend/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ai-blueking-docs",
-  "version": "1.0.4",
+  "version": "1.1.0-multi-session.beta.6",
   "description": "AI 小鲸智能对话组件文档",
   "scripts": {
     "dev": "vitepress dev docs --host",
@@ -9,7 +9,7 @@
     "server": "node ./server.cjs"
   },
   "dependencies": {
-    "@blueking/ai-blueking": "1.1.0-multi-session.beta.4",
+    "@blueking/ai-blueking": "1.1.0-multi-session.beta.6",
     "bkui-vue": "^2.0.1-beta.114",
     "express": "^5.1.0",
     "vue": "^3.3.4"


### PR DESCRIPTION
feat: 更新版本至 1.0.1-beta.6，升级依赖 @blueking/ai-blueking 至 1.1.0-multi-session.beta.6

feat: 更新版本至 1.1.0-multi-session.beta.6，升级依赖 @blueking/ai-blueking 至 1.1.0-multi-session.beta.6

feat: 移除会话切换时的调试日志