### PR TITLE
ci: 更新 pnpm 缓存依赖路径配置

### DIFF
--- a/.github/workflows/publish-ai-blueking.yml
+++ b/.github/workflows/publish-ai-blueking.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          cache-dependency-path: src/frontend/ai-blueking/pnpm-lock.yaml
+          cache-dependency-path: "src/frontend/**/pnpm-lock.yaml"
           registry-url: https://registry.npmjs.org/
 
       - name: Install uv

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/containers/draggable-container.vue
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/containers/draggable-container.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, defineEmits, defineExpose, defineProps, ref, watch, withDefaults } from 'vue';
+  import { computed, ref, watch } from 'vue';
 
   import VueDraggableResizable from 'vue-draggable-resizable';
 

--- a/src/frontend/ai-blueking/packages/chat-x/package.json
+++ b/src/frontend/ai-blueking/packages/chat-x/package.json
@@ -57,7 +57,9 @@
     "markdown-it-sup": "^2.0.0",
     "markdown-it-task-checkbox": "^1.0.6",
     "mermaid": "^11.12.2",
+    "tippy.js": "^6.3.7",
     "vue": "^3.5.24",
+    "vue-tippy": "^6.7.1",
     "zod": "^4.3.6"
   },
   "devDependencies": {
@@ -88,7 +90,6 @@
     "vite-bundle-analyzer": "^1.3.2",
     "vitepress": "2.0.0-alpha.16",
     "vitest": "^4.0.18",
-    "vue-tippy": "^6.7.1",
     "vue-tsc": "^3.1.4"
   }
 }


### PR DESCRIPTION
build(chat-x): 移动 vue-tippy 至生产依赖并添加 tippy.js

refactor: 移除未使用的 Vue 导入