### PR TITLE
feat(chat-x): 侧栏 Tab 与 executionGroups 对齐并调整 Biome/lint-staged

### DIFF
--- a/src/frontend/ai-blueking/.lintstagedrc.mjs
+++ b/src/frontend/ai-blueking/.lintstagedrc.mjs
@@ -14,13 +14,10 @@ const bin = cmd => {
   }
   return cmd;
 };
-
+//`${bin('biome')} check --write --files-ignore-unknown=true --no-errors-on-unmatched --colors=force --max-diagnostics=1000 --diagnostic-level=warn`,
+// 'src/frontend/ai-blueking/*.json': [`${bin('biome')} check --write`],
 export default {
-  'src/frontend/ai-blueking/*.(ts|tsx|js)': [
-    `${bin('biome')} check --write --files-ignore-unknown=true --no-errors-on-unmatched --colors=force --max-diagnostics=1000 --diagnostic-level=warn`,
-    `${bin('eslint')} --cache --fix`,
-  ],
+  'src/frontend/ai-blueking/*.(ts|tsx|js)': [`${bin('eslint')} --cache --fix`],
   'src/frontend/ai-blueking/src/**/*.(vue|scss|css|sass)': [`${bin('stylelint')} --cache --fix`],
-  'src/frontend/ai-blueking/*.json': [`${bin('biome')} check --write`],
   'src/frontend/ai-blueking/*.{md,yml}': [`${bin('prettier')} --ignore-unknown --write`],
 };

--- a/src/frontend/ai-blueking/biome.json
+++ b/src/frontend/ai-blueking/biome.json
@@ -1,7 +1,9 @@
 {
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
-  "extends": ["./node_modules/@blueking/bkui-lint/bk-biome.json"],
-  "root": false,
+  "extends": [
+    "./node_modules/@blueking/bkui-lint/bk-biome.json"
+  ],
+  "root": true,
   "linter": {
     "rules": {
       "correctness": {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -596,6 +596,16 @@ describe('ChatContainer', () => {
       expect(wrapper.find('.collapse-button').exists()).toBe(false);
     });
 
+    it('renderMode 为 Share 时 ResizeLayout 应应用 ai-is-collapse（与 executionGroups 无关）', () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages, renderMode: RenderMode.Share },
+      });
+
+      expect(wrapper.find('.ai-chat-container-resize-layout').classes()).toContain('ai-is-collapse');
+    });
+
     it('renderMode 为 Share 时底部输入区域（ChatInput、SelectionFooter、ShortcutRender）不应渲染', () => {
       const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -9,12 +9,12 @@
     <ResizeLayout
       v-else
       class="ai-chat-container-resize-layout"
-      :class="{ 'ai-is-collapse': isCollapse || messages?.length < 1 }"
+      :class="{ 'ai-is-collapse': isCollapse || executionGroups?.length < 1 || renderMode === RenderMode.Share }"
       v-bind="resizeProps"
       @resizing="handleResizing"
     >
       <template #aside>
-        <template v-if="!isCollapse && messages?.length && renderMode !== RenderMode.Share">
+        <template v-if="!isCollapse && executionGroups?.length && renderMode !== RenderMode.Share">
           <Tab
             :active="selectedTab.name"
             class="ai-chat-container-tab"
@@ -351,7 +351,7 @@
   const keyword = shallowRef('');
   const selectedUserMessages = deepRef<Message[]>([]);
   const resizeAsideWidth = shallowRef<number>(400);
-  const resizeMaindWidth = computed(() => {
+  const resizeMainWidth = computed(() => {
     return `calc(100% - ${resizeAsideWidth.value}px)`;
   });
 
@@ -369,6 +369,26 @@
     selectedUserMessages,
   });
 
+  watch(isCollapse, newVal => {
+    if (newVal) {
+      keyword.value = '';
+      resizeAsideWidth.value = 0;
+    }
+    emits('collapseChange', newVal, resizeAsideWidth.value);
+  });
+  watch(
+    () => executionGroups.value,
+    newVal => {
+      if (!newVal.length) {
+        resetCustomTab();
+      }
+    },
+    {
+      immediate: true,
+      deep: false,
+    },
+  );
+
   const handleShortcutRenderClose = () => {
     selectedShortcut.value = null;
     emits('shortcutClose');
@@ -385,13 +405,6 @@
   const handleUpdateModelValue = (value: string | TagSchema, selectedResourceList: IAiSlashMenuItem[]) => {
     emits('update:modelValue', value, selectedResourceList);
   };
-  watch(isCollapse, newVal => {
-    if (newVal) {
-      keyword.value = '';
-      resizeAsideWidth.value = 0;
-    }
-    emits('collapseChange', newVal, resizeAsideWidth.value);
-  });
 
   const handleCollapse = () => {
     isCollapse.value = !isCollapse.value;
@@ -537,7 +550,7 @@
 
       .bk-resize-layout-main {
         position: relative;
-        width: v-bind(resizeMaindWidth);
+        width: v-bind(resizeMainWidth);
 
         // width: 100%;
         padding: 8px;
@@ -549,12 +562,6 @@
       }
 
       &.ai-is-collapse {
-        // .bk-resize-layout-aside {
-        //   flex: 0 0 0;
-        //   width: 0;
-        //   padding: 0;
-        // }
-
         .bk-resize-layout-aside {
           flex: 0 0 0;
           width: 0;

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -135,8 +135,10 @@ export const useMessageGroup = (options: {
           m => m.role === MessageRole.Assistant && m.toolCalls?.some(t => t.id === message.toolCallId),
         ) as AssistantMessage | undefined;
         if (toolMessage) {
-          const toolCall = toolMessage.toolCalls!.find(t => t.id === message.toolCallId)!;
-          toolCall.toolMessage = message;
+          const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+          if (toolCall) {
+            toolCall.toolMessage = message;
+          }
           toolMessage.status = message.error ? MessageStatus.Error : toolMessage.status || MessageStatus.Complete;
           continue;
         }
@@ -223,10 +225,7 @@ export const useMessageGroup = (options: {
    */
   const onToggleShareAll = (isAllSelected: boolean) => {
     options.selectedUserMessages.value = isAllSelected
-      ? messageGroups.value
-          ?.filter(group => group.type === MessageRole.User)
-          .map(group => group.messages)
-          .flat()
+      ? messageGroups.value?.filter(group => group.type === MessageRole.User).flatMap(group => group.messages)
       : [];
   };
   /**
@@ -245,8 +244,7 @@ export const useMessageGroup = (options: {
     return (
       messageGroups.value
         ?.filter(group => group.checked && group.type === MessageRole.User)
-        .map(group => group.messages)
-        .flat() ?? []
+        .flatMap(group => group.messages) ?? []
     );
   };
 

--- a/src/frontend/ai-blueking/packages/chat-x/vite.config.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/vite.config.ts
@@ -24,8 +24,8 @@
  * IN THE SOFTWARE.
  */
 import vue from '@vitejs/plugin-vue';
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import { analyzer, unstableRolldownAdapter } from 'vite-bundle-analyzer';
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -182,7 +182,7 @@ domain: input
 
 ## 核心能力
 
-- **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏，侧边栏展示执行摘要 / 自定义 Tab
+- **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏；**侧栏是否展示 Tab / 执行摘要、以及分栏是否进入折叠样式（`ai-is-collapse`）以 `executionGroups` 为准**（由 `useMessageGroup` 从消息中过滤出工具调用与 FlowAgent 执行记录），**不以原始 `messages.length` 判断**。因此仅有普通对话、尚无执行类消息时，侧栏内容与「执行情况」区域可能为空，布局上与无执行数据时一致
 - **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
 - **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
 - **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
@@ -284,6 +284,10 @@ ai-chat-container
 
 侧边栏默认包含「执行情况」Tab，展示所有工具调用和 FlowAgent 类型的 Activity 消息。支持关键词搜索过滤和点击定位到对话中的消息位置。
 
+**展示条件**：当 `executionGroups` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。`renderMode === Share` 时侧栏隐藏，且分栏会应用与折叠一致的样式。
+
+**自定义 Tab 联动**：当 `executionGroups` 变为空（例如会话清空或仅剩无执行类消息）时，容器会**自动重置自定义 Tab**（`resetCustomTab`），避免残留节点详情等 Tab。
+
 ```vue
 <template>
   <ChatContainer
@@ -372,7 +376,7 @@ ai-chat-container
 
 ## 自定义 Tab
 
-通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab：
+通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab。若 **`executionGroups` 变为空**，容器会清空自定义 Tab 状态（与侧栏执行数据联动，见上文「侧边栏与执行摘要」）。
 
 ```vue
 <template>

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -71,12 +71,19 @@ role=user  role=tool     其他 role
 `role: 'tool'` 消息不会独立渲染，而是通过 `toolCallId` 注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段：
 
 ```typescript
-// 查找对应的 Assistant 消息
-const toolMessage = messages.find(m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === message.toolCallId));
-// 注入到 toolCall
-const toolCall = toolMessage.toolCalls.find(t => t.id === message.toolCallId);
-toolCall.toolMessage = message;
+const toolMessage = messages.find(
+  m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === message.toolCallId),
+);
+if (toolMessage) {
+  const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+  if (toolCall) {
+    toolCall.toolMessage = message;
+  }
+  // 同步 assistant 状态（错误等）
+}
 ```
+
+若找不到对应 `toolCall`（例如数据不一致），**跳过注入**，避免非空断言导致的运行时异常。
 
 ### pause 字段
 


### PR DESCRIPTION
feat(chat-x): 侧栏 Tab 与 executionGroups 对齐并调整 Biome/lint-staged

ChatContainer：折叠与侧栏 Tab 条件由 messages 改为 executionGroups；分享模式下侧栏收起；
executionGroups 为空时重置自定义 Tab；修正 resizeMainWidth 命名；整理 isCollapse 监听顺序。

use-message-group：工具消息绑定 toolCall 增加空值保护；分享全选/已选用 flatMap 简化。

工程：lint-staged 对 ts/js 仅保留 ESLint；biome.json 设为 root；vite 使用 node:fs/node:path；
移除 simple-git-hooks 中 biome-ignore 注释。