### PR TITLE
fix: Agent 取消时根据是否有 AI 输出区分 RUN_ERROR/RUN_FINISHED 事件类型，修复无输出时未触发暂停补写…

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -66,6 +66,7 @@ from .utils import (
     resolve_message_content,
     resolve_reasoning_content,
 )
+from aidev_agent.utils.event import RunId
 
 ProcessedEvents = (
     TextMessageStartEvent
@@ -134,6 +135,7 @@ class LangGraphAgent:
             "thinking_process": None,
             "node_name": None,
             "has_function_streaming": False,
+            "has_text_output": False,  # 是否有 AI 文本输出（根据流式是否有TEXT_MESSAGE_START）
         }
         self.active_run = INITIAL_ACTIVE_RUN
 
@@ -243,19 +245,36 @@ class LangGraphAgent:
             async for single_event in self._handle_single_event(event, state):
                 yield single_event
 
-        # 如果被取消，跳过正常的状态获取，直接发送 RunFinishedEvent
+        # 如果被取消，跳过正常的状态获取，直接发送结束事件
         if _cancelled:
             # 结束当前步骤（如果有）
             for ev in self.handle_node_change(None):
                 yield ev
-            # 发送 RunFinishedEvent，让前端走正常的结束流程
-            yield self._dispatch_event(
-                RunFinishedEvent(
-                    type=EventType.RUN_FINISHED,
-                    thread_id=thread_id,
-                    run_id=self.active_run["id"] or "cancelled",
-                )
+
+            # 根据是否有 AI 文本输出决定事件类型：
+            # - 无 AI 输出（仅有 thinking/tool/知识库等）：发 RUN_ERROR，触发暂停补写逻辑
+            # - 有 AI 输出：发 RUN_FINISHED(cancelled)，正常回写
+            has_text_output = self.active_run.get("has_text_output", False)
+            logger.info(
+                "Agent cancelled: thread_id=%s, has_text_output=%s",
+                thread_id,
+                has_text_output,
             )
+            if not has_text_output:
+                yield self._dispatch_event(
+                    RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message=RunId.CANCELLED_MESSAGE,
+                    )
+                )
+            else:
+                yield self._dispatch_event(
+                    RunFinishedEvent(
+                        type=EventType.RUN_FINISHED,
+                        thread_id=thread_id,
+                        run_id=RunId.CANCELLED,
+                    )
+                )
             self.active_run = INITIAL_ACTIVE_RUN
             return
 
@@ -715,6 +734,8 @@ class LangGraphAgent:
                             raw_event=event,
                         )
                     )
+                    # 标记已有 AI 文本输出，用于取消时决定发 RUN_ERROR 还是 RUN_FINISHED
+                    self.active_run["has_text_output"] = True
                     self.set_message_in_progress(
                         self.active_run["id"],
                         MessageInProgress(
@@ -773,6 +794,8 @@ class LangGraphAgent:
                         raw_event=event,
                     )
                 )
+                # 标记已有 AI 文本输出
+                self.active_run["has_text_output"] = True
                 yield self._dispatch_event(
                     TextMessageContentEvent(
                         type=EventType.TEXT_MESSAGE_CONTENT,

--- a/src/agent/aidev_agent/services/event_handlers/agui_writer.py
+++ b/src/agent/aidev_agent/services/event_handlers/agui_writer.py
@@ -88,8 +88,16 @@ class AGUISessionWriter(BaseSessionWriter):
         self._update_session_status(SessionsStatus.RUNNING.value)
 
     def set_streaming_finished(self) -> None:
-        """标记流式传输结束（会话状态设为 finished）"""
-        self._update_session_status(SessionsStatus.FINISHED.value)
+        """
+        标记流式传输结束
+        根据是否被取消选择不同的结束状态：
+        - 正常完成：会话状态设为 finished
+        - 用户取消/暂停：会话状态设为 cancelled
+        """
+        if self._is_cancelled:
+            self._update_session_status(SessionsStatus.CANCELLED.value)
+        else:
+            self._update_session_status(SessionsStatus.FINISHED.value)
 
     def _update_session_status(self, status: str) -> None:
         """更新会话状态（内部方法）

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -31,6 +31,7 @@ from aidev_agent.core.ag_ui.types import (
 )
 from aidev_agent.core.ag_ui.utils import camel_to_snake
 from aidev_agent.enums import ActivityType, PromptRole
+from aidev_agent.utils.event import RunId
 
 logger = getLogger(__name__)
 
@@ -52,6 +53,12 @@ class BaseSessionWriter(ABC):
     - 流式开始：set_streaming_started() 更新 session.status = running
     - 流式正常结束：set_streaming_finished() 更新 session.status = finished
     - 消息直接通过 create 创建，无需占位/变形
+
+    取消/暂停回写机制：
+    - 当用户在非 assistant 阶段（thinking/tool/activity）暂停时，handle_run_finished()
+      会转为 RUN_ERROR 语义，回写已有内容并补一条 role=assistant, content="用户已取消",
+      status="fail" 的消息
+    - 当用户在 assistant 阶段暂停时，已有的 assistant 消息以 status="complete" 正常回写
 
     使用方式：
     1. 简单场景：只实现 `_do_create_content` 方法，使用默认事件处理逻辑
@@ -80,6 +87,9 @@ class BaseSessionWriter(ABC):
         ```
     """
 
+    # 用户取消时补写的默认提示文本，与 RunId.CANCELLED_MESSAGE 保持一致
+    PAUSED_CONTENT_MESSAGE = "用户已取消"
+
     def __init__(self, session_code: str, username: str = "", tools: list | None = None):
         """初始化回写器
 
@@ -104,6 +114,11 @@ class BaseSessionWriter(ABC):
         # 用于追踪 flow_agent_result 记录，确保同一个 task_id 只有一条记录（后续轮询更新而非创建）
         self._flow_result_content_id: int | None = None
         self._flow_result_message_id: str | None = None
+        # 用于追踪本次运行是否因用户取消/暂停而结束
+        self._is_cancelled: bool = False
+        # 用于追踪 handle_model_end 是否已成功回写 assistant 消息
+        # 当 on_chat_model_end 触发时，assistant 消息已完整输出，取消时不应再补写暂停消息
+        self._model_end_written: bool = False
 
     # ---------- 公共事件入口 ----------
 
@@ -236,13 +251,39 @@ class BaseSessionWriter(ABC):
         这是一个后备机制：当 on_chat_model_end 事件没有被触发时，
         通过 RUN_FINISHED 事件来回写累积的流式消息内容。
 
+        取消/暂停场景处理：
+        - 取消 + 有 assistant 输出：以 status="complete" 正常回写，发 RUN_FINISHED
+        - 取消 + 无 assistant 输出（仅有 thinking/tool/知识库/MCP 等）：
+          回写已有内容 + 补一条 role=assistant, content="用户已取消", status="fail" 的消息，
+          并转为 RUN_ERROR 语义（确保前端正确展示暂停状态）
+
         Args:
             event: RUN_FINISHED 事件
         """
+        # 检测取消标识：run_id 为 "cancelled" 或 "stopped" 表示用户主动取消/暂停
+        run_id = getattr(event, "run_id", "")
+        if run_id in (RunId.CANCELLED, RunId.STOPPED):
+            self._is_cancelled = True
+            logger.info(
+                "Run finished with cancel signal: session_code=%s, run_id=%s",
+                self.session_code,
+                run_id,
+            )
+
         # 获取 thinking 内容
         thinking_content = self._thinking_content.strip() if self._thinking_content else ""
 
-        # 回写所有未写入的流式消息（包含 thinking 内容）
+        # 判断是否有 assistant 内容已流式输出或已通过 handle_model_end 回写
+        has_assistant_output = any(
+            mid not in self._written_message_ids for mid in self._streaming_messages
+        ) or self._model_end_written
+
+        # 取消 + 无 AI 输出：回写已有内容 + 补写"用户已取消" + status=fail
+        if self._is_cancelled and not has_assistant_output:
+            self._write_cancelled_messages(thinking_content)
+            return
+
+        # 正常回写或取消+有AI输出（正常回写即可）
         for message_id, message_data in list(self._streaming_messages.items()):
             if message_id in self._written_message_ids:
                 continue
@@ -256,7 +297,7 @@ class BaseSessionWriter(ABC):
                     reasoning_content=thinking_content,
                 )
 
-            # 回写 assistant 消息
+            # 回写 assistant 消息（status="complete"，不区分取消/非取消）
             self._write_assistant_message(
                 message_id=message_id,
                 content=content if content else "",
@@ -276,14 +317,80 @@ class BaseSessionWriter(ABC):
                 reasoning_content=thinking_content,
             )
 
-            # 回写空的 assistant 消息
-            self._write_assistant_message(
-                message_id=fallback_message_id,
-                content="",
-                tool_calls=[],
-            )
+            # 取消场景：补写"用户已取消" + status=fail
+            if self._is_cancelled:
+                self._write_assistant_message(
+                    message_id=fallback_message_id,
+                    content=self.PAUSED_CONTENT_MESSAGE,
+                    tool_calls=[],
+                    status="fail",
+                )
+            else:
+                self._write_assistant_message(
+                    message_id=fallback_message_id,
+                    content="",
+                    tool_calls=[],
+                )
 
             self._written_message_ids.add(fallback_message_id)
+
+        # 清理
+        self._streaming_messages.clear()
+        self._thinking_content = ""
+
+    def _write_cancelled_messages(self, thinking_content: str) -> None:
+        """回写取消/暂停场景下的消息
+
+        当用户在非 assistant 阶段（thinking/tool/知识库/MCP）取消时：
+        1. 回写已有的 thinking/reasoning 内容
+        2. 回写未写入的流式 assistant 消息（如有部分内容）
+        3. 补写一条 role=assistant, content="用户已取消", status="fail" 的消息
+
+        此方法由 handle_run_finished（取消+无AI输出）和 handle_run_error（取消场景）
+        共同调用，避免逻辑重复。
+
+        Args:
+            thinking_content: 已累积的 thinking 内容
+        """
+        logger.info(
+            "Writing cancelled messages: session_code=%s, "
+            "has_thinking=%s, streaming_messages=%d, _is_cancelled=%s",
+            self.session_code,
+            bool(thinking_content),
+            len(self._streaming_messages),
+            self._is_cancelled,
+        )
+
+        # 1. 回写未写入的 thinking/reasoning 内容
+        if thinking_content:
+            reasoning_message_id = f"rsn_{uuid.uuid4().hex[:12]}"
+            self._write_reasoning_message_simple(
+                message_id=reasoning_message_id,
+                reasoning_content=thinking_content,
+            )
+            self._written_message_ids.add(reasoning_message_id)
+
+        # 2. 回写未写入的流式 assistant 消息（如有部分内容）
+        for message_id, message_data in list(self._streaming_messages.items()):
+            if message_id in self._written_message_ids:
+                continue
+            content = message_data.get("content", "")
+            self._write_assistant_message(
+                message_id=message_id,
+                content=content if content else "",
+                tool_calls=[],
+            )
+            self._written_message_ids.add(message_id)
+
+        # 3. 补写 "用户已取消" + status=fail 的 assistant 消息
+        paused_message_id = f"paused_{uuid.uuid4().hex[:12]}"
+        self._write_assistant_message(
+            message_id=paused_message_id,
+            content=self.PAUSED_CONTENT_MESSAGE,
+            tool_calls=[],
+            status="fail",
+        )
+        self._written_message_ids.add(paused_message_id)
 
         # 清理
         self._streaming_messages.clear()
@@ -331,6 +438,8 @@ class BaseSessionWriter(ABC):
         self._streaming_messages.pop(message_id, None)
         # 清空 thinking 内容，避免 handle_run_finished 重复回写
         self._thinking_content = ""
+        # 标记 model_end 已回写，取消时不需要补写暂停消息
+        self._model_end_written = True
 
     def handle_tool_finish(self, event: RawEvent) -> None:
         """处理工具执行完成事件，回写 tool 消息
@@ -365,21 +474,75 @@ class BaseSessionWriter(ABC):
     def handle_run_error(self, event: RunErrorEvent) -> None:
         """处理运行时错误事件，回写 assistant 失败消息
 
+        对于取消/暂停场景（message 为 RunId.CANCELLED_MESSAGE），
+        会先回写已有的非 assistant 内容（thinking/tool/知识库/MCP 等），
+        再补写 content="用户已取消", status="fail" 的 assistant 消息。
+        对于真正的运行错误，直接写入错误消息。
+
         Args:
             event: 运行错误事件
         """
-        error_message_id = f"error_{uuid.uuid4().hex[:12]}"
+        # 检测是否为取消/暂停触发的 RUN_ERROR
+        # Agent 层取消时发送 RUN_ERROR(message=RunId.CANCELLED_MESSAGE)
+        # 防御 event.message 为 None 的场景（非标准事件对象）
+        error_message = event.message or ""
+        is_cancel_error = error_message == RunId.CANCELLED_MESSAGE
+        if is_cancel_error:
+            self._is_cancelled = True
+            logger.info(
+                "handle_run_error detected cancel: session_code=%s, message=%s",
+                self.session_code,
+                error_message,
+            )
+            # 取消场景：统一走 _write_cancelled_messages 回写已有内容 + 补写暂停消息
+            thinking_content = self._thinking_content.strip() if self._thinking_content else ""
+            self._write_cancelled_messages(thinking_content)
+            return
 
+        # 真正的运行错误处理
+        logger.info(
+            "handle_run_error writing error message: session_code=%s, message=%s",
+            self.session_code,
+            error_message,
+        )
+        # 回写未写入的 thinking/reasoning 内容（如有）
+        thinking_content = self._thinking_content.strip() if self._thinking_content else ""
+        if thinking_content:
+            reasoning_message_id = f"rsn_{uuid.uuid4().hex[:12]}"
+            self._write_reasoning_message_simple(
+                message_id=reasoning_message_id,
+                reasoning_content=thinking_content,
+            )
+            self._written_message_ids.add(reasoning_message_id)
+
+        # 回写未写入的流式 assistant 消息（如有部分内容）
+        for message_id, message_data in list(self._streaming_messages.items()):
+            if message_id in self._written_message_ids:
+                continue
+            content = message_data.get("content", "")
+            self._write_assistant_message(
+                message_id=message_id,
+                content=content if content else "",
+                tool_calls=[],
+            )
+            self._written_message_ids.add(message_id)
+
+        # 补写错误消息
+        error_message_id = f"error_{uuid.uuid4().hex[:12]}"
         self._create_session_content(
             message_id=error_message_id,
             role=PromptRole.ASSISTANT.value,
-            content=event.message,
+            content=error_message,
             status="fail",
             builtin_property={
                 "message_id": error_message_id,
                 "error": True,
             },
         )
+
+        # 清理
+        self._streaming_messages.clear()
+        self._thinking_content = ""
 
     def handle_reference_document(self, event: RawEvent) -> None:
         """处理引用文档事件，回写 activity 消息
@@ -633,6 +796,7 @@ class BaseSessionWriter(ABC):
         message_id: str,
         content: str,
         tool_calls: list,
+        status: str = "complete",
     ) -> None:
         """回写 assistant 消息
 
@@ -640,6 +804,7 @@ class BaseSessionWriter(ABC):
             message_id: assistant 消息 ID
             content: 消息内容
             tool_calls: 工具调用列表
+            status: 消息状态，默认 "complete"；取消/暂停场景使用 "fail"
         """
         assistant_property = {
             "message_id": message_id,
@@ -650,7 +815,7 @@ class BaseSessionWriter(ABC):
             message_id=message_id,
             role=PromptRole.ASSISTANT.value,
             content=content,
-            status="complete",
+            status=status,
             builtin_property=assistant_property,
         )
 
@@ -774,8 +939,11 @@ class BaseSessionWriter(ABC):
     def set_streaming_finished(self) -> None:
         """标记流式传输结束
 
-        子类应覆盖此方法来更新会话状态为 finished。
+        子类应覆盖此方法来更新会话状态。
         默认实现为空操作。
+
+        注意：当 _is_cancelled 为 True 时，子类应将会话状态设为 cancelled 而非 finished，
+        以便前端正确展示暂停/取消状态。
         """
 
     def update_flow_agent_info(self, task_id: str) -> None:

--- a/src/agent/aidev_agent/services/flow_agent.py
+++ b/src/agent/aidev_agent/services/flow_agent.py
@@ -29,7 +29,7 @@ from aidev_agent.config import settings as agent_settings
 from aidev_agent.core.ag_ui.types import CustomMessageType
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper, StreamCancelledError
 from aidev_agent.services.protocols import FlowAgentClient, FlowAgentPollClient
-from aidev_agent.utils.event import emit_run_finished_event
+from aidev_agent.utils.event import RunId, emit_run_finished_event
 
 logger = getLogger(__name__)
 
@@ -82,6 +82,10 @@ class FlowAgentCompletionAgent(BaseModel):
     # 事件处理器（用于回写数据库等）
     event_handler: Callable[[BaseEvent], None] | None = None
 
+    # 运行时状态：任务是否已启动根据flow_agent_start判断
+    # 用于取消时决定发 RUN_FINISHED（已启动）还是 RUN_ERROR（未启动）
+    _task_started: bool = False
+
     class Config:
         arbitrary_types_allowed = True
 
@@ -108,10 +112,12 @@ class FlowAgentCompletionAgent(BaseModel):
         """核心流程：启动（或使用已有 task_id）→ 轮询 → 产出 SSE 事件"""
         encoder = EventEncoder()
         run_id = str(uuid.uuid4())
+        # 每次运行重置任务启动状态
+        self._task_started = False
 
         logger.info(
-            f"[FLOW_AGENT] _run_flow started: session_code={self.session_code}, "
-            f"task_id={self.task_id}, skip_start={bool(self.task_id)}"
+            "[FLOW_AGENT] _run_flow started: session_code=%s, task_id=%s, skip_start=%s",
+            self.session_code, self.task_id, bool(self.task_id),
         )
 
         # 0. RUN_STARTED
@@ -123,23 +129,33 @@ class FlowAgentCompletionAgent(BaseModel):
             # start 接口使用 resource_manager（plugin 层传入的带认证 client）
             start_client = self._get_client()
 
+            # 在调用 start 接口前检查是否已取消，避免不必要的 API 调用
+            stream_thread_id = self.session_code or self.thread_id
+            if GeneratorStreamingHelper.is_cancelled(stream_thread_id):
+                logger.info("[FLOW_AGENT] Cancelled before start_flow_agent: session_code=%s", self.session_code)
+                error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE)
+                self._dispatch_event(error_event)
+                yield encoder.encode(error_event)
+                return
+
             # 1. 获取 task_id：优先使用已指定的 task_id，否则调用 start 接口
             task_id = self.task_id
             if not task_id:
                 logger.debug(
-                    f"[FLOW_AGENT] Calling start_flow_agent: "
-                    f"flow_start_params={self.flow_start_params}, client_type={type(start_client).__name__}"
+                    "[FLOW_AGENT] Calling start_flow_agent: "
+                    "flow_start_params=%s, client_type=%s",
+                    self.flow_start_params, type(start_client).__name__,
                 )
 
                 start_result = start_client.start_flow_agent(data=self.flow_start_params)
 
-                logger.debug(f"[FLOW_AGENT] start_flow_agent response: {start_result}")
+                logger.debug("[FLOW_AGENT] start_flow_agent response: %s", start_result)
 
                 task_id = start_result.get("task_id")
                 if not task_id:
                     raise ValueError(f"flow_agent/start response missing task_id: {start_result}")
 
-            logger.info(f"[FLOW_AGENT] task_id={task_id}, skip_start={bool(self.task_id)}")
+            logger.info("[FLOW_AGENT] task_id=%s, skip_start=%s", task_id, bool(self.task_id))
 
             # 2. 发送 flow_agent_start 事件
             # 仅在未指定 task_id 时发送 start 事件（指定 task_id 表示直接轮询已有任务）
@@ -150,8 +166,12 @@ class FlowAgentCompletionAgent(BaseModel):
                 )
                 self._dispatch_event(start_event)
                 yield encoder.encode(start_event)
+                # 标记任务已启动
+                self._task_started = True
             else:
-                logger.info(f"[FLOW_AGENT] Existing task_id provided, skip flow_agent_start event: task_id={task_id}")
+                # 已有 task_id，视为任务已启动
+                self._task_started = True
+                logger.info("[FLOW_AGENT] Existing task_id provided, skip flow_agent_start event: task_id=%s", task_id)
 
             # 3. 轮询任务状态 —— 直接使用 SDK 的 client 调平台 API Gateway，不经过 plugin 层中转
             poll_client = self._get_poll_client()
@@ -159,10 +179,12 @@ class FlowAgentCompletionAgent(BaseModel):
 
         except StreamCancelledError as e:
             # 任务被取消，通过 generator 机制向外传递异常
-            logger.info(f"[FLOW_AGENT] StreamCancelledError caught, re-raising: {e}")
+            logger.info(
+                "[FLOW_AGENT] StreamCancelledError caught, re-raising: %s", e,
+            )
             raise
         except Exception as e:
-            logger.exception(f"[FLOW_AGENT] Flow agent error: {e}")
+            logger.exception("[FLOW_AGENT] Flow agent error: %s", e)
             yield from self._emit_error_and_finish(encoder, run_id, str(e))
 
     def _poll_task(
@@ -179,18 +201,32 @@ class FlowAgentCompletionAgent(BaseModel):
         stream_thread_id = self.session_code or self.thread_id
         consecutive_failures = 0
         logger.info(
-            f"[FLOW_AGENT] Polling started: task_id={task_id}, session_code={self.session_code}, "
-            f"poll_interval={self.poll_interval}s, poll_timeout={self.poll_timeout}s"
+            "[FLOW_AGENT] Polling started: task_id=%s, session_code=%s, "
+            "poll_interval=%ss, poll_timeout=%ss",
+            task_id, self.session_code, self.poll_interval, self.poll_timeout,
         )
         _poll_count = 0
         while True:
             _poll_count += 1
             # 检查是否被取消
             if GeneratorStreamingHelper.is_cancelled(stream_thread_id):
-                logger.info(f"[FLOW_AGENT] Task cancelled: task_id={task_id}, poll_count={_poll_count}")
+                logger.info("[FLOW_AGENT] Task cancelled: task_id=%s, poll_count=%d", task_id, _poll_count)
 
-                # 发送 RUN_FINISHED 事件，明确告知前端任务已结束
-                yield from self._emit_finish(encoder, run_id)
+                # 根据任务是否已启动决定事件类型：
+                # - 已启动（flow_agent_start 已发送）：发 RUN_FINISHED，正常暂停
+                # - 未启动（任务还没真正开始）：发 RUN_ERROR，触发暂停补写逻辑
+                if self._task_started:
+                    logger.info("[FLOW_AGENT] Task already started, sending RUN_FINISHED: task_id=%s", task_id)
+                    yield emit_run_finished_event(
+                        thread_id=self.thread_id,
+                        run_id=RunId.CANCELLED,
+                        event_handler=self._dispatch_event,
+                    )
+                else:
+                    logger.info("[FLOW_AGENT] Task not started yet, sending RUN_ERROR: task_id=%s", task_id)
+                    error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE)
+                    self._dispatch_event(error_event)
+                    yield encoder.encode(error_event)
                 return
 
             # 检查超时

--- a/src/agent/aidev_agent/utils/event.py
+++ b/src/agent/aidev_agent/utils/event.py
@@ -23,10 +23,12 @@ class RunId:
     Attributes:
         CANCELLED: 用户主动取消场景
         STOPPED: 会话停止/超时场景
+        CANCELLED_MESSAGE: 用户取消提示文本
     """
 
     CANCELLED: RunIdType = "cancelled"
     STOPPED: RunIdType = "stopped"
+    CANCELLED_MESSAGE: str = "用户已取消"
 
 
 def emit_run_finished_event(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -4,20 +4,48 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ag_ui.core import EventType
+from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
 from aidev_agent.config import settings
 from aidev_agent.core.ag_ui.types import CustomMessageType
+from aidev_agent.enums import PromptRole
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.packages.langchain_core.models.mock import MockChatModel, MockResponse
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
 from aidev_agent.services.chat import ChatCompletionAgent, ExecuteKwargs
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
+from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
 from aidev_agent.services.pydantic_models import (
     AgentOptions,
     ChatPrompt,
     IntentRecognition,
 )
+from aidev_agent.utils.event import RunId
 from langchain_core.tools import ToolException, tool
+
+
+class _ConcreteWriter(BaseSessionWriter):
+    """可实例化的测试用 Writer，记录回写内容以便断言"""
+
+    def __init__(self, session_code: str = "test_session", **kwargs):
+        super().__init__(session_code=session_code, **kwargs)
+        self._created_contents: list[dict] = []
+
+    @property
+    def is_cancelled(self) -> bool:
+        """返回是否已被取消（只读）"""
+        return self._is_cancelled
+
+    @property
+    def created_contents(self) -> tuple[dict, ...]:
+        """返回已创建内容的只读副本"""
+        return tuple(self._created_contents)
+
+    def _do_create_content(self, payload: dict, headers: dict) -> int | None:
+        self._created_contents.append(payload)
+        return len(self._created_contents)
+
+    def _do_update_content(self, content_id: int, payload: dict, headers: dict) -> None:
+        pass
 
 
 def assert_content_type_equal(results: list[dict], event_type: EventType, content: str):
@@ -1092,3 +1120,258 @@ class TestFilterUnmatchedToolCalls:
         filtered = factory._filter_unmatched_tool_calls([])
 
         assert filtered == [], "空聊天历史应该返回空列表"
+
+
+# =====================================================================
+# 取消/暂停场景测试
+# =====================================================================
+
+
+def _run_cancel_in_thread(agent, cancel_signal_fn, wait_signal_fn, cancel_after=0.5, timeout=15.0):
+    """辅助函数：在子线程中消费流，满足条件后触发取消，返回 (sse_results, writer_created_contents)
+
+    Args:
+        agent: ChatCompletionAgent 实例（需已设置 event_handler=_ConcreteWriter）
+        cancel_signal_fn: 取消函数，如 GeneratorStreamingHelper.cancel(thread_id)
+        wait_signal_fn: 等待事件，流开始后触发取消
+        cancel_after: wait_signal 触发后等待秒数
+        timeout: 流结束超时
+    """
+    writer = agent.event_handler
+    results = []
+    stream_done = threading.Event()
+
+    def consume():
+        for each in agent.execute(ExecuteKwargs(stream=True)):
+            results.append(json.loads(each[6:]))
+        stream_done.set()
+
+    t = threading.Thread(target=consume)
+    t.start()
+    wait_signal_fn.wait(timeout=10.0)
+    time.sleep(cancel_after)
+    cancel_signal_fn()
+    stream_done.wait(timeout=timeout)
+    t.join(timeout=5.0)
+    return results, writer
+
+
+class TestCancelScenarios:
+    """取消场景端到端测试：验证取消后的事件流和 session 回写
+
+    核心场景：
+    - 取消 + 无 AI 文本输出（thinking/tool/MCP 等阶段）→ RUN_ERROR → writer 补写"用户已取消"
+    - 取消 + 有 AI 文本输出（TEXT_MESSAGE_CONTENT 已出现）→ RUN_FINISHED(cancelled) → writer 正常回写
+    - 模型错误 → RUN_ERROR(message=错误信息) → writer 回写错误消息 + error=True
+    """
+
+    def test_cancel_without_ai_output(self):
+        """取消 + 无 AI 输出（工具调用阶段）→ 流正常结束，writer 补写暂停消息"""
+        writer = _ConcreteWriter()
+        llm = MockChatModel(
+            mock_responses=[
+                MockResponse(content="", tool_calls=[{"name": "slow_task", "args": {"seconds": 5.0}, "id": "call_slow"}]),
+                MockResponse(content="任务已完成"),
+            ],
+            stream_chunk_size=2, loop=False,
+        )
+        thread_id = "test_cancel_no_output"
+        agent = ChatCompletionAgent(
+            thread_id=thread_id, chat_model=llm,
+            chat_history=[ChatPrompt(role="user", content="执行一个慢任务")],
+            tools=[slow_task], event_handler=writer,
+        )
+
+        first_event = threading.Event()
+        orig_handler = agent.event_handler
+
+        results = []
+        stream_done = threading.Event()
+
+        def consume():
+            for each in agent.execute(ExecuteKwargs(stream=True)):
+                results.append(json.loads(each[6:]))
+                if not first_event.is_set():
+                    first_event.set()
+            stream_done.set()
+
+        t = threading.Thread(target=consume)
+        t.start()
+        first_event.wait(timeout=10.0)
+        time.sleep(0.5)
+        GeneratorStreamingHelper.cancel(thread_id)
+        stream_done.wait(timeout=15.0)
+        t.join(timeout=5.0)
+
+        # 流应有结束事件
+        final_events = [r for r in results if r.get("type") in (EventType.RUN_ERROR, EventType.RUN_FINISHED)]
+        assert len(final_events) >= 1, "流应有结束事件"
+        # writer 应有回写内容或取消标记
+        assert writer.is_cancelled or len(writer.created_contents) > 0
+
+    def test_cancel_with_ai_output(self):
+        """取消 + 有 AI 输出 → 流正常结束，writer 回写已有内容"""
+        writer = _ConcreteWriter()
+        llm = MockChatModel(
+            mock_responses=[
+                MockResponse(content="让我帮你查一下。"),
+                MockResponse(content="", tool_calls=[{"name": "slow_task", "args": {"seconds": 5.0}, "id": "call_slow"}]),
+                MockResponse(content="查询完成"),
+            ],
+            stream_chunk_size=2, loop=False,
+        )
+        thread_id = "test_cancel_with_output"
+        agent = ChatCompletionAgent(
+            thread_id=thread_id, chat_model=llm,
+            chat_history=[ChatPrompt(role="user", content="执行一个慢任务")],
+            tools=[slow_task], event_handler=writer,
+        )
+
+        text_started = threading.Event()
+        results = []
+        stream_done = threading.Event()
+
+        def consume():
+            for each in agent.execute(ExecuteKwargs(stream=True)):
+                _each = json.loads(each[6:])
+                results.append(_each)
+                if _each.get("type") == EventType.TEXT_MESSAGE_START and not text_started.is_set():
+                    text_started.set()
+            stream_done.set()
+
+        t = threading.Thread(target=consume)
+        t.start()
+        text_started.wait(timeout=10.0)
+        time.sleep(0.5)
+        GeneratorStreamingHelper.cancel(thread_id)
+        stream_done.wait(timeout=15.0)
+        t.join(timeout=5.0)
+
+        final_events = [r for r in results if r.get("type") in (EventType.RUN_ERROR, EventType.RUN_FINISHED)]
+        assert len(final_events) >= 1, "流应有结束事件"
+        assistant_contents = [c for c in writer.created_contents if c.get("role") == PromptRole.ASSISTANT.value]
+        assert len(assistant_contents) >= 1
+
+    def test_model_error_writes_error_message(self):
+        """模型错误 → RUN_ERROR + writer 回写错误消息 + error=True"""
+        writer = _ConcreteWriter()
+        llm = MockChatModel(responses=[""], sleep_time=0)
+
+        with patch.object(llm, "_astream", side_effect=Exception("Authentication failed")):
+            agent = ChatCompletionAgent(
+                chat_model=llm, chat_history=[ChatPrompt(role="user", content="hi")],
+                event_handler=writer,
+            )
+            results = [json.loads(each[6:]) for each in agent.execute(ExecuteKwargs(stream=True))]
+
+        error_events = [r for r in results if r.get("type") == EventType.RUN_ERROR]
+        assert len(error_events) >= 1
+        assert "Authentication failed" in error_events[0].get("message", "")
+
+        error_contents = [
+            c for c in writer.created_contents
+            if c.get("role") == PromptRole.ASSISTANT.value and c.get("status") == "fail"
+        ]
+        assert len(error_contents) >= 1
+        prop = error_contents[0].get("property", {})
+        assert prop.get("builtin_property", {}).get("error") is True
+        assert writer.is_cancelled is False
+
+    def test_normal_finish_with_writer(self):
+        """回归：正常完成 → writer 回写 status=complete，不设置 _is_cancelled"""
+        writer = _ConcreteWriter()
+        llm = MockChatModel(responses=["你好，我可以帮你。"], stream_chunk_size=2)
+        agent = ChatCompletionAgent(
+            chat_model=llm, chat_history=[ChatPrompt(role="user", content="你好")],
+            event_handler=writer,
+        )
+        results = [json.loads(each[6:]) for each in agent.execute(ExecuteKwargs(stream=True))]
+
+        finished_events = [r for r in results if r.get("type") == EventType.RUN_FINISHED]
+        assert len(finished_events) >= 1
+        assert finished_events[0].get("runId") != RunId.CANCELLED
+
+        assert writer.is_cancelled is False
+        assistant_contents = [c for c in writer.created_contents if c.get("role") == PromptRole.ASSISTANT.value]
+        assert len(assistant_contents) >= 1
+        assert assistant_contents[0].get("status") == "complete"
+
+
+# =====================================================================
+# BaseSessionWriter 取消回写单元测试
+# =====================================================================
+
+
+class TestSessionWriterCancelUnit:
+    """BaseSessionWriter 取消/暂停回写逻辑的单元测试
+
+    覆盖 writer 级别的边界场景（不易通过端到端触发）：
+    - 取消 + 仅有 thinking/streaming 部分内容 → 补写"用户已取消"
+    - 取消 + model_end 已回写 → 不补写暂停消息
+    - RUN_FINISHED(cancelled) + 无 AI 输出 → 补写暂停消息
+    - 真正运行错误 → 回写错误消息 + builtin_property.error=True
+    - 常量一致性
+    """
+
+    def test_cancel_error_with_thinking_writes_reasoning_and_paused(self):
+        """取消 + thinking 内容 → 回写 reasoning + 补写"用户已取消" + status=fail"""
+        writer = _ConcreteWriter()
+        writer._thinking_content = "正在深度思考中..."
+        writer.handle_run_error(RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE))
+
+        assert writer.is_cancelled is True
+        assert any(c.get("role") == PromptRole.REASONING.value for c in writer.created_contents)
+        assert any(
+            c.get("role") == PromptRole.ASSISTANT.value and c.get("status") == "fail" and c.get("content") == "用户已取消"
+            for c in writer.created_contents
+        )
+
+    def test_cancel_error_no_content_writes_only_paused(self):
+        """取消 + 完全无内容 → 仅补写"用户已取消" + status=fail"""
+        writer = _ConcreteWriter()
+        writer.handle_run_error(RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE))
+
+        assert len(writer.created_contents) == 1
+        assert writer.created_contents[0]["content"] == "用户已取消"
+        assert writer.created_contents[0]["status"] == "fail"
+
+    def test_cancel_run_finished_no_output_writes_paused(self):
+        """RUN_FINISHED(cancelled) + 无 AI 输出 → 补写"用户已取消"（Flow Agent 任务已启动场景）"""
+        writer = _ConcreteWriter()
+        writer.handle_run_finished(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t1", run_id=RunId.CANCELLED))
+
+        assert writer.is_cancelled is True
+        assert any(c.get("content") == "用户已取消" and c.get("status") == "fail" for c in writer.created_contents)
+
+    def test_cancel_with_model_end_written_no_paused(self):
+        """取消 + model_end 已回写 → 不补写暂停消息（AI 已输出文本场景）"""
+        writer = _ConcreteWriter()
+        writer._model_end_written = True
+        writer.handle_run_finished(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t1", run_id=RunId.CANCELLED))
+
+        assert not any(c.get("content") == "用户已取消" and c.get("status") == "fail" for c in writer.created_contents)
+
+    def test_real_error_writes_error_with_builtin_flag(self):
+        """真正运行错误 → 回写错误消息 + builtin_property.error=True"""
+        writer = _ConcreteWriter()
+        writer.handle_run_error(RunErrorEvent(type=EventType.RUN_ERROR, message="模型调用异常"))
+
+        assert writer.is_cancelled is False
+        error = next(c for c in writer.created_contents if c.get("status") == "fail")
+        assert error.get("content") == "模型调用异常"
+        assert error.get("property", {}).get("builtin_property", {}).get("error") is True
+
+    def test_normal_finish_thinking_only_writes_empty_assistant(self):
+        """回归：正常完成 + 仅有 thinking → 空 assistant(status=complete)，非"用户已取消" """
+        writer = _ConcreteWriter()
+        writer._thinking_content = "思考过程..."
+        writer.handle_run_finished(RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t1", run_id="run-123"))
+
+        assert any(c.get("role") == PromptRole.REASONING.value for c in writer.created_contents)
+        assistant = next(c for c in writer.created_contents if c.get("role") == PromptRole.ASSISTANT.value)
+        assert assistant.get("status") == "complete"
+        assert assistant.get("content") != "用户已取消"
+
+    def test_constants_consistency(self):
+        """PAUSED_CONTENT_MESSAGE 和 RunId.CANCELLED_MESSAGE 应一致为"用户已取消" """
+        assert BaseSessionWriter.PAUSED_CONTENT_MESSAGE == RunId.CANCELLED_MESSAGE == "用户已取消"

--- a/src/agent/tests/services/test_flow_agent.py
+++ b/src/agent/tests/services/test_flow_agent.py
@@ -209,55 +209,101 @@ class TestFlowAgentMainFlow:
 
 
 class TestFlowAgentStop:
-    """stop 终止流程：验证取消信号能正确终止轮询"""
+    """stop 终止流程：验证取消信号能正确终止轮询
+
+    核心场景：
+    - 任务已启动（flow_agent_start 已发送）→ RUN_FINISHED(runId="cancelled")
+    - 任务未启动（start_flow_agent 之前取消）→ RUN_ERROR(message="用户已取消")
+    """
 
     @patch("aidev_agent.services.flow_agent.BKAidevApi")
-    def test_cancel_stops_polling(self, mock_api):
-        """轮询中触发取消信号 → 停止轮询并发出 RUN_FINISHED
+    def test_cancel_after_task_started_emits_run_finished(self, mock_api):
+        """任务已启动后取消 → 发 RUN_FINISHED(runId="cancelled")
 
-        模拟场景：用户点击「停止」，前端调 stop() → GeneratorStreamingHelper.cancel()
-        → _poll_task 下一次循环检测到 is_cancelled=True → 停止轮询
+        模拟场景：flow_agent_start 已发送，轮询中检测到取消信号。
+        _task_started=True → 发 RUN_FINISHED(cancelled)，writer 补写"用户已取消"。
         """
         poll_count = {"n": 0}
 
         def mock_is_cancelled(thread_id, **kwargs):
-            # 让前 2 次检查返回 False（正常轮询），第 3 次返回 True（模拟用户点停止）
             poll_count["n"] += 1
             return poll_count["n"] >= 3
 
-        mock_poll_client = MockPollClient(
-            task_info_sequence=[{"task_state": "RUNNING"}] * 10
-        )
+        mock_poll_client = MockPollClient(task_info_sequence=[{"task_state": "RUNNING"}] * 10)
         mock_api.get_client.return_value = mock_poll_client
 
         agent = FlowAgentCompletionAgent(
             resource_manager=MockFlowAgentClient(start_result={"task_id": "cancel_task"}),
-            flow_start_params={},
-            poll_interval=0.01,
-            poll_timeout=60.0,
+            flow_start_params={}, poll_interval=0.01, poll_timeout=60.0,
             session_code="stop_session",
         )
 
         with patch.object(GeneratorStreamingHelper, "is_cancelled", side_effect=mock_is_cancelled):
             events = _parse_sse_events(agent._run_flow())
 
-        # 有 RUN_STARTED
         assert events[0]["type"] == EventType.RUN_STARTED
+        assert len(_find_custom_events(events, CustomMessageType.FLOW_AGENT_START.value)) == 1
+        assert len(_find_custom_events(events, CustomMessageType.FLOW_AGENT_END.value)) == 0
 
-        # 有 flow_agent_start（start 接口成功了）
-        start_events = _find_custom_events(events, CustomMessageType.FLOW_AGENT_START.value)
-        assert len(start_events) == 1
+        # 任务已启动后取消 → RUN_FINISHED(runId="cancelled")
+        finished_events = _find_events_by_type(events, EventType.RUN_FINISHED)
+        assert len(finished_events) >= 1
+        assert finished_events[0].get("runId") == "cancelled"
 
-        # 有部分 flow_agent_result（取消前的轮询结果）
-        result_events = _find_custom_events(events, CustomMessageType.FLOW_AGENT_RESULT.value)
-        assert len(result_events) >= 1
+    @patch("aidev_agent.services.flow_agent.BKAidevApi")
+    def test_cancel_before_task_started_emits_run_error(self, mock_api):
+        """任务未启动时取消 → 发 RUN_ERROR(message="用户已取消")
 
-        # 没有 flow_agent_end（任务没有自然结束，是被取消的）
-        end_events = _find_custom_events(events, CustomMessageType.FLOW_AGENT_END.value)
-        assert len(end_events) == 0
+        模拟场景：start_flow_agent 调用前就已检测到取消信号。
+        _task_started=False → 发 RUN_ERROR(message="用户已取消")。
+        """
+        def mock_is_cancelled_true(thread_id, **kwargs):
+            return True  # 一开始就取消
 
-        # 最后一个事件是 RUN_FINISHED（确保前端收到结束信号）
-        assert events[-1]["type"] == EventType.RUN_FINISHED
+        mock_api.get_client.return_value = MockPollClient()
+
+        agent = FlowAgentCompletionAgent(
+            resource_manager=MockFlowAgentClient(start_result={"task_id": "pre_cancel"}),
+            flow_start_params={}, poll_interval=0.01, poll_timeout=60.0,
+            session_code="pre_cancel_session",
+        )
+
+        with patch.object(GeneratorStreamingHelper, "is_cancelled", side_effect=mock_is_cancelled_true):
+            events = _parse_sse_events(agent._run_flow())
+
+        # 没有 flow_agent_start（任务未启动就被取消）
+        assert len(_find_custom_events(events, CustomMessageType.FLOW_AGENT_START.value)) == 0
+
+        # 任务未启动取消 → RUN_ERROR(message="用户已取消")
+        error_events = _find_events_by_type(events, EventType.RUN_ERROR)
+        assert len(error_events) >= 1
+        from aidev_agent.utils.event import RunId
+        assert error_events[0].get("message") == RunId.CANCELLED_MESSAGE
+
+    @patch("aidev_agent.services.flow_agent.BKAidevApi")
+    def test_cancel_before_start_api_call(self, mock_api):
+        """在 start_flow_agent 调用前就取消 → 直接发 RUN_ERROR，不调用 start API"""
+        def mock_is_cancelled_true(thread_id, **kwargs):
+            return True
+
+        mock_start_client = MagicMock()
+        mock_api.get_client.return_value = MockPollClient()
+
+        agent = FlowAgentCompletionAgent(
+            resource_manager=mock_start_client,
+            flow_start_params={}, poll_interval=0.01, poll_timeout=60.0,
+            session_code="cancel_before_api",
+        )
+
+        with patch.object(GeneratorStreamingHelper, "is_cancelled", side_effect=mock_is_cancelled_true):
+            events = _parse_sse_events(agent._run_flow())
+
+        # start_flow_agent 不应被调用
+        mock_start_client.start_flow_agent.assert_not_called()
+
+        # 应有 RUN_ERROR
+        error_events = _find_events_by_type(events, EventType.RUN_ERROR)
+        assert len(error_events) >= 1
 
     @patch("aidev_agent.services.flow_agent.BKAidevApi")
     def test_stop_method_calls_cancel(self, mock_api):


### PR DESCRIPTION
…的问题 --story=156957602