### PR TITLE
refactor(chat-x): 上传个数由 ChatInput 统一校验并优化预览 blob URL

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -30,7 +30,7 @@
       }"
       :resources="MOCK_RESOURCES"
       :shortcuts="shortcuts"
-      :support-upload="false"
+      :support-upload="true"
       @delete-shortcut="handleDeleteShortcut"
       @select-shortcut="handleSelectShortcut"
       @shortcut-close="handleShortcutClose"
@@ -65,6 +65,8 @@
 
 <script setup lang="ts">
   import { ref as deepRef, onMounted, shallowRef } from 'vue';
+
+  import { tr } from 'zod/locales';
 
   import {
     type ActivityMessage,

--- a/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
@@ -125,7 +125,7 @@ export const CONST_UPDATE_TOOLS = [
 
 export const MAX_UPLOAD_FILES = 3; // 最大上传文件数量
 
-export const MAX_UPLOAD_FILE_SIZE = 2.5 * 1024 * 1024; // 最大上传文件大小 2.5MB
+export const MAX_UPLOAD_FILE_SIZE = 2.4 * 1024 * 1024; // 最大上传文件大小 2.5MB
 
 /**
  * 关键词高亮类名

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -57,11 +57,15 @@ vi.mock('../../../lang/lang', () => ({
   t: (key: string) => key,
 }));
 
-vi.mock('../../../common', () => ({
-  isEn: false,
-  MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
-  MAX_UPLOAD_FILES: 3,
-}));
+vi.mock('../../../common', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../../common')>();
+  return {
+    ...actual,
+    isEn: false,
+    MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
+    MAX_UPLOAD_FILES: 3,
+  };
+});
 
 // ============= 辅助函数 =============
 
@@ -159,7 +163,7 @@ describe('FileUploadBtn', () => {
 
   // ---------- Props 测试 ----------
   describe('Props 测试', () => {
-    it('accept 默认值应该为 image/*', () => {
+    it('accept 默认值应该为 image/*（含 SVG）', () => {
       wrapper = mount(FileUploadBtn);
 
       const input = wrapper.find('input[type="file"]');
@@ -285,7 +289,7 @@ describe('FileUploadBtn', () => {
 
   // ---------- 文件验证测试 ----------
   describe('文件验证测试', () => {
-    it('超过最大文件数量应该显示错误提示', async () => {
+    it('单次多选时发出全部尺寸合法的文件，不在按钮层按个数截断或提示', async () => {
       wrapper = mount(FileUploadBtn, {
         props: { maxFiles: 2 },
       });
@@ -298,11 +302,10 @@ describe('FileUploadBtn', () => {
       ];
       await triggerFileChange(wrapper, files);
 
-      expect(mockMessage).toHaveBeenCalledWith({
-        message: '最多上传2个文件',
-        theme: 'error',
-      });
-      expect(wrapper.emitted('upload')).toBeFalsy();
+      expect(mockMessage).not.toHaveBeenCalled();
+      const emitted = wrapper.emitted('upload')?.[0]?.[0] as File[];
+      expect(emitted).toHaveLength(4);
+      expect(emitted.map(f => f.name)).toEqual(['a.png', 'b.png', 'c.png', 'd.png']);
     });
 
     it('文件数量不超过限制时不应该显示错误', async () => {
@@ -324,6 +327,10 @@ describe('FileUploadBtn', () => {
       const emptyFile = createFile('empty.png', 0);
       await triggerFileChange(wrapper, [validFile, emptyFile]);
 
+      expect(mockMessage).toHaveBeenCalledWith({
+        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        theme: 'error',
+      });
       const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
       expect(emittedFiles).toHaveLength(1);
       expect(emittedFiles[0].name).toBe('valid.png');
@@ -336,22 +343,25 @@ describe('FileUploadBtn', () => {
       const oversizedFile = createFile('huge.png', 3 * 1024 * 1024);
       await triggerFileChange(wrapper, [validFile, oversizedFile]);
 
+      expect(mockMessage).toHaveBeenCalledWith({
+        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        theme: 'error',
+      });
       const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
       expect(emittedFiles).toHaveLength(1);
       expect(emittedFiles[0].name).toBe('small.png');
     });
 
-    it('maxFiles 取 props.maxFiles 和 MAX_UPLOAD_FILES 的较大值', async () => {
+    it('maxFiles 较小仍一次发出多选的全部合法文件（个数由上层处理）', async () => {
       wrapper = mount(FileUploadBtn, {
         props: { maxFiles: 1 },
       });
 
-      // MAX_UPLOAD_FILES = 3，Math.max(1, 3) = 3，所以 4 个文件才会超限
       const files = [createFile('a.png', 1024), createFile('b.png', 1024), createFile('c.png', 1024)];
       await triggerFileChange(wrapper, files);
 
       expect(mockMessage).not.toHaveBeenCalled();
-      expect(wrapper.emitted('upload')).toBeTruthy();
+      expect((wrapper.emitted('upload')?.[0]?.[0] as File[]).map(f => f.name)).toEqual(['a.png', 'b.png', 'c.png']);
     });
   });
 
@@ -389,15 +399,17 @@ describe('FileUploadBtn', () => {
       expect(wrapper.emitted('upload')).toBeFalsy();
     });
 
-    it('所有文件都被过滤后应该触发 upload 事件并返回空数组', async () => {
+    it('所有文件都被过滤后不应触发 upload 但应提示错误', async () => {
       wrapper = mount(FileUploadBtn);
 
       const emptyFile = createFile('empty.png', 0);
       await triggerFileChange(wrapper, [emptyFile]);
 
-      expect(wrapper.emitted('upload')).toBeTruthy();
-      const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
-      expect(emittedFiles).toHaveLength(0);
+      expect(wrapper.emitted('upload')).toBeFalsy();
+      expect(mockMessage).toHaveBeenCalledWith({
+        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        theme: 'error',
+      });
     });
 
     it('刚好等于最大尺寸的文件应该被过滤', async () => {
@@ -406,8 +418,11 @@ describe('FileUploadBtn', () => {
       const maxSizeFile = createFile('max.png', 2.5 * 1024 * 1024);
       await triggerFileChange(wrapper, [maxSizeFile]);
 
-      const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
-      expect(emittedFiles).toHaveLength(0);
+      expect(wrapper.emitted('upload')).toBeFalsy();
+      expect(mockMessage).toHaveBeenCalledWith({
+        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        theme: 'error',
+      });
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
@@ -30,9 +30,10 @@
   import { Message } from 'bkui-vue';
   import { directive as vTippy } from 'vue-tippy';
 
-  import { isEn, MAX_UPLOAD_FILE_SIZE, MAX_UPLOAD_FILES } from '../../../common';
+  import { isEn, MAX_UPLOAD_FILE_SIZE } from '../../../common';
   import { FileUploadIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
+  import { formatUploadNotAddedMessage } from '../../../utils';
 
   import type { AITippyProps } from '../../../types';
 
@@ -44,9 +45,9 @@
     multiple?: boolean;
     tippyOptions?: AITippyProps;
   };
-  const props = withDefaults(defineProps<FileUploadBtnProps>(), {
-    accept: 'image/*', // 默认只允许上传图片
-    maxFiles: 3,
+  withDefaults(defineProps<FileUploadBtnProps>(), {
+    accept: 'image/*', // 默认允许常见图片类型（含 SVG）
+    maxFiles: 3, // 预留/文档用；实际上传个数由上层（如 ChatInput）校验
     multiple: true,
   });
   const emit = defineEmits<{
@@ -62,18 +63,27 @@
     const target = event.target as HTMLInputElement;
     const files = target.files;
     if (files?.length) {
-      if (files.length > Math.max(props.maxFiles, MAX_UPLOAD_FILES)) {
+      const maxMb = (MAX_UPLOAD_FILE_SIZE / (1024 * 1024)).toFixed(1);
+      const picked = Array.from(files);
+      const toEmit: File[] = [];
+      let sizeRejected = 0;
+      for (const file of picked) {
+        if (file.size > 0 && file.size < MAX_UPLOAD_FILE_SIZE) {
+          toEmit.push(file);
+        } else {
+          sizeRejected += 1;
+        }
+      }
+      // 上传个数上限由上层（如 ChatInput）统一处理并提示，避免与按钮层「单次截断」各弹一条 Message
+      if (sizeRejected > 0) {
         Message({
-          message: isEn ? `You can only upload up to ${props.maxFiles} files` : `最多上传${props.maxFiles}个文件`,
+          message: formatUploadNotAddedMessage(sizeRejected, maxMb, isEn),
           theme: 'error',
         });
-        return;
       }
-      // 限制最大上传文件数量
-      emit(
-        'upload',
-        Array.from(files).filter(file => file.size > 0 && file.size < MAX_UPLOAD_FILE_SIZE),
-      );
+      if (toEmit.length) {
+        emit('upload', toEmit);
+      }
     }
     target.value = '';
   };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -35,16 +35,27 @@ import ChatInput from './chat-input.vue';
 import type { UploadFile } from '../../types';
 import type { IAiSlashMenuItem } from '../../types/editor';
 
-// Mock common
-vi.mock('../../common', () => ({
-  CHAT_Z_INDEX: 1000,
-  isEn: false,
-  commonSVGProps: {
-    class: 'mock-svg-icon',
-    xmlns: 'http://www.w3.org/2000/svg',
-    viewBox: '0 0 24 24',
-  },
+const mockBkMessage = vi.fn();
+vi.mock('bkui-vue', () => ({
+  Message: (...args: unknown[]) => mockBkMessage(...args),
 }));
+
+// Mock common
+vi.mock('../../common', async importOriginal => {
+  const actual = await importOriginal<typeof import('../../common')>();
+  return {
+    ...actual,
+    CHAT_Z_INDEX: 1000,
+    isEn: false,
+    MAX_UPLOAD_FILES: 3,
+    MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
+    commonSVGProps: {
+      class: 'mock-svg-icon',
+      xmlns: 'http://www.w3.org/2000/svg',
+      viewBox: '0 0 24 24',
+    },
+  };
+});
 
 // Mock edix
 vi.mock('../../edix', () => ({

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -1,5 +1,8 @@
 <template>
-  <div class="chat-input-container" :style="{ '--chat-z-index': CHAT_Z_INDEX }">
+  <div
+    class="chat-input-container"
+    :style="{ '--chat-z-index': CHAT_Z_INDEX }"
+  >
     <slot name="top" />
     <div
       class="chat-input"
@@ -81,8 +84,10 @@
 <script setup lang="ts">
   import { computed, ref as deepRef, shallowRef, useTemplateRef, watchPostEffect } from 'vue';
 
+  import { Message } from 'bkui-vue';
+
   import { type UserMessage, MessageContentType, MessageStatus } from '../../ag-ui/types';
-  import { CHAT_Z_INDEX, isEn } from '../../common';
+  import { CHAT_Z_INDEX, isEn, MAX_UPLOAD_FILE_SIZE, MAX_UPLOAD_FILES } from '../../common';
   import { type KeyboardPayload, docToString } from '../../edix';
   import { CloseIcon } from '../../icons';
   import {
@@ -93,6 +98,7 @@
     type UploadFile,
     UploadStatus,
   } from '../../types';
+  import { formatUploadNotAddedMessage } from '../../utils';
   import FileUploadBtn from '../ai-buttons/file-upload-btn/file-upload-btn.vue';
   import ShortcutBtn from '../ai-shortcut/shortcut-btn/shortcut-btn.vue';
   import ShortcutBtns from '../ai-shortcut/shortcut-btns/shortcut-btns.vue';
@@ -235,14 +241,35 @@ Use Shift + Enter to enter a new line`
     emit('deleteShortcut');
   };
   const fileKey = (f: File) => `${f.name}_${f.size}_${f.lastModified}`;
+  const maxUploadMb = (MAX_UPLOAD_FILE_SIZE / (1024 * 1024)).toFixed(1);
   const handleUpload = async (files: File[]) => {
     if (!props.supportUpload) {
       return;
     }
+    if (uploadFiles.value.length >= MAX_UPLOAD_FILES) {
+      if (files.length > 0) {
+        Message({
+          message: formatUploadNotAddedMessage(files.length, maxUploadMb, isEn),
+          theme: 'error',
+        });
+      }
+      return;
+    }
     const existingKeys = new Set(uploadFiles.value.map(item => (item.file ? fileKey(item.file) : '')));
-    for (const file of files) {
+    let notUploadedCount = 0;
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      if (uploadFiles.value.length >= MAX_UPLOAD_FILES) {
+        notUploadedCount += files.length - i;
+        break;
+      }
       const key = fileKey(file);
       if (existingKeys.has(key)) {
+        notUploadedCount += 1;
+        continue;
+      }
+      if (file.size <= 0 || file.size >= MAX_UPLOAD_FILE_SIZE) {
+        notUploadedCount += 1;
         continue;
       }
       existingKeys.add(key);
@@ -264,6 +291,12 @@ Use Shift + Enter to enter a new line`
         .catch(() => {
           fileItem.status = UploadStatus.Error;
         });
+    }
+    if (notUploadedCount > 0) {
+      Message({
+        message: formatUploadNotAddedMessage(notUploadedCount, maxUploadMb, isEn),
+        theme: 'error',
+      });
     }
   };
   const handleDeleteFile = (file: Partial<UploadFile>) => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/image-preview/image-preview.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/image-preview/image-preview.spec.ts
@@ -267,6 +267,31 @@ describe('ImagePreview', () => {
       expect(wrapper.find('.ai-image-preview-img').exists()).toBe(true);
     });
 
+    it('关闭后再次打开 File 预览应重新生成可用的 blob URL', async () => {
+      const file = new File(['dummy'], 'photo.png', { type: 'image/png' });
+
+      wrapper = mount(ImagePreview, {
+        props: {
+          visible: true,
+          images: [file],
+          'onUpdate:visible': (v: boolean) => wrapper.setProps({ visible: v }),
+        },
+        global: {
+          stubs: { Teleport: true },
+        },
+      });
+
+      const firstSrc = wrapper.find('.ai-image-preview-img').attributes('src');
+      expect(firstSrc).toMatch(/^blob:/);
+
+      await wrapper.setProps({ visible: false });
+      await wrapper.setProps({ visible: true });
+
+      const secondSrc = wrapper.find('.ai-image-preview-img').attributes('src');
+      expect(secondSrc).toMatch(/^blob:/);
+      expect(secondSrc).not.toBe(firstSrc);
+    });
+
     it('应该支持混合类型 images（string + File + ImageItem）', () => {
       const file = new File(['dummy'], 'photo.png', { type: 'image/png' });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/image-preview/image-preview.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/image-preview/image-preview.vue
@@ -90,7 +90,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed, onBeforeUnmount, shallowRef, watch } from 'vue';
+  import { computed, onBeforeUnmount, shallowRef } from 'vue';
 
   import { ArrowLeftIcon, ArrowRightPreviewIcon, ImageBrokenIcon, PreviewCloseIcon } from '../../icons/image-preview';
   import { t } from '../../lang/lang';
@@ -137,7 +137,13 @@
     return { url, name: file.name, file };
   };
 
+  // visible 必须参与计算：关闭时会 revoke blob URL，若仅依赖 props.images，
+  // computed 缓存仍指向已失效的 url，再次打开预览会加载失败。
   const normalizedImages = computed<ImageItem[]>(() => {
+    if (!visible.value) {
+      revokeObjectUrls();
+      return [];
+    }
     revokeObjectUrls();
     return props.images.map(img => {
       if (img instanceof File) return fileToImageItem(img);
@@ -145,10 +151,6 @@
       if (img.file && !img.url) return { ...img, url: fileToImageItem(img.file).url };
       return img;
     });
-  });
-
-  watch(visible, val => {
-    if (!val) revokeObjectUrls();
   });
 
   onBeforeUnmount(revokeObjectUrls);

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/file.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/file.ts
@@ -62,5 +62,24 @@ export const formatFileSize = (file?: File): string => {
   const size = file.size;
   const units = ['B', 'KB', 'M', 'GB'];
   const index = Math.floor(Math.log2(size) / 10);
-  return `${(size / Math.pow(1024, index)).toFixed(2)} ${units[index]}`;
+  return `${(size / 1024 ** index).toFixed(2)} ${units[index]}`;
+};
+
+/**
+ * 未成功添加的文件统一提示（中文在数量为 1 时不带「n个」前缀）
+ */
+export const formatUploadNotAddedMessage = (count: number, maxMb: string, isEn: boolean): string => {
+  if (count < 1) {
+    return '';
+  }
+  if (isEn) {
+    // if (count === 1) {
+    //   return `The file was not uploaded; it may exceed ${maxMb} MB or the upload count limit.`;
+    // }
+    return `${count} files were not uploaded; they may exceed ${maxMb} MB or the upload count limit.`;
+  }
+  // if (count === 1) {
+  //   return `文件未上传，可能文件超过 ${maxMb} MB或超出上传个数`;
+  // }
+  return `有 ${count} 个文件未上传，可能文件超过 ${maxMb} MB或超出上传个数`;
 };

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/file-upload-btn.md
@@ -4,10 +4,10 @@ slug: file-upload-btn
 category: atomic
 description: >-
   聊天输入框内置的文件上传触发按钮，点击后弹出系统文件选择框。内部包含隐藏的 `<input type="file">`
-  与可见的图标按钮，并内置文件数量及大小校验逻辑。
+  与可见的图标按钮；在按钮层过滤空文件与超过单文件大小上限的文件，**上传个数上限由上层（如 ChatInput）统一处理**。
 aiSummary: >
-  FileUploadBtn 提供隐藏 file input 与图标按钮，选择文件后 emit upload，并内置数量与单文件大小上限校验。
-  常用于 ChatInput 工具条；与 FileContent 等展示列表配合形成「选择 → 展示 → 发送」链路。
+  FileUploadBtn 提供隐藏 file input 与图标按钮，选择后在按钮层过滤空文件与超大单文件并 emit upload；
+  个数上限不在此截断，由 ChatInput 等与 FileContent 配合完成「选择 → 展示 → 发送」链路。
 relatedComponents:
   - slug: chat-input
     relation: 输入区附件上传按钮常见挂载位置
@@ -29,7 +29,7 @@ domain: media
 
 > **层级**：原子组件 · **功能域**：文件与图片
 
-聊天输入框内置的文件上传触发按钮，点击后弹出系统文件选择框。内部包含隐藏的 `<input type="file">` 与可见的图标按钮，并内置文件数量及大小校验逻辑。
+聊天输入框内置的文件上传触发按钮，点击后弹出系统文件选择框。内部包含隐藏的 `<input type="file">` 与可见的图标按钮；在按钮层对**单文件**做大小与空文件过滤，**已选文件个数上限**由上层（如 `ChatInput`）统一校验并提示，避免按钮与输入区各弹一条错误提示。
 
 ## 组件结构
 
@@ -48,26 +48,30 @@ domain: media
 ```
 用户选择文件
   │
-  ├─ files.length > Math.max(maxFiles, MAX_UPLOAD_FILES[3])
-  │       ↓ true → bkui-vue Message.error("最多上传 N 个文件")，终止，不 emit
+  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（约 2.4MB）→ 加入 toEmit
+  │       size 为 0 或 ≥ 上限 → sizeRejected += 1
   │
-  └─ emit('upload', files.filter(f => f.size > 0 && f.size < MAX_UPLOAD_FILE_SIZE[2.5MB]))
-        ↓
-      target.value = ''（重置 input，允许再次选择同一文件）
+  ├─ sizeRejected > 0 → bkui-vue Message.error（formatUploadNotAddedMessage，说明可能超大或超出个数等）
+  │
+  ├─ toEmit.length > 0 → emit('upload', toEmit)
+  │
+  └─ target.value = ''（重置 input，允许再次选择同一文件）
 ```
 
 **关键边界行为**：
 
-| 场景                                      | 结果                                                        |
-| ----------------------------------------- | ----------------------------------------------------------- |
-| 文件数超过 `Math.max(maxFiles, 3)`        | 弹出错误 toast，**不触发** `upload`                         |
-| 文件数未超限，但部分文件被大小过滤        | **仍触发** `upload`，payload 为过滤后的数组（可能为空数组） |
-| `file.size === 0`                         | 被过滤（空文件）                                            |
-| `file.size >= 2.5MB`（即 `2621440` 字节） | 被过滤（使用严格小于 `<`，等于 2.5MB 也会被过滤）           |
-| `maxFiles` 设为小于 3 的值（如 `1`）      | 实际限制取 `Math.max(1, 3) = 3`，不低于全局下限             |
-| 选择后取消                                | `files.length === 0`，不触发 `upload`                       |
+| 场景                                                         | 结果                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| 一次多选超过上层允许个数（如 `ChatInput` 内已达 3 个）       | 由 **ChatInput** 侧 toast 并丢弃/不计入，不在本按钮内按个数提前拦截 |
+| 部分文件因空文件或单文件超大被过滤                           | 弹出错误 toast；若仍有合法文件，**仍触发** `upload`（payload 为合法子集） |
+| 全部被过滤（均为空或超大）                                   | 仅 toast，**不触发** `upload`                                        |
+| `file.size === 0`                                          | 计入未添加提示，不进入 `upload` payload                              |
+| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，约 2.4MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
+| 选择后取消                                                   | `files.length === 0`，不触发 `upload`                                |
 
 > `multiple` prop 声明存在但当前模板中 `input` 的 `multiple` 属性为**硬编码**（非 `:multiple="multiple"` 绑定），始终允许多选，该 prop 暂时无实际效果。
+
+> **`maxFiles` prop**：当前版本在按钮内**不参与截断或计数校验**，仅作类型与文档预留；列表最多几个文件由上层（如 `ChatInput` 的 `MAX_UPLOAD_FILES`）控制。详见 [ChatInput 文件上传](../molecular/chat-input.md#file-upload)。
 
 ## 基础用法
 
@@ -126,31 +130,6 @@ domain: media
 
 > `accept` 仅影响文件选择框的过滤 UI，不做服务端验证，请在 `upload` 回调中自行校验 MIME 类型。
 
-## 限制上传数量
-
-`maxFiles` 限制单次选择的文件上传上限，实际生效值为 `Math.max(maxFiles, 3)`，不会低于全局下限 3：
-
-```vue
-<template>
-  <!-- maxFiles=5：可一次选 5 个文件 -->
-  <FileUploadBtn
-    :max-files="5"
-    @upload="handleUpload"
-  />
-
-  <!-- maxFiles=1：实际等效 maxFiles=3（取 Math.max(1,3)） -->
-  <FileUploadBtn
-    :max-files="1"
-    @upload="handleUpload"
-  />
-</template>
-```
-
-<div class="demo" style="display: flex; gap: 12px;">
-  <FileUploadBtn :max-files="5" @upload="handleUpload" />
-  <FileUploadBtn :max-files="1" @upload="handleUpload" />
-</div>
-
 ## 自定义图标
 
 通过默认插槽替换上传图标：
@@ -173,18 +152,18 @@ domain: media
 
 ### Props
 
-| 属性名       | 类型           | 默认值      | 说明                                                   |
-| ------------ | -------------- | ----------- | ------------------------------------------------------ |
-| accept       | `string`       | `'image/*'` | 文件选择框过滤类型，遵循 `<input accept>` 规范         |
-| maxFiles     | `number`       | `3`         | 单次选择文件数上限；实际限制为 `Math.max(maxFiles, 3)` |
-| multiple     | `boolean`      | `true`      | 声明属性（当前版本未实际绑定到 input，始终多选）       |
-| tippyOptions | `AITippyProps` | —           | 扩展 tooltip 配置，会与内置配置合并                    |
+| 属性名       | 类型           | 默认值      | 说明                                                                 |
+| ------------ | -------------- | ----------- | -------------------------------------------------------------------- |
+| accept       | `string`       | `'image/*'` | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
+| maxFiles     | `number`       | `3`         | 预留字段，**当前不在按钮内生效**；个数上限见 `ChatInput` 与全局常量 |
+| multiple     | `boolean`      | `true`      | 声明属性（当前版本未实际绑定到 input，始终多选）                     |
+| tippyOptions | `AITippyProps` | —           | 扩展 tooltip 配置，会与内置配置合并                                |
 
 ### Events
 
 | 事件名 | 参数              | 说明                                                                                      |
 | ------ | ----------------- | ----------------------------------------------------------------------------------------- |
-| upload | `(files: File[])` | 校验通过后触发；`files` 为过滤掉空文件和超大文件（≥ 2.5MB）后的数组；超出数量限制时不触发 |
+| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，约 2.4MB）后的数组；个数截断不在此组件内完成 |
 
 ### Slots
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/atomic/index.md
@@ -10,7 +10,7 @@
 | `ToolBtn`          | 工具栏图标按钮；内置 10 个预置 SVG 图标（含 `activeLike`/`activeUnLike`），Tippy tooltip，`active`/`disabled` 态 | `MessageTools`                                          | [查看](./tool-btn.md)          |
 | `ShortcutBtn`      | 单个快捷指令按钮；`btn`/`menu` 两种布局，图标支持 URL / CSS 类名 / 函数 / 组件                                   | `ShortcutBtns`、`AiSelection`、`ChatInput`              | [查看](./shortcut-btn.md)      |
 | `ShortcutBtns`     | 快捷指令按钮组；内置 `useObserverVisibleList` 响应式溢出，超出容器宽度自动收入"更多"菜单                         | `ChatInput`                                             | [查看](./shortcut-btns.md)     |
-| `FileUploadBtn`    | 文件上传触发按钮；多选、类型过滤、2.5MB 大小校验、文件数上限（`max(maxFiles, 3)`）                               | `ChatInput`                                             | [查看](./file-upload-btn.md)   |
+| `FileUploadBtn`    | 文件上传触发按钮；多选、类型过滤、单文件约 2.4MB 过滤；个数上限由 `ChatInput` 统一处理                         | `ChatInput`                                             | [查看](./file-upload-btn.md)   |
 | `AiLoading`        | AI 思考中动画；SVG 三色（蓝→紫→粉）渐变脉冲，`uid` 隔离多实例渐变 ID                                             | `LoadingMessage`、`ReasoningMessage`、`ActivityMessage` | [查看](./ai-loading.md)        |
 | `HighlightKeyword` | 关键词高亮；函数式组件，通过 `inject` 获取搜索关键词，匹配文本自动高亮                                           | `ExecutionSummary`                                      | [查看](./highlight-keyword.md) |
 | `SelectionFooter`  | 选择操作栏；消息多选模式底部栏，提供全选/取消/确认操作                                                           | `ChatContainer`                                         | [查看](./selection-footer.md)  |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/index.md
@@ -27,7 +27,7 @@
 | `ToolBtn`       | 工具栏图标按钮；内置 10 个预置图标，支持激活 / 禁用态 | [查看](./atomic/tool-btn.md)        |
 | `ShortcutBtn`   | 单个快捷指令按钮；`btn` / `menu` 两种布局             | [查看](./atomic/shortcut-btn.md)    |
 | `ShortcutBtns`  | 快捷指令按钮组；响应式溢出自动收入"更多"菜单          | [查看](./atomic/shortcut-btns.md)   |
-| `FileUploadBtn` | 文件上传触发按钮；多选、类型过滤、2.5MB 校验          | [查看](./atomic/file-upload-btn.md) |
+| `FileUploadBtn` | 文件上传触发按钮；多选、类型过滤、单文件约 2.4MB 校验 | [查看](./atomic/file-upload-btn.md) |
 | `AiLoading`     | AI 思考中三色渐变脉冲动画                             | [查看](./atomic/ai-loading.md)      |
 
 ### 内容渲染

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-input.md
@@ -373,7 +373,7 @@ chat-input-container
   />
 </div>
 
-## 文件上传
+## 文件上传 {#file-upload}
 
 `supportUpload` 默认为 `true`，底部工具栏自动显示文件上传按钮。传入 `onUpload` 回调后即可处理文件上传：
 
@@ -382,6 +382,12 @@ chat-input-container
 - `onUpload` 每次传入**单个** `File`，返回 `{ download_url?: string }`
 - 文件自动去重（基于 `name + size + lastModified` 复合键），不会重复上传
 - 发送成功后，`uploadFiles` 自动清空
+
+**个数与大小校验（与 `FileUploadBtn` 分工）**：
+
+- 列表最多保留 **`MAX_UPLOAD_FILES`（3）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
+- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）**、或与已有文件重复的项会被跳过；若本轮有任意文件因此未加入列表，会在处理结束后弹出**同一条文案风格**的错误提示，汇总未成功添加的数量。
+- `FileUploadBtn` 仅在按钮层过滤**空文件与单文件超大**，把合法文件以数组形式 `upload` 上来；**个数上限与重复校验**在 `ChatInput` 的 `handleUpload` 中统一处理，避免与按钮层各弹一条提示。
 
 **发送内容格式**（有文件时）：
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/image-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/image-preview.md
@@ -238,8 +238,8 @@ Teleport(to="body")
 
 > **ObjectURL 生命周期管理**：组件内部维护 `objectUrls` 数组，在以下时机自动回收：
 >
-> - `images` prop 变化触发 `normalizedImages` 重新计算时
-> - `visible` 从 `true` 变为 `false` 时
+> - `normalizedImages` 计算属性重算时（会先 `revokeObjectUrls`，再按当前 `images` 与 `visible` 生成新列表）
+> - **`visible` 为 `false` 时**：计算属性直接清空并 `revokeObjectURL`，避免仅依赖 `props.images` 时 computed 仍缓存**已失效**的 blob URL，导致关闭预览后再次打开加载失败
 > - 组件 `onBeforeUnmount` 时
 
 ## API


### PR DESCRIPTION
refactor(chat-x): 上传个数由 ChatInput 统一校验并优化预览 blob URL

- FileUploadBtn：不再在按钮层按个数截断；仅过滤空文件与超大文件，
  部分被拒时通过 formatUploadNotAddedMessage 提示；合法子集仍 emit upload
- ChatInput：统一处理个数上限、重复与未入队提示；与按钮层避免重复 toast
- constants：MAX_UPLOAD_FILE_SIZE 调整为 2.4MB，与「严格小于」上限语义一致
- utils/file：新增 formatUploadNotAddedMessage 供上传相关提示复用
- ImagePreview：visible 为 false 时回收 ObjectURL，避免关闭后再打开加载失败
- 更新 file-upload-btn / chat-input / image-preview 单测与 wikis 文档
- playground：开启 support-upload 便于联调