### PR TITLE
feat(chat-x): 消息组 uuid 改为 uid，并支持自定义 Tab「在对话中定位」

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/messages.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/messages.ts
@@ -28,13 +28,12 @@ import type { OldShortcut, Shortcut } from '../../types';
 import type { MessageContentType, MessageRole, MessageStatus } from './constants';
 import type { ContentMap, InputContent } from './contents';
 
-export interface ActivityMessage
-  extends BaseMessage<
-    MessageRole.Activity,
-    | ContentMap[MessageContentType.FlowAgent]
-    | ContentMap[MessageContentType.KnowledgeRag]
-    | ContentMap[MessageContentType.ReferenceDocument]
-  > {
+export interface ActivityMessage extends BaseMessage<
+  MessageRole.Activity,
+  | ContentMap[MessageContentType.FlowAgent]
+  | ContentMap[MessageContentType.KnowledgeRag]
+  | ContentMap[MessageContentType.ReferenceDocument]
+> {
   activityType:
     | MessageContentType.FlowAgent
     | MessageContentType.KnowledgeRag
@@ -59,6 +58,7 @@ export interface BaseMessage<T extends MessageType, C = string> {
   name?: string;
   role: T;
   status: MessageStatus;
+  uid?: string;
   property?: {
     extra?: {
       cite:

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -35,6 +35,24 @@ import ChatContainer from './chat-container.vue';
 import type { AssistantMessage, Message, UserMessage } from '../../ag-ui/types';
 
 vi.mock('bkui-vue', () => {
+  const Button = defineComponent({
+    name: 'Button',
+    props: {
+      size: { type: String, default: '' },
+      text: { type: Boolean, default: false },
+      theme: { type: String, default: 'default' },
+    },
+    emits: ['click'],
+    setup(_, { slots, emit }) {
+      return () =>
+        h(
+          'button',
+          { class: 'mock-bk-button', type: 'button', onClick: () => emit('click') },
+          slots.default?.(),
+        );
+    },
+  });
+
   const TabPanel = defineComponent({
     name: 'TabPanel',
     props: { name: String, label: [String, Function] },
@@ -58,6 +76,7 @@ vi.mock('bkui-vue', () => {
   (Tab as unknown as Record<string, unknown>).TabPanel = TabPanel;
 
   return {
+    Button,
     ResizeLayout: defineComponent({
       name: 'ResizeLayout',
       props: {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -80,7 +80,19 @@
                 :is="selectedTab?.data?.component"
                 :key="selectedTab.name"
                 v-bind="selectedTab?.data?.props"
-              />
+              >
+                <template #locateButton>
+                  <Button
+                    class="ai-locate-button"
+                    size="small"
+                    text
+                    theme="primary"
+                    @click="handleLocateMessageGroup(selectedTab?.data?.messageUid)"
+                  >
+                    {{ t('在对话中定位') }}
+                  </Button>
+                </template>
+              </component>
             </div>
           </template>
         </template>
@@ -211,7 +223,7 @@
     withDirectives,
   } from 'vue';
 
-  import { ResizeLayout, Tab } from 'bkui-vue';
+  import { Button, ResizeLayout, Tab } from 'bkui-vue';
 
   import { RenderMode } from '../../common';
   import { useMessageGroup } from '../../composables';
@@ -399,11 +411,19 @@
   /**
    * 定位消息组
    */
-  const handleLocateMessageGroup = (uuid: string) => {
-    const dom = document.getElementById(uuid);
-    if (dom) {
-      dom.scrollIntoView({ behavior: 'smooth' });
+  const handleLocateMessageGroup = (uid?: string) => {
+    if (!uid) {
+      return;
     }
+    const dom = document.getElementById(uid);
+    if (!dom) {
+      const group = messageGroups.value.find(group => group.messages.some(message => message.uid === uid));
+      if (group) {
+        document.getElementById(group.uid)?.scrollIntoView({ behavior: 'smooth' });
+      }
+      return;
+    }
+    dom.scrollIntoView({ behavior: 'smooth' });
   };
   const handleUpdateTabActive = (name: string) => {
     selectCustomTab(tabs.value.find(tab => tab.name === name)!);
@@ -579,6 +599,12 @@
     &-message-slot {
       width: 100%;
       height: calc(100% - 40px);
+
+      .ai-locate-button {
+        margin-left: auto;
+        font-size: 12px;
+        font-weight: normal;
+      }
     }
 
     .collapse-button {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
@@ -303,5 +303,22 @@ describe('FlowAgentContent', () => {
 
       expect(mockRemoveCustomTab).not.toHaveBeenCalled();
     });
+
+    it('打开节点详情时应将 messageUid 传入自定义 Tab 的 data', async () => {
+      const messageUid = 'flow-msg-uid-1';
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent(),
+          messageUid,
+        },
+      });
+
+      const detailBtn = wrapper.find('.flow-agent-node-detail-btn');
+      await detailBtn.trigger('click');
+
+      expect(mockAddCustomTab).toHaveBeenCalled();
+      const payload = mockAddCustomTab.mock.calls[0]?.[0] as { data?: { messageUid?: string } };
+      expect(payload?.data?.messageUid).toBe(messageUid);
+    });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
@@ -176,6 +176,7 @@
 
   const props = defineProps<{
     content?: BkFlowMessageContent;
+    messageUid?: string;
     status?: MessageStatusType;
   }>();
 
@@ -262,6 +263,7 @@
         name: `${taskId}|${node.id}|${node.name}`,
         data: {
           component: BkFlowNodeDetail,
+          messageUid: props.messageUid,
           props: {
             loading: true,
             node_id: node.id,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.spec.ts
@@ -97,6 +97,18 @@ describe('FlowAgentNodeDetail', () => {
   });
 
   describe('渲染测试', () => {
+    it('应该渲染 locateButton 插槽内容', () => {
+      wrapper = mount(FlowAgentNodeDetail, {
+        props: baseProps,
+        slots: {
+          locateButton: () => h('button', { class: 'mock-locate-slot-btn' }, '在对话中定位'),
+        },
+      });
+
+      expect(wrapper.find('.mock-locate-slot-btn').exists()).toBe(true);
+      expect(wrapper.find('.mock-locate-slot-btn').text()).toBe('在对话中定位');
+    });
+
     it('应该正确渲染组件', () => {
       wrapper = mount(FlowAgentNodeDetail, {
         props: baseProps,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue
@@ -5,7 +5,13 @@
         <span>{{ t('节点') }}：</span>
         <span class="skeleton-title ai-skeleton-element" />
       </template>
-      <template v-else>{{ t('节点') }}：{{ basicInfo?.node_name }}</template>
+      <div
+        v-else
+        class="detail-title-content"
+      >
+        {{ t('节点') }}：{{ basicInfo?.node_name }}
+      </div>
+      <slot name="locateButton" />
     </h3>
     <div class="detail-tab-bar">
       <div
@@ -121,7 +127,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, shallowRef } from 'vue';
+  import { type VNode, computed, shallowRef } from 'vue';
 
   import { isEn } from '../../../common/lang';
   import { NodeOutputIcon, NodeTabIcon } from '../../../icons';
@@ -131,7 +137,9 @@
 
   import type { CustomBkFlowTabData, NodeDetailData } from '../../../types';
   import type { SimpleTableColumn } from './simple-table.vue';
-
+  defineSlots<{
+    locateButton: () => VNode;
+  }>();
   enum DetailTab {
     Config = 'config',
     Output = 'output',
@@ -244,14 +252,20 @@
     font-size: 12px;
 
     .detail-title {
+      display: flex;
+      align-items: center;
       margin: 0 0 16px;
-      overflow: hidden;
-      text-overflow: ellipsis;
-      font-size: 16px;
-      font-weight: bold;
       line-height: 24px;
       color: $color-title;
-      white-space: nowrap;
+
+      &-content {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        font-size: 16px;
+        font-weight: bold;
+        white-space: nowrap;
+      }
     }
 
     .detail-tab-bar {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue
@@ -34,6 +34,7 @@
 
   const props = defineProps<{
     content?: KnowledgeRagMessageContent;
+    messageUid?: string;
     status?: MessageStatusType;
   }>();
   const collapsed = defineModel<boolean>('collapsed', {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/reference-doc-content/reference-doc-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/reference-doc-content/reference-doc-content.vue
@@ -23,6 +23,7 @@
 
   const props = defineProps<{
     content?: ReferenceDocumentContent[];
+    messageUid?: string;
   }>();
   const collapsed = defineModel<boolean>('collapsed', {
     default: false,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
@@ -98,10 +98,20 @@ vi.mock('../../chat-content/flow-agent-content/flow-agent-content.vue', () => ({
       content: { type: Object, default: () => ({}) },
       status: { type: String, default: '' },
       collapsed: { type: Boolean, default: false },
+      messageUid: { type: String, default: '' },
     },
     emits: ['update:collapsed'],
     setup(props) {
-      return () => h('div', { class: 'mock-flow-agent-content', 'data-status': props.status }, 'FlowAgentContent');
+      return () =>
+        h(
+          'div',
+          {
+            class: 'mock-flow-agent-content',
+            'data-status': props.status,
+            'data-message-uid': props.messageUid || '',
+          },
+          'FlowAgentContent',
+        );
     },
   }),
 }));
@@ -422,6 +432,18 @@ describe('ActivityMessage', () => {
       });
 
       expect(wrapper.find('.mock-flow-agent-content').attributes('data-status')).toBe('streaming');
+    });
+
+    it('应将 uid 作为 messageUid 传递给 FlowAgentContent', () => {
+      wrapper = mount(ActivityMessage, {
+        props: {
+          activityType: 'flow-agent',
+          content: {},
+          uid: 'activity-uid-1',
+        },
+      });
+
+      expect(wrapper.find('.mock-flow-agent-content').attributes('data-message-uid')).toBe('activity-uid-1');
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.vue
@@ -4,6 +4,7 @@
     v-if="activityComponent"
     v-model:collapsed="collapsed"
     :content="content"
+    :message-uid="uid"
     :status="status"
   />
 </template>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -208,7 +208,7 @@ type MessageGroup = {
   pause?: boolean;
   startTime?: number;
   type: string;
-  uuid: string;
+  uid: string;
 };
 
 const buildGroups = (messages: Message[]): MessageGroup[] => {
@@ -217,7 +217,7 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
   for (const msg of messages) {
     if (msg.role === MessageRole.User) {
       groups.push({
-        uuid: `group-${msg.id}`,
+        uid: `group-${msg.id}`,
         messages: [msg],
         type: MessageRole.User,
         isHover: false,
@@ -229,7 +229,7 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
         lastGroup.messages.push(msg);
       } else {
         groups.push({
-          uuid: `group-${msg.id}`,
+          uid: `group-${msg.id}`,
           messages: [msg],
           type: MessageRole.Assistant,
           isHover: false,
@@ -249,7 +249,7 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
   const lastMsg = messages[messages.length - 1];
   if (lastMsg && lastMsg.role === MessageRole.User) {
     groups.push({
-      uuid: 'loading-group',
+      uid: 'loading-group',
       messages: [
         {
           id: 'loading',

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -5,7 +5,7 @@
   >
     <div
       v-for="(group, groupIndex) in messageGroups"
-      :id="group.uuid"
+      :id="group.uid"
       :key="groupIndex"
       class="message-group"
       :style="{

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-render/message-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-render/message-render.vue
@@ -54,8 +54,7 @@
                 { content: props.message.content || '', status: props.message.status },
                 slots.codeHeader
                   ? {
-                      codeHeader: (slotProps: { language: string; token: Token[] }) =>
-                        slots.codeHeader?.(slotProps),
+                      codeHeader: (slotProps: { language: string; token: Token[] }) => slots.codeHeader?.(slotProps),
                     }
                   : undefined,
               ),

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.spec.ts
@@ -96,7 +96,7 @@ vi.mock('../chat-message/message-render/message-render.vue', () => ({
 }));
 
 const createMessageGroup = (overrides: Partial<MessageGroup> = {}): MessageGroup => ({
-  uuid: `group-${Math.random().toString(36).slice(2, 8)}`,
+  uid: `group-${Math.random().toString(36).slice(2, 8)}`,
   messages: [],
   type: 'assistant' as MessageGroup['type'],
   isHover: false,
@@ -192,7 +192,7 @@ describe('ExecutionSummary', () => {
 
   describe('事件测试', () => {
     it('点击定位按钮应该触发 locateMessageGroup 事件', async () => {
-      const group = createMessageGroup({ uuid: 'test-uuid', userMessageTitle: '测试消息' });
+      const group = createMessageGroup({ uid: 'test-uid', userMessageTitle: '测试消息' });
 
       wrapper = mount(ExecutionSummary, {
         props: { messageGroups: [group] },
@@ -205,7 +205,7 @@ describe('ExecutionSummary', () => {
       await locateBtn.trigger('click');
 
       expect(wrapper.emitted('locateMessageGroup')).toBeTruthy();
-      expect(wrapper.emitted('locateMessageGroup')?.[0]?.[0]).toBe('test-uuid');
+      expect(wrapper.emitted('locateMessageGroup')?.[0]?.[0]).toBe('test-uid');
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
@@ -13,9 +13,9 @@
       <template v-if="messageGroups.length">
         <div
           v-for="(group, index) in messageGroups"
-          :key="group.uuid"
+          :key="group.uid"
           class="execution-summary-content-item"
-          @mouseenter="hoverGroupId = group.uuid"
+          @mouseenter="hoverGroupId = group.uid"
           @mouseleave="hoverGroupId = undefined"
         >
           <div class="content-item-header">
@@ -29,7 +29,7 @@
               }}
             </span>
             <Button
-              v-show="hoverGroupId === group.uuid"
+              v-show="hoverGroupId === group.uid"
               class="content-item-locate"
               text
               theme="primary"
@@ -88,7 +88,7 @@
   }>();
 
   const emits = defineEmits<{
-    (e: 'locateMessageGroup', uuid: string, group: MessageGroup): void;
+    (e: 'locateMessageGroup', uid: string, group: MessageGroup): void;
     (e: 'updateKeyword', keyword: string): void;
   }>();
   const commonTippyOptions = useCommonTippyInject();
@@ -105,7 +105,7 @@
   };
 
   const handleLocate = (group: MessageGroup) => {
-    emits('locateMessageGroup', group.uuid, group);
+    emits('locateMessageGroup', group.uid, group);
   };
   const handleClearSearch = () => {
     keyword.value = '';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.vue
@@ -248,7 +248,7 @@
 </script>
 
 <style lang="scss">
-  .ai-message-container .code-content-wrapper {
+  .code-content-wrapper {
     width: 100%;
     margin-bottom: 12px;
 
@@ -271,7 +271,9 @@
         color: #999;
       }
     }
+  }
 
+  .ai-message-container .code-content-wrapper {
     .hljs-pre {
       padding: 8px 16px;
       margin: 0;

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -94,6 +94,17 @@ describe('useMessageGroup', () => {
       expect(messageGroups.value.length).toBe(0);
     });
 
+    it('无 uid 的消息应在分组前被补充 uid', async () => {
+      const userMsg = createUserMessage('1');
+      expect(userMsg.uid).toBeUndefined();
+
+      const { messageGroups } = setupMessageGroup([userMsg]);
+      await nextTick();
+
+      expect(userMsg.uid).toBeDefined();
+      expect(messageGroups.value[0]?.messages[0]?.uid).toBe(userMsg.uid);
+    });
+
     it('单条用户消息应该创建 User 组 + Loading 组', async () => {
       const { messageGroups } = setupMessageGroup([createUserMessage('1')]);
       await nextTick();

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -45,8 +45,8 @@ export type MessageGroup = {
   pause?: boolean;
   startTime?: number; // 执行时间
   type: MessageRole;
+  uid: string;
   userMessageTitle?: number | string;
-  uuid: string;
 };
 
 type SearchTextExtractor = (message: Message) => string[];
@@ -109,6 +109,9 @@ export const useMessageGroup = (options: {
     let assistantMessages: Message[] = [];
     const list: MessageGroup[] = [];
     for (const message of options.messages.value) {
+      if (!message?.uid) {
+        message.uid = generateUUID();
+      }
       if (message.role === MessageRole.User) {
         if (assistantMessages.length > 0) {
           list.push({
@@ -116,7 +119,7 @@ export const useMessageGroup = (options: {
             type: MessageRole.Assistant,
             isHover: false,
             checked: false,
-            uuid: generateUUID(),
+            uid: generateUUID(),
             pause: assistantMessages?.some(m => m.property?.extra?.pause) ?? false,
           });
           assistantMessages = [];
@@ -126,7 +129,7 @@ export const useMessageGroup = (options: {
           type: MessageRole.User,
           isHover: false,
           checked: false,
-          uuid: generateUUID(),
+          uid: generateUUID(),
         });
         continue;
       }
@@ -149,7 +152,7 @@ export const useMessageGroup = (options: {
         type: MessageRole.Assistant,
         isHover: false,
         checked: false,
-        uuid: generateUUID(),
+        uid: generateUUID(),
         pause: assistantMessages?.some(m => m.property?.extra?.pause) ?? false,
       });
     }
@@ -162,12 +165,13 @@ export const useMessageGroup = (options: {
             status: MessageStatus.Pending,
             messageId: '',
             id: 'loading',
+            uid: generateUUID(),
           },
         ],
         type: MessageRole.Loading,
         isHover: false,
         checked: false,
-        uuid: generateUUID(),
+        uid: generateUUID(),
       });
     }
     messageGroups.value = list;

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
@@ -36,7 +36,7 @@ export type CustomBkFlowTabData = CustomTabData<{
 }>;
 
 export type CustomTab<T extends CustomTabData<Record<string, unknown>>> = {
-  data?: T;
+  data?: T & { messageUid?: string };
   icon?: string;
   label: string; // 显示标签
   name: string; // 唯一标识

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/theme/index.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/theme/index.ts
@@ -25,6 +25,11 @@
  */
 import DefaultTheme from 'vitepress/theme';
 
+// 文档站内直接演示源码组件时，确保 Markdown 正文、代码高亮、公式样式与线上一致
+// （避免仅依赖组件链路的按需 CSS 在部分页面未打入）
+import '../../../src/components/chat-content/markdown-content/markdown-content.css';
 import './custom.scss';
+import 'highlight.js/styles/github-dark.css';
+import 'katex/dist/katex.min.css';
 
 export default DefaultTheme;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/code-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/code-content.md
@@ -143,23 +143,19 @@ export function useCounter(initial = 0) {
 
 ## 组件结构
 
-样式根选择器为 **`.ai-message-container .code-content-wrapper`**：代码块头部与 `pre` 区样式仅在消息容器（如 `MessageContainer` 根上的 `ai-message-container`）下生效。Wiki 与业务中独立演示时，请将 `CodeContent` 包在带 `ai-message-container` 类名的父节点内。
+根类名为 **`.code-content-wrapper`**：外层宽度、下边距以及 **`.code-content-header`**（深色顶栏）在任意父级下均生效。**代码区** `.hljs-pre`、行内高亮等样式选择器为 **`.ai-message-container .code-content-wrapper`**，仅在消息列表（`MessageContainer` 根上的 `ai-message-container`）内与对话区一致。Wiki 与业务中若要完整还原代码区外观，请将 `CodeContent` 包在带 `ai-message-container` 类名的父节点内。
 
 ```
-.ai-message-container .code-content-wrapper（width: 100%，margin-bottom: 12px）
-├── .code-content-header（height: 40px，bg: #2f333d，border: 1px solid #1a1a1a）
-│     ├── .code-header-language（color: #999，显示 token.info 原始字符串）
-│     ├── slot#header（{ language, token }）— 自定义头部操作按钮区域
-│     └── ToolBtn id="copy"（点击复制 codeRef.innerText）
+.code-content-wrapper
+├── .code-content-header（深色顶栏；不依赖 .ai-message-container）
+│     ├── .code-header-language（token.info）
+│     ├── slot#header（{ language, token }）
+│     └── ToolBtn id="copy"
 │
-└── .hljs-pre（bg: #282c34，padding: 8×16，overflow-x: auto）
+└── .hljs-pre（完整 padding / 背景 / code 字体：需父级为 .ai-message-container .code-content-wrapper）
       └── <code class="hljs language-{raw-info}">
-            ├── v-for completedLines
-            │     <span class="code-line" v-html="line.html" /> + '\n'
-            │     （已完成行，经过 hljs.highlight 高亮）
-            └── v-if currentLineText
-                  <span class="code-line current-line" v-html="currentLineHtml" />
-                  （最后一行，也经过 highlightLine，用 .current-line 标识正在输入）
+            ├── v-for completedLines → <span class="code-line" />
+            └── v-if currentLineText → <span class="code-line current-line" />
 ```
 
 ## 基础用法
@@ -168,7 +164,7 @@ export function useCounter(initial = 0) {
 
 ```vue
 <template>
-  <!-- 完整深色头部与 pre 样式依赖父级 .ai-message-container（与对话消息区一致） -->
+  <!-- 代码区 .hljs-pre 的完整样式依赖父级 .ai-message-container（与对话消息区一致）；顶栏单独也可用 -->
   <div class="ai-message-container">
     <CodeContent
       :token="codeTokens"

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
@@ -56,6 +56,8 @@ domain: message
 
 活动消息组件，用于展示 AI 的知识检索（Knowledge RAG）过程、参考文档引用列表和 FlowAgent 流程执行情况。通过 `activityType` 切换三种工作模式，点击标题栏可折叠/展开内容区域。
 
+组件会将父级传入消息上的 **`uid`** 以 **`message-uid`** 形式透传给各活动子组件（`FlowAgentContent` / `KnowledgeRagContent` / `ReferenceDocContent`），用于侧栏自定义 Tab、`addCustomTab` 的 `data.messageUid` 与主对话区「在对话中定位」联动（详见 [ChatContainer](./chat-container.md)）。
+
 ## 三种工作模式
 
 组件根据 `activityType` 的值决定渲染模式：

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -200,7 +200,7 @@ ai-chat-container
     │   │   ├── 执行情况（默认 Tab）
     │   │   └── 自定义 Tab × N（可关闭）
     │   ├── ExecutionSummary（执行情况 Tab 内容）
-    │   ├── 自定义 Tab 组件（通过 component :is 渲染）
+    │   ├── 自定义 Tab 组件（通过 component :is 渲染，可向子组件注入 #locateButton）
     │   └── collapse-button（折叠按钮）
     └── main（主内容区）
         ├── MessageContainer（有消息时）
@@ -374,6 +374,12 @@ ai-chat-container
 
 通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab：
 
+### 自定义 Tab 与「在对话中定位」
+
+`addCustomTab` 的 `data` 可携带 **`messageUid`**（与对应活动消息的 `message.uid` 一致）。`ChatContainer` 在侧栏用 `<component :is>` 渲染自定义 Tab 时，会向子组件提供 **`locateButton` 插槽**：默认渲染「在对话中定位」按钮，点击后调用内部 `handleLocateMessageGroup(messageUid)`，优先滚动到主区域 `document.getElementById(messageUid)`；若不存在该节点，则在当前 `messageGroups` 中查找包含 `message.uid === messageUid` 的消息组，并滚动到该组的容器（`MessageGroup.uid` 作为组级 `id`）。
+
+子组件若需展示该按钮，请在模板中声明 `<slot name="locateButton" />`（例如 FlowAgent 节点详情标题栏）。`FlowAgentContent` 等会在打开节点详情 Tab 时将 `messageUid` 写入 `data`，与 `ActivityMessage` 下传给内容区的 `message-uid` 对齐。
+
 ```vue
 <template>
   <ChatContainer
@@ -394,13 +400,14 @@ ai-chat-container
   const chatContainerRef = useTemplateRef<InstanceType<typeof ChatContainer>>('chatContainerRef');
 
   // 添加自定义 Tab（如 FlowAgent 节点详情）
-  const addNodeDetailTab = (nodeId: string, nodeName: string) => {
+  const addNodeDetailTab = (nodeId: string, nodeName: string, messageUid?: string) => {
     chatContainerRef.value?.addCustomTab({
       name: `node-${nodeId}`,
       label: nodeName,
       data: {
-        component: MyNodeDetail, // 自定义组件
+        component: MyNodeDetail, // 自定义组件（模板内需 <slot name="locateButton" /> 以展示侧栏「在对话中定位」）
         props: { loading: true, data: {} },
+        messageUid, // 与活动消息 message.uid 一致时可省略；用于主对话定位
       },
     });
   };
@@ -724,11 +731,11 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 ```typescript
 import { ChatContainer, RenderMode, type CustomTab, type Shortcut, type Message } from '@blueking/chat-x';
 
-// 自定义 Tab
+// 自定义 Tab（data 可与 messageUid 组合，供侧栏定位主对话）
 interface CustomTab<T = Record<string, unknown>> {
   label: string;
   name: string;
-  data?: T;
+  data?: T & { messageUid?: string };
 }
 
 // 快捷指令

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/execution-summary.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/execution-summary.md
@@ -25,7 +25,7 @@ domain: helper
 
   const mockGroups = [
     {
-      uuid: 'group-1',
+      uid: 'group-1',
       type: 'assistant',
       checked: false,
       isHover: false,
@@ -55,7 +55,7 @@ domain: helper
       ],
     },
     {
-      uuid: 'group-2',
+      uid: 'group-2',
       type: 'assistant',
       checked: false,
       isHover: false,
@@ -86,8 +86,8 @@ domain: helper
     },
   ];
 
-  const handleLocate = (uuid, group) => {
-    locateInfo.value = `定位到消息组: ${uuid}（${new Date(group.startTime).toLocaleTimeString()}）`;
+  const handleLocate = (uid, group) => {
+    locateInfo.value = `定位到消息组: ${uid}（${new Date(group.startTime).toLocaleTimeString()}）`;
   };
 
   const handleUpdateKeyword = (keyword) => {
@@ -124,8 +124,8 @@ domain: helper
 <script setup lang="ts">
   import { ExecutionSummary, type MessageGroup } from '@blueking/chat-x';
 
-  const handleLocate = (uuid: string, group: MessageGroup) => {
-    const dom = document.getElementById(uuid);
+  const handleLocate = (uid: string, group: MessageGroup) => {
+    const dom = document.getElementById(uid);
     dom?.scrollIntoView({ behavior: 'smooth' });
   };
 
@@ -203,7 +203,7 @@ execution-summary
 
 | 事件名             | 参数                                  | 说明                     |
 | ------------------ | ------------------------------------- | ------------------------ |
-| locateMessageGroup | `(uuid: string, group: MessageGroup)` | 点击「在对话中定位」按钮 |
+| locateMessageGroup | `(uid: string, group: MessageGroup)` | 点击「在对话中定位」按钮，参数为消息组 `MessageGroup.uid` |
 | updateKeyword      | `(keyword: string)`                   | 搜索关键词变更           |
 
 ## 类型定义
@@ -212,7 +212,7 @@ execution-summary
 import { type MessageGroup } from '@blueking/chat-x';
 
 interface MessageGroup {
-  uuid: string;
+  uid: string;
   type: MessageRole;
   messages: Message[];
   checked: boolean;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
@@ -383,6 +383,7 @@ domain: message
 
 **关键细节**：
 
+- 每个消息组外层 DOM 的 `id` 为 **`MessageGroup.uid`**（由 `useMessageGroup` 生成），供执行摘要「在对话中定位」、侧栏自定义 Tab 等场景滚动锚定
 - `role: 'tool'` 消息**不会独立渲染**，而是被注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段
 - 若 `toolMessage.error` 存在，AssistantMessage 的 `status` 会被强制设为 `MessageStatus.Error`
 - `MessageTools` 工具栏只在 `type === 'assistant'` 的消息组底部渲染（不依赖鼠标悬停，始终可见），且满足以下条件时**不渲染**：

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
@@ -117,7 +117,8 @@ tabManager?.removeCustomTab('node-detail-123');
 interface CustomTab<T = Record<string, unknown>> {
   label: string;
   name: string;
-  data?: T;
+  /** 可与 `component` / `props` 并列；用于侧栏「在对话中定位」与主消息 `message.uid` 对齐 */
+  data?: T & { messageUid?: string };
 }
 ```
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -47,6 +47,8 @@ function useMessageGroup(options: {
 
 `watchEffect` 遍历 `messages` 数组，按以下规则分组：
 
+**消息 `uid`：** 若某条消息缺少 `uid`，分组前会自动为其生成并写入 `uid`（与 `MessageGroup.uid` 及 DOM 定位约定配合）。
+
 ```
 messages 原始数组（按顺序处理）
          │
@@ -165,7 +167,7 @@ const { messageGroups, executionGroups, isShareMode, isAllSelected, onToggleShar
 import { type MessageGroup } from '@blueking/chat-x';
 
 interface MessageGroup {
-  uuid: string;
+  uid: string;
   type: MessageRole;
   messages: Message[];
   checked: boolean;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/plugins/markdown-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/plugins/markdown-container.md
@@ -2,7 +2,7 @@
 name: markdownItContainer
 slug: markdown-container
 category: plugin
-description: Markdown-it 自定义容器插件，支持 ::: name ... ::: 语法，用于对齐块等场景。
+description: "Markdown-it 自定义容器插件，支持 ::: name ... ::: 语法，用于对齐块等场景。"
 aiSummary: >
   markdownItContainer 基于 markdown-it-container，支持字符串或正则匹配容器名；MarkdownContent 中用于 hljs-left/center/right 对齐。
   渲染为带 class 的 div，与 tokens-to-vnodes 及样式配合。

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -53,6 +53,9 @@ interface BaseMessage<T extends MessageType, C = string> {
   // 消息状态
   status: MessageStatus;
 
+  // 可选：单条消息实例唯一标识（`useMessageGroup` 在缺失时会自动生成并写回）
+  uid?: string;
+
   // 消息名称（可选）
   name?: string;
 


### PR DESCRIPTION
feat(chat-x): 消息组 uuid 改为 uid，并支持自定义 Tab「在对话中定位」

- BaseMessage 增加可选 uid；useMessageGroup 为缺失 uid 的消息补全并统一 MessageGroup 使用 uid
- 自定义 Tab 数据支持 messageUid；FlowAgent 节点详情透传 messageUid
- ChatContainer 为自定义 Tab 提供 locateButton 插槽与定位逻辑（含按消息 uid 回退到消息组）
- FlowAgentNodeDetail 增加 locateButton 插槽；ActivityMessage 向 FlowAgentContent 传入 messageUid
- 同步 ExecutionSummary、单测与 wikis 文档
# Reviewed, transaction id: 78527