### PR TITLE
fix(chat-x): Markdown 自定义规则 options 与欢迎区插槽结构

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/package.json
+++ b/src/frontend/ai-blueking/packages/chat-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/chat-x",
-  "version": "0.0.20",
+  "version": "0.0.21",
   "description": "蓝鲸智云 AI Chat 组件库 —— 遵循 AG-UI，为 AI Agent 和人类开发者共同设计的对话 UI 组件库。",
   "main": "index.js",
   "scripts": {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -413,6 +413,19 @@ describe('ChatContainer', () => {
       expect(wrapper.find('.ai-welcome-remark').exists()).toBe(false);
     });
 
+    it('使用 welcome 插槽时应替换整块默认欢迎区（含 Banner 与默认标题）', () => {
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, openingRemark: '默认开场白' },
+        slots: {
+          welcome: ({ openingRemark }: { openingRemark: string }) =>
+            h('div', { class: 'custom-welcome' }, `自定义: ${openingRemark}`),
+        },
+      });
+
+      expect(wrapper.find('.mock-banner-icon').exists()).toBe(false);
+      expect(wrapper.find('.ai-welcome-title').exists()).toBe(false);
+    });
+
     it('不传 welcome 插槽时应使用默认开场白渲染', () => {
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, openingRemark: '欢迎使用' },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -137,22 +137,23 @@
             </template>
           </MessageContainer>
         </slot>
-        <div v-else>
-          <div class="ai-welcome-content">
+        <div
+          v-else
+          class="ai-welcome-content"
+        >
+          <slot
+            name="welcome"
+            v-bind="{ openingRemark }"
+          >
             <AIBluekingBannerIcon />
             <h2 class="ai-welcome-title">{{ t('你好，我是小鲸') }}</h2>
-            <slot
-              name="welcome"
-              v-bind="{ openingRemark }"
+            <div
+              v-if="openingRemark"
+              class="ai-welcome-remark"
             >
-              <div
-                v-if="openingRemark"
-                class="ai-welcome-remark"
-              >
-                <ContentRender :content="openingRemark" />
-              </div>
-            </slot>
-          </div>
+              <ContentRender :content="openingRemark" />
+            </div>
+          </slot>
         </div>
         <template v-if="isShareMode">
           <SelectionFooter

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
@@ -121,6 +121,7 @@
     .use(markdownItContainer, /^hljs-(left|center|right)$/);
   const vnodeOptions = {
     html: true,
+    mditOptions: md.options,
     renderer: md.renderer,
     sanitize: (html: string) => dompurify.sanitize(html, domPurifyConfig),
   };

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Options, Renderer, Token } from '../markdown-it';
+import { tokensToVNodes } from './tokens-to-vnodes';
+
+describe('tokensToVNodes', () => {
+  describe('renderer.rules 自定义块', () => {
+    it('应将 mditOptions 作为规则第三参传入 markdown-it 规则', () => {
+      const mditOptions = { breaks: true } as Options;
+      const rule = vi.fn((_tokens: Token[], _idx: number, options: Options) => {
+        expect(options).toBe(mditOptions);
+        return '<span class="rule-out">x</span>';
+      });
+
+      const renderer = {
+        rules: {
+          plugin_block: rule,
+        },
+      } as unknown as Renderer;
+
+      const token = {
+        type: 'plugin_block',
+        nesting: 0,
+        tag: '',
+        hidden: false,
+      } as Token;
+
+      tokensToVNodes([token], {
+        renderer,
+        mditOptions,
+        sanitize: html => html,
+      });
+
+      expect(rule).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.ts
@@ -28,7 +28,7 @@ import { type VNode, h, Text } from 'vue';
 
 import { ImageContent } from '../components/markdown-token';
 
-import type { Renderer, Token } from '../markdown-it';
+import type { Options, Renderer, Token } from '../markdown-it';
 
 export interface TokenToVNodeOptions {
   /**
@@ -38,6 +38,11 @@ export interface TokenToVNodeOptions {
 
   highlight?: ((str: string, lang: string, attrs?: any) => string) | null;
   html?: boolean;
+  /**
+   * 与产生 tokens 的 MarkdownIt 实例的 `options` 一致，供 `renderer.rules` 第三参使用
+   * （markdown-it 的 rule 签名为 (tokens, idx, options, env, self)，并非 Renderer 上的字段）
+   */
+  mditOptions?: Options;
   renderer?: Renderer;
   /**
    * HTML 净化函数，用于处理 innerHTML 的内容
@@ -173,14 +178,19 @@ const tokensToVNodesInternal = (tokens: Token[], options: TokenToVNodeOptions): 
     const parent = stack[stack.length - 1]!;
 
     // 1. 自定义渲染规则
-    if (token.nesting === 0 && !token.tag && options.renderer?.rules[token.type]) {
-      const html = options.renderer.rules[token.type](tokens, i, options.renderer.options || {}, {}, options.renderer);
-      const safeHtml = options.sanitize ? options.sanitize(html) : html;
-      // 使用基于内容的稳定 key
-      parent.children.push(
-        h('span', { innerHTML: safeHtml, class: `md-custom-${token.type}`, key: generateTokenKey(token) }),
-      );
-      continue;
+    const mdRenderer = options.renderer;
+    if (token.nesting === 0 && !token.tag && mdRenderer) {
+      const customRule = mdRenderer.rules[token.type];
+      if (typeof customRule === 'function') {
+        const mdOpts: Options = options.mditOptions ?? {};
+        const html = customRule(tokens, i, mdOpts, {}, mdRenderer);
+        const safeHtml = options.sanitize ? options.sanitize(html) : html;
+        // 使用基于内容的稳定 key
+        parent.children.push(
+          h('span', { innerHTML: safeHtml, class: `md-custom-${token.type}`, key: generateTokenKey(token) }),
+        );
+        continue;
+      }
     }
 
     // 2. Inline Tokens

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/markdown-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/markdown-content.md
@@ -177,6 +177,8 @@ props.content → completeMarkdownSyntax → md.parse → groupTokens → groupe
                     └──── handleTokenMounted（throttle 100ms）→ containerScroll.toScrollBottom()
 ```
 
+`VNodeRenderer` 的 `options` 中包含与当前 `MarkdownIt` 实例一致的 `mditOptions`（即 `md.options`），以便 `tokensToVNodes` 调用 `renderer.rules` 时第三参与 markdown-it 原生规则签名一致。
+
 ### Token 分组（groupTokens）
 
 `groupTokens` 使用栈将扁平 Token 数组转为分组数组，每组对应一个顶层 DOM 节点（段落、标题、列表、代码块等）：

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -205,10 +205,8 @@ ai-chat-container
     └── main（主内容区）
         ├── MessageContainer（有消息时）
         │   └── 消息列表 + 工具栏
-        ├── 欢迎页（无消息时）
-        │   ├── AIBluekingBannerIcon
-        │   ├── 欢迎标题
-        │   └── welcome 插槽（默认：开场白 ContentRender）
+        ├── 欢迎页（无消息时，容器 .ai-welcome-content）
+        │   └── welcome 插槽（默认：Banner + 欢迎标题 + 开场白 ContentRender；自定义则整块替换）
         ├── SelectionFooter（分享模式时）
         ├── ShortcutRender（有快捷指令时）
         └── ChatInput（默认状态）
@@ -458,7 +456,7 @@ ai-chat-container
 </template>
 ```
 
-> **注意**：使用 `welcome` 插槽后，默认的 `openingRemark` 渲染（`ContentRender`）将被替换，需要自行处理开场白展示逻辑。
+> **注意**：使用 `welcome` 插槽后，将**整块替换**默认欢迎区（含 Banner 图标、默认欢迎标题与 `openingRemark` 的 `ContentRender` 渲染），需自行编排完整欢迎页；插槽参数 `openingRemark` 仍可用于读取传入的开场白文本。
 
 **渲染效果**
 
@@ -680,7 +678,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | codeHeader | `{ language: string; token: Token[] }` | 代码块头部自定义操作区域，透传给 MessageRender → ContentRender → MarkdownContent → CodeContent |
 | default    | 消息列表相关绑定（messages 等）        | 自定义消息列表区域                                                                             |
 | message    | `{ message, messageToolsStatus }`      | 自定义单条消息渲染                                                                             |
-| welcome    | `{ openingRemark: string }`            | 自定义欢迎页内容，替换默认的 openingRemark 渲染，无消息时显示                                  |
+| welcome    | `{ openingRemark: string }`            | 无消息时自定义欢迎页；传入则替换默认 Banner、标题与开场白区域（整块替换）                      |
 
 ### Expose
 

--- a/src/frontend/ai-blueking/pnpm-lock.yaml
+++ b/src/frontend/ai-blueking/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: 0.0.1-beta.36
         version: 0.0.1-beta.36(vue@3.5.32(typescript@5.9.3))
       '@blueking/chat-x':
-        specifier: '>=0.0.19'
-        version: 0.0.19(typescript@5.9.3)
+        specifier: '>=0.0.20'
+        version: 0.0.20(typescript@5.9.3)
       bkui-vue:
         specifier: 2.0.2-beta.81
         version: 2.0.2-beta.81(highlight.js@11.11.1)(vue@3.5.32(typescript@5.9.3))
@@ -432,8 +432,8 @@ packages:
     peerDependencies:
       vue: ^3.5.25
 
-  '@blueking/chat-x@0.0.19':
-    resolution: {integrity: sha512-JW8R1qrSm/u68TEg25Nq1cqXRRGLOWSM5Ix6U1ckBCxYkapWBzanX3l6duRkdtr9nLZ6UYWbzb3eTvjFnqURvg==}
+  '@blueking/chat-x@0.0.20':
+    resolution: {integrity: sha512-HFuILeVK3+J9Y5+UxtE66H2JP+zlzZjkv8cQKWMRA1sohSrqVz6xKWJV+jAQhvtV2WLXBa24wQevXO8VqZTsBA==}
     hasBin: true
 
   '@blueking/chat-x@0.0.9':
@@ -7132,7 +7132,7 @@ snapshots:
     dependencies:
       vue: 3.5.32(typescript@5.9.3)
 
-  '@blueking/chat-x@0.0.19(typescript@5.9.3)':
+  '@blueking/chat-x@0.0.20(typescript@5.9.3)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.3.6)
       bkui-vue: 2.0.2-beta.81(highlight.js@11.11.1)(vue@3.5.32(typescript@5.9.3))
@@ -7147,7 +7147,9 @@ snapshots:
       markdown-it-sup: 2.0.0
       markdown-it-task-checkbox: 1.0.6
       mermaid: 11.14.0
+      tippy.js: 6.3.7
       vue: 3.5.32(typescript@5.9.3)
+      vue-tippy: 6.7.1(vue@3.5.32(typescript@5.9.3))
       zod: 4.3.6
     transitivePeerDependencies:
       - '@cfworker/json-schema'


### PR DESCRIPTION
## 摘要

- **tokensToVNodes**：向 `renderer.rules` 传入与 MarkdownIt 一致的 `mditOptions`（第三参）
- **MarkdownContent**：透传 `md.options`
- **ChatContainer**：调整 `welcome` 插槽默认 DOM（整块默认内容可被插槽替换）
- **版本**：`@blueking/chat-x` 0.0.20 → 0.0.21，同步 `pnpm-lock.yaml`
- **测试**：新增 `tokens-to-vnodes.spec.ts`，补充 `ChatContainer` welcome 行为用例
- **文档**：更新 ChatContainer / MarkdownContent Wiki

## 验证

- `pnpm --filter @blueking/chat-x exec vitest run src/components/chat-container/chat-container.spec.ts src/utils/tokens-to-vnodes.spec.ts`（及相关 spec）已通过

## 关联

- 分支：`feat/wellcome_slot` → `2.0.0`


Made with [Cursor](https://cursor.com)