### PR TITLE
refactor: 注释 Flow Agent 任务输出展示区块

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
@@ -252,7 +252,8 @@ describe('FlowAgentContent', () => {
   });
 
   describe('task_outputs', () => {
-    it('应展示 task_outputs 的 JSON 字符串', () => {
+    // 与模板一致：任务输出展示区块已注释，不在 DOM 中渲染
+    it('不应渲染 .flow-agent-task-outputs', () => {
       const outputs = { result: 'ok', n: 1 };
       wrapper = mount(FlowAgentContent, {
         props: {
@@ -260,9 +261,7 @@ describe('FlowAgentContent', () => {
         },
       });
 
-      const el = wrapper.find('.flow-agent-task-outputs');
-      expect(el.exists()).toBe(true);
-      expect(el.text()).toBe(JSON.stringify(outputs));
+      expect(wrapper.find('.flow-agent-task-outputs').exists()).toBe(false);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
@@ -109,12 +109,12 @@
       </div>
     </div>
   </ActivityLayout>
-  <div
+  <!-- <div
     v-if="taskData?.task_outputs"
     class="flow-agent-task-outputs"
   >
     {{ typeof taskData.task_outputs === 'object' ? JSON.stringify(taskData.task_outputs) : taskData.task_outputs }}
-  </div>
+  </div> -->
 </template>
 <script setup lang="ts">
   import { cloneVNode, computed, ref } from 'vue';


### PR DESCRIPTION
refactor: 注释 Flow Agent 任务输出展示区块

- 将 task_outputs 原始输出区域改为注释，避免界面展示 JSON 调试信息
- 同步调整 flow-agent-content 单元测试