### PR TITLE
feat(chat-x): 侧栏 Tab/内容可自定义渲染，FlowAgent 支持有效证据与激活态

### DIFF
--- a/src/frontend/ai-blueking/biome.json
+++ b/src/frontend/ai-blueking/biome.json
@@ -11,6 +11,12 @@
           "fix": "none",
           "level": "error"
         }
+      },
+      "suspicious": {
+        "noDebugger": {
+          "fix": "none",
+          "level": "error"
+        }
       }
     }
   }

--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -13,6 +13,8 @@
       v-model:render-mode="chatMode"
       v-model:selected-shortcut="selectedShortcut"
       :enable-selection="false"
+      :get-side-render-component="getSideRenderComponent"
+      :get-side-tab-render-component="getSideTabRenderComponent"
       :messages="messages"
       :model-value="userInput"
       :on-agent-action="handleAgentAction"
@@ -64,7 +66,7 @@
 </template>
 
 <script setup lang="ts">
-  import { ref as deepRef, onMounted, shallowRef } from 'vue';
+  import { ref as deepRef, h, onMounted, shallowRef } from 'vue';
 
   import { tr } from 'zod/locales';
 
@@ -84,11 +86,12 @@
     MessageStatus,
     RenderMode,
   } from '../src';
+  import CustomTabContent from './custom-tab-content.vue';
   import { streamContent } from './markdown';
   import { MOCK_PROMPTS, MOCK_RESOURCES } from './mock';
   import { uploadFileToSession } from './upload-file';
 
-  import type { IAiSlashMenuItem, Shortcut, TagSchema } from '../src/types';
+  import type { CustomTab, IAiSlashMenuItem, Shortcut, TagSchema } from '../src/types';
   import type { IToolBtn } from '../src/types/tool';
 
   import '../src/styles/global.scss';
@@ -257,6 +260,8 @@
       content: [
         {
           task_id: 634859,
+          has_confidence: true,
+          is_active: true,
           task_name: 'benny-flow7_20260202160324',
           task_state: 'FAILED',
           nodes: {
@@ -531,6 +536,35 @@
             { label: '类型A', value: 'A' },
             { label: '类型B', value: 'B' },
           ],
+        },
+        {
+          name: '分析维度',
+          key: 'analysis_dimensions',
+          type: 'checkboxGroup',
+          required: false,
+          fillBack: false,
+          props: {
+            modelValue: ['trace', 'metrics'],
+            options: [
+              { label: '链路 Trace', value: 'trace' },
+              { label: '指标 Metrics', value: 'metrics' },
+              { label: '日志 Log', value: 'log' },
+            ],
+          },
+        },
+        {
+          name: '输出粒度',
+          key: 'output_granularity',
+          type: 'radioGroup',
+          required: true,
+          fillBack: false,
+          props: {
+            modelValue: 'summary',
+            options: [
+              { label: '摘要', value: 'summary' },
+              { label: '详细', value: 'detail' },
+            ],
+          },
         },
       ],
     },
@@ -1087,6 +1121,48 @@
     return MOCK_NODE_DETAIL;
   };
 
+  /**
+   * ChatContainer `getSideRenderComponent` 与侧栏 `<component :is="...">` 配合使用：
+   * - 返回 `undefined`：使用 `addCustomTab` 时 `data.component`（如 FlowAgent 里的 BkFlowNodeDetail）。
+   * - 返回 VNode：用 `createElement`（即 `h`）挂自定义根，例如 `createElement(CustomTabContent, props)`；
+   *   `props` 与 `tab.data.props` 一致（含 node_name、task_id、loading、data 等）。
+   * 将下方开关改为 `true` 时侧栏使用 `./custom-tab-content.vue` 覆盖默认的 BkFlowNodeDetail。
+   */
+  // const PLAYGROUND_GET_SIDE_VNODE_DEMO = true;
+
+  const getSideRenderComponent = (createElement: typeof h, props?: Record<string, unknown>) => {
+    // if (!PLAYGROUND_GET_SIDE_VNODE_DEMO) {
+    //   return undefined;
+    // }
+    const raw = props ?? {};
+    const taskIdRaw = raw.task_id;
+    const taskId =
+      typeof taskIdRaw === 'number'
+        ? taskIdRaw
+        : typeof taskIdRaw === 'string' && taskIdRaw !== ''
+          ? Number(taskIdRaw)
+          : undefined;
+    return createElement(CustomTabContent, {
+      loading: Boolean(raw.loading),
+      nodeId: typeof raw.node_id === 'string' ? raw.node_id : '',
+      nodeName: typeof raw.node_name === 'string' ? raw.node_name : '',
+      taskId: Number.isFinite(taskId as number) ? (taskId as number) : undefined,
+      taskName: typeof raw.task_name === 'string' ? raw.task_name : '',
+      data:
+        typeof raw.data === 'object' && raw.data !== null && !Array.isArray(raw.data)
+          ? (raw.data as Record<string, unknown>)
+          : {},
+    });
+  };
+
+  const getSideTabRenderComponent = (createElement: typeof h, tab: CustomTab<Record<string, unknown>>) => {
+    console.info(tab);
+    if (tab.name === '634859') {
+      return createElement('div', {}, 'dddd');
+    }
+    return undefined;
+  };
+
   const handleAgentAction = async (tool: IToolBtn) => {
     console.log('agent action:', tool);
     await new Promise(resolve => setTimeout(resolve, 2000));
@@ -1177,7 +1253,7 @@
 
   onMounted(() => {
     let content = '';
-    const chunkSize = 1000000000000000;
+    const chunkSize = 1999999999;
     const interval = setInterval(() => {
       content += streamContent.slice(content.length, content.length + chunkSize);
       const status = content.length >= streamContent.length ? MessageStatus.Complete : MessageStatus.Streaming;

--- a/src/frontend/ai-blueking/packages/chat-x/playground/custom-tab-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/custom-tab-content.vue
@@ -1,0 +1,209 @@
+<!--
+  Playground 侧栏自定义 Tab 内容示例：与 FlowAgent addCustomTab 的 data.props 语义对齐（在 chat-bot-new 中映射为 camelCase），
+  模板内需保留 locateButton 插槽，以便 ChatContainer 注入「在对话中定位」按钮。
+-->
+<template>
+  <div class="playground-custom-tab-root">
+    <header class="playground-custom-tab-header">
+      <h3 class="playground-custom-tab-title">
+        <template v-if="loading">
+          <span class="playground-custom-tab-title-text">自定义侧栏</span>
+          <span class="playground-custom-tab-skeleton-title ai-skeleton-element" />
+        </template>
+        <template v-else>
+          {{ titleText }}
+        </template>
+      </h3>
+      <div class="playground-custom-tab-actions">
+        <slot name="locateButton" />
+      </div>
+    </header>
+
+    <div class="playground-custom-tab-body">
+      <p
+        v-if="!loading"
+        class="playground-custom-tab-hint"
+      >
+        Playground 示例：<code>getSideRenderComponent</code> 返回 <code>h(CustomTabContent, props)</code>；props 与
+        tab.data.props 对应字段一致。
+      </p>
+
+      <dl
+        v-if="!loading"
+        class="playground-custom-tab-meta"
+      >
+        <div class="playground-custom-tab-meta-row">
+          <dt>task_id</dt>
+          <dd>{{ taskIdDisplay }}</dd>
+        </div>
+        <div class="playground-custom-tab-meta-row">
+          <dt>task_name</dt>
+          <dd>{{ taskName || '—' }}</dd>
+        </div>
+        <div class="playground-custom-tab-meta-row">
+          <dt>node_id</dt>
+          <dd>{{ nodeId || '—' }}</dd>
+        </div>
+        <div class="playground-custom-tab-meta-row">
+          <dt>node_name</dt>
+          <dd>{{ nodeName || '—' }}</dd>
+        </div>
+      </dl>
+
+      <div
+        v-if="loading"
+        class="playground-custom-tab-loading"
+      >
+        <div
+          v-for="i in 4"
+          :key="i"
+          class="playground-custom-tab-skeleton-row ai-skeleton-element"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed } from 'vue';
+
+  const props = withDefaults(
+    defineProps<{
+      /** 节点详情等业务数据（与侧栏 data.props.data 对齐） */
+      data?: Record<string, unknown>;
+      loading?: boolean;
+      nodeId?: string;
+      nodeName?: string;
+      taskId?: number;
+      taskName?: string;
+    }>(),
+    {
+      data: () => ({}),
+      loading: false,
+      nodeId: '',
+      nodeName: '',
+      taskName: '',
+    },
+  );
+
+  const titleText = computed(() => {
+    const name = props.nodeName?.trim();
+    return name ? `自定义侧栏：${name}` : '自定义侧栏';
+  });
+
+  const taskIdDisplay = computed(() => (props.taskId != null ? String(props.taskId) : '—'));
+</script>
+
+<style lang="scss" scoped>
+  .playground-custom-tab-root {
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #63656e;
+    background: #f5f7fa;
+  }
+
+  .playground-custom-tab-header {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: space-between;
+    padding: 12px 16px;
+    background: #fff;
+    border-bottom: 1px solid #dcdee5;
+  }
+
+  .playground-custom-tab-title {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    min-height: 22px;
+    margin: 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: #313238;
+  }
+
+  .playground-custom-tab-title-text {
+    flex-shrink: 0;
+  }
+
+  .playground-custom-tab-skeleton-title {
+    display: inline-block;
+    width: 120px;
+    height: 14px;
+    vertical-align: middle;
+    border-radius: 2px;
+  }
+
+  .playground-custom-tab-actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    margin-left: 12px;
+  }
+
+  .playground-custom-tab-body {
+    flex: 1;
+    padding: 12px 16px;
+    overflow: auto;
+  }
+
+  .playground-custom-tab-hint {
+    margin: 0 0 12px;
+    color: #979ba5;
+
+    code {
+      padding: 0 4px;
+      font-family: monospace;
+      font-size: 11px;
+      color: #313238;
+      background: #eaebf0;
+      border-radius: 2px;
+    }
+  }
+
+  .playground-custom-tab-meta {
+    margin: 0;
+  }
+
+  .playground-custom-tab-meta-row {
+    display: grid;
+    grid-template-columns: 88px 1fr;
+    gap: 8px;
+    padding: 6px 0;
+    border-bottom: 1px solid #eaebf0;
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    dt {
+      margin: 0;
+      font-weight: 500;
+      color: #979ba5;
+    }
+
+    dd {
+      margin: 0;
+      color: #313238;
+      word-break: break-all;
+    }
+  }
+
+  .playground-custom-tab-loading {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding-top: 8px;
+  }
+
+  .playground-custom-tab-skeleton-row {
+    height: 12px;
+    border-radius: 2px;
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/markdown.ts
@@ -1179,6 +1179,7 @@ export const streamContent = `
 **Markdown 行内链接**：[腾讯蓝鲸](https://bk.tencent.com/) · [chat-x npm](https://www.npmjs.com/package/@blueking/chat-x)
 **Markdown 自动链接**：<https://github.com/TencentBlueKing/bk-aidev-agent>
 
+
 #### 3. Align content
 
 ::: hljs-left
@@ -1268,4 +1269,62 @@ git status
     function legacy() {
       return 'indented block';
     }
+
+---
+
+#### 5. XSS / HTML 注入风险回归（playground）
+
+以下用于验证 Markdown 渲染与 \`sanitizeHtmlFragment\` 等净化逻辑；**勿在生产会话中粘贴未信任内容**。
+
+**行内 / 块级 HTML（事件、可执行载体）**
+
+<img src=x onerror=alert(1)>
+<img src="x" onerror="alert(String.fromCharCode(88,83,83))">
+<svg/onload=alert(1)>
+<body onload=alert(1)>
+<input onfocus=alert(1) autofocus>
+<details open ontoggle=alert(1)>
+<marquee onstart=alert(1)>x</marquee>
+<script>alert('markdown-inline-script')</script>
+<script src="https://example.com/evil.js"></script>
+
+**危险协议与伪协议链接（Markdown 语法）**
+
+[javascript: 伪协议](javascript:alert(1))
+[javascript: 含空格绕过尝试](java script:alert(1))
+[data: HTML](data:text/html,<script>alert(1)</script>)
+[vbscript: 协议](vbscript:msgbox(1))
+[file: 协议](file:///etc/passwd)
+
+**原始 a / img / iframe / object**
+
+<a href="javascript:alert(1)">a href javascript</a>
+<a href="JavaScript:alert(1)">大小写混合 javascript</a>
+<a href="#" onclick="alert(1)">含 onclick 的 a</a>
+<a href="https://bk.tencent.com" onclick="alert(1)">合法 href + 事件属性</a>
+<img src="javascript:alert(1)" alt="img js src">
+<iframe src="javascript:alert(1)"></iframe>
+<object data="javascript:alert(1)"></object>
+<embed src="javascript:alert(1)">
+
+**style 与 CSS 注入（含 expression、url）**
+
+<div style="width:100px;height:100px;background:red">正常 style</div>
+<div style="background:url('javascript:alert(1)')">style url javascript</div>
+<div style="width:expression(alert(1))">IE expression（历史向量）</div>
+<div style="behavior:url(xss.htc)">behavior（IE）</div>
+
+**实体编码 / 混淆尝试（解析器差异）**
+
+<img src=x onerror&#61;"alert(1)">
+<a href="&#106;avascript:alert(1)">实体编码 javascript</a>
+
+**Markdown 自动链接角括号（若解析为链接需校验协议）**
+
+<javascript:alert(1)>
+<data:text/html,<base href=//evil.com/>>
+
+**「看起来像代码」但实际为 HTML 的行（非围栏块）**
+
+<code onclick="alert(1)">可点代码</code>
 `;

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
@@ -86,6 +86,8 @@ export type BkFlowNode = {
 };
 
 export type BkFlowTask = {
+  has_confidence?: boolean; // 是否有有效证据， 置信度
+  is_active?: boolean; // 是否默认激活
   nodes: Record<string, BkFlowNode>;
   statistics: {
     state_counts: Record<string, number>;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.spec.ts
@@ -60,7 +60,7 @@ vi.mock('bkui-vue', () => {
     setup(props, { slots }) {
       return () =>
         h('div', { class: 'mock-form-item', 'data-property': props.property }, [
-          h('label', { class: 'mock-label' }, props.label),
+          slots.label ? slots.label() : h('label', { class: 'mock-label' }, props.label),
           slots.default?.(),
         ]);
     },
@@ -304,6 +304,26 @@ describe('ShortcutRender', () => {
       });
 
       expect(wrapper.find('.mock-input').exists()).toBe(true);
+    });
+
+    it('应通过 label 插槽渲染 component.name', () => {
+      const components: ShortcutComponent[] = [
+        {
+          key: 'name',
+          name: '姓名',
+          type: 'input',
+        },
+      ];
+
+      wrapper = mount(ShortcutRender, {
+        props: {
+          id: 'test',
+          name: '测试',
+          components,
+        },
+      });
+
+      expect(wrapper.find('.shortcut-render-form-label').text()).toBe('姓名');
     });
 
     it('应该渲染 textarea 类型组件', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.vue
@@ -25,6 +25,11 @@
             class="shortcut-render-form-item"
             :style="{ gridColumn: getGridColumn(component, index) }"
           >
+            <template #label>
+              <span class="shortcut-render-form-label">
+                {{ component.name ?? component.formItemProps?.label }}
+              </span>
+            </template>
             <component :is="getComponent(component)" />
           </Form.FormItem>
         </template>
@@ -107,6 +112,7 @@
     const { options: oldOptions, ...oldProps } = component ?? {};
     const options = (componentOptions ?? oldOptions) as { label: string; value: string }[];
     const componentProps = {
+      class: `shortcut-render-form-item_${component.type}`,
       ...oldProps,
       ...otherProps,
       modelValue: localFormModel[component.key],
@@ -148,6 +154,7 @@
           componentProps,
           options?.map(option =>
             h(Checkbox, {
+              class: 'shortcut-render-form-item_checkbox',
               ...option,
             }),
           ),
@@ -159,6 +166,7 @@
           componentProps,
           options?.map(option =>
             h(Radio, {
+              class: 'shortcut-render-form-item_radio',
               ...option,
             }),
           ),
@@ -274,17 +282,21 @@
           }
         }
 
-        .#{$bk-prefix}-form-label {
+        &-label {
           font-size: 12px;
           color: #4d4f56;
         }
 
-        .#{$bk-prefix}-form-item {
+        &-item {
           margin-bottom: 16px;
 
-          .#{$bk-prefix}-radio-label,
-          .#{$bk-prefix}-checkbox-label {
+          &_radio,
+          &_checkbox {
             font-size: 12px;
+
+            span {
+              font-size: 12px;
+            }
           }
 
           &:last-child {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -23,27 +23,55 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, h } from 'vue';
+import { type Ref, defineComponent, h, nextTick } from 'vue';
 
-import { type VueWrapper, mount } from '@vue/test-utils';
+import { type ComponentMountingOptions, type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { MessageRole, MessageStatus } from '../../ag-ui/types';
 import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
-import ChatContainer from './chat-container.vue';
+import ChatContainer, { type ChatContainerProps } from './chat-container.vue';
 
 import type { AssistantMessage, Message, UserMessage } from '../../ag-ui/types';
+
+/** defineExpose 暴露的实例 API */
+type ChatContainerExposed = {
+  addCustomTab: (tab: { data?: Record<string, unknown>; label: string; name: string }) => void;
+  enterShareMode: () => void;
+  exitShareMode: () => void;
+  removeCustomTab: (name: string) => void;
+  selectCustomTab: (tab: unknown) => void;
+  selectedTab: unknown;
+};
+
+/** 测试 mount 时使用的 props 集合 */
+type ChatContainerMountProps = ChatContainerProps & {
+  messages: Message[];
+  messageStatus: MessageStatus;
+  modelValue: string;
+  renderMode?: RenderMode;
+};
+
+type MockMessageGroup = {
+  messages: Array<{ id?: string }>;
+};
+
+const getChatContainerExposed = (w: VueWrapper): ChatContainerExposed => w.vm as unknown as ChatContainerExposed;
+
+const getMountProps = (w: VueWrapper): ChatContainerMountProps => w.props() as ChatContainerMountProps;
 
 /** 供 useMessageGroup mock 注入，用于验证 inputStatus 对 Loading 占位消息的推导 */
 const mockMessageGroupsRef = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { ref } = require('vue');
-  return ref<
-    Array<{
-      messages: Array<{ id?: string }>;
-    }>
-  >([]);
+  const { ref: vueRef } = require('vue');
+  return vueRef([]) as Ref<MockMessageGroup[]>;
 });
+const mockExecutionGroupsRef = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: vueRef } = require('vue');
+  return vueRef([]) as Ref<unknown[]>;
+});
+const mockUseMessageGroup = vi.hoisted(() => vi.fn());
 const mockUseRenderModeProvider = vi.hoisted(() => vi.fn());
 
 vi.mock('bkui-vue', () => {
@@ -57,19 +85,19 @@ vi.mock('bkui-vue', () => {
     emits: ['click'],
     setup(_, { slots, emit }) {
       return () =>
-        h(
-          'button',
-          { class: 'mock-bk-button', type: 'button', onClick: () => emit('click') },
-          slots.default?.(),
-        );
+        h('button', { class: 'mock-bk-button', type: 'button', onClick: () => emit('click') }, slots.default?.());
     },
   });
 
   const TabPanel = defineComponent({
     name: 'TabPanel',
     props: { name: String, label: [String, Function] },
-    setup(_, { slots }) {
-      return () => h('div', { class: 'mock-tab-panel' }, slots.default?.());
+    setup(props, { slots }) {
+      return () =>
+        h('div', { class: 'mock-tab-panel', 'data-name': props.name }, [
+          typeof props.label === 'function' ? props.label() : props.label,
+          slots.default?.(),
+        ]);
     },
   });
 
@@ -118,25 +146,27 @@ vi.mock('../../lang/lang', () => ({
 }));
 
 vi.mock('../../composables', () => ({
-  useMessageGroup: vi.fn((_options: { messages: { value: Message[] } }) => {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { computed, shallowRef } = require('vue');
-    const messageGroups = mockMessageGroupsRef;
-    const executionGroups = computed(() => []);
-    const isShareMode = shallowRef(false);
-    const isAllSelected = computed(() => false);
-    return {
-      messageGroups,
-      executionGroups,
-      isShareMode,
-      isAllSelected,
-      onToggleShareAll: vi.fn(),
-      onCancelShare: vi.fn(() => {
-        isShareMode.value = false;
-      }),
-      onConfirmShare: vi.fn(() => []),
-    };
-  }),
+  useMessageGroup: mockUseMessageGroup.mockImplementation(
+    (_options: { keyword: { value: string }; messages: { value: Message[] } }) => {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { computed, shallowRef } = require('vue');
+      const messageGroups = mockMessageGroupsRef;
+      const executionGroups = computed(() => mockExecutionGroupsRef.value);
+      const isShareMode = shallowRef(false);
+      const isAllSelected = computed(() => false);
+      return {
+        messageGroups,
+        executionGroups,
+        isShareMode,
+        isAllSelected,
+        onToggleShareAll: vi.fn(),
+        onCancelShare: vi.fn(() => {
+          isShareMode.value = false;
+        }),
+        onConfirmShare: vi.fn(() => []),
+      };
+    },
+  ),
 }));
 
 vi.mock('../../composables/use-common', () => ({
@@ -356,16 +386,29 @@ const createAssistantMessage = (id: string, content: string): AssistantMessage =
 describe('ChatContainer', () => {
   let wrapper: VueWrapper;
 
-  const defaultProps = {
-    messages: [] as Message[],
+  const defaultProps: ChatContainerMountProps = {
+    messages: [],
     messageStatus: MessageStatus.Complete,
     /** ChatInput 必填 v-model，避免测试告警 */
     modelValue: '',
   };
 
+  /** welcome 插槽单测：仅注入 welcome，避免补齐全部 slots 类型 */
+  const mountWithWelcomeSlot = (openingRemark: string) => {
+    const options = {
+      props: { ...defaultProps, openingRemark },
+      slots: {
+        welcome: ({ openingRemark: remark }: { openingRemark?: string }) =>
+          h('div', { class: 'custom-welcome' }, `自定义: ${remark ?? ''}`),
+      },
+    } as unknown as ComponentMountingOptions<typeof ChatContainer>;
+    return mount(ChatContainer, options);
+  };
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockMessageGroupsRef.value = [];
+    mockExecutionGroupsRef.value = [];
   });
 
   afterEach(() => {
@@ -435,13 +478,7 @@ describe('ChatContainer', () => {
     });
 
     it('应该支持 welcome 插槽自定义欢迎内容', () => {
-      wrapper = mount(ChatContainer, {
-        props: { ...defaultProps, openingRemark: '默认开场白' },
-        slots: {
-          welcome: ({ openingRemark }: { openingRemark: string }) =>
-            h('div', { class: 'custom-welcome' }, `自定义: ${openingRemark}`),
-        },
-      });
+      wrapper = mountWithWelcomeSlot('默认开场白');
 
       expect(wrapper.find('.custom-welcome').exists()).toBe(true);
       expect(wrapper.find('.custom-welcome').text()).toBe('自定义: 默认开场白');
@@ -449,13 +486,7 @@ describe('ChatContainer', () => {
     });
 
     it('使用 welcome 插槽时应替换整块默认欢迎区（含 Banner 与默认标题）', () => {
-      wrapper = mount(ChatContainer, {
-        props: { ...defaultProps, openingRemark: '默认开场白' },
-        slots: {
-          welcome: ({ openingRemark }: { openingRemark: string }) =>
-            h('div', { class: 'custom-welcome' }, `自定义: ${openingRemark}`),
-        },
-      });
+      wrapper = mountWithWelcomeSlot('默认开场白');
 
       expect(wrapper.find('.mock-banner-icon').exists()).toBe(false);
       expect(wrapper.find('.ai-welcome-title').exists()).toBe(false);
@@ -530,11 +561,11 @@ describe('ChatContainer', () => {
         props: defaultProps,
       });
 
-      const vm = wrapper.vm;
-      expect(vm.selectedTab).toBeDefined();
-      expect(vm.addCustomTab).toBeDefined();
-      expect(vm.removeCustomTab).toBeDefined();
-      expect(vm.selectCustomTab).toBeDefined();
+      const exposed = getChatContainerExposed(wrapper);
+      expect(exposed.selectedTab).toBeDefined();
+      expect(exposed.addCustomTab).toBeDefined();
+      expect(exposed.removeCustomTab).toBeDefined();
+      expect(exposed.selectCustomTab).toBeDefined();
     });
 
     it('应该暴露 enterShareMode 和 exitShareMode 方法', () => {
@@ -542,9 +573,9 @@ describe('ChatContainer', () => {
         props: defaultProps,
       });
 
-      const vm = wrapper.vm;
-      expect(typeof vm.enterShareMode).toBe('function');
-      expect(typeof vm.exitShareMode).toBe('function');
+      const exposed = getChatContainerExposed(wrapper);
+      expect(typeof exposed.enterShareMode).toBe('function');
+      expect(typeof exposed.exitShareMode).toBe('function');
     });
   });
 
@@ -554,7 +585,7 @@ describe('ChatContainer', () => {
         props: defaultProps,
       });
 
-      expect(wrapper.props().placement).toBe('left');
+      expect(getMountProps(wrapper).placement).toBe('left');
     });
 
     it('应该接收 placement 属性', () => {
@@ -562,7 +593,7 @@ describe('ChatContainer', () => {
         props: { ...defaultProps, placement: 'right' },
       });
 
-      expect(wrapper.props().placement).toBe('right');
+      expect(getMountProps(wrapper).placement).toBe('right');
     });
   });
 
@@ -698,6 +729,67 @@ describe('ChatContainer', () => {
       });
 
       expect(wrapper.find('.mock-chat-input').exists()).toBe(true);
+    });
+  });
+
+  describe('侧边栏渲染扩展', () => {
+    it('应接收 getSideRenderComponent 与 getSideTabRenderComponent 属性', () => {
+      const getSideRenderComponent = vi.fn();
+      const getSideTabRenderComponent = vi.fn();
+
+      wrapper = mount(ChatContainer, {
+        props: {
+          ...defaultProps,
+          getSideRenderComponent,
+          getSideTabRenderComponent,
+        },
+      });
+
+      expect(getMountProps(wrapper).getSideRenderComponent).toBe(getSideRenderComponent);
+      expect(getMountProps(wrapper).getSideTabRenderComponent).toBe(getSideTabRenderComponent);
+    });
+
+    it('有搜索关键词且 executionGroups 为空时展开侧栏仍应展示 Tab', async () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages },
+      });
+
+      const keywordRef = mockUseMessageGroup.mock.calls.at(-1)?.[0]?.keyword as { value: string };
+      keywordRef.value = 'search';
+      await nextTick();
+
+      getChatContainerExposed(wrapper).addCustomTab({ label: '自定义 Tab', name: 'custom-tab' });
+      await nextTick();
+
+      expect(wrapper.find('.ai-chat-container-tab').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-container-resize-layout').classes()).not.toContain('ai-is-collapse');
+    });
+
+    it('传入 getSideTabRenderComponent 时应优先使用其渲染 Tab 标签', async () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      const getSideTabRenderComponent = vi.fn((createElement, tab) =>
+        createElement('span', { class: 'custom-tab-label' }, tab.name),
+      );
+
+      wrapper = mount(ChatContainer, {
+        props: {
+          ...defaultProps,
+          messages,
+          getSideTabRenderComponent,
+        },
+      });
+
+      const keywordRef = mockUseMessageGroup.mock.calls.at(-1)?.[0]?.keyword as { value: string };
+      keywordRef.value = 'search';
+      await nextTick();
+
+      getChatContainerExposed(wrapper).addCustomTab({ label: '自定义 Tab', name: 'custom-tab' });
+      await nextTick();
+
+      expect(getSideTabRenderComponent).toHaveBeenCalled();
+      expect(wrapper.find('.custom-tab-label').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -12,12 +12,15 @@
     <ResizeLayout
       v-else
       class="ai-chat-container-resize-layout"
-      :class="{ 'ai-is-collapse': isCollapse || executionGroups?.length < 1 || renderMode === RenderMode.Share }"
+      :class="{
+        'ai-is-collapse':
+          isCollapse || (!keyword?.length && executionGroups?.length < 1) || renderMode === RenderMode.Share,
+      }"
       v-bind="resizeProps"
       @resizing="handleResizing"
     >
       <template #aside>
-        <template v-if="!isCollapse && executionGroups?.length && renderMode !== RenderMode.Share">
+        <template v-if="!isCollapse && (executionGroups?.length || keyword?.length) && renderMode !== RenderMode.Share">
           <Tab
             :active="selectedTab.name"
             class="ai-chat-container-tab"
@@ -28,6 +31,7 @@
             <TabPanel
               v-for="tab in tabs"
               :key="tab.name"
+              class="ai-chat-container-tab-panel"
               :label="
                 () =>
                   h(
@@ -40,7 +44,9 @@
                         }
                       },
                     },
-                    [
+                    getSideTabRenderComponent?.(h, tab, {
+                      removeCustomTab,
+                    }) ?? [
                       h(tab.name === EXECUTION_TAB_NAME ? ExecutionIcon : NodeTabIcon, {
                         class: 'ai-execution-summary-icon',
                       }),
@@ -80,7 +86,7 @@
           <template v-if="selectedTab">
             <div class="ai-chat-container-message-slot">
               <component
-                :is="selectedTab?.data?.component"
+                :is="getSideRenderComponent?.(h, selectedTab?.data?.props ?? {}) ?? selectedTab?.data?.component"
                 :key="selectedTab.name"
                 v-bind="selectedTab?.data?.props"
               >
@@ -262,6 +268,14 @@
   export type ChatContainerProps = {
     chatLoading?: boolean;
     commonTippyOptions?: AITippyProps;
+    // 用于获取侧边栏组件的渲染
+    getSideRenderComponent?: (createElement: typeof h, props?: Record<string, unknown>) => undefined | VNode;
+    // 用于获取侧边栏 tab 的渲染
+    getSideTabRenderComponent?: (
+      createElement: typeof h,
+      tab: CustomTab<Record<string, unknown>>,
+      events: { removeCustomTab: typeof removeCustomTab },
+    ) => undefined | VNode;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onCustomTabChange?: (tab: CustomTab<CustomBkFlowTabData>) => Promise<any>;
     openingRemark?: string;
@@ -397,7 +411,7 @@
   watch(
     () => executionGroups.value,
     newVal => {
-      if (!newVal.length) {
+      if (!newVal.length && !keyword.value) {
         resetCustomTab();
       }
     },
@@ -524,7 +538,7 @@
     &-tab {
       padding: 0 16px;
 
-      .#{$bk-prefix}-tab-header-nav {
+      .bk-tab-header-nav {
         &::-webkit-scrollbar {
           display: inline;
           width: unset;
@@ -532,11 +546,11 @@
         }
       }
 
-      .#{$bk-prefix}-tab-content {
+      .bk-tab-content {
         display: none;
       }
 
-      .#{$bk-prefix}-tab-header-item {
+      .bk-tab-header-item {
         padding: 0 16px;
         font-size: 14px;
       }
@@ -570,35 +584,29 @@
       height: 100%;
       border: none !important;
 
-      .#{$bk-prefix}-resize-layout-main,
-      .#{$bk-prefix}-resize-layout-aside {
-        display: flex;
-        flex-direction: column;
+      > main,
+      > aside {
+        display: flex !important;
+        flex-direction: column !important;
         height: 100%;
-
-        &-content {
-          display: flex;
-          flex-direction: column;
-          height: 100%;
-        }
       }
 
-      .#{$bk-prefix}-resize-layout-main {
+      > aside > div:first-child {
+        display: flex !important;
+        flex-direction: column !important;
+        height: 100% !important;
+      }
+
+      > main {
         position: relative;
         width: var(--resize-main-width);
-
-        // width: 100%;
         padding: 8px;
         overflow: visible;
       }
 
-      .#{$bk-prefix}-resize-layout-aside {
-        display: flex;
-      }
-
       &.ai-is-collapse {
-        .#{$bk-prefix}-resize-layout-aside {
-          flex: 0 0 0;
+        > aside {
+          flex: 0 0 0 !important;
           width: 0;
           padding: 0;
           border: none;
@@ -607,11 +615,7 @@
             display: none;
           }
 
-          .#{$bk-prefix}-resize-trigger {
-            display: none;
-          }
-
-          .#{$bk-prefix}-resize-proxy {
+          > i {
             display: none;
           }
         }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
@@ -34,13 +34,14 @@ import FlowAgentContent from './flow-agent-content.vue';
 
 import type { BkFlowMessageContent, BkFlowTask } from '../../../ag-ui/types/contents';
 
-const { mockAddCustomTab, mockRemoveCustomTab, mockScrollRef } = vi.hoisted(() => {
+const { mockAddCustomTab, mockRemoveCustomTab, mockScrollRef, mockSelectedTab } = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref } = require('vue');
   return {
     mockAddCustomTab: vi.fn(),
     mockRemoveCustomTab: vi.fn(),
     mockScrollRef: ref({ autoScrollEnabled: true }),
+    mockSelectedTab: ref<undefined | { name?: string }>(undefined),
   };
 });
 
@@ -75,7 +76,11 @@ vi.mock('../../../composables', () => ({
 }));
 
 vi.mock('../../../composables/use-custom-tab', () => ({
-  useCustomTabConsumer: () => ({ addCustomTab: mockAddCustomTab, removeCustomTab: mockRemoveCustomTab }),
+  useCustomTabConsumer: () => ({
+    addCustomTab: mockAddCustomTab,
+    removeCustomTab: mockRemoveCustomTab,
+    selectedTab: mockSelectedTab,
+  }),
 }));
 
 // 与业务侧 icons 一致：导出为 VNode，供 cloneVNode / 模板使用
@@ -177,6 +182,7 @@ describe('FlowAgentContent', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockScrollRef.value = { autoScrollEnabled: true };
+    mockSelectedTab.value = undefined;
   });
 
   afterEach(() => {
@@ -339,6 +345,101 @@ describe('FlowAgentContent', () => {
       expect(wrapper.find('.flow-agent-node-time').exists()).toBe(false);
       expect(wrapper.find('.flow-agent-node-detail-btn').exists()).toBe(false);
     });
+
+    it('renderMode 为 Share 时不应渲染任务耗时和有效证据入口', () => {
+      const Parent = defineComponent({
+        setup() {
+          useRenderModeProvider({ renderMode: RenderMode.Share });
+          return () =>
+            h(FlowAgentContent, {
+              content: createContent({ has_confidence: true }),
+            });
+        },
+      });
+
+      wrapper = mount(Parent);
+
+      expect(wrapper.find('.flow-agent-task-trailing').exists()).toBe(false);
+      expect(wrapper.find('.flow-agent-task-time').exists()).toBe(false);
+      expect(wrapper.find('.flow-agent-task-confidence-btn').exists()).toBe(false);
+    });
+  });
+
+  describe('有效证据', () => {
+    it('has_confidence 为 true 时应展示有效证据按钮', () => {
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent({ has_confidence: true }),
+        },
+      });
+
+      expect(wrapper.find('.flow-agent-task-confidence-btn').exists()).toBe(true);
+      expect(wrapper.text()).toContain('有效证据');
+    });
+
+    it('has_confidence 为 true 时任务头应带 has-confidence 类', () => {
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent({ has_confidence: true }),
+        },
+      });
+
+      expect(wrapper.find('.flow-agent-task-header').classes()).toContain('has-confidence');
+    });
+
+    it('点击有效证据应打开带 has_confidence 的自定义 Tab', async () => {
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent({ has_confidence: true }),
+        },
+      });
+
+      await wrapper.find('.flow-agent-task-confidence-btn').trigger('click');
+
+      expect(mockAddCustomTab).toHaveBeenCalled();
+      const payload = mockAddCustomTab.mock.calls.at(-1)?.[0] as {
+        data?: { props?: { has_confidence?: boolean; task_id?: number } };
+        label?: string;
+        name?: string;
+      };
+      expect(payload?.label).toBe('有效证据');
+      expect(payload?.name).toBe('100');
+      expect(payload?.data?.props?.has_confidence).toBe(true);
+      expect(payload?.data?.props?.task_id).toBe(100);
+    });
+  });
+
+  describe('任务选中态', () => {
+    it('未手动选 Tab 时 is_active 任务应带 is-selected 类', () => {
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent({ is_active: true }),
+        },
+      });
+
+      expect(wrapper.find('.flow-agent-task-header').classes()).toContain('is-selected');
+    });
+
+    it('is_active 且 task_tab 为 true 时应自动打开任务 Tab', () => {
+      wrapper = mount(FlowAgentContent, {
+        props: {
+          content: createContent({
+            is_active: true,
+            task_tab: true,
+          } as Partial<BkFlowTask>),
+        },
+      });
+
+      expect(mockAddCustomTab).toHaveBeenCalled();
+      const payload = mockAddCustomTab.mock.calls[0]?.[0] as {
+        data?: { props?: { task_id?: number } };
+        label?: string;
+        name?: string;
+      };
+      expect(payload?.label).toBe('测试任务');
+      expect(payload?.name).toBe('100');
+      expect(payload?.data?.props?.task_id).toBe(100);
+    });
   });
 
   describe('task_outputs', () => {
@@ -375,6 +476,8 @@ describe('FlowAgentContent', () => {
 
       wrapper.unmount();
 
+      expect(mockRemoveCustomTab).toHaveBeenCalledWith('100');
+      expect(mockRemoveCustomTab).toHaveBeenCalledWith('101');
       expect(mockRemoveCustomTab).toHaveBeenCalledWith('100|n1|节点一');
       expect(mockRemoveCustomTab).toHaveBeenCalledWith('100|n2|节点二');
       expect(mockRemoveCustomTab).toHaveBeenCalledWith('101|n3|节点三');

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
@@ -39,13 +39,16 @@
     >
       <div
         class="flow-agent-task-header"
-        @click.stop="toggleTaskExpanded(task)"
+        :class="{
+          'has-confidence': task.has_confidence,
+          'is-selected': isTaskSelected(task),
+        }"
       >
         <span
           class="flow-agent-task-arrow"
           :class="{ 'is-expanded': isTaskExpanded(task) }"
         >
-          <ArrowRightIcon />
+          <ArrowRightIcon @click.stop="toggleTaskExpanded(task)" />
         </span>
         <span class="flow-agent-task-state-icon">
           <Loading
@@ -65,7 +68,20 @@
         >
           <HighlightKeyword :text="task.task_name" />
         </span>
-        <span class="flow-agent-task-time">{{ getTaskTotalTime(task) }}</span>
+        <span
+          v-if="renderMode !== RenderMode.Share"
+          class="flow-agent-task-trailing"
+        >
+          <span class="flow-agent-task-time">{{ getTaskTotalTime(task) }}</span>
+          <span
+            v-if="task.has_confidence"
+            class="flow-agent-task-action-btn flow-agent-task-confidence-btn"
+            @click.stop="handleTaskConfidence(task)"
+          >
+            <NodeOutputIcon />
+            {{ t('有效证据') }}
+          </span>
+        </span>
       </div>
       <div
         v-show="isTaskExpanded(task)"
@@ -75,6 +91,7 @@
           v-for="node in getNodeList(task)"
           :key="node.id"
           class="flow-agent-node-item"
+          :class="{ 'is-selected': isNodeSelected(task, node) }"
         >
           <span
             class="flow-agent-node-status"
@@ -123,7 +140,7 @@
   </div> -->
 </template>
 <script setup lang="ts">
-  import { type ComputedRef, cloneVNode, computed, onUnmounted, shallowRef } from 'vue';
+  import { type ComputedRef, cloneVNode, computed, onUnmounted, shallowRef, watch } from 'vue';
 
   import { Loading } from 'bkui-vue';
 
@@ -187,7 +204,36 @@
     status?: MessageStatusType;
   }>();
 
-  const { addCustomTab, removeCustomTab } = useCustomTabConsumer<CustomBkFlowTabData>()!;
+  const { addCustomTab, removeCustomTab, selectedTab } = useCustomTabConsumer<CustomBkFlowTabData>()!;
+  /** 与 addCustomTab 的 name 保持一致，用于 task / node 选中态 */
+  const selectedTabName = computed(() => selectedTab.value?.name ?? '');
+  const getTaskTabName = (task: BkFlowTask) => (task.task_id != null ? `${task.task_id}` : '');
+  const getConfidenceTabName = (task: BkFlowTask) => (task.task_id != null ? `${task.task_id}` : '');
+  const getNodeTabName = (task: BkFlowTask, node: BkFlowNode) =>
+    task.task_id != null ? `${task.task_id}|${node.id}|${node.name}` : '';
+  /** 用户手动切换 Tab 后不再沿用 is_active 默认高亮 */
+  const hasUserSelectedTab = shallowRef(false);
+  const skipNextTabSelectionMark = shallowRef(false);
+  const hasAutoOpenedActiveTask = shallowRef(false);
+  const markUserTabSelection = () => {
+    hasUserSelectedTab.value = true;
+  };
+  const displaySelectedTabName = computed(() => {
+    if (hasUserSelectedTab.value) {
+      return selectedTabName.value;
+    }
+    const activeTask = taskList.value.find(task => task.is_active);
+    if (activeTask?.task_id != null) {
+      return getTaskTabName(activeTask);
+    }
+    return selectedTabName.value;
+  });
+  const isTaskSelected = (task: BkFlowTask) => {
+    const name = displaySelectedTabName.value;
+    return name === getTaskTabName(task) || name === getConfidenceTabName(task);
+  };
+  const isNodeSelected = (task: BkFlowTask, node: BkFlowNode) =>
+    displaySelectedTabName.value === getNodeTabName(task, node);
   const provideContainerScrollData = useContainerScrollConsumer();
   const collapsed = defineModel<boolean>('collapsed', {
     default: false,
@@ -275,12 +321,32 @@
     return parts.join('');
   };
 
+  const openTaskTab = (task: BkFlowTask, extraProps?: Record<string, unknown>) => {
+    const taskId = task.task_id;
+    if (taskId == null) return;
+    addCustomTab?.({
+      label: task.task_name,
+      name: getTaskTabName(task),
+      data: {
+        component: BkFlowNodeDetail,
+        messageUid: props.messageUid,
+        props: {
+          loading: true,
+          task_id: taskId,
+          task_name: task.task_name,
+          data: {},
+          ...extraProps,
+        },
+      },
+    });
+  };
   const handleNodeDetail = (task: BkFlowTask, node: BkFlowNode) => {
     const taskId = task.task_id;
     if (taskId != null) {
+      markUserTabSelection();
       addCustomTab?.({
         label: node.name,
-        name: `${taskId}|${node.id}|${node.name}`,
+        name: getNodeTabName(task, node),
         data: {
           component: BkFlowNodeDetail,
           messageUid: props.messageUid,
@@ -296,6 +362,46 @@
       });
     }
   };
+  const handleTaskConfidence = (task: BkFlowTask) => {
+    const taskId = task.task_id;
+    if (taskId == null) return;
+    markUserTabSelection();
+    addCustomTab?.({
+      label: t('有效证据'),
+      name: getConfidenceTabName(task),
+      data: {
+        component: BkFlowNodeDetail,
+        messageUid: props.messageUid,
+        props: {
+          loading: true,
+          has_confidence: true,
+          task_id: taskId,
+          task_name: task.task_name,
+          data: {},
+        },
+      },
+    });
+  };
+  watch(
+    () => taskList.value,
+    () => {
+      if (hasAutoOpenedActiveTask.value || hasUserSelectedTab.value) return;
+      const activeTask = taskList.value.find(task => task.is_active && task.task_tab);
+      if (!activeTask) return;
+      hasAutoOpenedActiveTask.value = true;
+      skipNextTabSelectionMark.value = true;
+      openTaskTab(activeTask);
+    },
+    { immediate: true },
+  );
+  watch(selectedTabName, (_name, oldName) => {
+    if (oldName === undefined) return;
+    if (skipNextTabSelectionMark.value) {
+      skipNextTabSelectionMark.value = false;
+      return;
+    }
+    markUserTabSelection();
+  });
   onUnmounted(() => {
     // 这里用于判断是否是在 message-container 中被销毁的.
     // 如果是执行情况下的销毁，则不进行移除
@@ -303,8 +409,10 @@
       return;
     }
     for (const task of taskList.value) {
+      removeCustomTab?.(getTaskTabName(task));
+      removeCustomTab?.(getConfidenceTabName(task));
       for (const node of getNodeList(task)) {
-        removeCustomTab?.(`${task.task_id}|${node.id}|${node.name}`);
+        removeCustomTab?.(getNodeTabName(task, node));
       }
     }
   });
@@ -319,6 +427,7 @@
     $color-danger: #ea3636;
     $color-warning: #f59500;
     $color-hover-bg: #eaebf0;
+    $color-selected-bg: #e1ecff;
     $color-pending: #dcdee5;
     $status-colors: (
       success: $color-success,
@@ -340,6 +449,20 @@
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+    }
+
+    %flow-agent-action-btn {
+      display: none;
+      gap: 2px;
+      align-items: center;
+      justify-content: center;
+      font-size: 12px;
+      color: $color-primary;
+      cursor: pointer;
+
+      &:hover {
+        color: $color-primary-light;
+      }
     }
 
     .ai-activity-message-title {
@@ -396,6 +519,41 @@
         &:hover {
           background: $color-hover-bg;
         }
+
+        &.has-confidence:hover {
+          .flow-agent-task-confidence-btn {
+            display: flex;
+          }
+
+          .flow-agent-task-time {
+            display: none;
+          }
+        }
+
+        &.is-selected {
+          background: $color-selected-bg;
+
+          &:hover {
+            background: $color-selected-bg;
+          }
+        }
+
+        &.has-confidence.is-selected {
+          .flow-agent-task-time {
+            display: none;
+          }
+        }
+      }
+
+      &-trailing {
+        display: flex;
+        flex-shrink: 0;
+        align-items: center;
+        margin-left: 8px;
+      }
+
+      &-action-btn {
+        @extend %flow-agent-action-btn;
       }
 
       &-arrow {
@@ -433,9 +591,9 @@
       }
 
       &-time {
-        flex-shrink: 0;
-        margin-left: 8px;
         color: $color-text-secondary;
+        text-align: right;
+        white-space: nowrap;
       }
     }
 
@@ -488,17 +646,7 @@
       }
 
       &-detail-btn {
-        display: none;
-        gap: 2px;
-        align-items: center;
-        justify-content: center;
-        font-size: 12px;
-        color: $color-primary;
-        cursor: pointer;
-
-        &:hover {
-          color: $color-primary-light;
-        }
+        @extend %flow-agent-action-btn;
       }
 
       &-item {
@@ -517,6 +665,14 @@
 
           .flow-agent-node-time {
             display: none;
+          }
+        }
+
+        &.is-selected {
+          background: $color-selected-bg;
+
+          &:hover {
+            background: $color-selected-bg;
           }
         }
       }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.spec.ts
@@ -106,8 +106,9 @@ vi.mock('../vnode-renderer', () => ({
   }),
 }));
 
-// Mock markdown plugins
+// Mock markdown plugins（与 markdown-content.vue 中 .use() 的导入保持一致）
 vi.mock('../../../plugins', () => ({
+  markdownItBkInlineStyle: vi.fn(() => () => {}),
   markdownItLatex: vi.fn(() => () => {}),
   markdownItMermaid: vi.fn(() => () => {}),
 }));

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
@@ -100,9 +100,6 @@
   const containerScrollConsumer = useContainerScrollConsumer();
 
   const groupedTokens = shallowRef<Token[][]>([]);
-
-  // 代码高亮由 CodeContent 组件处理，不在 MarkdownIt 解析时进行
-  // 这样可以避免流式输入时的同步高亮开销，提升性能
   const md = new MarkdownIt()
     // .use(markdownAnimationAttrs)
     .use(markdownItBkInlineStyle)

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
@@ -53,7 +53,10 @@
       </template>
       <template v-else>
         <div class="execution-summary-content-empty">
-          <Exception type="empty" />
+          <Exception
+            class="empty-exception"
+            type="empty"
+          />
           <div class="execution-summary-content-empty-text">
             {{ keyword ? t('搜索结果为空') : t('暂无数据') }}
             <Button
@@ -201,8 +204,8 @@
         justify-content: center;
         width: 100%;
 
-        .#{$bk-prefix}-exception-page {
-          .#{$bk-prefix}-exception-img {
+        .empty-exception {
+          img {
             height: 200px;
           }
         }

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
@@ -27,7 +27,8 @@
 import { type ShallowRef, ref as deepRef, inject, nextTick, provide, shallowRef } from 'vue';
 
 import { t } from '../lang/lang';
-import { type CustomTab } from '../types';
+
+import type { CustomTab } from '../types';
 
 export const CUSTOM_TAB_TOKEN = Symbol('CUSTOM_TAB_TOKEN');
 export const EXECUTION_TAB_NAME = 'execution';

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -37,7 +37,7 @@ export const lang = {
   删除: 'Delete',
   引用: 'Quote',
   重新生成: 'Regenerate',
-  '重新生成将清空下文内容': 'Regenerating will clear the content below',
+  重新生成将清空下文内容: 'Regenerating will clear the content below',
   提交: 'Submit',
   取消: 'Cancel',
   预览内容: 'Preview Content',
@@ -125,6 +125,7 @@ export const lang = {
   '你好，我是小鲸': 'Hello, I am BlueKing AI Bot',
   清空搜索: 'Clear Search',
   搜索结果为空: 'Search Result is Empty',
+  有效证据: 'Valid Evidence',
 } as const;
 
 export const t = (key: keyof typeof lang) => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
@@ -28,6 +28,7 @@ export type CustomBkFlowTab = CustomTab<CustomBkFlowTabData>;
 
 export type CustomBkFlowTabData = CustomTabData<{
   data?: Partial<NodeDetailData>;
+  has_confidence?: boolean;
   loading?: boolean;
   node_id?: string;
   node_name?: string;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/config.mts
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/config.mts
@@ -171,6 +171,8 @@ function sidebarAI() {
       items: [
         { text: 'MCP 服务', link: 'mcp' },
         { text: '自定义消息类型', link: 'custom-message' },
+        { text: '自定义侧栏 Tab 标签', link: 'custom-side-tab' },
+        { text: '自定义侧栏内容', link: 'custom-side-content' },
         { text: '最佳实践', link: 'best-practices' },
       ],
     },

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
@@ -3,220 +3,303 @@ name: 自定义消息类型
 slug: custom-message
 category: ai
 description: >
-  通过类型扩展、Slot 机制和 Activity 子类型模式，在 chat-x 中添加自定义消息渲染。
+  通过类型声明合并、ChatContainer/MessageContainer 插槽、MessageRender 与 ContentRender
+  分层扩展，在 chat-x 中实现自定义消息与正文渲染；Activity 子类型与侧栏 Tab 为内置场景。
 aiSummary: >
-  chat-x 提供三级自定义扩展：1) MessageContainer 默认 slot 按 role 分发整条消息，
-  2) AssistantMessage 默认 slot 替换正文渲染（toolCalls 仍内置），
-  3) Activity 子类型通过 ActivityLayout + activityComponentMap 注册新活动组件。
-  类型侧通过 declare global AIBluekingMessageMap/AIBluekingContentMap 声明合并扩展。
-  useCustomTab 支持从内容组件动态添加侧栏 Tab 面板。
+  渲染链：ChatContainer#message → MessageContainer#default → MessageRender 按 role 分发；
+  Assistant 可走 #default/#codeHeader 插槽与 ContentRender；Activity 由 activityComponentMap 按 activityType 挂载子组件。
+  自定义 role 须 AIBluekingMessageMap 声明合并并在插槽中显式渲染。FlowAgent 通过 useCustomTabConsumer 联动侧栏。
 relatedComponents:
+  - slug: chat-container
+    relation: '#message 插槽为应用层主扩展入口'
   - slug: message-container
-    relation: 自定义消息通过 MessageContainer 的默认 slot 渲染
+    relation: 默认 slot 包裹每条消息的 MessageRender
   - slug: message-render
-    relation: MessageRender 内部按 role 分发，未注册的 role 返回 null
+    relation: 按 MessageRole 分发，未注册 role 返回 null
   - slug: assistant-message
-    relation: AssistantMessage 默认 slot 可替换正文渲染
-sinceVersion: '1.0.0'
+    relation: 正文 default slot，toolCalls 内置渲染
+  - slug: activity-message
+    relation: activityType 映射 FlowAgent / KnowledgeRag / ReferenceDoc
+sinceVersion: '2.1.0'
 ---
 
 # 自定义消息类型
 
 ## 概述
 
-chat-x 提供 **三级扩展机制**，覆盖从「整条消息」到「正文内容块」到「活动子类型」的不同粒度：
+chat-x 的消息渲染是 **由外到内的插槽链 + 按 role 分发**，而不是单一「替换 MessageRender」就能覆盖全部场景。应用集成时最常接触的是 `ChatContainer` 的 **`#message`**；库内默认路径是 `MessageContainer` → `MessageRender` → 各角色组件 → `ContentRender` / Activity 子组件。
 
-| 扩展级别       | 切入点                                    | 适用场景                                     |
-| -------------- | ----------------------------------------- | -------------------------------------------- |
-| **整条消息**   | `MessageContainer` 默认 slot              | 新增全新的消息角色（如审批单、图表卡片）     |
-| **助手正文**   | `AssistantMessage` 默认 slot              | 替换 AI 回复的正文渲染，保留 toolCalls 列表  |
-| **活动子类型** | `ActivityLayout` + `activityComponentMap` | 新增 Activity 消息的子类型（如流程、知识库） |
+```text
+ChatContainer
+├── #aside … 侧栏 Tab / ExecutionSummary（见侧栏专题文档）
+└── #main
+     ├── #default（整块主区域，可替换整个 MessageContainer）
+     └── MessageContainer
+          └── #default（每条 message）← 库内默认挂 MessageRender
+               └── [#message] ← ChatContainer 透出；无内容时该条不渲染
+                    └── MessageRender（按 message.role 分发）
+                         ├── UserMessage / ToolMessage / …
+                         ├── AssistantMessage
+                         │    ├── #default → ContentRender → MarkdownContent …
+                         │    └── toolCalls → ToolCallRender（不受 slot 影响）
+                         └── ActivityMessage → activityComponentMap[activityType]
+```
 
-每级扩展均配合 **TypeScript 声明合并** 实现类型安全。
+扩展时先确定粒度，再选入口（见文末决策表）。
 
 ## 类型扩展
 
-### 消息类型扩展
+### 消息 role：`AIBluekingMessageMap`
 
-库内通过空接口预留扩展点，业务侧声明合并即可将自定义 `role` 并入 `Message` 联合类型：
+库内在 `messages.ts` 预留空接口，与内置 `MessageRole` 合并为 `MessageMap`：
 
 ```typescript
-// 库内定义（messages.ts）
+// 库内
 declare global {
   interface AIBluekingMessageMap {}
 }
-type MessageMap = AIBluekingMessageMap & {
+export type MessageMap = AIBluekingMessageMap & {
   [MessageRole.Assistant]: AssistantMessage;
   [MessageRole.User]: UserMessage;
-  // ... 内置角色
+  [MessageRole.Activity]: ActivityMessage;
+  // … 其余内置 role
 };
-type Message = MessageMap[MessageType];
+export type Message = MessageMap[MessageType];
+```
 
-// 业务扩展（如 types/approval.d.ts）
+业务侧声明合并（建议在独立 `*.d.ts`）：
+
+```typescript
 import type { BaseMessage } from '@blueking/chat-x';
 
-interface ApprovalContent {
-  title: string;
-  status: 'approved' | 'pending' | 'rejected';
-  approvers: string[];
+interface ChartPayload {
+  chartType: string;
+  series: unknown[];
 }
 
 declare global {
   interface AIBluekingMessageMap {
-    approval: BaseMessage<'approval', ApprovalContent>;
+    chart: BaseMessage<'chart', ChartPayload>;
   }
 }
 ```
 
-扩展后 `Message` 联合自动包含 `approval` 类型，TypeScript 可在 `switch(message.role)` 后收窄。
+`MessageRender` 的 `switch (message.role)` **不包含**自定义 role，会落入 `default: return null`。因此 **`chart` 等扩展 role 必须在 `MessageContainer` / `ChatContainer#message` 插槽里自行渲染**。
 
-### 内容类型扩展
+### 内容块：`AIBluekingContentMap`
 
-同理，内容块类型通过 `AIBluekingContentMap` 扩展：
+用于扩展 `ContentMap`（Assistant 的 `content`、Activity 的 `content` 结构等）：
 
 ```typescript
-// 库内定义（contents.ts）
+// 库内 contents.ts
 declare global {
   interface AIBluekingContentMap {}
 }
-type ContentMap = AIBluekingContentMap & {
+export type ContentMap = AIBluekingContentMap & {
   [MessageContentType.Text]: string;
   [MessageContentType.FlowAgent]: BkFlowMessageContent;
-  // ... 内置内容类型
+  [MessageContentType.KnowledgeRag]: KnowledgeRagMessageContent;
+  // …
 };
-
-// 业务扩展
-declare global {
-  interface AIBluekingContentMap {
-    chart: { type: 'chart'; chartType: string; data: unknown[] };
-  }
-}
 ```
 
-## 第一级：整条消息替换
+扩展后可在类型层面约束 `ActivityMessage['content']` 或业务 props，但 **Activity 子组件映射表仍在库内**（见下文 Activity 一节）。
 
-### MessageContainer 的默认 slot
+### `BaseMessage` 常用字段
 
-`MessageContainer` 在遍历 `group.messages` 时为每条消息提供默认 slot：
+| 字段 | 说明 |
+| ---- | ---- |
+| `id` / `messageId` | 客户端 / 服务端标识 |
+| `role` | `MessageRole` 或扩展 role |
+| `content` | 由泛型 `C` 决定结构 |
+| `status` | `pending` / `streaming` / `complete` / `error` 等 |
+| `uid` | 可选；Activity 会作为 `message-uid` 传给子组件，供侧栏定位 |
+| `property.extra` | 快捷指令、引用 `cite`、`pause`（控制 MessageTools）等 |
 
-```vue
-<!-- MessageContainer 内部实现 -->
-<template v-for="(message, index) in group.messages" :key="index">
-  <slot
-    name="default"
-    v-bind="{ message, messageToolsStatus }"
-  >
-    <MessageRender
-      :message="message"
-      ...
-    />
-  </slot>
-</template>
-```
+## 应用层：`ChatContainer` 的 `#message` 插槽
 
-**slot 参数**：
-
-- `message` — 当前消息对象（`Message` 类型）
-- `messageToolsStatus` — 工具栏状态（控制按钮禁用/隐藏）
-
-未覆盖 slot 时使用内置 `MessageRender`；`MessageRender` 对未注册的 `role` 返回 `null`，因此自定义 `role` **必须在 slot 中处理**。
-
-### 使用示例
+`ChatContainer` 将 `MessageContainer` 的每条消息默认 slot **透传**为具名插槽 `message`：
 
 ```vue
-<template>
-  <MessageContainer
-    :messages="messages"
-    :message-groups="messageGroups"
-  >
-    <template #default="{ message, messageToolsStatus }">
-      <!-- 自定义角色 -->
-      <ApprovalMessage
-        v-if="message.role === 'approval'"
-        :message="message"
-      />
-      <!-- 其余回退到内置渲染 -->
-      <MessageRender
-        v-else
-        :message="message"
-        :message-tools-status="messageToolsStatus"
-      />
-    </template>
-  </MessageContainer>
-</template>
-
-<script setup lang="ts">
-  import { MessageContainer, MessageRender, useMessageGroup } from '@blueking/chat-x';
-  import { computed, ref as deepRef } from 'vue';
-  import ApprovalMessage from './approval-message.vue';
-
-  const messages = deepRef<Message[]>([]);
-  const { messageGroups } = useMessageGroup({
-    messages: computed(() => messages.value),
-    selectedUserMessages: deepRef(undefined),
-  });
-</script>
-```
-
-## 第二级：助手正文替换
-
-### AssistantMessage 的默认 slot
-
-`AssistantMessage` 将正文渲染与 `toolCalls` 渲染分离：
-
-```vue
-<!-- AssistantMessage 内部实现 -->
-<div class="assistant-message-content">
-  <slot v-bind="{ content }">
-    <ContentRender :content="content || ''" :status="status" :type="MessageContentType.Text" />
-  </slot>
-</div>
-<!-- toolCalls 始终由 AssistantMessage 自行渲染，不受 slot 影响 -->
-<template v-if="toolCalls?.length">
-  <ToolcallRender
-    v-for="toolCall in toolCalls"
-    :key="toolCall.id"
-    ...
-  />
-</template>
-```
-
-**slot 参数**：`{ content }` — 助手消息的 `content` 字段。
-
-覆盖默认 slot 后，**只替换正文区域**，工具调用列表仍由组件内部渲染。
-
-### 使用示例
-
-当 AI 回复中包含特殊内容格式（如图表 JSON），可在 `MessageRender` 层传递 slot 到 `AssistantMessage`：
-
-```vue
-<MessageContainer :messages="messages" :message-groups="messageGroups">
+<!-- chat-container.vue -->
+<MessageContainer ...>
   <template #default="{ message, messageToolsStatus }">
-    <MessageRender :message="message" :message-tools-status="messageToolsStatus">
-      <template #default="{ content }">
-        <ChartRenderer v-if="isChartContent(content)" :data="content" />
-        <ContentRender v-else :content="content || ''" :type="MessageContentType.Text" />
-      </template>
-    </MessageRender>
+    <slot name="message" v-bind="{ message, messageToolsStatus }" />
   </template>
 </MessageContainer>
 ```
 
-`MessageRender` 仅将 `#default` slot 透传给 `AssistantMessage`，其他角色不受影响。
+**重要**：chat-x 的 `ChatContainer` **没有**为 `#message` 提供默认回退；插槽为空时该条消息区域不渲染。使用 `ChatContainer` 时应：
 
-## 第三级：Activity 子类型
+- 在 `#message` 内渲染 `MessageRender`（并透传必要 props），或
+- 使用 `@blueking/ai-blueking` 的 `ChatBot`（内部在未提供外层 `#message` 时自动回退 `MessageRender`）
 
-### 模式说明
+### 推荐写法（含 `codeHeader`）
 
-Activity 消息通过 `activityType` 字段分发到不同的子组件。库内已注册三种子类型：
+Playground [`chat-bot-new.vue`](../../playground/chat-bot-new.vue) 与 ai-blueking `ChatBot` 均采用此模式：
 
-| activityType         | 组件                  | 用途                                                |
-| -------------------- | --------------------- | --------------------------------------------------- |
-| `flow_agent`         | `FlowAgentContent`    | BkFlow 流程执行（节点列表、状态统计、节点详情 Tab） |
-| `knowledge_rag`      | `KnowledgeRagContent` | 知识库检索（检索摘要 + 引用文档列表）               |
-| `reference_document` | `ReferenceDocContent` | 引用文档列表                                        |
+```vue
+<ChatContainer :messages="messages" ...>
+  <template #message="{ message, messageToolsStatus }">
+    <MessageRender
+      :message="message"
+      :message-tools-status="messageToolsStatus"
+      :on-action="tool => handleUserAction(tool, message)"
+      :on-input-confirm="(content, docSchema) => handleUserInputConfirm(message, content, docSchema)"
+      :on-shortcut-confirm="formModel => handleUserShortcutConfirm(message, formModel)"
+      :tippy-options="commonTippyOptions"
+    >
+      <template #codeHeader="{ language, token }">
+        <span @click="onInsert(language)">插入</span>
+      </template>
+    </MessageRender>
+  </template>
+</ChatContainer>
+```
 
-分发机制在 `activity-message.vue` 中：
+自定义整条消息时，在 `#message` 内分支 `message.role`，**其余 role 仍交给 `MessageRender`**，避免漏掉用户消息工具链（删除/编辑/复制/引用等）：
+
+```vue
+<template #message="{ message, messageToolsStatus }">
+  <ChartMessage v-if="message.role === 'chart'" :message="message" />
+  <MessageRender
+    v-else
+    :message="message"
+    :message-tools-status="messageToolsStatus"
+    :on-action="..."
+    :on-input-confirm="..."
+    :on-shortcut-confirm="..."
+  />
+</template>
+```
+
+> 若自定义 `#message` 却未向 `MessageRender` 传递 `on-action` / `on-input-confirm` / `on-shortcut-confirm`，用户消息工具栏会失效；AI 消息工具栏在 `MessageContainer` 内独立渲染，不受影响。
+
+更复杂的「Markdown 内嵌自定义块」可参考 ai-blueking Playground `CustomMessageSlotView`：解析 ` ```custom-component ` 等 fence 后，在 `#message` 内混合 `MessageRender` 与业务组件。
+
+## `MessageContainer` 默认 slot
+
+直接使用 `MessageContainer`（不经过 `ChatContainer`）时，每条消息有带默认内容的 slot：
+
+```vue
+<MessageContainer :message-groups="messageGroups" :messages="messages" ...>
+  <template #default="{ message, messageToolsStatus }">
+    <ApprovalCard v-if="message.role === 'approval'" :message="message" />
+    <MessageRender
+      v-else
+      :message="message"
+      :message-tools-status="messageToolsStatus"
+      ...
+    />
+  </template>
+</MessageContainer>
+```
+
+未覆盖 slot 时使用内置 `MessageRender`（已绑定 `on-action`、`on-input-confirm` 等）。
+
+## `MessageRender`：按 role 分发
+
+实现为 `computed` + `h()`，根据 `message.role` 创建对应组件（`message-render.vue`）：
+
+| `MessageRole` | 组件 |
+| ------------- | ---- |
+| `user` | `UserMessage` |
+| `assistant` | `AssistantMessage`（支持 default / codeHeader 插槽） |
+| `activity` | `ActivityMessage` |
+| `tool` | `ToolMessage` |
+| `reasoning` | `ReasoningMessage` |
+| `info` | `InfoMessage` |
+| `loading` | `LoadingMessage` |
+| 其他 / 扩展 role | `null`（不渲染） |
+
+### 插槽
+
+```typescript
+defineSlots<{
+  /** 仅 Assistant 链路：替换正文 */
+  default: (props: { content: string; status: MessageStatus }) => VNode;
+  /** Markdown 代码块头部，透传至 ContentRender → MarkdownContent */
+  codeHeader: (props: { language: string; token: Token[] }) => VNode;
+}>();
+```
+
+Assistant 分支将 `default` 传给 `AssistantMessage`，默认内容为 `ContentRender`：
+
+```typescript
+h(AssistantMessage, props.message, {
+  default: slotProps =>
+    renderSlot(slots, 'default', slotProps, () => [
+      h(ContentRender, {
+        content: props.message.content || '',
+        status: props.message.status,
+      }, slots.codeHeader ? { codeHeader: ... } : undefined),
+    ]),
+});
+```
+
+## 助手正文：`AssistantMessage` + `ContentRender`
+
+### `AssistantMessage`
+
+- **`#default` slot**：参数 `{ content }`，用于替换正文。
+- **`toolCalls`**：始终在组件内用 `ToolCallRender` 列表渲染，**不受** default slot 影响。
+
+### `ContentRender`
+
+根据 `content` 形态与 `type` 选择子组件：
+
+| 条件 | 渲染 |
+| ---- | ---- |
+| `content` 为 `string` 或 `type === text` | `MarkdownContent`（流式补全、Mermaid、LaTeX、代码高亮） |
+| `content` 为数组 | `ReferenceContent`（引用文档列表） |
+| 其他 | `undefined`（需通过 slot 或上层自定义） |
+
+`ContentRender` 自带 **`#default`** slot（参数 `{ content }`），可在 `MessageRender#default` 内进一步包装：
+
+```vue
+<MessageRender :message="message" ...>
+  <template #default="{ content }">
+    <ContentRender :content="content" :status="message.status">
+      <template #default="{ content: c }">
+        <MyChart v-if="isChart(c)" :data="c" />
+        <MarkdownContent v-else :content="String(c)" :status="message.status" />
+      </template>
+    </ContentRender>
+  </template>
+</MessageRender>
+```
+
+### `codeHeader`：代码块头部
+
+插槽链路：`MessageRender` → `ContentRender` → `MarkdownContent` → `CodeContent#header`。
+
+用于「插入 / 应用 / 复制」等操作，见 Playground `chat-bot-new.vue` 与 ai-blueking `ChatBot` / `AIBlueking` 的 `#codeHeader` 透传。
+
+## Activity 消息与子类型
+
+### 消息结构
+
+```typescript
+interface ActivityMessage extends BaseMessage<MessageRole.Activity, Flow | KnowledgeRag | ReferenceDocument> {
+  activityType:
+    | MessageContentType.FlowAgent
+    | MessageContentType.KnowledgeRag
+    | MessageContentType.ReferenceDocument
+    | string;
+}
+```
+
+`ActivityMessage` 将 `uid` 以 **`message-uid`** 传给子组件，供 `addCustomTab({ data: { messageUid } })` 与侧栏「在对话中定位」使用。
+
+### 内置 `activityComponentMap`
+
+在 `activity-message.vue` 中 **硬编码**（当前不支持应用层注册）：
+
+| `activityType`（`MessageContentType`） | 组件 | 用途 |
+| -------------------------------------- | ---- | ---- |
+| `flow_agent` | `FlowAgentContent` | BkFlow 任务/节点、侧栏详情 Tab |
+| `knowledge_rag` | `KnowledgeRagContent` | 检索摘要 + 引用 |
+| `reference_document` | `ReferenceDocContent` | 引用文档列表 |
 
 ```typescript
 const activityComponentMap: Record<string, Component> = {
@@ -224,152 +307,62 @@ const activityComponentMap: Record<string, Component> = {
   [MessageContentType.KnowledgeRag]: KnowledgeRagContent,
   [MessageContentType.ReferenceDocument]: ReferenceDocContent,
 };
-// <component :is="activityComponentMap[activityType]" />
+// activityType 不在 map 中 → 不渲染（v-if="activityComponent"）
 ```
 
-### ActivityLayout：统一外框
+新增 Activity 子类型需要 **修改 chat-x 源码**（增加组件并写入 `activityComponentMap`），或改用 **自定义 `message.role` + `#message` 插槽** 完全自绘。
 
-所有 Activity 子组件使用 `ActivityLayout` 作为外框，提供：
+### `ActivityLayout`
 
-- **折叠/展开**：`v-model:collapsed`，标题行可点击切换
-- **标题 slot**：`#title`，放置图标、状态文字、统计信息
-- **内容 slot**：默认 slot，放置展开后的详细内容
+Flow / KnowledgeRag 等子组件的外框：
 
-```vue
-<ActivityLayout v-model:collapsed="collapsed" :activity-type="MessageContentType.FlowAgent">
-  <template #title>
-    <span class="ai-activity-message-title-icon">
-      <AiLoading v-if="isLoading" :size="12" />
-      <ArrowRightIcon v-else />
-    </span>
-    <span class="ai-activity-message-title-text">执行情况: ...</span>
-  </template>
-  <!-- 展开后的详细内容 -->
-  <div class="flow-agent-task-group">...</div>
-</ActivityLayout>
-```
+- `v-model:collapsed` 折叠
+- `#title`：标题行（图标、状态文案）
+- 默认 slot：展开区内容
+- `activityType === flow_agent` 时标题栏不显示右侧折叠箭头（Flow 自有交互）
 
-### 源码案例：FlowAgentContent
+### FlowAgent 要点（`FlowAgentContent`）
 
-`FlowAgentContent` 是最复杂的 Activity 子类型，展示了以下模式：
+- **内容类型**：`BkFlowMessageContent` = `BkFlowTask[]`（`task_id`、`nodes`、`statistics`、`has_confidence`、`is_active`、`task_tab` 等）
+- **侧栏 Tab**：`useCustomTabConsumer()` → `addCustomTab` / `removeCustomTab`
+  - 任务 Tab：`name = String(task_id)`
+  - 节点 Tab：`name = \`${task_id}|${node.id}|${node.name}\``
+  - 有效证据：`has_confidence` + 独立 Tab
+  - `is_active && task_tab` 时首次自动 `openTaskTab`
+  - 组件在 `MessageContainer` 内卸载时批量 `removeCustomTab`
+- **默认详情组件**：`BkFlowNodeDetail`（需 `<slot name="locateButton" />`）
+- **应用覆盖**：`ChatContainer` 的 `getSideRenderComponent` / `onCustomTabChange`（详见侧栏文档）
 
-**Props**：
+KnowledgeRag / ReferenceDoc 模式见 [ActivityMessage](../components/molecular/activity-message.md)。
 
-- `content?: BkFlowMessageContent` — 流程任务数组（每个任务包含 nodes、statistics、task_state 等）
-- `status?: MessageStatus` — 消息状态（Pending/Streaming 时显示加载动画）
+## 侧栏自定义 Tab（与消息联动）
 
-**内容数据结构**（`BkFlowMessageContent`）：
+Activity（尤其 FlowAgent）可在对话区点击「详情」等操作，通过 **`useCustomTabConsumer`** 在 `ChatContainer` 侧栏追加 Tab；数据加载与内容/标签自定义由容器 Props 完成。
 
-```typescript
-type BkFlowMessageContent = BkFlowTask[];
-
-type BkFlowTask = {
-  nodes: Record<string, BkFlowNode>;
-  statistics: { state_counts: Record<string, number>; total: number };
-  task_id: number;
-  task_name: string;
-  task_outputs: unknown;
-  task_state: string;
-};
-
-type BkFlowNode = {
-  elapsed_time: number;
-  id: string;
-  name: string;
-  state: string;
-  // ...
-};
-```
-
-**侧栏 Tab 集成**：
-
-`FlowAgentContent` 通过 `useCustomTabConsumer` 注入 `addCustomTab`，点击节点「详情」时动态添加侧栏 Tab：
-
-```typescript
-const { addCustomTab } = useCustomTabConsumer<CustomBkFlowTabData>()!;
-
-function handleNodeDetail(task: BkFlowTask, node: BkFlowNode) {
-  addCustomTab?.({
-    label: node.name,
-    name: `${task.task_id}|${node.id}|${node.name}`,
-    data: {
-      component: BkFlowNodeDetail,      // 渲染组件
-      props: { node_id: node.id, task_id: task.task_id, ... }, // 组件 props
-    },
-  });
-}
-```
-
-### 源码案例：KnowledgeRagContent
-
-`KnowledgeRagContent` 是最简洁的 Activity 子类型，标准模式：
-
-```vue
-<ActivityLayout v-model:collapsed="collapsed">
-  <template #title>
-    <span class="ai-activity-message-title-icon">
-      <AiLoading v-if="isLoading" />
-      <DocumentIcon v-else style="font-size: 12px" />
-    </span>
-    <span class="ai-activity-message-title-text">{{ title }}</span>
-  </template>
-  <MarkdownContent :content="content?.content || ''" />
-  <ReferenceContent :content="content?.referenceDocument || []" />
-</ActivityLayout>
-```
-
-**要点**：标题根据 `status`（Pending/Streaming → 检索中，否则 → 检索完成）动态切换文字。
-
-## useCustomTab：侧栏面板扩展
-
-### 机制
-
-`ChatContainer` 内部调用 `useCustomTabProvider` 注入 Tab 管理能力，深层组件通过 `useCustomTabConsumer` 消费：
-
-```
-ChatContainer
-  └── useCustomTabProvider()  ← provide
-       └── ResizeLayout #aside
-            └── Tab + TabPanel
-                 └── ExecutionSummary / 自定义 Tab
-
-FlowAgentContent（深层）
-  └── useCustomTabConsumer()  ← inject
-       └── addCustomTab({ label, name, data: { component, props } })
-```
-
-### CustomTab 类型
-
-```typescript
-type CustomTab<T> = {
-  label: string; // Tab 显示名
-  name: string; // 唯一标识（重复 name 不会重复添加）
-  icon?: string;
-  data?: {
-    component?: Component; // 渲染组件
-    props?: T; // 组件 props
-  };
-};
-```
-
-### 行为
-
-- `addCustomTab(tab)`：若 `tabs` 中无同名项则追加，展开侧栏，`nextTick` 后自动选中新 Tab
-- `removeCustomTab(name)`：移除并切回默认的「执行情况」Tab
-- `selectCustomTab(tab)`：切换选中 Tab
+| 文档 | 内容 |
+| ---- | ---- |
+| [自定义侧栏内容](./custom-side-content.md) | `getSideRenderComponent`、`onCustomTabChange`、`locateButton` |
+| [自定义侧栏 Tab 标签](./custom-side-tab.md) | `getSideTabRenderComponent` |
+| [useCustomTab](../composables/use-custom-tab.md) | Provider / Consumer API |
 
 ## 扩展决策指南
 
-| 需求                                | 推荐方案                                                 |
-| ----------------------------------- | -------------------------------------------------------- |
-| 全新消息角色（不是 Assistant 变体） | 第一级：`AIBluekingMessageMap` + `MessageContainer` slot |
-| AI 回复中嵌入特殊内容（图表、表格） | 第二级：`AssistantMessage` slot                          |
-| 新增 Activity 子类型（如审计日志）  | 第三级：`ActivityLayout` + `activityComponentMap` 注册   |
-| 侧栏展示详情面板                    | `useCustomTabConsumer` + `addCustomTab`                  |
-| 扩展内容块类型                      | `AIBluekingContentMap` 声明合并                          |
+| 需求 | 推荐方案 |
+| ---- | -------- |
+| 集成 ChatContainer，仅改代码块头部 | `#message` + `MessageRender#codeHeader` |
+| 集成 ChatContainer，替换部分 Assistant 正文 | `#message` + `MessageRender#default` / 内层 `ContentRender#default` |
+| 全新 `message.role`（审批、图表卡片等） | `AIBluekingMessageMap` + `#message` 或 `MessageContainer#default` 分支 + 自建组件 |
+| 仅直接使用 MessageContainer | `#default` slot + 同上 |
+| 新增 Activity 子类型（flow 同类） | 改库 `activity-message.vue` 的 map，或改用自定义 role |
+| Flow 节点/任务详情 + 侧栏 | 使用内置 FlowAgent + `onCustomTabChange` / `getSideRenderComponent` |
+| 扩展 Assistant 结构化 content 类型 | `AIBluekingContentMap` + `ContentRender` slot / 自定义渲染 |
 
 ## 相关文档
 
-- [架构总览](../architecture.md) — 渲染管线、MessageRender 分发机制
-- [设计理念](../design-philosophy.md) — 类型系统设计、声明合并原理
-- [最佳实践](./best-practices.md) — 性能优化、安全规范
+- [自定义侧栏 Tab 标签](./custom-side-tab.md)
+- [自定义侧栏内容](./custom-side-content.md)
+- [ChatContainer](../components/molecular/chat-container.md)
+- [ActivityMessage](../components/molecular/activity-message.md)
+- [useCustomTab](../composables/use-custom-tab.md)
+- [架构总览](../architecture.md)
+- [最佳实践](./best-practices.md)

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-content.md
@@ -1,0 +1,302 @@
+---
+name: 自定义侧栏内容
+slug: custom-side-content
+category: ai
+description: >
+  通过 getSideRenderComponent、onCustomTabChange 与 addCustomTab 的 data.component/props
+  自定义 ChatContainer 侧栏内容区；支持 locateButton 与主对话定位联动。
+aiSummary: >
+  选中非 execution 的自定义 Tab 时，ChatContainer 用 getSideRenderComponent(h, props) ?? data.component 渲染内容，
+  并 v-bind data.props；切换 Tab 时 onCustomTabChange 拉取数据写入 props.loading/data。
+  子组件需声明 locateButton 插槽以展示「在对话中定位」；messageUid 与 message.uid 对齐。
+relatedComponents:
+  - slug: chat-container
+    relation: 侧栏内容区 component :is 与 onCustomTabChange
+  - slug: flow-agent-content
+    relation: addCustomTab 默认挂载 BkFlowNodeDetail
+sinceVersion: '2.1.0'
+---
+
+# 自定义侧栏内容
+
+## 概述
+
+用户选中侧栏某个 **自定义 Tab**（非默认「执行情况」）后，`ChatContainer` 在 Tab 栏下方渲染 **内容面板**。内容来源按优先级：
+
+1. **`getSideRenderComponent(h, props)`** 返回的 VNode（应用层完全接管根组件）
+2. 否则使用 **`addCustomTab` 时传入的 `data.component`**，并 `v-bind="data.props"`
+
+异步数据通过 **`onCustomTabChange`** 在 Tab 切换时拉取，结果写入 `selectedTab.data.props`（含 `loading`、`data` 等字段）。
+
+| 能力 | 入口 |
+| ---- | ---- |
+| 注册 Tab + 默认组件 | `addCustomTab` / `useCustomTabConsumer` |
+| 切换时拉取详情 | `onCustomTabChange` |
+| 覆盖内容根组件 | `getSideRenderComponent` |
+| 主对话定位 | `data.messageUid` + 子组件 `#locateButton` 插槽 |
+
+Tab **标签** UI 见 [自定义侧栏 Tab 标签](./custom-side-tab.md)。
+
+## 数据流
+
+```mermaid
+sequenceDiagram
+  participant Msg as FlowAgentContent等
+  participant Provider as useCustomTabProvider
+  participant App as 应用层 onCustomTabChange
+  participant UI as 侧栏 component
+
+  Msg->>Provider: addCustomTab({ name, label, data: { component, props, messageUid } })
+  Provider->>Provider: isCollapse=false, selectCustomTab
+  Provider->>App: onTabChange(tab)
+  Note over Provider: props.loading=true
+  App-->>Provider: 详情数据
+  Note over Provider: props.loading=false, props.data=结果
+  Provider->>UI: getSideRenderComponent(h, props) ?? component + v-bind props
+```
+
+## 类型
+
+```typescript
+import type { Component } from 'vue';
+import type { CustomTab, CustomTabData } from '@blueking/chat-x';
+
+// 库内 Flow 场景扩展（custom.ts）
+type CustomBkFlowTabData = CustomTabData<{
+  loading?: boolean;
+  data?: Partial<NodeDetailData>;
+  task_id?: number;
+  task_name?: string;
+  node_id?: string;
+  node_name?: string;
+  has_confidence?: boolean;
+}>;
+
+type CustomTab<T extends CustomTabData<Record<string, unknown>>> = {
+  label: string;
+  name: string;
+  icon?: string;
+  data?: T & {
+    messageUid?: string; // 与活动消息 message.uid 一致，供「在对话中定位」
+  };
+};
+
+type CustomTabData<T> = {
+  component?: Component;
+  props?: T;
+};
+```
+
+业务可自定义 `props` 字段；`ChatContainer` 的 `onCustomTabChange` 泛型默认对齐 `CustomBkFlowTabData`。
+
+## addCustomTab：注册内容与初始 props
+
+深层组件通过 `useCustomTabConsumer` 注入 `addCustomTab`（须在 `ChatContainer` 子树内）。
+
+`FlowAgentContent` 打开节点详情时的典型 payload：
+
+```typescript
+addCustomTab?.({
+  label: node.name,
+  name: `${task.task_id}|${node.id}|${node.name}`,
+  data: {
+    component: BkFlowNodeDetail, // 库内默认节点详情
+    messageUid: props.messageUid,
+    props: {
+      loading: true,
+      node_id: node.id,
+      node_name: node.name,
+      task_id: taskId,
+      task_name: task.task_name,
+      data: {},
+    },
+  },
+});
+```
+
+| 字段 | 说明 |
+| ---- | ---- |
+| `data.component` | 未配置 `getSideRenderComponent` 或其对当前 props 返回 `undefined` 时使用的 Vue 组件 |
+| `data.props` | 传给内容组件的 props；切换 Tab 时会被 `onCustomTabChange` 结果合并 |
+| `data.messageUid` | 与 `ActivityMessage` 下发的 `message-uid` 一致，供侧栏「在对话中定位」 |
+
+组件卸载时 `FlowAgentContent` 会按 task/node 调用 `removeCustomTab` 清理对应 Tab，避免残留。
+
+## onCustomTabChange：切换时加载数据
+
+```typescript
+type OnCustomTabChange = (tab: CustomTab<CustomBkFlowTabData>) => Promise<unknown>;
+```
+
+`ChatContainer` 在 `useCustomTabProvider` 的 `onTabChange` 中：
+
+1. 将当前 Tab 的 `data.props` 设为 `{ ...原 props, loading: true, data: {} }`（保留 task_id 等）
+2. `await onCustomTabChange(tab)`
+3. 合并为 `{ ...props, loading: false, data: 返回值 }`
+
+应用层示例（Playground 模拟 3.5s 延迟后返回节点详情）：
+
+```typescript
+const handleCustomTabChange = async () => {
+  await new Promise(resolve => setTimeout(resolve, 3500));
+  return MOCK_NODE_DETAIL; // 写入 props.data
+};
+```
+
+内容组件应：
+
+- 根据 **`loading`** 展示骨架屏（如 `BkFlowNodeDetail`、`CustomTabContent`）
+- 根据 **`data`** 渲染业务详情（节点基础信息、inputs/outputs 等）
+
+## getSideRenderComponent：覆盖内容根组件
+
+```typescript
+type GetSideRenderComponent = (
+  createElement: typeof h,
+  props?: Record<string, unknown>,
+) => VNode | undefined;
+```
+
+`props` 即当前选中 Tab 的 **`selectedTab.data.props`**（snake_case 字段与 Flow 协议一致，如 `task_id`、`node_name`）。
+
+| 返回值 | 行为 |
+| ------ | ---- |
+| `VNode` | 使用该 VNode 作为侧栏内容根（**不再**使用 `data.component`） |
+| `undefined` | 使用 `selectedTab.data.component`，并 `v-bind="selectedTab.data.props"` |
+
+模板渲染（`chat-container.vue`）：
+
+```vue
+<component
+  :is="getSideRenderComponent?.(h, selectedTab?.data?.props ?? {}) ?? selectedTab?.data?.component"
+  :key="selectedTab.name"
+  v-bind="selectedTab?.data?.props"
+>
+  <template #locateButton>
+    <Button @click="handleLocateMessageGroup(selectedTab?.data?.messageUid)">
+      {{ t('在对话中定位') }}
+    </Button>
+  </template>
+</component>
+```
+
+### Playground：CustomTabContent
+
+[`playground/custom-tab-content.vue`](../../playground/custom-tab-content.vue) 演示业务自定义侧栏：
+
+- 头部保留 **`<slot name="locateButton" />`**，由容器注入定位按钮
+- 根据 `loading` / `taskId` / `nodeName` 等 props 展示骨架或元数据
+
+[`playground/chat-bot-new.vue`](../../playground/chat-bot-new.vue) 中 `getSideRenderComponent` 将 `tab.data.props` 映射为组件 camelCase props：
+
+```typescript
+const getSideRenderComponent = (createElement: typeof h, props?: Record<string, unknown>) => {
+  const raw = props ?? {};
+  return createElement(CustomTabContent, {
+    loading: Boolean(raw.loading),
+    nodeId: typeof raw.node_id === 'string' ? raw.node_id : '',
+    nodeName: typeof raw.node_name === 'string' ? raw.node_name : '',
+    taskId: /* 从 raw.task_id 解析 */,
+    taskName: typeof raw.task_name === 'string' ? raw.task_name : '',
+    data:
+      typeof raw.data === 'object' && raw.data !== null && !Array.isArray(raw.data)
+        ? (raw.data as Record<string, unknown>)
+        : {},
+  });
+};
+```
+
+将 `PLAYGROUND_GET_SIDE_VNODE_DEMO` 设为 `false` 并 `return undefined` 可回退为库内 **`BkFlowNodeDetail`**。
+
+## locateButton 与主对话定位
+
+容器向内容组件提供具名插槽 **`locateButton`**。子组件在标题栏等区域声明：
+
+```vue
+<header>
+  <h3>{{ title }}</h3>
+  <slot name="locateButton" />
+</header>
+```
+
+点击后 `ChatContainer` 执行 `handleLocateMessageGroup(messageUid)`：
+
+1. 若存在 `document.getElementById(messageUid)`，滚动到该 DOM
+2. 否则在 `messageGroups` 中查找 `message.uid === messageUid` 的消息组，滚动到组容器（`MessageGroup.uid`）
+
+**务必**在 `addCustomTab` 的 `data` 上设置 `messageUid`（与活动消息 `message.uid` 一致）。`ActivityMessage` 向 `FlowAgentContent` 传递的 `message-uid` 即为此值。
+
+库内参考：`flow-agent-node-detail.vue` 标题行内的 `<slot name="locateButton" />`。
+
+## 完整接入示例
+
+```vue
+<template>
+  <ChatContainer
+    ref="chatContainerRef"
+    :messages="messages"
+    :get-side-render-component="getSideRenderComponent"
+    :on-custom-tab-change="handleCustomTabChange"
+    ...
+  />
+</template>
+
+<script setup lang="ts">
+  import { h, useTemplateRef } from 'vue';
+  import { ChatContainer, type CustomTab } from '@blueking/chat-x';
+  import MySidePanel from './MySidePanel.vue';
+
+  const chatContainerRef = useTemplateRef('chatContainerRef');
+
+  const handleCustomTabChange = async (tab: CustomTab) => {
+    if (tab.name === 'execution') return;
+    const detail = await fetchDetail(tab.name);
+    return detail;
+  };
+
+  const getSideRenderComponent = (createElement: typeof h, props?: Record<string, unknown>) => {
+    if (props?.has_confidence) {
+      return createElement(MyConfidencePanel, props);
+    }
+    return undefined; // 使用 addCustomTab 注册的 component
+  };
+
+  // 也可由外层直接打开 Tab
+  const openPanel = (messageUid: string) => {
+    chatContainerRef.value?.addCustomTab({
+      name: 'my-panel-1',
+      label: '业务面板',
+      data: {
+        component: MySidePanel,
+        messageUid,
+        props: { loading: true, data: {} },
+      },
+    });
+  };
+</script>
+```
+
+`MySidePanel.vue` 需处理 `loading` / `data`，并预留 `locateButton` 插槽。
+
+## 与「执行情况」Tab 的区别
+
+| Tab | 内容 |
+| --- | ---- |
+| `EXECUTION_TAB_NAME`（`execution`） | 内置 `ExecutionSummary`，不走 `component` / `getSideRenderComponent` |
+| 自定义 Tab | `getSideRenderComponent` ?? `data.component` + `onCustomTabChange` 数据 |
+
+当 **`executionGroups` 为空且搜索关键词为空** 时，容器会 **`resetCustomTab`**，清空自定义 Tab 并折叠侧栏，避免无执行数据时仍显示节点详情 Tab。
+
+## 设计建议
+
+- **组件 + 拉数分离**：`data.component` 负责 UI 结构，`onCustomTabChange` 负责请求；避免在内容组件内重复监听 Tab 切换。
+- **props 命名**：与后端/Flow 协议对齐时用 snake_case 写入 `data.props`，在 `getSideRenderComponent` 内再映射为组件 camelCase，与 Playground 一致。
+- **loading 态**：切换 Tab 时容器会先置 `loading: true`，业务组件应统一骨架样式（可用全局 `.ai-skeleton-element`）。
+- **key**：容器对内容使用 `:key="selectedTab.name"`，切换 Tab 会 remount，勿在子组件内假设长期挂载。
+
+## 相关文档
+
+- [自定义侧栏 Tab 标签](./custom-side-tab.md) — `getSideTabRenderComponent`
+- [useCustomTab](../composables/use-custom-tab.md) — Provider / Consumer API
+- [ChatContainer](../components/molecular/chat-container.md) — 侧栏、expose、`collapseChange`
+- [自定义消息类型](./custom-message.md) — Activity / FlowAgent 与 `addCustomTab` 关系

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-tab.md
@@ -1,0 +1,189 @@
+---
+name: 自定义侧栏 Tab 标签
+slug: custom-side-tab
+category: ai
+description: >
+  通过 ChatContainer 的 getSideTabRenderComponent 自定义侧栏 Tab 栏标签的渲染，
+  覆盖默认的图标 + 文案 + 关闭按钮组合。
+aiSummary: >
+  ChatContainer 在 ResizeLayout 侧栏 TabPanel 的 label 插槽中调用 getSideTabRenderComponent(h, tab, { removeCustomTab })。
+  返回 VNode 时完全接管该 Tab 标签 UI；返回 undefined 时走内置 ExecutionIcon/NodeTabIcon + 文案 + CloseIcon。
+  与 addCustomTab 的 name/label 配合；关闭逻辑可复用 events.removeCustomTab 或依赖默认关闭按钮。
+relatedComponents:
+  - slug: chat-container
+    relation: getSideTabRenderComponent 定义与 Tab 栏渲染入口
+  - slug: flow-agent-content
+    relation: FlowAgent 通过 addCustomTab 追加节点/任务 Tab
+sinceVersion: '2.1.0'
+---
+
+# 自定义侧栏 Tab 标签
+
+## 概述
+
+`ChatContainer` 右侧（或 `placement` 指定侧）侧栏顶部为 **Tab 标签栏**：默认包含固定的「执行情况」Tab，以及由 `addCustomTab` 动态追加的自定义 Tab。
+
+应用层可通过 **`getSideTabRenderComponent`** 按 Tab 粒度自定义**标签区域**的展示（图标、文案、关闭按钮、徽章等），而不改动 Tab 的 `name` / `label` 数据模型与 `addCustomTab` 流程。
+
+| 能力 | Prop | 作用范围 |
+| ---- | ---- | -------- |
+| 自定义 **Tab 标签** | `getSideTabRenderComponent` | 仅 Tab 栏每一枚标签的 `label` 插槽 |
+| 自定义 **侧栏内容** | `getSideRenderComponent` | 选中 Tab 后下方内容区（见 [自定义侧栏内容](./custom-side-content.md)） |
+
+Tab 的增删、选中、数据加载仍由 [useCustomTab](../composables/use-custom-tab.md) 与 `onCustomTabChange` 负责，本文只描述**标签 UI** 扩展。
+
+## 渲染位置
+
+侧栏结构（简化）：
+
+```
+ResizeLayout #aside
+├── Tab（:active="selectedTab.name"）
+│   └── TabPanel × N
+│        └── label: getSideTabRenderComponent(h, tab, { removeCustomTab }) ?? 默认标签
+├── ExecutionSummary（选中「执行情况」时）
+└── component :is（选中自定义 Tab 时的内容区）
+```
+
+源码入口（`chat-container.vue`）：`TabPanel` 的 `label` 为函数，内部优先调用 `getSideTabRenderComponent`，未返回有效 VNode 时使用默认实现。
+
+## API
+
+### getSideTabRenderComponent
+
+```typescript
+type GetSideTabRenderComponent = (
+  createElement: typeof h,
+  tab: CustomTab<Record<string, unknown>>,
+  events: { removeCustomTab: (tabName: string) => void },
+) => VNode | undefined;
+```
+
+| 参数 | 说明 |
+| ---- | ---- |
+| `createElement` | Vue 的 `h`，用于创建 VNode |
+| `tab` | 当前 Tab 项，含 `name`、`label`、可选 `icon`、`data` |
+| `events.removeCustomTab` | 与容器内部一致的移除方法，传入 `tab.name` 即可关闭该 Tab |
+
+| 返回值 | 行为 |
+| ------ | ---- |
+| `VNode` | **完全替换**该 Tab 的标签 UI（不再自动渲染默认图标、文案、关闭按钮） |
+| `undefined` | 使用内置标签：执行情况 Tab 用 `ExecutionIcon`，其余用 `NodeTabIcon` + `tab.label`（溢出 tooltip）+ `CloseIcon`（非执行情况 Tab 可点关闭） |
+
+### 与 CustomTab 的关系
+
+`addCustomTab` / `useCustomTabConsumer` 写入的 `CustomTab` 决定 Tab **是否存在**以及 **name / label**；`getSideTabRenderComponent` 只决定**已存在 Tab 在标签栏长什么样**。
+
+```typescript
+import type { CustomTab } from '@blueking/chat-x';
+
+// 典型：FlowAgent 打开的节点 Tab
+// name: `${task_id}|${node.id}|${node.name}`
+// label: node.name
+```
+
+内置常量 `EXECUTION_TAB_NAME === 'execution'` 对应默认「执行情况」Tab，一般不需要自定义其标签；若返回自定义 VNode，需自行处理「不可关闭」等产品规则。
+
+## 默认标签行为
+
+当 `getSideTabRenderComponent` 返回 `undefined` 时，每个 `TabPanel` 的 `label` 为：
+
+1. **图标**：`tab.name === EXECUTION_TAB_NAME` → `ExecutionIcon`，否则 `NodeTabIcon`
+2. **文案**：`tab.label`，带 `vOverflowTips` 防止过长截断
+3. **关闭**：仅非 `execution` Tab 渲染 `CloseIcon`，`onClick` 调用 `removeCustomTab(tab.name)`
+
+选中 Tab 时，对应标签会 `scrollIntoView({ behavior: 'smooth' })` 滚入可视区域。
+
+## 使用示例
+
+### 按 Tab name 定制标签
+
+```vue
+<template>
+  <ChatContainer
+    :get-side-tab-render-component="getSideTabRenderComponent"
+    ...
+  />
+</template>
+
+<script setup lang="ts">
+  import { h } from 'vue';
+  import { ChatContainer, type CustomTab } from '@blueking/chat-x';
+
+  const getSideTabRenderComponent = (
+    createElement: typeof h,
+    tab: CustomTab<Record<string, unknown>>,
+    { removeCustomTab },
+  ) => {
+    // 示例：某一业务 Tab 使用纯文本标签
+    if (tab.name === '634859') {
+      return createElement('span', { class: 'my-tab-label' }, tab.label);
+    }
+    // 其余 Tab 走默认图标 + 文案 + 关闭
+    return undefined;
+  };
+</script>
+```
+
+### 自定义标签并自行处理关闭
+
+```typescript
+const getSideTabRenderComponent = (createElement, tab, { removeCustomTab }) => {
+  if (!tab.name.startsWith('custom-')) {
+    return undefined;
+  }
+
+  return createElement('span', { class: 'custom-tab-label' }, [
+    createElement('span', {}, tab.label),
+    createElement('button', {
+      type: 'button',
+      onClick: (e: Event) => {
+        e.stopPropagation();
+        removeCustomTab(tab.name);
+      },
+    }, '×'),
+  ]);
+};
+```
+
+> 自定义标签时若未提供关闭入口，用户只能依赖其它逻辑调用 `removeCustomTab`，或等待 `executionGroups` 清空后容器 `resetCustomTab`。
+
+## Playground 参考
+
+[`playground/chat-bot-new.vue`](../../playground/chat-bot-new.vue) 中注册了 `getSideTabRenderComponent`：当 `tab.name === '634859'` 时返回简单文本节点，用于验证「覆盖默认标签」路径；其余 Tab 返回 `undefined` 走默认 UI。
+
+```typescript
+const getSideTabRenderComponent = (createElement: typeof h, tab: CustomTab<Record<string, unknown>>) => {
+  if (tab.name === '634859') {
+    return createElement('div', {}, 'dddd');
+  }
+  return undefined;
+};
+```
+
+本地调试：在 FlowAgent 消息中触发会生成对应 `name` 的 Tab，或经 `chatContainerRef.addCustomTab({ name: '634859', label: '...' })` 手动添加。
+
+## 与内容区、数据加载的配合
+
+| 步骤 | 说明 |
+| ---- | ---- |
+| 1 | 消息内组件（如 `FlowAgentContent`）`addCustomTab({ name, label, data })` |
+| 2 | 可选：`getSideTabRenderComponent` 美化该 Tab 的标签 |
+| 3 | 选中 Tab 时触发 `onCustomTabChange`，合并进 `data.props`（见 [custom-side-content](./custom-side-content.md)） |
+| 4 | 可选：`getSideRenderComponent` 覆盖侧栏内容组件 |
+
+标签与内容相互独立：可只定制标签、只定制内容，或两者同时定制。
+
+## 注意事项
+
+- **不要**在 `getSideTabRenderComponent` 内修改 `tabs` 列表；增删 Tab 请用 `addCustomTab` / `removeCustomTab`。
+- 返回的 VNode 应处理好 **点击关闭 vs 切换 Tab** 的事件冒泡（关闭按钮建议 `stopPropagation`）。
+- `tab.label` 为空时默认文案区域仍渲染，业务侧应在 `addCustomTab` 时保证可读 `label`。
+- 分享模式 `RenderMode.Share` 下侧栏不展示，该 Prop 不会生效。
+
+## 相关文档
+
+- [自定义侧栏内容](./custom-side-content.md) — `getSideRenderComponent`、`onCustomTabChange`、`locateButton`
+- [useCustomTab](../composables/use-custom-tab.md) — `addCustomTab` / `removeCustomTab` / Provider-Consumer
+- [ChatContainer](../components/molecular/chat-container.md) — 侧栏整体行为与 expose API
+- [自定义消息类型](./custom-message.md) — FlowAgent 内 `addCustomTab` 场景

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
@@ -263,11 +263,14 @@ domain: message
 ### 核心交互
 
 - **标题栏**：显示「执行情况」+ 所有任务聚合后的各状态计数（执行中 / 成功 / 失败 / 挂起），颜色区分
-- **任务组**：逐个展示任务行，带状态图标和总耗时
+- **任务组**：逐个展示任务行，带状态图标、总耗时；点击箭头图标可折叠/展开节点列表
+- **有效证据**：`task.has_confidence === true` 时，任务行右侧展示「有效证据」按钮，点击后在侧栏打开置信度/证据详情 Tab（`props.has_confidence: true`）
+- **默认激活**：`task.is_active === true` 且存在 `task_tab` 时，首次加载会自动在侧栏打开该任务 Tab；用户手动切换 Tab 后不再沿用 `is_active` 默认高亮
+- **选中态**：当前侧栏 Tab 与任务行 / 节点行联动高亮（`is-selected`）；任务 Tab 与「有效证据」Tab 均视为该任务的选中态
 - **节点列表**：每个节点显示状态圆点、名称和耗时；hover 时出现「详情」按钮
-- **节点详情**：点击「详情」按钮会通过 `useCustomTabConsumer` 在 `ChatContainer` 侧边栏新增自定义 Tab，展示节点配置（基础信息、输入参数、输出参数）
+- **节点详情**：点击「详情」会通过 `useCustomTabConsumer` 在 `ChatContainer` 侧边栏新增自定义 Tab，展示节点配置（基础信息、输入参数、输出参数）
 
-> `FlowAgentContent` 会读取 `ChatContainer` 注入的 `renderMode`。当 `renderMode === RenderMode.Share` 时，节点列表仅展示状态和名称，不展示节点耗时与「详情」按钮，避免分享预览中出现可交互的节点详情入口。独立使用 `ActivityMessage` 且没有上层 Provider 时，默认按 `Chat` 模式渲染。
+> `FlowAgentContent` 会读取 `ChatContainer` 注入的 `renderMode`。当 `renderMode === RenderMode.Share` 时，任务行不展示总耗时与「有效证据」，节点列表不展示耗时与「详情」按钮，避免分享预览中出现可交互入口。独立使用 `ActivityMessage` 且没有上层 Provider 时，默认按 `Chat` 模式渲染。
 
 ### 内部渲染结构
 
@@ -279,16 +282,16 @@ FlowAgentContent（activityType = 'flow_agent'）
 │       └── 执行情况：执行中 N / 成功 N / 失败 N / 挂起 N
 └── #default
     └── TaskGroup × N
-        ├── TaskHeader（可折叠/展开）
+        ├── TaskHeader（is-selected / has-confidence；箭头点击折叠）
         │   ├── 状态图标（running=Loading / success / failed / suspended）
         │   ├── task_name（HighlightKeyword 支持搜索高亮）
-        │   └── 总耗时
+        │   └── trailing：总耗时 + 「有效证据」（has_confidence 时）
         └── NodeList
-            └── NodeItem × N
+            └── NodeItem × N（is-selected 与侧栏 Tab 联动）
                 ├── 状态圆点（颜色对应状态）
                 ├── node.name（HighlightKeyword 支持搜索高亮）
                 ├── node.elapsed_time
-                └── 详情按钮（hover 显示）→ 打开自定义 Tab
+                └── 详情按钮（hover 显示）→ 打开节点详情 Tab
 ```
 
 ### 用法示例
@@ -401,9 +404,19 @@ const messages = [
 | `suspended` | SUSPENDED                                                                           | #F59500 |
 | `pending`   | PENDING                                                                             | #DCDEE5 |
 
+### 侧栏 Tab 命名规则
+
+| 场景       | `tab.name` 格式                          |
+| ---------- | ---------------------------------------- |
+| 任务详情   | `{task_id}`                              |
+| 有效证据   | `{task_id}`（与任务 Tab 同名，label 为「有效证据」） |
+| 节点详情   | `{task_id}\|{node.id}\|{node.name}`      |
+
+`CustomBkFlowTabData` 支持 `has_confidence?: boolean`，用于侧栏详情组件区分证据视图与节点视图。应用层可通过 `ChatContainer` 的 `getSideRenderComponent` 覆盖渲染组件。
+
 ### 节点详情 Tab
 
-点击节点的「详情」按钮，内部调用 `useCustomTabConsumer().addCustomTab()` 在 `ChatContainer` 侧边栏新开一个 Tab，渲染 `FlowAgentNodeDetail` 组件，该组件提供：
+点击节点的「详情」按钮，内部调用 `useCustomTabConsumer().addCustomTab()` 在 `ChatContainer` 侧边栏新开一个 Tab，渲染 `BkFlowNodeDetail`（或 `getSideRenderComponent` 返回的自定义组件），该组件提供：
 
 - **节点配置** Tab：基础信息表单（流程模板、节点名称、步骤名称、失败处理、超时控制）+ 输入参数表 + 输出参数表
 - **节点输出** Tab：结构化输出参数表
@@ -417,6 +430,8 @@ import { MessageContentType, type BkFlowMessageContent, type BkFlowNode, type Bk
 type BkFlowMessageContent = BkFlowTask[];
 
 type BkFlowTask = {
+  has_confidence?: boolean; // 是否展示「有效证据」入口
+  is_active?: boolean; // 是否默认激活并自动打开侧栏 Tab
   nodes: Record<string, BkFlowNode>;
   statistics: { state_counts: Record<string, number>; total: number };
   task_id: number;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -182,7 +182,7 @@ domain: input
 
 ## 核心能力
 
-- **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏；**侧栏是否展示 Tab / 执行摘要、以及分栏是否进入折叠样式（`ai-is-collapse`）以 `executionGroups` 为准**（由 `useMessageGroup` 从消息中过滤出工具调用与 FlowAgent 执行记录），**不以原始 `messages.length` 判断**。因此仅有普通对话、尚无执行类消息时，侧栏内容与「执行情况」区域可能为空，布局上与无执行数据时一致
+- **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏；**侧栏是否展示 Tab / 执行摘要、以及分栏是否进入折叠样式（`ai-is-collapse`）以 `executionGroups` 与执行情况搜索关键词 `keyword` 共同决定**（`executionGroups` 由 `useMessageGroup` 从消息中过滤工具调用与 FlowAgent 记录；`keyword` 来自 `ExecutionSummary` 的 `@update-keyword`）。当 `executionGroups` 为空且未输入搜索词时，侧栏 Tab 与执行摘要不展示；**用户正在搜索执行情况时（`keyword` 非空），即使暂无执行类消息也会保留侧栏**，避免搜索态被折叠
 - **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
 - **输入区状态推导**：传给 `MessageContainer` 与 `ChatInput` 的 `messageStatus` 为内部计算值 `inputStatus`：当分组中存在 id 为 `LOADING_MESSAGE_ID`（`'__loading__'`，由 `useMessageGroup` 注入的占位 Loading 消息）时，对内使用 `MessageStatus.Fetching`；否则使用外部传入的 `messageStatus`。用于在「已发用户消息、尚未流式」阶段与流式中一致地展示停止能力，并避免输入区重复发送
 - **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
@@ -200,9 +200,9 @@ ai-chat-container
     ├── aside（侧边栏）
     │   ├── Tab 标签页
     │   │   ├── 执行情况（默认 Tab）
-    │   │   └── 自定义 Tab × N（可关闭）
+    │   │   └── 自定义 Tab × N（可关闭；标签可由 `getSideTabRenderComponent` 自定义）
     │   ├── ExecutionSummary（执行情况 Tab 内容）
-    │   ├── 自定义 Tab 组件（通过 component :is 渲染，可向子组件注入 #locateButton）
+    │   ├── 自定义 Tab 组件（`getSideRenderComponent` 优先，否则 `data.component`；可向子组件注入 #locateButton）
     │   └── collapse-button（折叠按钮）
     └── main（主内容区）
         ├── MessageContainer（有消息时）
@@ -286,9 +286,9 @@ ai-chat-container
 
 侧边栏默认包含「执行情况」Tab，展示所有工具调用和 FlowAgent 类型的 Activity 消息。支持关键词搜索过滤和点击定位到对话中的消息位置。
 
-**展示条件**：当 `executionGroups` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。`renderMode === Share` 时侧栏隐藏，且分栏会应用与折叠一致的样式。
+**展示条件**：当 `executionGroups` 为空且 `keyword` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。用户在执行情况中输入搜索词后，侧栏会保持展示以显示「搜索结果为空」等状态。`renderMode === Share` 时侧栏隐藏，且分栏会应用与折叠一致的样式。
 
-**自定义 Tab 联动**：当 `executionGroups` 变为空（例如会话清空或仅剩无执行类消息）时，容器会**自动重置自定义 Tab**（`resetCustomTab`），避免残留节点详情等 Tab。
+**自定义 Tab 联动**：当 `executionGroups` 变为空且搜索词已清空时，容器会**自动重置自定义 Tab**（`resetCustomTab`），避免残留节点详情等 Tab；若用户仍在搜索（`keyword` 非空），不会触发重置。
 
 ```vue
 <template>
@@ -378,7 +378,45 @@ ai-chat-container
 
 ## 自定义 Tab
 
-通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab。若 **`executionGroups` 变为空**，容器会清空自定义 Tab 状态（与侧栏执行数据联动，见上文「侧边栏与执行摘要」）。
+通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab。若 **`executionGroups` 变为空且搜索词已清空**，容器会清空自定义 Tab 状态（与侧栏执行数据联动，见上文「侧边栏与执行摘要」）。
+
+### 侧栏渲染扩展
+
+应用层可通过以下 Props 覆盖默认 Tab 标签与侧栏内容区的渲染逻辑（例如 FlowAgent 节点详情使用业务自定义组件）：
+
+| Prop | 说明 |
+| ---- | ---- |
+| `getSideTabRenderComponent` | `(h, tab, { removeCustomTab }) => VNode \| undefined`。返回自定义 Tab 标签 VNode；未返回时使用默认图标 + `tab.label` + 关闭按钮 |
+| `getSideRenderComponent` | `(h, props) => VNode \| undefined`。返回侧栏内容区组件 VNode；未返回时使用 `selectedTab.data.component` |
+
+```vue
+<template>
+  <ChatContainer
+    :get-side-tab-render-component="renderSideTab"
+    :get-side-render-component="renderSidePanel"
+    ...
+  />
+</template>
+
+<script setup lang="ts">
+  import { h } from 'vue';
+  import type { CustomTab } from '@blueking/chat-x';
+
+  const renderSideTab = (createElement, tab, { removeCustomTab }) => {
+    if (tab.name.startsWith('custom-')) {
+      return createElement('span', {}, tab.label);
+    }
+    return undefined; // 走默认 Tab 标签
+  };
+
+  const renderSidePanel = (createElement, props) => {
+    if (props?.has_confidence) {
+      return createElement(MyConfidencePanel, props);
+    }
+    return undefined; // 走 tab.data.component
+  };
+</script>
+```
 
 ### 自定义 Tab 与「在对话中定位」
 
@@ -655,9 +693,11 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 
 | 属性名             | 类型                                                                         | 默认值   | 说明                                                                                                                                          |
 | ------------------ | ---------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
-| chatLoading        | `boolean`                                                                    | —        | 整体加载状态，`true` 时显示 Loading 遮罩                                                                                                      |
-| commonTippyOptions | `AITippyProps`                                                               | —        | 通用 Tippy 配置，传入的选项会注入到所有使用 `v-overflow-tips` 的子组件中                                                                      |
-| openingRemark      | `string`                                                                     | —        | 开场白，无消息时显示，支持 Markdown                                                                                                           |
+| chatLoading                 | `boolean`                                                                    | —        | 整体加载状态，`true` 时显示 Loading 遮罩                                                                                                      |
+| commonTippyOptions          | `AITippyProps`                                                               | —        | 通用 Tippy 配置，传入的选项会注入到所有使用 `v-overflow-tips` 的子组件中                                                                      |
+| getSideRenderComponent      | `(h, props?) => VNode \| undefined`                                          | —        | 自定义侧栏内容区渲染；未返回时使用 `selectedTab.data.component`                                                                               |
+| getSideTabRenderComponent   | `(h, tab, { removeCustomTab }) => VNode \| undefined`                        | —        | 自定义侧栏 Tab 标签渲染；未返回时使用默认图标 + 文案 + 关闭按钮                                                                               |
+| openingRemark               | `string`                                                                     | —        | 开场白，无消息时显示，支持 Markdown                                                                                                           |
 | placement          | `'left' \| 'right'`                                                          | `'left'` | 侧边栏位置                                                                                                                                    |
 | resizeProps        | `{ disabled?: boolean; initialDivide?: number \| string; max?: number; min?: number }` | —        | 透传给内部 `ResizeLayout` 的可选配置，与默认 `collapsible: false`、`immediate: true`、`min: 400` 合并；`placement` 始终取自本组件 `placement`；`initialDivide` 可为像素数字或百分比等字符串（与 bkui ResizeLayout 一致） |
 | onCustomTabChange  | `(tab: CustomTab) => Promise<any>`                                           | —        | 自定义 Tab 切换回调，返回值作为 Tab 组件 props                                                                                                |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/shortcut-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/shortcut-render.md
@@ -466,7 +466,7 @@ const components: ShortcutComponent[] = [
 | ------------- | ------------------------------------ | ---- | ------------------------------------------------------------------------------------------ |
 | type          | 见[表单类型](#表单组件类型)          | ✓    | 控件类型；未知类型返回 `null`，不渲染                                                      |
 | key           | `string`                             | ✓    | 表单字段名；`submit` 事件返回对象以此为 key；同时作为校验 property                         |
-| name          | `string`                             | —    | 表单项标签（`Form.FormItem` 的 `label`）                                                   |
+| name          | `string`                             | —    | 表单项标签；优先于 `formItemProps.label`，通过 `#label` 插槽渲染为 `.shortcut-render-form-label` |
 | default       | `string`                             | —    | 字段初始值；优先于 `formModel`，在 `watchEffect` 中覆盖写入                                |
 | fillBack      | `boolean`                            | —    | `true` 时映射为 `required: true`（必填校验），同时标记回填语义                             |
 | placeholder   | `string`                             | —    | 占位文本（`input` / `textarea` / `number` 可用）                                           |
@@ -535,7 +535,7 @@ interface BaseShortcutComponent {
 
 ## 样式说明
 
-组件内部使用 SCSS 变量 `$bk-prefix` 拼接 bkui-vue 组件类名（如 `Form`、`FormItem`、`Radio`、`Checkbox` 等），替代原先硬编码的 `.bk-*` 类名选择器，确保在不同构建环境下类名前缀的一致性。
+表单项与控件会附加类型化 class，便于样式覆盖：`shortcut-render-form-item_{type}`（如 `_radio`、`_checkbox`），单选/多选项子项为 `shortcut-render-form-item_radio` / `shortcut-render-form-item_checkbox`。表单项标签使用 BEM 风格类名 `shortcut-render-form-label`。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/i18n/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/i18n/index.md
@@ -173,6 +173,7 @@ t('未定义的文本'); // ✗ 编译报错
 | `挂起`       | Pending           |
 | `待执行`     | To Be Executed    |
 | `详情`       | Details           |
+| `有效证据`   | Valid Evidence    |
 | `节点`       | Node              |
 | `节点配置`   | Node Config       |
 | `节点输出`   | Node Output       |


### PR DESCRIPTION
ChatContainer：
- 新增 getSideRenderComponent / getSideTabRenderComponent，应用层可覆盖侧栏内容与 Tab 标签
- 搜索有关键字时也可展示侧栏；调整 ResizeLayout 与 Tab 相关样式选择器

FlowAgent：
- BkFlowTask 扩展 has_confidence、is_active；支持「有效证据」侧栏 Tab
- is_active && task_tab 时首次自动打开任务 Tab；任务/节点与侧栏 Tab 选中态联动
- Share 模式隐藏任务耗时与有效证据入口；卸载时清理任务/节点/证据 Tab

其他：
- ShortcutRender 使用 label 插槽展示 component.name，优化 checkbox/radio 样式
- Playground 增加 custom-tab-content 与侧栏渲染示例；新增/更新 wikis 侧栏文档
- 国际化「有效证据」；biome 增加 noDebugger 规则 # Reviewed, transaction id: 80303