### PR TITLE
fix: Markdown 外链新窗口与安全 rel

### DIFF
--- a/src/frontend/ai-blueking/package.json
+++ b/src/frontend/ai-blueking/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "postinstall": "simple-git-hooks && node ./scripts/cp-git-hooks.mjs",
+    "postinstall": "pnpm exec simple-git-hooks && node ./scripts/cp-git-hooks.mjs",
     "dev:ui": "pnpm --filter @blueking/chat-x dev",
     "build:ui": "pnpm --filter @blueking/chat-x build",
     "test:ui": "pnpm --filter @blueking/chat-x test",

--- a/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
@@ -1175,6 +1175,9 @@ async function loadUserData() {
 5. **容器化**：使用Docker将应用及其依赖打包
 `;
 export const streamContent = `
+#### 4. 链接与 a 标签示例
+**Markdown 行内链接**：[腾讯蓝鲸](https://bk.tencent.com/) · [chat-x npm](https://www.npmjs.com/package/@blueking/chat-x)
+**Markdown 自动链接**：<https://github.com/TencentBlueKing/bk-aidev-agent>
 
 #### 3. Align content
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
@@ -119,7 +119,7 @@
   --color-prettylights-syntax-string-regexp: #116329;
   --color-prettylights-syntax-sublimelinter-gutter-mark: #818b98;
   --color-prettylights-syntax-variable: #953800;
-  --fgColor-accent: #0969da;
+  --fgColor-accent: #3a84ff;
   --fgColor-attention: #9a6700;
   --fgColor-done: #8250df;
   --fgColor-muted: #59636e;

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/tokens-to-vnodes.ts
@@ -265,6 +265,9 @@ const tokensToVNodesInternal = (tokens: Token[], options: TokenToVNodeOptions): 
       if (!tag) {
         tag = token.block ? 'div' : 'span';
         props.class = props.class ? `${props.class} md-unknown-${token.type}` : `md-unknown-${token.type}`;
+      } else if (tag === 'a') {
+        props.target = '_blank';
+        props.rel = 'noopener noreferrer';
       }
 
       const newContext: StackNode = {
@@ -297,7 +300,6 @@ const tokensToVNodesInternal = (tokens: Token[], options: TokenToVNodeOptions): 
 
       const vnode = h(tag, props);
       parent.children.push(vnode);
-      continue;
     }
   }
 


### PR DESCRIPTION
- tokens-to-vnodes 为锚点补充 target 与 rel，降低 tab 劫持风险
- 主题强调色 --fgColor-accent 调整为蓝鲸主色 #3a84ff
- playground 流式内容增加行内链接与自动链接示例 # Reviewed, transaction id: 78379