### PR TITLE
feat: fix 400 error & update @blueking/ai-blueking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint:
 build-aidev-ai-blueking:
 	rm -rf ${ROOT_DIR}/src/plugins/aidev_ai_blueking/aidev_ai_blueking/templates
 	rm -rf ${ROOT_DIR}/src/plugins/aidev_ai_blueking/aidev_ai_blueking/static
-	cd ./src/frontend/publish-template/ && rm -rf node_modules/.cache && pnpm install && pnpm run build && cd -
+	cd ./src/frontend/publish-template/ && rm -rf node_modules/.cache && pnpm install --no-frozen-lockfile && pnpm run build && cd -
 	mv ${ROOT_DIR}/src/frontend/publish-template/dist/static ${ROOT_DIR}/src/plugins/aidev_ai_blueking/aidev_ai_blueking
 	mkdir ${ROOT_DIR}/src/plugins/aidev_ai_blueking/aidev_ai_blueking/templates
 	mv ${ROOT_DIR}/src/frontend/publish-template/dist/index.html ${ROOT_DIR}/src/plugins/aidev_ai_blueking/aidev_ai_blueking/templates/home.html

--- a/src/frontend/ai-blueking/package.json
+++ b/src/frontend/ai-blueking/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/ai-blueking",
-  "version": "2.0.0-dev.11",
+  "version": "2.0.0-dev.15",
   "description": "AI 小鲸",
   "license": "MIT",
   "author": "Tencent BlueKing",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -217,8 +217,8 @@ importers:
   publish-template:
     dependencies:
       '@blueking/ai-blueking':
-        specifier: 2.0.0-dev.9
-        version: 2.0.0-dev.9(highlight.js@11.11.1)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))
+        specifier: 2.0.0-dev.15
+        version: 2.0.0-dev.15(highlight.js@11.11.1)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))
       '@blueking/chat-x':
         specifier: 0.0.1-beta.7
         version: 0.0.1-beta.7(typescript@5.8.3)
@@ -1000,8 +1000,8 @@ packages:
       dayjs: ^1.10.7
       markdown-it: ^13.0.1
 
-  '@blueking/ai-blueking@2.0.0-dev.9':
-    resolution: {integrity: sha512-oQ6OHLnokoQyqwI5dbvpiH1LLLHH0mhJ6UtC8xgSVNuKjIyUN3/4PtSs+KNx/RWmDgkiNwAowvUCwzMF42VxRg==}
+  '@blueking/ai-blueking@2.0.0-dev.15':
+    resolution: {integrity: sha512-O1ACyrqqvXPyCaBo6kKpndp+JDQWqBMFrjsd0jn2CQXT3798/JZkmF3xajIA0upDIR5qJT5qtyXJqNhx+UELRg==}
     peerDependencies:
       vue: ^3.5.24
 
@@ -1017,16 +1017,16 @@ packages:
   '@blueking/bkui-library@0.0.0-beta.6':
     resolution: {integrity: sha512-1M6pNDIOQYWzOu3uVRxo0h67d+huTbBQYDjj8+QF4Ka3HSe/mLgSrIkaZhhUVlJJl5zP8HK+UwXpkWcjL8zIsw==}
 
-  '@blueking/chat-helper@0.0.1-beta.10':
-    resolution: {integrity: sha512-83CC7BSCtPoGgBwY7jOLUitZp2pkzLX0ERfV82Yyd3O6OouEGzGtCybAAApbfJvIuT7+bEmqAhLlVuTa7EbHeg==}
+  '@blueking/chat-helper@0.0.1-beta.14':
+    resolution: {integrity: sha512-a2yU9WqQ5kw1BBhJMBajczzA55fe9SqB7OfChwjtE6OT4yAbmgeysZ3A3Ue417nmXEpEWnyN1TypCwI+Nc5AIg==}
     peerDependencies:
       vue: ^3.5.24
 
+  '@blueking/chat-x@0.0.1-beta.10':
+    resolution: {integrity: sha512-6eI6sfzf3p7MZAdn9g31s0Dt03926nCzQq9YD4gIAD1xV/Vz2a6wZVZPget7iqQz1jtQ6wTZQvKn3coS8TMfZw==}
+
   '@blueking/chat-x@0.0.1-beta.7':
     resolution: {integrity: sha512-uPU5oJSzgE1QXmPKhYqpSmRkm/dfmQYlOk40TTFB86IubBqOo5MtbJ4R4z2WTDv/REYYWikHatgbWkNyt95ycg==}
-
-  '@blueking/chat-x@0.0.1-beta.8':
-    resolution: {integrity: sha512-IUerFNZpvAf2ejjQcrITtT2QRZmlBkaftRL07ZSjnwdIPjYgR/5z3H8Pr2pM5dno+fR9a7WU3NZBYkjjuBomqw==}
 
   '@blueking/cli-service@0.1.1':
     resolution: {integrity: sha512-CSfHppH93eLejvP4V9gMoMB+Eq0S0n0fHf31dCpQ3tBgnl6NreJ3rCbdXS7t9t1RMPy9gw8X3228KXmzVzcVEA==}
@@ -9564,10 +9564,10 @@ snapshots:
       - vue
       - vue-router
 
-  '@blueking/ai-blueking@2.0.0-dev.9(highlight.js@11.11.1)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))':
+  '@blueking/ai-blueking@2.0.0-dev.15(highlight.js@11.11.1)(typescript@5.8.3)(vue@3.5.27(typescript@5.8.3))':
     dependencies:
-      '@blueking/chat-helper': 0.0.1-beta.10(vue@3.5.27(typescript@5.8.3))
-      '@blueking/chat-x': 0.0.1-beta.8(typescript@5.8.3)
+      '@blueking/chat-helper': 0.0.1-beta.14(vue@3.5.27(typescript@5.8.3))
+      '@blueking/chat-x': 0.0.1-beta.10(typescript@5.8.3)
       bkui-vue: 2.0.1(highlight.js@11.11.1)(vue@3.5.27(typescript@5.8.3))
       tippy.js: 6.3.7
       vue: 3.5.27(typescript@5.8.3)
@@ -9597,11 +9597,11 @@ snapshots:
     dependencies:
       '@vue/runtime-dom': 3.5.27
 
-  '@blueking/chat-helper@0.0.1-beta.10(vue@3.5.27(typescript@5.8.3))':
+  '@blueking/chat-helper@0.0.1-beta.14(vue@3.5.27(typescript@5.8.3))':
     dependencies:
       vue: 3.5.27(typescript@5.8.3)
 
-  '@blueking/chat-x@0.0.1-beta.7(typescript@5.8.3)':
+  '@blueking/chat-x@0.0.1-beta.10(typescript@5.8.3)':
     dependencies:
       bkui-vue: 2.0.1(highlight.js@11.11.1)(vue@3.5.27(typescript@5.8.3))
       dompurify: 3.2.6
@@ -9619,7 +9619,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@blueking/chat-x@0.0.1-beta.8(typescript@5.8.3)':
+  '@blueking/chat-x@0.0.1-beta.7(typescript@5.8.3)':
     dependencies:
       bkui-vue: 2.0.1(highlight.js@11.11.1)(vue@3.5.27(typescript@5.8.3))
       dompurify: 3.2.6

--- a/src/frontend/publish-template/package.json
+++ b/src/frontend/publish-template/package.json
@@ -12,7 +12,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@blueking/ai-blueking": "2.0.0-dev.9",
+    "@blueking/ai-blueking": "2.0.0-dev.15",
     "@blueking/chat-x": "0.0.1-beta.7",
     "@blueking/cli-service": "0.1.1",
     "bkui-vue": "2.0.1",

--- a/src/frontend/publish-template/src/views/page-demo.vue
+++ b/src/frontend/publish-template/src/views/page-demo.vue
@@ -91,7 +91,6 @@
 
   const handleSdkError = (error: any) => {
     console.error("SDK错误:", error)
-    router.push("/403")
   }
 
   // 设置 AIBlueking 组件的宽度为容器宽度减去会话列表宽度

--- a/src/frontend/publish-template/src/views/side-slider-demo.vue
+++ b/src/frontend/publish-template/src/views/side-slider-demo.vue
@@ -143,7 +143,6 @@
 
   const handleSdkError = (error: any) => {
     console.error("SDK错误:", error)
-    router.push("/403")
   }
 
   onMounted(async () => {

--- a/src/plugins/aidev_ai_blueking/pyproject.toml
+++ b/src/plugins/aidev_ai_blueking/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aidev-ai-blueking"
-version = "2.0.0-dev.11"
+version = "2.0.0-dev.15"
 description = "小鲸静态资源包"
 readme = "readme.md"
 requires-python = ">=3.11.9, <4"

--- a/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "aidev-agent==1.1.0b7",
     "aidev-bkplugin==1.1.0b3",
     "aidev-wxbot==1.1.0b1",
-    "aidev-ai-blueking==2.0.0-dev.11",
+    "aidev-ai-blueking==2.0.0-dev.15",
     "bk-plugin-framework>=2.3.7",
     "bkapi-bk-apigateway==1.0.12",
     "celery==5.4.0",

--- a/template/{{cookiecutter.project_name}}/requirements.txt
+++ b/template/{{cookiecutter.project_name}}/requirements.txt
@@ -2,7 +2,7 @@ ag-ui-protocol==0.1.10
 aidev-agent==1.1.0b7
 aidev-bkplugin==1.1.0b3
 aidev-wxbot==1.1.0b1
-aidev-ai-blueking==2.0.0-dev.11
+aidev-ai-blueking==2.0.0-dev.15
 aiohappyeyeballs==2.6.1
 aiohttp==3.13.3
 aiosignal==1.4.0


### PR DESCRIPTION
chore: update @blueking/ai-blueking and related dependencies to version 2.0.0-dev.12 in package.json and pnpm-lock.yaml; adjust Makefile to use --no-frozen-lockfile during installation

release: 2.0.0-dev.13

release: 2.0.0-dev.14

chore: update @blueking/ai-blueking to version 2.0.0-dev.15 in package.json; enhance error handling in page-demo.vue and side-slider-demo.vue by using Message component for better user feedback

release: 2.0.0-dev.15