### PR TITLE
fix: 统一 MessageContentType 字符串为下划线形式

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
@@ -28,10 +28,10 @@ export enum MessageContentType {
   Binary = 'binary',
   FlowAgent = 'flow_agent',
   Function = 'function',
-  KeyValue = 'key-value',
-  KnowledgeRag = 'knowledge-rag',
+  KeyValue = 'key_value',
+  KnowledgeRag = 'knowledge_rag',
   Other = 'other',
-  ReferenceDocument = 'reference-document',
+  ReferenceDocument = 'reference_document',
   Text = 'text',
 }
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
@@ -25,7 +25,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { type MessageContentType } from './constants';
+import type { MessageContentType } from './constants';
 
 export interface BinaryInputContent {
   data?: string;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/activity-layout/activity-layout.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/activity-layout/activity-layout.spec.ts
@@ -32,9 +32,9 @@ import ActivityLayout from './activity-layout.vue';
 
 vi.mock('../../../ag-ui/types/constants', () => ({
   MessageContentType: {
-    FlowAgent: 'flow-agent',
-    KnowledgeRag: 'knowledge-rag',
-    ReferenceDocument: 'reference-document',
+    FlowAgent: 'flow_agent',
+    KnowledgeRag: 'knowledge_rag',
+    ReferenceDocument: 'reference_document',
   },
 }));
 
@@ -61,7 +61,7 @@ describe('ActivityLayout', () => {
   describe('渲染测试', () => {
     it('应该正确渲染组件', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
       });
 
       expect(wrapper.find('.ai-activity-message').exists()).toBe(true);
@@ -69,7 +69,7 @@ describe('ActivityLayout', () => {
 
     it('应该渲染标题区域', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
       });
 
       expect(wrapper.find('.ai-activity-message-title').exists()).toBe(true);
@@ -77,7 +77,7 @@ describe('ActivityLayout', () => {
 
     it('应该渲染内容区域', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
         slots: {
           default: () => h('div', { class: 'test-content' }, '内容'),
         },
@@ -91,7 +91,7 @@ describe('ActivityLayout', () => {
   describe('折叠功能测试', () => {
     it('默认应该展开显示内容', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
         slots: {
           default: () => h('div', { class: 'test-content' }),
         },
@@ -103,7 +103,7 @@ describe('ActivityLayout', () => {
     it('点击标题应该切换折叠状态', async () => {
       wrapper = mount(ActivityLayout, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           collapsed: false,
           'onUpdate:collapsed': (val: boolean) => wrapper.setProps({ collapsed: val }),
         },
@@ -123,7 +123,7 @@ describe('ActivityLayout', () => {
     it('折叠时 collapsed-icon 应该有 is-collapsed 类', async () => {
       wrapper = mount(ActivityLayout, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           collapsed: false,
           'onUpdate:collapsed': (val: boolean) => wrapper.setProps({ collapsed: val }),
         },
@@ -137,7 +137,7 @@ describe('ActivityLayout', () => {
     it('折叠时内容区域应该隐藏', async () => {
       wrapper = mount(ActivityLayout, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           collapsed: false,
           'onUpdate:collapsed': async (val: boolean) => {
             await wrapper.setProps({ collapsed: val });
@@ -160,7 +160,7 @@ describe('ActivityLayout', () => {
   describe('FlowAgent 特殊处理测试', () => {
     it('FlowAgent 类型不应该渲染折叠图标', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'flow-agent' },
+        props: { activityType: 'flow_agent' },
       });
 
       expect(wrapper.find('.collapsed-icon').exists()).toBe(false);
@@ -168,7 +168,7 @@ describe('ActivityLayout', () => {
 
     it('非 FlowAgent 类型应该渲染折叠图标', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
       });
 
       expect(wrapper.find('.collapsed-icon').exists()).toBe(true);
@@ -179,7 +179,7 @@ describe('ActivityLayout', () => {
   describe('Slot 测试', () => {
     it('应该支持 title scoped slot', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
         slots: {
           title: ({ collapsed }: { collapsed: boolean }) =>
             h('span', { class: 'custom-title', 'data-collapsed': String(collapsed) }, '自定义标题'),
@@ -192,7 +192,7 @@ describe('ActivityLayout', () => {
 
     it('应该支持默认 slot', () => {
       wrapper = mount(ActivityLayout, {
-        props: { activityType: 'reference-document' },
+        props: { activityType: 'reference_document' },
         slots: {
           default: () => h('div', { class: 'custom-content' }, '自定义内容'),
         },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
@@ -80,9 +80,9 @@ vi.mock('../../../lang/lang', () => ({
 
 vi.mock('../../../ag-ui/types/constants', () => ({
   MessageContentType: {
-    FlowAgent: 'flow-agent',
-    KnowledgeRag: 'knowledge-rag',
-    ReferenceDocument: 'reference-document',
+    FlowAgent: 'flow_agent',
+    KnowledgeRag: 'knowledge_rag',
+    ReferenceDocument: 'reference_document',
   },
   MessageStatus: {
     Pending: 'pending',
@@ -167,7 +167,7 @@ describe('ActivityMessage', () => {
     it('应该正确渲染组件', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -178,7 +178,7 @@ describe('ActivityMessage', () => {
     it('应该渲染标题区域', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -189,7 +189,7 @@ describe('ActivityMessage', () => {
     it('应该渲染 DocumentIcon', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -200,7 +200,7 @@ describe('ActivityMessage', () => {
     it('应该渲染 CollapsedIcon', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -217,7 +217,7 @@ describe('ActivityMessage', () => {
 
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content,
         },
       });
@@ -228,7 +228,7 @@ describe('ActivityMessage', () => {
     it('应该渲染 ReferenceContent 组件', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -239,7 +239,7 @@ describe('ActivityMessage', () => {
     it('应该处理空的 content 数组', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [],
         },
       });
@@ -252,7 +252,7 @@ describe('ActivityMessage', () => {
     it('默认应该展开显示内容', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -263,7 +263,7 @@ describe('ActivityMessage', () => {
     it('点击标题应该切换折叠状态', async () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
           collapsed: false,
           'onUpdate:collapsed': (val: boolean) => wrapper.setProps({ collapsed: val }),
@@ -280,7 +280,7 @@ describe('ActivityMessage', () => {
     it('折叠时 collapsed-icon 应该有 is-collapsed 类', async () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -292,10 +292,10 @@ describe('ActivityMessage', () => {
   });
 
   describe('KnowledgeRag 类型测试', () => {
-    it('activityType 为 knowledge-rag 且 status 为 pending 时应该渲染 AiLoading', () => {
+    it('activityType 为 knowledge_rag 且 status 为 pending 时应该渲染 AiLoading', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           status: 'pending',
           content: {
             content: '检索内容',
@@ -308,10 +308,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.mock-document-icon').exists()).toBe(false);
     });
 
-    it('activityType 为 knowledge-rag 且无 status 时应该显示 DocumentIcon', () => {
+    it('activityType 为 knowledge_rag 且无 status 时应该显示 DocumentIcon', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           content: {
             content: '检索内容',
             referenceDocument: [],
@@ -323,10 +323,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.mock-document-icon').exists()).toBe(true);
     });
 
-    it('activityType 为 knowledge-rag 且 status 为 pending 时应该显示检索中', () => {
+    it('activityType 为 knowledge_rag 且 status 为 pending 时应该显示检索中', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           status: 'pending',
           content: {
             content: '检索内容',
@@ -338,10 +338,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.ai-activity-message-title-text').text()).toBe('检索中');
     });
 
-    it('activityType 为 knowledge-rag 且 status 为 streaming 时应该显示检索中', () => {
+    it('activityType 为 knowledge_rag 且 status 为 streaming 时应该显示检索中', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           status: 'streaming',
           content: {
             content: '检索内容',
@@ -353,10 +353,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.ai-activity-message-title-text').text()).toBe('检索中');
     });
 
-    it('activityType 为 knowledge-rag 且 status 为 complete 时应该显示检索完成', () => {
+    it('activityType 为 knowledge_rag 且 status 为 complete 时应该显示检索完成', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           status: 'complete',
           content: {
             content: '检索内容',
@@ -368,10 +368,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.ai-activity-message-title-text').text()).toBe('检索完成');
     });
 
-    it('activityType 为 knowledge-rag 时应该渲染 MarkdownContent', () => {
+    it('activityType 为 knowledge_rag 时应该渲染 MarkdownContent', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'knowledge-rag',
+          activityType: 'knowledge_rag',
           content: {
             content: '这是检索内容',
             referenceDocument: [],
@@ -383,10 +383,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.mock-markdown-content').exists()).toBe(true);
     });
 
-    it('activityType 非 knowledge-rag 时不应该渲染 knowledge-rag-content', () => {
+    it('activityType 非 knowledge_rag 时不应该渲染 knowledge-rag-content', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });
@@ -395,10 +395,10 @@ describe('ActivityMessage', () => {
       expect(wrapper.find('.mock-document-icon').exists()).toBe(true);
     });
 
-    it('status 为 pending 且非 knowledge-rag 时应该显示 DocumentIcon', () => {
+    it('status 为 pending 且非 knowledge_rag 时应该显示 DocumentIcon', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           status: 'pending',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
@@ -413,7 +413,7 @@ describe('ActivityMessage', () => {
     it('应该渲染 FlowAgentContent', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'flow-agent',
+          activityType: 'flow_agent',
           content: {},
         },
       });
@@ -425,7 +425,7 @@ describe('ActivityMessage', () => {
       const content = { task_name: '测试任务', nodes: {} };
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'flow-agent',
+          activityType: 'flow_agent',
           content,
           status: 'streaming',
         },
@@ -437,7 +437,7 @@ describe('ActivityMessage', () => {
     it('应将 uid 作为 messageUid 传递给 FlowAgentContent', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'flow-agent',
+          activityType: 'flow_agent',
           content: {},
           uid: 'activity-uid-1',
         },
@@ -451,7 +451,7 @@ describe('ActivityMessage', () => {
     it('应该具有正确的类名结构', () => {
       wrapper = mount(ActivityMessage, {
         props: {
-          activityType: 'reference-document',
+          activityType: 'reference_document',
           content: [{ name: '文档1', url: 'https://example.com', originFile: '' }],
         },
       });

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
@@ -213,8 +213,8 @@ Activity 消息通过 `activityType` 字段分发到不同的子组件。库内�
 | activityType         | 组件                  | 用途                                                |
 | -------------------- | --------------------- | --------------------------------------------------- |
 | `flow_agent`         | `FlowAgentContent`    | BkFlow 流程执行（节点列表、状态统计、节点详情 Tab） |
-| `knowledge-rag`      | `KnowledgeRagContent` | 知识库检索（检索摘要 + 引用文档列表）               |
-| `reference-document` | `ReferenceDocContent` | 引用文档列表                                        |
+| `knowledge_rag`      | `KnowledgeRagContent` | 知识库检索（检索摘要 + 引用文档列表）               |
+| `reference_document` | `ReferenceDocContent` | 引用文档列表                                        |
 
 分发机制在 `activity-message.vue` 中：
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
@@ -65,10 +65,10 @@ domain: message
 | `activityType`    | 模式           | 标题文案                             | 图标             | 内容区                              |
 | ----------------- | -------------- | ------------------------------------ | ---------------- | ----------------------------------- |
 | `'knowledge_rag'` | 知识检索模式   | 检索中 / 检索完成（随 status 切换）  | Loading / 文档   | Markdown 检索摘要 + 引用列表        |
-| `'flow-agent'`    | FlowAgent 模式 | 执行情况: 成功 N / 失败 N / 执行中 N | Loading / 箭头   | 任务节点树 + 节点详情（自定义 Tab） |
+| `'flow_agent'`    | FlowAgent 模式 | 执行情况: 成功 N / 失败 N / 执行中 N | Loading / 箭头   | 任务节点树 + 节点详情（自定义 Tab） |
 | 其他任意值        | 引用文档模式   | 引用 N 篇资料作为参考                | 文档图标（固定） | 引用文档列表                        |
 
-> **注意：** 只有值严格等于 `'knowledge_rag'` 才进入知识检索模式；严格等于 `'flow-agent'`（`MessageContentType.FlowAgent`）才进入 FlowAgent 模式；其他值均按引用文档模式处理。
+> **注意：** 只有值严格等于 `'knowledge_rag'` 才进入知识检索模式；严格等于 `'flow_agent'`（`MessageContentType.FlowAgent`）才进入 FlowAgent 模式；其他值均按引用文档模式处理。
 
 ## 引用文档模式
 
@@ -258,7 +258,7 @@ domain: message
 
 ## FlowAgent 执行情况模式
 
-`activityType` 设为 `MessageContentType.FlowAgent`（`'flow-agent'`），`content` 传入 `BkFlowMessageContent` 对象。用于展示蓝鲸标准运维（BkFlow）任务的执行状态、节点列表和统计信息。
+`activityType` 设为 `MessageContentType.FlowAgent`（`'flow_agent'`），`content` 传入 `BkFlowMessageContent` 对象。用于展示蓝鲸标准运维（BkFlow）任务的执行状态、节点列表和统计信息。
 
 ### 核心交互
 
@@ -270,7 +270,7 @@ domain: message
 ### 内部渲染结构
 
 ```
-FlowAgentContent（activityType = 'flow-agent'）
+FlowAgentContent（activityType = 'flow_agent'）
 ├── ActivityLayout（公共折叠布局容器）
 │   └── #title
 │       ├── Loading / ArrowIcon（随 status 切换）
@@ -367,7 +367,7 @@ const messages = [
   {
     id: '3',
     role: 'activity',
-    activityType: MessageContentType.FlowAgent, // 'flow-agent'
+    activityType: MessageContentType.FlowAgent, // 'flow_agent'
     status: MessageStatus.Streaming,
     content: {
       task_id: 100,
@@ -430,9 +430,9 @@ type BkFlowNode = {
 };
 
 enum MessageContentType {
-  FlowAgent = 'flow-agent',
-  KnowledgeRag = 'knowledge-rag',
-  ReferenceDocument = 'reference-document',
+  FlowAgent = 'flow_agent',
+  KnowledgeRag = 'knowledge_rag',
+  ReferenceDocument = 'reference_document',
   // ...
 }
 ```
@@ -483,7 +483,7 @@ enum MessageContentType {
 | 属性名       | 类型                                                                        | 默认值 | 说明                                                      |
 | ------------ | --------------------------------------------------------------------------- | ------ | --------------------------------------------------------- |
 | content      | `ReferenceDocumentContent[] \| KnowledgeRagContent \| BkFlowMessageContent` | -      | 内容数据，格式随 `activityType` 不同                      |
-| activityType | `'knowledge_rag' \| 'flow-agent' \| 'reference_document' \| string`         | -      | 活动类型，决定渲染模式（知识检索 / FlowAgent / 引用文档） |
+| activityType | `'knowledge_rag' \| 'flow_agent' \| 'reference_document' \| string`         | -      | 活动类型，决定渲染模式（知识检索 / FlowAgent / 引用文档） |
 | status       | `MessageStatus`                                                             | -      | 消息状态，仅在 `knowledge_rag` 模式下影响标题和图标       |
 | id           | `string \| number`                                                          | -      | 消息 ID                                                   |
 | messageId    | `string \| number`                                                          | -      | 消息唯一标识                                              |
@@ -514,9 +514,9 @@ interface KnowledgeRagContent {
 
 // activityType 枚举值
 enum MessageContentType {
-  FlowAgent = 'flow-agent',
-  KnowledgeRag = 'knowledge-rag',
-  ReferenceDocument = 'reference-document',
+  FlowAgent = 'flow_agent',
+  KnowledgeRag = 'knowledge_rag',
+  ReferenceDocument = 'reference_document',
   // ...
 }
 ```
@@ -525,7 +525,7 @@ enum MessageContentType {
 
 - **知识检索过程**：以 `knowledge_rag` 模式展示 RAG 检索全过程，从"检索中"到"检索完成"的状态流转
 - **参考资料引用**：以 `reference_document` 模式展示 AI 回复所引用的参考文档列表
-- **FlowAgent 执行监控**：以 `flow-agent` 模式展示 BkFlow 流程执行状态、节点列表和详情
+- **FlowAgent 执行监控**：以 `flow_agent` 模式展示 BkFlow 流程执行状态、节点列表和详情
 - **流式场景**：`pending` → `streaming` → `complete` 状态变化配合流式响应实时更新
 - **自动渲染**：通过 `MessageContainer` 或 `MessageRender` 自动处理 `role: 'activity'` 消息，无需手动引入
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/content-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/content-render.md
@@ -330,7 +330,7 @@ enum MessageContentType {
   ReferenceDocument = 'reference_document', // ReferenceDocumentContent[]，引用列表
   Binary = 'binary',
   Function = 'function',
-  KeyValue = 'key-value',
+  KeyValue = 'key_value',
   KnowledgeRag = 'knowledge_rag',
   Other = 'other',
 }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
@@ -84,11 +84,12 @@ enum MessageStatus {
 ```typescript
 enum MessageContentType {
   Binary = 'binary',
+  FlowAgent = 'flow_agent',
   Function = 'function',
-  KeyValue = 'key-value',
-  KnowledgeRag = 'knowledge-rag',
+  KeyValue = 'key_value',
+  KnowledgeRag = 'knowledge_rag',
   Other = 'other',
-  ReferenceDocument = 'reference-document',
+  ReferenceDocument = 'reference_document',
   Text = 'text',
 }
 ```

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -383,20 +383,23 @@ enum MessageContentType {
   // 二进制内容
   Binary = 'binary',
 
+  // FlowAgent 流程执行
+  FlowAgent = 'flow_agent',
+
   // 函数调用
   Function = 'function',
 
   // 键值对
-  KeyValue = 'key-value',
+  KeyValue = 'key_value',
 
   // 知识检索
-  KnowledgeRag = 'knowledge-rag',
+  KnowledgeRag = 'knowledge_rag',
 
   // 其他
   Other = 'other',
 
   // 引用文档
-  ReferenceDocument = 'reference-document',
+  ReferenceDocument = 'reference_document',
 
   // 文本
   Text = 'text',


### PR DESCRIPTION
fix: 统一 MessageContentType 字符串为下划线形式
    
    - 将 KeyValue、KnowledgeRag、ReferenceDocument 等枚举值由连字符改为 snake_case
    - contents.ts 使用 import type 导入 MessageContentType
    - 同步更新 Wiki 中 MessageContentType 与 Activity 相关说明
    - 同步调整 ActivityMessage / ActivityLayout 单元测试中的枚举 mock 与用例
    
    Made-with: Cursor
    # Reviewed, transaction id: 78806