### PR TITLE
feat(chat-x): 新增 Fetching 状态并推导 inputStatus 对齐 Loading 占位

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
@@ -64,6 +64,7 @@ export enum MessageStatus {
   Complete = 'complete',
   Disabled = 'disabled',
   Error = 'error',
+  Fetching = 'fetching', // 请求中
   Pending = 'pending',
   Stop = 'stop',
   StopLoading = 'stop-loading',

--- a/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
@@ -137,3 +137,5 @@ export enum RenderMode {
   Share = 'share',
   Test = 'test',
 }
+
+export const LOADING_MESSAGE_ID = '__loading__';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -29,10 +29,21 @@ import { type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageRole, MessageStatus } from '../../ag-ui/types';
-import { RenderMode } from '../../common';
+import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
 import ChatContainer from './chat-container.vue';
 
 import type { AssistantMessage, Message, UserMessage } from '../../ag-ui/types';
+
+/** 供 useMessageGroup mock 注入，用于验证 inputStatus 对 Loading 占位消息的推导 */
+const mockMessageGroupsRef = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref } = require('vue');
+  return ref<
+    Array<{
+      messages: Array<{ id?: string }>;
+    }>
+  >([]);
+});
 
 vi.mock('bkui-vue', () => {
   const Button = defineComponent({
@@ -108,8 +119,8 @@ vi.mock('../../lang/lang', () => ({
 vi.mock('../../composables', () => ({
   useMessageGroup: vi.fn((_options: { messages: { value: Message[] } }) => {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { computed, ref: deepRef, shallowRef } = require('vue');
-    const messageGroups = deepRef<unknown[]>([]);
+    const { computed, shallowRef } = require('vue');
+    const messageGroups = mockMessageGroupsRef;
     const executionGroups = computed(() => []);
     const isShareMode = shallowRef(false);
     const isAllSelected = computed(() => false);
@@ -352,6 +363,7 @@ describe('ChatContainer', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockMessageGroupsRef.value = [];
   });
 
   afterEach(() => {
@@ -464,6 +476,34 @@ describe('ChatContainer', () => {
       });
 
       expect(wrapper.find('.mock-chat-input').exists()).toBe(true);
+    });
+
+    it('当分组中存在 LOADING_MESSAGE_ID 占位消息时，MessageContainer 与 ChatInput 应收到 Fetching 状态', () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      mockMessageGroupsRef.value = [{ messages: [{ id: LOADING_MESSAGE_ID }] }];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages, messageStatus: MessageStatus.Complete },
+      });
+
+      const mc = wrapper.findComponent({ name: 'MessageContainer' });
+      const ci = wrapper.findComponent({ name: 'ChatInput' });
+      expect(mc.props('messageStatus')).toBe(MessageStatus.Fetching);
+      expect(ci.props('messageStatus')).toBe(MessageStatus.Fetching);
+    });
+
+    it('无 Loading 占位时 messageStatus 应透传为 props.messageStatus', () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      mockMessageGroupsRef.value = [{ messages: [{ id: 'other-id' }] }];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages, messageStatus: MessageStatus.Streaming },
+      });
+
+      const mc = wrapper.findComponent({ name: 'MessageContainer' });
+      const ci = wrapper.findComponent({ name: 'ChatInput' });
+      expect(mc.props('messageStatus')).toBe(MessageStatus.Streaming);
+      expect(ci.props('messageStatus')).toBe(MessageStatus.Streaming);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -130,7 +130,7 @@
             v-model:selected-user-messages="selectedUserMessages"
             :enable-selection="isShareMode"
             :message-groups="messageGroups"
-            :message-status="messageStatus"
+            :message-status="inputStatus"
             :message-tools-status="messageToolsStatus"
             :message-tools-tippy-options="commonTippyOptions"
             :messages="messages"
@@ -188,7 +188,7 @@
           <template v-else>
             <ChatInput
               v-model:cite="cite"
-              :message-status="messageStatus"
+              :message-status="inputStatus"
               :model-value="modelValue"
               :on-send-message="onSendMessage"
               :on-stop-sending="onStopSending"
@@ -225,7 +225,8 @@
 
   import { Button, ResizeLayout, Tab } from 'bkui-vue';
 
-  import { RenderMode } from '../../common';
+  import { type Message, type UserMessage, MessageStatus } from '../../ag-ui/types';
+  import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
   import { useMessageGroup } from '../../composables';
   import { useCommonTippyProvider } from '../../composables/use-common';
   import { EXECUTION_TAB_NAME, useCustomTabProvider } from '../../composables/use-custom-tab';
@@ -245,7 +246,6 @@
   import MessageLoading from '../message-loading/message-loading.vue';
   import SelectionFooter from '../selection-footer/selection-footer.vue';
 
-  import type { Message, UserMessage } from '../../ag-ui/types';
   import type {
     AITippyProps,
     CustomBkFlowTabData,
@@ -400,7 +400,12 @@
       deep: false,
     },
   );
-
+  const inputStatus = computed(() => {
+    if (messageGroups.value?.some(group => group.messages.some(message => message.id === LOADING_MESSAGE_ID))) {
+      return MessageStatus.Fetching;
+    }
+    return props.messageStatus;
+  });
   const handleShortcutRenderClose = () => {
     selectedShortcut.value = null;
     emits('shortcutClose');

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -499,6 +499,18 @@ describe('ChatInput', () => {
       const inputAttachment = wrapper.findComponent({ name: 'InputAttachment' });
       expect(inputAttachment.props('messageState')).toBe(MessageStatus.Streaming);
     });
+
+    it('messageStatus 为 Fetching 时应优先返回 Fetching（即使输入为空）', () => {
+      wrapper = mount(ChatInput, {
+        props: {
+          modelValue: '',
+          messageStatus: MessageStatus.Fetching,
+        },
+      });
+
+      const inputAttachment = wrapper.findComponent({ name: 'InputAttachment' });
+      expect(inputAttachment.props('messageState')).toBe(MessageStatus.Fetching);
+    });
   });
 
   describe('事件测试', () => {
@@ -538,6 +550,22 @@ describe('ChatInput', () => {
       wrapper = mount(ChatInput, {
         props: {
           modelValue: '',
+          onSendMessage,
+        },
+      });
+
+      await wrapper.find('.mock-ai-slash-input').trigger('keydown', { key: 'Enter' });
+
+      expect(onSendMessage).not.toHaveBeenCalled();
+    });
+
+    it('Enter 键在 Fetching 状态下不应该发送消息', async () => {
+      const onSendMessage = vi.fn();
+
+      wrapper = mount(ChatInput, {
+        props: {
+          modelValue: 'hello',
+          messageStatus: MessageStatus.Fetching,
           onSendMessage,
         },
       });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -150,7 +150,10 @@ Use Shift + Enter to enter a new line`
     return props.shortcuts?.find(shortcut => shortcut.id === props.shortcutId);
   });
   const messageState = computed(() => {
-    if (props.messageStatus && [MessageStatus.Pending, MessageStatus.Streaming].includes(props.messageStatus)) {
+    if (
+      props.messageStatus &&
+      [MessageStatus.Pending, MessageStatus.Streaming, MessageStatus.Fetching].includes(props.messageStatus)
+    ) {
       return props.messageStatus;
     }
     if (props.modelValue?.length < 1) {
@@ -207,6 +210,9 @@ Use Shift + Enter to enter a new line`
         return;
       }
       if (messageState.value === MessageStatus.Disabled) {
+        return;
+      }
+      if (messageState.value === MessageStatus.Fetching) {
         return;
       }
       handleSendMessage();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.spec.ts
@@ -129,6 +129,22 @@ describe('InputAttachment', () => {
       expect(wrapper.find('.mock-loading-icon').exists()).toBe(true);
     });
 
+    it('Fetching 状态应该显示 LoadingMessageIcon', () => {
+      wrapper = mount(InputAttachment, {
+        props: {
+          messageState: MessageStatus.Fetching,
+        },
+        global: {
+          directives: {
+            tippy: {},
+          },
+        },
+      });
+
+      expect(wrapper.find('.mock-loading-icon').exists()).toBe(true);
+      expect(wrapper.find('.mock-send-icon').exists()).toBe(false);
+    });
+
     it('Complete 状态应该显示 SendMessageIcon', () => {
       wrapper = mount(InputAttachment, {
         props: {
@@ -191,6 +207,21 @@ describe('InputAttachment', () => {
       expect(wrapper.find('.send-message-icon__pending').exists()).toBe(true);
     });
 
+    it('Fetching 状态应该有对应的样式类', () => {
+      wrapper = mount(InputAttachment, {
+        props: {
+          messageState: MessageStatus.Fetching,
+        },
+        global: {
+          directives: {
+            tippy: {},
+          },
+        },
+      });
+
+      expect(wrapper.find('.send-message-icon__fetching').exists()).toBe(true);
+    });
+
     it('Disabled 状态应该有对应的样式类', () => {
       wrapper = mount(InputAttachment, {
         props: {
@@ -229,6 +260,23 @@ describe('InputAttachment', () => {
       wrapper = mount(InputAttachment, {
         props: {
           messageState: MessageStatus.Streaming,
+        },
+        global: {
+          directives: {
+            tippy: {},
+          },
+        },
+      });
+
+      await wrapper.find('.mock-loading-icon').trigger('click');
+
+      expect(wrapper.emitted('stopSending')).toBeTruthy();
+    });
+
+    it('Fetching 状态点击 LoadingMessageIcon 应该发出 stopSending 事件', async () => {
+      wrapper = mount(InputAttachment, {
+        props: {
+          messageState: MessageStatus.Fetching,
         },
         global: {
           directives: {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
@@ -7,7 +7,11 @@
         :class="{ ['send-message-icon__' + messageState]: true }"
       >
         <LoadingMessageIcon
-          v-if="messageState === MessageStatus.Streaming || messageState === MessageStatus.Pending"
+          v-if="
+            messageState === MessageStatus.Streaming ||
+            messageState === MessageStatus.Pending ||
+            messageState === MessageStatus.Fetching
+          "
           v-tippy="{ ...tippyOptions, content: t('停止'), theme: 'ai-chat-box', offset: [0, 16] }"
           @click="handleStopSending"
         />

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -30,7 +30,7 @@ import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageContentType, MessageRole, MessageStatus } from '../../../ag-ui/types';
-import { RenderMode } from '../../../common';
+import { LOADING_MESSAGE_ID, RenderMode } from '../../../common';
 import { MessageToolsStatus } from '../../../types/tool';
 import MessageContainer from './message-container.vue';
 
@@ -252,7 +252,7 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
       uid: 'loading-group',
       messages: [
         {
-          id: 'loading',
+          id: LOADING_MESSAGE_ID,
           content: '',
           role: MessageRole.Loading,
           status: MessageStatus.Pending,
@@ -408,6 +408,37 @@ describe('MessageContainer', () => {
         props: {
           ...defaultProps,
           messageStatus: MessageStatus.Streaming,
+        },
+      });
+
+      await nextTick();
+
+      const scrollBtns = wrapper.findAll('.mock-scroll-btn');
+      const stopBtn = scrollBtns.find(btn => btn.text().includes('停止生成'));
+      expect(stopBtn?.isVisible()).toBe(true);
+    });
+
+    it('Fetching 状态时应该显示停止生成按钮', async () => {
+      wrapper = mount(MessageContainer, {
+        props: {
+          ...defaultProps,
+          messageStatus: MessageStatus.Fetching,
+        },
+      });
+
+      await nextTick();
+
+      const scrollBtns = wrapper.findAll('.mock-scroll-btn');
+      const stopBtn = scrollBtns.find(btn => btn.text().includes('停止生成'));
+      expect(stopBtn?.isVisible()).toBe(true);
+      expect(stopBtn?.attributes('data-loading')).toBeUndefined();
+    });
+
+    it('Pending 状态时应该显示停止生成按钮', async () => {
+      wrapper = mount(MessageContainer, {
+        props: {
+          ...defaultProps,
+          messageStatus: MessageStatus.Pending,
         },
       });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -81,7 +81,12 @@
     />
     <div class="ai-message-fixed-bottom">
       <ScrollBtn
-        v-show="messageStatus === MessageStatus.Streaming || messageStatus === MessageStatus.StopLoading"
+        v-show="
+          messageStatus === MessageStatus.Streaming ||
+          messageStatus === MessageStatus.StopLoading ||
+          messageStatus === MessageStatus.Fetching ||
+          messageStatus === MessageStatus.Pending
+        "
         :loading="messageStatus === MessageStatus.StopLoading"
         :title="messageStatus === MessageStatus.StopLoading ? t('正在停止') : t('停止生成')"
         @click="$emit('stopStreaming')"

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -28,13 +28,18 @@ import { computed, ref as deepRef, nextTick, shallowRef } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageContentType, MessageRole, MessageStatus } from '../ag-ui/types';
+import { LOADING_MESSAGE_ID } from '../common/constants';
 import { useMessageGroup } from './use-message-group';
 
 import type { AssistantMessage, Message, ToolMessage, UserMessage } from '../ag-ui/types';
 
-vi.mock('../utils', () => ({
-  generateUUID: vi.fn(() => `uuid-${Math.random().toString(36).slice(2, 8)}`),
-}));
+vi.mock('../utils', async importOriginal => {
+  const actual = await importOriginal<typeof import('../utils')>();
+  return {
+    ...actual,
+    generateUUID: vi.fn(() => `uuid-${Math.random().toString(36).slice(2, 8)}`),
+  };
+});
 
 const createUserMessage = (id: string, content = 'hello'): UserMessage => ({
   id,
@@ -112,6 +117,14 @@ describe('useMessageGroup', () => {
       expect(messageGroups.value.length).toBe(2);
       expect(messageGroups.value[0]?.type).toBe(MessageRole.User);
       expect(messageGroups.value[1]?.type).toBe(MessageRole.Loading);
+    });
+
+    it('Loading 组占位消息 id 应为 LOADING_MESSAGE_ID', async () => {
+      const { messageGroups } = setupMessageGroup([createUserMessage('1')]);
+      await nextTick();
+
+      const loadingMsg = messageGroups.value[1]?.messages[0];
+      expect(loadingMsg?.id).toBe(LOADING_MESSAGE_ID);
     });
 
     it('单条助手消息应该创建 Assistant 组', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -34,6 +34,7 @@ import {
   MessageRole,
   MessageStatus,
 } from '../ag-ui/types';
+import { LOADING_MESSAGE_ID } from '../common/constants';
 import { generateUUID } from '../utils';
 
 import type { BkFlowMessageContent } from '../ag-ui/types/contents';
@@ -166,7 +167,7 @@ export const useMessageGroup = (options: {
             content: '',
             status: MessageStatus.Pending,
             messageId: '',
-            id: 'loading',
+            id: LOADING_MESSAGE_ID,
             uid: generateUUID(),
           },
         ],

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -8,7 +8,7 @@ description: >-
   `SelectionFooter`（多选操作栏）。提供完整的 AI 对话界面布局能力。
 aiSummary: >
   ChatContainer 提供完整 AI 对话布局：分栏（ResizeLayout）、消息列表（MessageContainer）、输入（ChatInput）、执行摘要（ExecutionSummary）、快捷表单（ShortcutRender）与多选栏（SelectionFooter）。
-  内置 useMessageGroup、分享与自定义 Tab 等能力，适合一站式接入。
+  内置 useMessageGroup、分享与自定义 Tab 等能力；对 MessageContainer/ChatInput 下推 inputStatus（末尾 Loading 占位时推导 Fetching），适合一站式接入。
   通过 props 传入 messages、shortcuts 等，事件与 ChatInput/MessageContainer 对齐。
 relatedComponents:
   - slug: message-container
@@ -184,6 +184,7 @@ domain: input
 
 - **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏；**侧栏是否展示 Tab / 执行摘要、以及分栏是否进入折叠样式（`ai-is-collapse`）以 `executionGroups` 为准**（由 `useMessageGroup` 从消息中过滤出工具调用与 FlowAgent 执行记录），**不以原始 `messages.length` 判断**。因此仅有普通对话、尚无执行类消息时，侧栏内容与「执行情况」区域可能为空，布局上与无执行数据时一致
 - **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
+- **输入区状态推导**：传给 `MessageContainer` 与 `ChatInput` 的 `messageStatus` 为内部计算值 `inputStatus`：当分组中存在 id 为 `LOADING_MESSAGE_ID`（`'__loading__'`，由 `useMessageGroup` 注入的占位 Loading 消息）时，对内使用 `MessageStatus.Fetching`；否则使用外部传入的 `messageStatus`。用于在「已发用户消息、尚未流式」阶段与流式中一致地展示停止能力，并避免输入区重复发送
 - **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
 - **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
 - **分享模式**：内置消息多选分享流程，选中用户消息后确认分享

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-input.md
@@ -154,10 +154,10 @@ chat-input-container
 | `messageStatus`               | 输入框有内容时按钮表现                                 | 输入框空时               |
 | ----------------------------- | ------------------------------------------------------ | ------------------------ |
 | `complete` / `stop` / `error` | 蓝色发送按钮，点击触发 `onSendMessage`                 | 灰色禁用                 |
-| `streaming` / `pending`       | 蓝色停止按钮（Loading 图标），点击触发 `onStopSending` | 蓝色停止按钮（仍可点击） |
+| `streaming` / `pending` / `fetching` | 蓝色停止按钮（Loading 图标），点击触发 `onStopSending` | 蓝色停止按钮（仍可点击） |
 | `disabled`                    | 灰色禁用，点击无效                                     | 灰色禁用                 |
 
-> **实现细节**：组件内部用 `messageState` 计算属性决定实际按钮状态：当 `messageStatus` 为 `pending` 或 `streaming` 时直接使用该状态（确保停止按钮始终可用）；否则当输入为空或仅含空白字符时强制为 `disabled`，其余情况使用 `messageStatus` 的值。
+> **实现细节**：组件内部用 `messageState` 计算属性决定实际按钮状态：当 `messageStatus` 为 `pending`、`streaming` 或 `fetching` 时直接使用该状态（确保停止按钮始终可用）；否则当输入为空或仅含空白字符时强制为 `disabled`，其余情况使用 `messageStatus` 的值。`fetching` 时按 Enter **不会**触发发送（避免请求中与 Loading 占位阶段重复提交）。
 
 ### Complete（可发送）
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
@@ -279,7 +279,7 @@ domain: message
 - **消息分组**：将连续的非用户消息合并为一组，每组共享一个工具栏
 - **Tool 消息关联**：自动将 `role: 'tool'` 消息注入到对应 Assistant 消息的 toolCall 中
 - **Loading 自动注入**：末尾为用户消息时，自动追加 Loading 动画组
-- **滚动管理**：流式输出时显示"停止生成"，离开底部时显示"返回底部"
+- **滚动管理**：`messageStatus` 为流式、等待响应或请求中（`streaming` / `pending` / `fetching`）时显示「停止生成」，离开底部时显示「返回底部」
 - **多选模式**：支持按消息组勾选，用户消息与 AI 回复联动选中
 
 ## 基础用法
@@ -413,9 +413,9 @@ domain: message
   </div>
 </div>
 
-## 流式输出
+## 流式输出与停止生成
 
-`messageStatus` 为 `streaming` 时，底部固定区域显示「停止生成」按钮，点击后触发 `@stop-streaming` 事件。
+当 `messageStatus` 为 `streaming`、`pending`（等待首包）或 `fetching`（请求中、与末尾 Loading 占位一致）时，底部固定区域显示「停止生成」按钮（`stop-loading` 时按钮展示为正在停止），点击后触发 `@stop-streaming` 事件。
 
 点击下方按钮体验完整的流式输出过程：
 
@@ -892,10 +892,10 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 
 底部固定区域（`position: sticky; bottom: 12px`）根据条件显示两个按钮：
 
-| 按钮         | 显示条件                                                                     | 点击行为               |
-| ------------ | ---------------------------------------------------------------------------- | ---------------------- |
-| 「停止生成」 | `messageStatus === 'streaming'`                                              | 触发 `@stop-streaming` |
-| 「返回底部」 | `debouncedShowScrollBottomBtn`（距底部 > 100px，且防抖 300ms 后才显示/隐藏） | 滚动到消息列表底部     |
+| 按钮         | 显示条件                                                                                       | 点击行为               |
+| ------------ | ---------------------------------------------------------------------------------------------- | ---------------------- |
+| 「停止生成」 | `messageStatus` 为 `streaming`、`pending`、`fetching` 或 `stop-loading`（停止中 loading 态） | 触发 `@stop-streaming` |
+| 「返回底部」 | `debouncedShowScrollBottomBtn`（距底部 > 100px，且防抖 300ms 后才显示/隐藏）                     | 滚动到消息列表底部     |
 
 > **防抖说明**：「返回底部」按钮的显隐使用 300ms 防抖，避免快速滚动时按钮频繁闪烁。隐藏时立即生效（无防抖），显示时延迟 300ms。
 
@@ -907,7 +907,7 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 | ------------------------ | -------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
 | messages                 | `Message[]`                                                                                  | —       | **必填**，消息列表                                                                                                                       |
 | messageGroups            | `MessageGroup[]`                                                                             | —       | 预计算的消息分组；传入时跳过内部分组逻辑，由 `ChatContainer` 通过 `useMessageGroup` 提供                                                 |
-| messageStatus            | `MessageStatus`                                                                              | —       | 当前整体消息状态，控制停止生成按钮显示                                                                                                   |
+| messageStatus            | `MessageStatus`                                                                              | —       | 当前整体消息状态，控制底部「停止生成」按钮显示；`ChatContainer` 会结合末尾 Loading 占位推导 `fetching` 等再传入                                                                                                   |
 | messageToolsStatus       | `MessageToolsStatus`                                                                         | —       | 工具栏状态，透传给 `MessageTools` 和 `MessageRender`                                                                                     |
 | messageToolsTippyOptions | `AITippyProps`                                                                               | —       | 透传给 `MessageTools` 和 `MessageRender`（进而透传给 `UserMessage` 的工具栏）的 Tippy 配置，用于自定义 tooltip 挂载点（如 `appendTo`）等 |
 | enableSelection          | `boolean`                                                                                    | `false` | 是否启用多选模式                                                                                                                         |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -6,7 +6,7 @@ description: >-
   核心消息分组逻辑，将原始 `Message[]` 数组转换为结构化的 `MessageGroup[]`。处理 Tool 消息合并、Loading
   自动注入、执行摘要过滤和消息多选/分享等逻辑。
 aiSummary: >
-  useMessageGroup 接收 keyword、messages、selectedUserMessages，通过 watchEffect 产出 messageGroups（User/Assistant/Tool 合并、末尾 Loading 注入、pause 与分享勾选等）。
+  useMessageGroup 接收 keyword、messages、selectedUserMessages，通过 watchEffect 产出 messageGroups（User/Assistant/Tool 合并、末尾 Loading 注入且占位 id 为 LOADING_MESSAGE_ID、pause 与分享勾选等）。
   executionGroups 供侧边执行摘要过滤，并暴露 isShareMode、全选与 onConfirmShare。
   ChatContainer 组装后传给 MessageContainer；ExecutionSummary 消费 executionGroups。
 relatedComponents:
@@ -67,6 +67,8 @@ role=user  role=tool     其他 role
 ④ 遍历结束后将剩余 assistantMessages 推入 list
 ⑤ 末尾为 user 消息 → 追加 Loading 消息组
 ```
+
+注入的占位 Loading 消息使用固定 id：`LOADING_MESSAGE_ID`（`'__loading__'`，定义于 `common/constants`）。`ChatContainer` 据此判断是否在「请求中」阶段，并向 `ChatInput` / `MessageContainer` 下传 `MessageStatus.Fetching`，与流式中的停止、防重复发送行为对齐。
 
 ### Tool 消息处理
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
@@ -4,7 +4,7 @@ slug: constants
 category: type
 description: '`@blueking/chat-x` 导出的常量和枚举类型。'
 aiSummary: >
-  汇总 MessageRole、MessageStatus、MessageContentType、MessageToolsStatus、MessageState、Z-Index 与 CONST_MESSAGE_TOOLS 等导出常量。
+  汇总 MessageRole、MessageStatus（含 Fetching 请求中）、MessageContentType、MessageToolsStatus、MessageState、Z-Index 与 CONST_MESSAGE_TOOLS 等导出常量。
   用于构造消息、配置 MessageContainer 工具栏与输入态，以及层级与默认快捷指令。与类型 messages 配套使用。
 relatedComponents:
   - slug: message-tools
@@ -61,14 +61,21 @@ enum MessageRole {
 
 ```typescript
 enum MessageStatus {
-  Pending = 'pending',
-  Streaming = 'streaming',
   Complete = 'complete',
-  Error = 'error',
-  Stop = 'stop',
   Disabled = 'disabled',
+  Error = 'error',
+  Fetching = 'fetching', // 请求中（例如已发用户消息、尚未开始流式，与末尾 Loading 占位一致）
+  Pending = 'pending',
+  Stop = 'stop',
+  StopLoading = 'stop-loading',
+  Streaming = 'streaming',
+  Success = 'success',
 }
 ```
+
+| 枚举值          | 说明 |
+| --------------- | ---- |
+| `Fetching`      | 请求中：与 `useMessageGroup` 在末尾用户消息后注入的 Loading 占位（`LOADING_MESSAGE_ID`）配合时，`ChatContainer` 会将传入输入区与列表底部的状态推导为该值，便于展示「停止」与禁止重复发送。 |
 
 ### MessageContentType
 


### PR DESCRIPTION
feat(chat-x): 新增 Fetching 状态并推导 inputStatus 对齐 Loading 占位

- 新增 MessageStatus.Fetching 与常量 LOADING_MESSAGE_ID（__loading__）
- ChatContainer 根据分组内是否存在 Loading 占位消息计算 inputStatus，并传给 MessageContainer/ChatInput
- ChatInput/MessageContainer/InputAttachment 在 fetching 下与流式阶段一致展示停止能力，并避免重复发送
- 补充单测与 wikis 文档