### PR TITLE
feat(chat-x): update interrupt outcome payload

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
@@ -23,9 +23,26 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus, RunFinishedOutcome } from '../src';
+import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus } from '../src';
 
-import type { Message } from '../src';
+import type { Interrupt, Message } from '../src';
+
+const approvalInterrupt: Interrupt = {
+  id: 'interrupt_ai_dev_tool_approval',
+  reason: InterruptReason.AIDevToolApproval,
+  toolCallId: 'tool_call_review_ticket',
+  message: '算法方案评审单正在评审中',
+  metadata: {
+    ticket: {
+      approvers: ['张三', '李四', 'xddddssss', 'ddd'],
+      sn: 'REV-2026-04-24-001',
+      status: APPROVAL_STATUS.PENDING,
+      submit_time: '2026-04-24 14:30:15',
+      title: '算法方案评审单',
+      url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+    },
+  },
+};
 
 export const MOCK_INTERRUPT_MESSAGES: Message[] = [
   {
@@ -41,25 +58,11 @@ export const MOCK_INTERRUPT_MESSAGES: Message[] = [
     role: MessageRole.Interrupt,
     status: MessageStatus.Complete,
     content: '',
-    outcome: RunFinishedOutcome.Interrupt,
     runId: 'run_ai_dev_tool_approval',
     threadId: 'thread_ai_dev_tool_approval',
-    interrupt: [
-      {
-        reason: InterruptReason.AIDevToolApproval,
-        toolCallId: 'tool_call_review_ticket',
-        message: '算法方案评审单正在评审中',
-        metadata: {
-          ticket: {
-            approvers: ['张三', '李四', 'xddddssss', 'ddd'],
-            sn: 'REV-2026-04-24-001',
-            status: APPROVAL_STATUS.PENDING,
-            submit_time: '2026-04-24 14:30:15',
-            title: '算法方案评审单',
-            url: 'https://example.com/review-tickets/REV-2026-04-24-001',
-          },
-        },
-      },
-    ],
+    outcome: {
+      type: 'interrupt',
+      interrupts: [approvalInterrupt],
+    },
   },
 ];

--- a/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
@@ -1175,6 +1175,18 @@ async function loadUserData() {
 5. **容器化**：使用Docker将应用及其依赖打包
 `;
 export const streamContent = `
+**斜体**
+_斜体_
+*斜体*
+**粗体**
+__粗体__
+***粗斜体***
+___粗斜体___
+**_粗斜体_**
+_**粗斜体**_
+
+#### 斜体
+
 #### 4. 链接与 a 标签示例
 **Markdown 行内链接**：[腾讯蓝鲸](https://bk.tencent.com/) · [chat-x npm](https://www.npmjs.com/package/@blueking/chat-x)
 **Markdown 自动链接**：<https://github.com/TencentBlueKing/bk-aidev-agent>

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
@@ -25,7 +25,15 @@
  */
 
 import { t } from '../../lang/lang';
-import { APPROVAL_STATUS } from './interrupt';
+
+export enum APPROVAL_STATUS {
+  ABANDONED = 'abandoned', // 已废弃
+  APPROVED = 'approved', // 已批准
+  CANCELLED = 'cancelled', // 已取消
+  EXPIRED = 'expired', // 已过期
+  PENDING = 'pending', // 待审批
+  REJECTED = 'rejected', // 已拒绝
+}
 
 export enum InterruptReason {
   AIDevToolApproval = 'ai_dev:tool_approval', // AI dev 第三方审批
@@ -70,7 +78,6 @@ export enum MessageRole {
   Tool = 'tool',
   User = 'user',
 }
-
 export enum MessageStatus {
   Complete = 'complete',
   Disabled = 'disabled',
@@ -80,11 +87,6 @@ export enum MessageStatus {
   Stop = 'stop',
   StopLoading = 'stop-loading',
   Streaming = 'streaming',
-  Success = 'success',
-}
-
-export enum RunFinishedOutcome {
-  Interrupt = 'interrupt',
   Success = 'success',
 }
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
@@ -25,17 +25,8 @@
  * IN THE SOFTWARE.
  */
 
-import type { InterruptReason, MessageRole, RunFinishedOutcome } from './constants';
+import type { APPROVAL_STATUS, InterruptReason, MessageRole } from './constants';
 import type { BaseMessage } from './messages';
-
-export enum APPROVAL_STATUS {
-  ABANDONED = 'abandoned', // 已废弃
-  APPROVED = 'approved', // 已批准
-  CANCELLED = 'cancelled', // 已取消
-  EXPIRED = 'expired', // 已过期
-  PENDING = 'pending', // 待审批
-  REJECTED = 'rejected', // 已拒绝
-}
 
 export type AIDevToolApprovalInterrupt = BaseInterrupt<
   InterruptReason.AIDevToolApproval,
@@ -58,19 +49,23 @@ export type AIDevToolApprovalInterrupt = BaseInterrupt<
 >;
 
 export type BaseInterrupt<T extends InterruptReason, M extends Record<string, any>> = {
+  expiresAt?: string;
+  id: string;
   message?: string;
   metadata?: M;
   properties?: Record<string, any>;
   reason: T;
+  // responseSchema?: JSONSchema4;
   toolCallId: string;
 };
 
-export type InterruptItem = AIDevToolApprovalInterrupt | BaseInterrupt<InterruptReason, Record<string, any>>;
+export type Interrupt = AIDevToolApprovalInterrupt | BaseInterrupt<InterruptReason, Record<string, any>>;
 
+export type InterruptItem = Interrupt;
 /**
  * 中断消息
  *
- * 对应 AG-UI 协议 `RUN_FINISHED { outcome: "interrupt", interrupt }` 事件。
+ * 对应 AG-UI 协议 `RUN_FINISHED { outcome: { type: "interrupt", interrupts } }` 事件。
  * 当 Agent 需要 human-in-the-loop（审批 / 补充信息 / 策略阻断等）时，
  * 会派生此类型消息以驱动 UI 渲染等待用户响应；用户响应后通过
  * `RunAgentInput.resume = { interruptId, payload }` 把结果回传给 Agent。
@@ -78,14 +73,14 @@ export type InterruptItem = AIDevToolApprovalInterrupt | BaseInterrupt<Interrupt
  * @see https://docs.ag-ui.com/drafts/interrupts
  */
 export interface InterruptMessage extends BaseMessage<MessageRole.Interrupt, string> {
-  /** outcome === interrupt 时，中断消息内容 */
-  interrupt?: InterruptItem[];
   message?: string;
-  /** 是否已被用户响应（rsume）过，用于 UI 区分"等待响应 / 已处理"两种态 */
+  /** 是否已被用户响应（resume）过，用于 UI 区分"等待响应 / 已处理"两种态 */
   outcome?: RunFinishedOutcome;
-  /** outcome === success 用户 resume 时回传给 Agent 的 payload，便于回放与持久化 */
+  /** outcome.type === success 用户 resume 时回传给 Agent 的 payload，便于回放与持久化 */
   result?: any;
   runId?: string;
   threadId?: string;
 }
-export type OnInterruptResume = (interrupt: InterruptItem, payload?: Record<string, any>) => Promise<void> | void;
+
+export type OnInterruptResume = (interrupt: Interrupt, payload?: Record<string, any>) => Promise<void> | void;
+export type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -27,10 +27,10 @@
 import { type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { APPROVAL_STATUS } from '../../../ag-ui/types/interrupt';
+import { APPROVAL_STATUS, InterruptReason } from '../../../ag-ui/types/constants';
 import InterruptMessage from './interrupt-message.vue';
 
-import type { AIDevToolApprovalInterrupt } from '../../../ag-ui/types/interrupt';
+import type { AIDevToolApprovalInterrupt, Interrupt } from '../../../ag-ui/types/interrupt';
 
 const copyMock = vi.fn();
 
@@ -45,7 +45,8 @@ vi.mock('../../../lang/lang', () => ({
 }));
 
 const approvalInterrupt: AIDevToolApprovalInterrupt = {
-  reason: 'ai_dev:tool_approval',
+  id: 'interrupt-1',
+  reason: InterruptReason.AIDevToolApproval,
   toolCallId: 'tool-call-1',
   message: '需要关注技术评审单据',
   metadata: {
@@ -58,6 +59,13 @@ const approvalInterrupt: AIDevToolApprovalInterrupt = {
       url: 'https://example.com/ticket/REV-2026-04-24-001',
     },
   },
+};
+
+const unsupportedInterrupt: Interrupt = {
+  id: 'interrupt-2',
+  reason: 'unknown_reason' as InterruptReason,
+  toolCallId: 'tool-call-2',
+  message: '暂不支持的中断消息',
 };
 
 describe('InterruptMessage', () => {
@@ -76,7 +84,10 @@ describe('InterruptMessage', () => {
   it('应该按设计稿渲染 AI Dev 工具审批单信息', () => {
     wrapper = mount(InterruptMessage, {
       props: {
-        interrupt: [approvalInterrupt],
+        outcome: {
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        },
       },
     });
 
@@ -92,7 +103,10 @@ describe('InterruptMessage', () => {
     const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {
       props: {
-        interrupt: [approvalInterrupt],
+        outcome: {
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        },
         onInterruptResume,
       },
     });
@@ -107,7 +121,10 @@ describe('InterruptMessage', () => {
     const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {
       props: {
-        interrupt: [approvalInterrupt],
+        outcome: {
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        },
         onInterruptResume,
       },
     });
@@ -121,17 +138,27 @@ describe('InterruptMessage', () => {
   it('不支持的中断类型应该显示兜底文案', () => {
     wrapper = mount(InterruptMessage, {
       props: {
-        interrupt: [
-          {
-            reason: 'unknown_reason',
-            toolCallId: 'tool-call-2',
-            message: '暂不支持的中断消息',
-          } as AIDevToolApprovalInterrupt,
-        ],
+        outcome: {
+          type: 'interrupt',
+          interrupts: [unsupportedInterrupt],
+        },
       },
     });
 
     expect(wrapper.find('.ai-interrupt-message__fallback').exists()).toBe(true);
     expect(wrapper.text()).toContain('暂不支持的中断消息');
+  });
+
+  it('success outcome 不渲染中断卡片', () => {
+    wrapper = mount(InterruptMessage, {
+      props: {
+        outcome: {
+          type: 'success',
+        },
+      },
+    });
+
+    expect(wrapper.find('.ai-tool-approval-card').exists()).toBe(false);
+    expect(wrapper.find('.ai-interrupt-message__fallback').exists()).toBe(false);
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
@@ -33,23 +33,18 @@
   import { t } from '../../../lang/lang';
   import ToolApprovalCard from './tool-approval-card.vue';
 
-  import type { InterruptItem, InterruptMessage, OnInterruptResume } from '../../../ag-ui/types/interrupt';
+  import type { Interrupt, InterruptMessage, OnInterruptResume } from '../../../ag-ui/types/interrupt';
 
   const interruptRenderers: Partial<Record<InterruptReason, Component>> = {
     [InterruptReason.AIDevToolApproval]: ToolApprovalCard,
   };
 
-  const props = defineProps<
-    Partial<InterruptMessage> & {
-      interrupt?: InterruptItem[];
-      onInterruptResume?: OnInterruptResume;
-    }
-  >();
+  const props = defineProps<Partial<InterruptMessage> & { onInterruptResume?: OnInterruptResume }>();
 
-  const interruptList = computed(() => props.interrupt ?? []);
+  const interruptList = computed(() => (props.outcome?.type === 'interrupt' ? props.outcome.interrupts : []));
   const displayMessage = computed(() => props.message || props.content);
 
-  const getRenderer = (item: InterruptItem) => interruptRenderers[item.reason];
+  const getRenderer = (item: Interrupt) => interruptRenderers[item.reason];
 </script>
 
 <style lang="scss">

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -65,7 +65,7 @@
   import { Button } from 'bkui-vue';
 
   import { APPROVAL_STATUS_MAP } from '../../../ag-ui/types/constants';
-  import { APPROVAL_STATUS } from '../../../ag-ui/types/interrupt';
+  import { APPROVAL_STATUS } from '../../../ag-ui/types/constants';
   import { useClipboard } from '../../../composables';
   import { useCommonTippyInject } from '../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../directives/overflow-tips';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.vue
@@ -2,17 +2,18 @@
   <div class="toolcall-desc">
     <div class="desc-title">{{ title }}</div>
     <div class="desc-panel">
-      <template v-if="typeof data === 'object'">
+      <!-- null 的 typeof 为 object，需排除，避免 v-for 异常；键/值统一转字符串以满足 HighlightKeyword -->
+      <template v-if="data !== null && typeof data === 'object'">
         <div
           v-for="(value, key) in data"
           :key="key"
           class="desc-panel-item"
         >
-          <span class="desc-label"><HighlightKeyword :text="key" />:</span>
+          <span class="desc-label"><HighlightKeyword :text="String(key)" />:</span>
           <span class="desc-value">
             <HighlightKeyword
               style="word-break: break-all"
-              :text="typeof value === 'object' && value ? JSON.stringify(value) : value"
+              :text="formatHighlightSegment(value)"
             />
           </span>
         </div>
@@ -20,7 +21,7 @@
       <template v-else
         ><HighlightKeyword
           :style="{ wordBreak: 'break-all' }"
-          :text="data"
+          :text="formatHighlightSegment(data)"
       /></template>
     </div>
   </div>
@@ -34,9 +35,17 @@
     desc?: string;
     title: string;
   }>();
-  const data = computed<Record<string, string>>(() => {
+
+  /** JSON 解析后的标量 / 嵌套对象均转为可展示的字符串，供 HighlightKeyword（String prop）使用 */
+  const formatHighlightSegment = (value: unknown): string => {
+    if (value === undefined || value === null) return '';
+    if (typeof value === 'object') return JSON.stringify(value);
+    return String(value);
+  };
+
+  const data = computed(() => {
     try {
-      return JSON.parse(props.desc || '');
+      return JSON.parse(props.desc || '') as unknown;
     } catch {
       return props.desc;
     }

--- a/src/frontend/ai-blueking/packages/chat-x/src/directives/overflow-tips.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/directives/overflow-tips.ts
@@ -28,7 +28,7 @@ import type { ObjectDirective } from 'vue';
 
 import tippy, { type Instance, type Props } from 'tippy.js';
 
-import { type noop } from '../types';
+import type { noop } from '../types';
 
 import 'tippy.js/dist/tippy.css';
 
@@ -54,6 +54,13 @@ export const OverflowTips: ObjectDirective<OverflowElement, Partial<Props> & { d
       }
       isMouseenter = true;
       if (!instance) {
+        // text / disabled 为指令扩展字段，不可传入 tippy（否则会触发「text is not a valid prop」等开发态警告）
+        const src: Partial<Props> & { disabled?: boolean; text?: string } = {
+          ...(binding.value ?? {}),
+        };
+        const overflowTipText = src.text;
+        delete src.text;
+        delete src.disabled;
         instance = tippy(
           el,
           Object.assign(
@@ -61,9 +68,9 @@ export const OverflowTips: ObjectDirective<OverflowElement, Partial<Props> & { d
             {
               trigger: 'mouseenter',
               delay: [DelayMs, 0],
-              content: binding.value?.text || binding.value?.content || el.innerText,
-              placement: binding.value?.placement || 'auto',
-              theme: binding.value?.theme || 'ai-chat-box',
+              content: overflowTipText || src.content || el.innerText,
+              placement: src.placement || 'auto',
+              theme: src.theme || 'ai-chat-box',
               onShow: () => {
                 if (!getIsEllipsis(el)) {
                   return false;
@@ -75,9 +82,7 @@ export const OverflowTips: ObjectDirective<OverflowElement, Partial<Props> & { d
                 instance = undefined;
               },
             },
-            {
-              ...binding.value,
-            },
+            src,
           ),
         );
         // 初始化第一次进入时 tippy 可能出现不展示的情况 这里直接延时处理

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-render.md
@@ -170,6 +170,7 @@ MessageRender
 │     ├── 'tool'       → ToolMessage（转发 message）
 │     ├── 'activity'   → ActivityMessage（转发 message）
 │     ├── 'loading'    → LoadingMessage（转发 message）
+│     ├── 'interrupt'  → InterruptMessage（转发 message + onInterruptResume）
 │     │
 │     └── 其他 / 未知   → null（不渲染任何内容）
 ```
@@ -442,6 +443,7 @@ slot 参数类型与 `AssistantMessage` 的 slot 保持一致（`Partial<Assista
 | messageToolsStatus | `MessageToolsStatus`                                                       | —      | 工具按钮状态；**仅转发给 `UserMessage`**          |
 | onAction           | `(tool: IToolBtn) => Promise<string[] \| void>`                            | —      | 工具操作回调；**仅转发给 `UserMessage`**          |
 | onInputConfirm     | `(content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | —      | 用户编辑确认回调；**仅转发给 `UserMessage`**      |
+| onInterruptResume  | `(interrupt: Interrupt, payload?: Record<string, any>) => Promise<void>`   | —      | 中断响应回调；**仅转发给 `InterruptMessage`**     |
 | onShortcutConfirm  | `(formModel: Record<string, unknown>) => Promise<void>`                    | —      | 用户快捷指令提交回调；**仅转发给 `UserMessage`**  |
 | tippyOptions       | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>` | —      | 自定义 Tippy 配置；**仅转发给 `UserMessage`**     |
 
@@ -463,6 +465,7 @@ slot 参数类型与 `AssistantMessage` 的 slot 保持一致（`Partial<Assista
 | `tool`        | `ToolMessage`      | `message`                                                                                               | 工具调用返回结果      |
 | `activity`    | `ActivityMessage`  | `message`                                                                                               | 知识检索 / 引用文档   |
 | `loading`     | `LoadingMessage`   | `message`（字段被忽略，组件无 Props）                                                                   | 等待响应的加载占位    |
+| `interrupt`   | `InterruptMessage` | `message` + `onInterruptResume`                                                                         | human-in-the-loop 中断 |
 | 其他 / 未知   | —                  | —                                                                                                       | 返回 `null`，不渲染   |
 
 ## 类型定义

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
@@ -41,6 +41,7 @@ enum MessageRole {
   HiddenSystem = 'hidden-system',
   HiddenUser = 'hidden-user',
   Info = 'info',
+  Interrupt = 'interrupt',
   Loading = 'loading',
   Pause = 'pause',
   Placeholder = 'placeholder',
@@ -76,6 +77,42 @@ enum MessageStatus {
 | 枚举值          | 说明 |
 | --------------- | ---- |
 | `Fetching`      | 请求中：与 `useMessageGroup` 在末尾用户消息后注入的 Loading 占位（`LOADING_MESSAGE_ID`）配合时，`ChatContainer` 会将传入输入区与列表底部的状态推导为该值，便于展示「停止」与禁止重复发送。 |
+
+### InterruptReason
+
+human-in-the-loop 中断原因枚举，用于 `Interrupt.reason` 区分中断类型并选择对应的 UI 渲染器。
+
+```typescript
+enum InterruptReason {
+  AIDevToolApproval = 'ai_dev:tool_approval',
+  HumanApproval = 'human_approval',
+  UserMultiChoice = 'user_multi_choice',
+  UserSingleChoice = 'user_single_choice',
+}
+```
+
+### APPROVAL_STATUS
+
+AI Dev 工具审批单状态枚举，`AIDevToolApprovalInterrupt.metadata.ticket.status` 使用该类型。
+
+```typescript
+enum APPROVAL_STATUS {
+  ABANDONED = 'abandoned',
+  APPROVED = 'approved',
+  CANCELLED = 'cancelled',
+  EXPIRED = 'expired',
+  PENDING = 'pending',
+  REJECTED = 'rejected',
+}
+```
+
+### RunFinishedOutcome
+
+AG-UI `RUN_FINISHED` 事件的结束结果类型。中断结果不再是字符串枚举，而是对象联合类型；`type: 'interrupt'` 时，中断列表放在 `interrupts` 字段中。
+
+```typescript
+type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
+```
 
 ### MessageContentType
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -112,6 +112,9 @@ enum MessageRole {
   // 信息消息
   Info = 'info',
 
+  // human-in-the-loop 中断消息
+  Interrupt = 'interrupt',
+
   // 加载中消息
   Loading = 'loading',
 
@@ -341,6 +344,53 @@ const knowledgeRagMessage: ActivityMessage = {
 | `name`       | `string` | 文档名称         |
 | `url`        | `string` | 文档预览链接     |
 | `originFile` | `string` | 文档原始文件链接 |
+
+### InterruptMessage
+
+human-in-the-loop 中断消息，对应 AG-UI `RUN_FINISHED` 事件的 `outcome` 对象结构。`type: 'interrupt'` 时，组件从 `outcome.interrupts` 渲染中断卡片；`type: 'success'` 表示 resume 后的成功结果，不渲染中断卡片。
+
+```typescript
+type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
+
+interface InterruptMessage extends BaseMessage<MessageRole.Interrupt, string> {
+  message?: string;
+  outcome?: RunFinishedOutcome;
+  result?: unknown;
+  runId?: string;
+  threadId?: string;
+}
+
+const interruptMessage: InterruptMessage = {
+  id: 'interrupt-message-1',
+  messageId: 'interrupt-message-1',
+  role: MessageRole.Interrupt,
+  content: '',
+  status: MessageStatus.Complete,
+  runId: 'run_ai_dev_tool_approval',
+  threadId: 'thread_ai_dev_tool_approval',
+  outcome: {
+    type: 'interrupt',
+    interrupts: [
+      {
+        id: 'interrupt_ai_dev_tool_approval',
+        reason: InterruptReason.AIDevToolApproval,
+        toolCallId: 'tool_call_review_ticket',
+        message: '算法方案评审单正在评审中',
+        metadata: {
+          ticket: {
+            approvers: ['张三', '李四'],
+            sn: 'REV-2026-04-24-001',
+            status: APPROVAL_STATUS.PENDING,
+            submit_time: '2026-04-24 14:30:15',
+            title: '算法方案评审单',
+            url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+          },
+        },
+      },
+    ],
+  },
+};
+```
 
 ### InfoMessage
 


### PR DESCRIPTION
- ag-ui types 新增 InterruptReason / RunFinishedOutcome 枚举与 MessageRole.Interrupt
- 新增 interrupt.ts 类型定义（InterruptMessage、UserChoicePayload、OnInterruptResume 等）
- 新增 interrupt-message 组件族：interrupt-message / interrupt-choice-list /
  interrupt-option-btn / interrupt-result，支持单选 & 多选两种 reason
- message-render / message-container / chat-container / chat-input 透传
  onInterruptResume 回调，串联用户响应到上层
- playground 增加 mock 中断消息用于联调验证
- lang 补充“请选择以继续 / 继续 / 收到信息”等文案
# Reviewed, transaction id: 79003