### PR TITLE
feat(chat-x): InterruptMessage 字段迁入 content 并完善审批卡片

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
@@ -25,44 +25,173 @@
  */
 import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus } from '../src';
 
-import type { Interrupt, Message } from '../src';
+import type { Interrupt, InterruptMessage, Message, RunFinishedOutcome } from '../src';
 
-const approvalInterrupt: Interrupt = {
-  id: 'interrupt_ai_dev_tool_approval',
-  reason: InterruptReason.AIDevToolApproval,
-  toolCallId: 'tool_call_review_ticket',
-  message: '算法方案评审单正在评审中',
-  metadata: {
-    ticket: {
-      approvers: ['张三', '李四', 'xddddssss', 'ddd'],
-      sn: 'REV-2026-04-24-001',
-      status: APPROVAL_STATUS.PENDING,
-      submit_time: '2026-04-24 14:30:15',
-      title: '算法方案评审单',
-      url: 'https://example.com/review-tickets/REV-2026-04-24-001',
-    },
-  },
+type ApprovalInterruptOptions = {
+  id: string;
+  message?: string;
+  sn: string;
+  status: APPROVAL_STATUS;
+  title?: string;
+  toolCallId?: string;
 };
 
-export const MOCK_INTERRUPT_MESSAGES: Message[] = [
-  {
-    id: 'msg_ai_dev_tool_approval_intro',
-    role: MessageRole.Assistant,
-    content: '我已经为您生成了5个冒泡排序算法方案。同时，我注意到有一个相关的技术评审单据需要您关注：',
-    status: MessageStatus.Complete,
-    messageId: 'msg_ai_dev_tool_approval_intro',
-  },
-  {
-    id: 'msg_ai_dev_tool_approval_interrupt',
-    messageId: 'msg_ai_dev_tool_approval_interrupt',
-    role: MessageRole.Interrupt,
-    status: MessageStatus.Complete,
-    content: '',
-    runId: 'run_ai_dev_tool_approval',
-    threadId: 'thread_ai_dev_tool_approval',
-    outcome: {
-      type: 'interrupt',
-      interrupts: [approvalInterrupt],
+/** 构造 AI Dev 工具审批类 Interrupt */
+const createApprovalInterrupt = (options: ApprovalInterruptOptions): Interrupt => ({
+  id: options.id,
+  reason: InterruptReason.AIDevToolApproval,
+  toolCallId: options.toolCallId ?? `tool_call_${options.id}`,
+  message: options.message ?? '算法方案评审单需要您关注',
+  metadata: {
+    ticket: {
+      approvers: ['张三', '李四', '王五'],
+      sn: options.sn,
+      status: options.status,
+      submit_time: '2026-04-24 14:30:15',
+      title: options.title ?? '算法方案评审单',
+      url: `https://example.com/review-tickets/${options.sn}`,
     },
   },
+});
+
+type InterruptMessageContent = InterruptMessage['content'];
+
+/** 构造 InterruptMessage.content，字段与 InterruptMessage 类型对齐 */
+const createInterruptContent = (
+  interrupt: Interrupt,
+  outcome: RunFinishedOutcome,
+  extras?: Pick<InterruptMessageContent, 'result' | 'runId' | 'threadId'>,
+): InterruptMessageContent => ({
+  message: interrupt.message,
+  runId: extras?.runId ?? `run_${interrupt.id}`,
+  threadId: extras?.threadId ?? `thread_${interrupt.id}`,
+  outcome,
+  result: extras?.result,
+});
+
+/** 单场景：[引导 Assistant, InterruptMessage] */
+const createInterruptScenario = (params: {
+  interrupt: Interrupt;
+  intro: string;
+  outcome: RunFinishedOutcome;
+  result?: unknown;
+  scenarioId: string;
+  status?: MessageStatus;
+}): Message[] => {
+  const { scenarioId, intro, interrupt, outcome, status = MessageStatus.Complete, result } = params;
+
+  return [
+    {
+      id: `msg_${scenarioId}_intro`,
+      messageId: `msg_${scenarioId}_intro`,
+      role: MessageRole.Assistant,
+      content: intro,
+      status: MessageStatus.Complete,
+    },
+    {
+      id: `msg_${scenarioId}_interrupt`,
+      messageId: `msg_${scenarioId}_interrupt`,
+      role: MessageRole.Interrupt,
+      status,
+      content: createInterruptContent(interrupt, outcome, { result }),
+    },
+  ];
+};
+
+// —— 场景 1：待审批（outcome.interrupt，消息 Pending，等待 resume）——
+const pendingInterrupt = createApprovalInterrupt({
+  id: 'interrupt_pending',
+  sn: 'REV-2026-04-24-001',
+  status: APPROVAL_STATUS.PENDING,
+  message: '算法方案评审单正在评审中',
+});
+const pendingScenario = createInterruptScenario({
+  scenarioId: 'interrupt_pending',
+  intro: '【待审批】已生成算法方案，关联评审单待您处理：',
+  interrupt: pendingInterrupt,
+  outcome: { type: 'interrupt', interrupts: [pendingInterrupt] },
+  status: MessageStatus.Pending,
+});
+
+// —— 场景 2：已批准（单据 approved，仍展示审批卡片）——
+const approvedInterrupt = createApprovalInterrupt({
+  id: 'interrupt_approved',
+  sn: 'REV-2026-04-24-002',
+  status: APPROVAL_STATUS.APPROVED,
+  message: '算法方案评审单已通过',
+});
+const approvedScenario = createInterruptScenario({
+  scenarioId: 'interrupt_approved',
+  intro: '【已批准】评审单已通过，可继续后续流程：',
+  interrupt: approvedInterrupt,
+  outcome: { type: 'interrupt', interrupts: [approvedInterrupt] },
+});
+
+// —— 场景 3：已拒绝 ——
+const rejectedInterrupt = createApprovalInterrupt({
+  id: 'interrupt_rejected',
+  sn: 'REV-2026-04-24-003',
+  status: APPROVAL_STATUS.REJECTED,
+  message: '算法方案评审单已被拒绝',
+});
+const rejectedScenario = createInterruptScenario({
+  scenarioId: 'interrupt_rejected',
+  intro: '【已拒绝】评审单未通过，请根据意见调整后重提：',
+  interrupt: rejectedInterrupt,
+  outcome: { type: 'interrupt', interrupts: [rejectedInterrupt] },
+});
+
+// —— 场景 4：已取消 ——
+const cancelledInterrupt = createApprovalInterrupt({
+  id: 'interrupt_cancelled',
+  sn: 'REV-2026-04-24-004',
+  status: APPROVAL_STATUS.CANCELLED,
+  message: '算法方案评审单已取消',
+});
+const cancelledScenario = createInterruptScenario({
+  scenarioId: 'interrupt_cancelled',
+  intro: '【已取消】该评审单已被发起人撤销：',
+  interrupt: cancelledInterrupt,
+  outcome: { type: 'interrupt', interrupts: [cancelledInterrupt] },
+});
+
+// —— 场景 5：用户已 resume（outcome.success + result，不渲染中断卡片）——
+const resumedScenario = createInterruptScenario({
+  scenarioId: 'interrupt_resumed',
+  intro: '【已处理】您已确认关注该评审单，Agent 将继续执行：',
+  interrupt: createApprovalInterrupt({
+    id: 'interrupt_resumed',
+    sn: 'REV-2026-04-24-005',
+    status: APPROVAL_STATUS.PENDING,
+  }),
+  outcome: { type: 'success' },
+  result: {
+    interruptId: 'interrupt_resumed',
+    status: 'acknowledged',
+    payload: { action: 'view_ticket' },
+  },
+});
+
+// —— 场景 6：不支持的中断类型（走兜底文案）——
+const unsupportedInterrupt: Interrupt = {
+  id: 'interrupt_unsupported',
+  reason: 'unknown_reason' as InterruptReason,
+  toolCallId: 'tool_call_unsupported',
+  message: '暂不支持的中断类型示例',
+};
+const unsupportedScenario = createInterruptScenario({
+  scenarioId: 'interrupt_unsupported',
+  intro: '【兜底】以下中断类型暂未实现专用卡片：',
+  interrupt: unsupportedInterrupt,
+  outcome: { type: 'interrupt', interrupts: [unsupportedInterrupt] },
+});
+
+/** playground 全量中断 mock：覆盖审批态 + resume 态 + 兜底态 */
+export const MOCK_INTERRUPT_MESSAGES: Message[] = [
+  ...pendingScenario,
+  ...approvedScenario,
+  ...rejectedScenario,
+  ...cancelledScenario,
+  ...resumedScenario,
+  ...unsupportedScenario,
 ];

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
@@ -30,13 +30,14 @@ export enum APPROVAL_STATUS {
   ABANDONED = 'abandoned', // 已废弃
   APPROVED = 'approved', // 已批准
   CANCELLED = 'cancelled', // 已取消
+  DRAFT = 'draft', // 草稿 - 待审批
   EXPIRED = 'expired', // 已过期
   PENDING = 'pending', // 待审批
   REJECTED = 'rejected', // 已拒绝
 }
 
 export enum InterruptReason {
-  AIDevToolApproval = 'ai_dev:tool_approval', // AI dev 第三方审批
+  AIDevToolApproval = 'aidev:tool_approval', // AI dev 第三方审批
   HumanApproval = 'human_approval', // 人工审批
   UserMultiChoice = 'user_multi_choice', // 用户多选
   UserSingleChoice = 'user_single_choice', // 用户单选
@@ -92,9 +93,10 @@ export enum MessageStatus {
 
 export const APPROVAL_STATUS_MAP: Record<APPROVAL_STATUS, string> = {
   [APPROVAL_STATUS.ABANDONED]: t('已废弃'),
-  [APPROVAL_STATUS.APPROVED]: t('已批准'),
+  [APPROVAL_STATUS.APPROVED]: t('已审批'),
   [APPROVAL_STATUS.CANCELLED]: t('已取消'),
   [APPROVAL_STATUS.EXPIRED]: t('已过期'),
-  [APPROVAL_STATUS.PENDING]: t('评审中'),
+  [APPROVAL_STATUS.PENDING]: t('待审批'),
   [APPROVAL_STATUS.REJECTED]: t('已拒绝'),
+  [APPROVAL_STATUS.DRAFT]: t('待审批'),
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
@@ -72,15 +72,18 @@ export type InterruptItem = Interrupt;
  *
  * @see https://docs.ag-ui.com/drafts/interrupts
  */
-export interface InterruptMessage extends BaseMessage<MessageRole.Interrupt, string> {
-  message?: string;
-  /** 是否已被用户响应（resume）过，用于 UI 区分"等待响应 / 已处理"两种态 */
-  outcome?: RunFinishedOutcome;
-  /** outcome.type === success 用户 resume 时回传给 Agent 的 payload，便于回放与持久化 */
-  result?: any;
-  runId?: string;
-  threadId?: string;
-}
+export type InterruptMessage = BaseMessage<
+  MessageRole.Interrupt,
+  {
+    message?: string;
+    /** 是否已被用户响应（resume）过，用于 UI 区分"等待响应 / 已处理"两种态 */
+    outcome?: RunFinishedOutcome;
+    /** outcome.type === success 用户 resume 时回传给 Agent 的 payload，便于回放与持久化 */
+    result?: any;
+    runId?: string;
+    threadId?: string;
+  }
+>;
 
 export type OnInterruptResume = (interrupt: Interrupt, payload?: Record<string, any>) => Promise<void> | void;
 export type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -232,7 +232,7 @@
 
   import { Button, ResizeLayout, Tab } from 'bkui-vue';
 
-  import { type Message, type UserMessage, MessageRole, MessageStatus } from '../../ag-ui/types';
+  import { type Message, type UserMessage, MessageStatus } from '../../ag-ui/types';
   import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
   import { useMessageGroup } from '../../composables';
   import { useCommonTippyProvider, useRenderModeProvider } from '../../composables/use-common';
@@ -245,7 +245,6 @@
   import ShortcutRender from '../ai-shortcut/shortcut-render/shortcut-render.vue';
   import ContentRender from '../chat-content/content-render/content-render.vue';
   import ChatInput, { type ChatInputEmits, type ChatInputProps } from '../chat-input/chat-input.vue';
-  import InterruptMessage from '../chat-message/interrupt-message/interrupt-message.vue';
   import MessageContainer, {
     type MessageContainerEmits,
     type MessageContainerProps,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -68,6 +68,14 @@ const unsupportedInterrupt: Interrupt = {
   message: '暂不支持的中断消息',
 };
 
+/** 与 message-render 透传一致：outcome / message 位于 content 内 */
+const buildInterruptProps = (outcome: { interrupts?: Interrupt[]; type: string }, message?: string) => ({
+  content: {
+    message,
+    outcome,
+  },
+});
+
 describe('InterruptMessage', () => {
   let wrapper: VueWrapper;
 
@@ -83,17 +91,15 @@ describe('InterruptMessage', () => {
 
   it('应该按设计稿渲染 AI Dev 工具审批单信息', () => {
     wrapper = mount(InterruptMessage, {
-      props: {
-        outcome: {
-          type: 'interrupt',
-          interrupts: [approvalInterrupt],
-        },
-      },
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [approvalInterrupt],
+      }),
     });
 
     expect(wrapper.find('.ai-interrupt-message').exists()).toBe(true);
     expect(wrapper.find('.ai-tool-approval-card__title').text()).toBe('算法方案评审单');
-    expect(wrapper.find('.ai-tool-approval-card__status').text()).toBe('评审中');
+    expect(wrapper.find('.ai-tool-approval-card__status').text()).toBe('待审批');
     expect(wrapper.text()).toContain('REV-2026-04-24-001');
     expect(wrapper.text()).toContain('2026-04-24 14:30:15');
     expect(wrapper.text()).toContain('张三、李四、王五');
@@ -103,10 +109,10 @@ describe('InterruptMessage', () => {
     const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {
       props: {
-        outcome: {
+        ...buildInterruptProps({
           type: 'interrupt',
           interrupts: [approvalInterrupt],
-        },
+        }),
         onInterruptResume,
       },
     });
@@ -121,10 +127,10 @@ describe('InterruptMessage', () => {
     const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {
       props: {
-        outcome: {
+        ...buildInterruptProps({
           type: 'interrupt',
           interrupts: [approvalInterrupt],
-        },
+        }),
         onInterruptResume,
       },
     });
@@ -137,12 +143,10 @@ describe('InterruptMessage', () => {
 
   it('不支持的中断类型应该显示兜底文案', () => {
     wrapper = mount(InterruptMessage, {
-      props: {
-        outcome: {
-          type: 'interrupt',
-          interrupts: [unsupportedInterrupt],
-        },
-      },
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [unsupportedInterrupt],
+      }),
     });
 
     expect(wrapper.find('.ai-interrupt-message__fallback').exists()).toBe(true);
@@ -151,14 +155,26 @@ describe('InterruptMessage', () => {
 
   it('success outcome 不渲染中断卡片', () => {
     wrapper = mount(InterruptMessage, {
-      props: {
-        outcome: {
-          type: 'success',
-        },
-      },
+      props: buildInterruptProps({
+        type: 'success',
+      }),
     });
 
     expect(wrapper.find('.ai-tool-approval-card').exists()).toBe(false);
     expect(wrapper.find('.ai-interrupt-message__fallback').exists()).toBe(false);
+  });
+
+  it('content.message 存在时应渲染提示文案', () => {
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps(
+        {
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        },
+        '需要关注技术评审单据',
+      ),
+    });
+
+    expect(wrapper.find('.ai-interrupt-message__content').text()).toBe('需要关注技术评审单据');
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
@@ -41,8 +41,10 @@
 
   const props = defineProps<Partial<InterruptMessage> & { onInterruptResume?: OnInterruptResume }>();
 
-  const interruptList = computed(() => (props.outcome?.type === 'interrupt' ? props.outcome.interrupts : []));
-  const displayMessage = computed(() => props.message || props.content);
+  const interruptList = computed(() =>
+    props.content?.outcome?.type === 'interrupt' ? props.content.outcome.interrupts : [],
+  );
+  const displayMessage = computed(() => props.content?.message);
 
   const getRenderer = (item: Interrupt) => interruptRenderers[item.reason];
 </script>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -9,9 +9,20 @@
         class="ai-tool-approval-card__status"
         :class="`ai-tool-approval-card__status--${ticket.status}`"
       >
-        <span
-          v-if="ticket.status === APPROVAL_STATUS.PENDING"
+        <CheckCircleFillIcon
+          v-if="ticket.status === APPROVAL_STATUS.APPROVED"
           class="ai-tool-approval-card__status-icon"
+        />
+        <CloseCircleFillIcon
+          v-else-if="ticket.status === APPROVAL_STATUS.REJECTED"
+          class="ai-tool-approval-card__status-icon"
+        />
+        <Loading
+          v-else
+          class="ai-tool-approval-card__status-icon"
+          mode="spin"
+          size="mini"
+          theme="primary"
         />
         {{ statusText }}
       </span>
@@ -29,7 +40,7 @@
     </dl>
 
     <div class="ai-tool-approval-card__processor">
-      <span class="ai-tool-approval-card__processor-icon" />
+      <TimeIcon class="ai-tool-approval-card__processor-icon" />
       <span
         v-overflow-tips="{ ...commonTippyOptions }"
         class="ai-tool-approval-card__processor-text"
@@ -62,13 +73,14 @@
 <script setup lang="ts">
   import { computed } from 'vue';
 
-  import { Button } from 'bkui-vue';
+  import { Button, Loading } from 'bkui-vue';
 
   import { APPROVAL_STATUS_MAP } from '../../../ag-ui/types/constants';
   import { APPROVAL_STATUS } from '../../../ag-ui/types/constants';
   import { useClipboard } from '../../../composables';
   import { useCommonTippyInject } from '../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../directives/overflow-tips';
+  import { CheckCircleFillIcon, CloseCircleFillIcon, TimeIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
 
   import type { AIDevToolApprovalInterrupt } from '../../../ag-ui/types/interrupt';
@@ -183,9 +195,6 @@
       flex: 0 0 16px;
       width: 16px;
       height: 16px;
-      border: 2px solid currentcolor;
-      border-left-color: transparent;
-      border-radius: 50%;
     }
 
     &__fields {
@@ -230,35 +239,10 @@
     }
 
     &__processor-icon {
-      position: relative;
       flex: 0 0 16px;
       width: 16px;
       height: 16px;
-      border: 1.5px solid #3a84ff;
-      border-radius: 50%;
-
-      &::before,
-      &::after {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        display: block;
-        width: 1.5px;
-        content: '';
-        background: #3a84ff;
-        border-radius: 1px;
-        transform-origin: top center;
-      }
-
-      &::before {
-        height: 5px;
-        transform: translate(-50%, -90%);
-      }
-
-      &::after {
-        height: 4px;
-        transform: translate(-50%, -10%) rotate(90deg);
-      }
+      color: #3a84ff;
     }
 
     &__processor-text {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -225,7 +225,7 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
       });
     } else if (msg.role === MessageRole.Assistant) {
       const lastGroup = groups[groups.length - 1];
-      if (lastGroup && lastGroup.type === MessageRole.Assistant) {
+      if (lastGroup?.type === MessageRole.Assistant) {
         lastGroup.messages.push(msg);
       } else {
         groups.push({
@@ -240,14 +240,14 @@ const buildGroups = (messages: Message[]): MessageGroup[] => {
       }
     } else if (msg.role === MessageRole.Tool) {
       const lastGroup = groups[groups.length - 1];
-      if (lastGroup && lastGroup.type === MessageRole.Assistant) {
+      if (lastGroup?.type === MessageRole.Assistant) {
         lastGroup.messages.push(msg);
       }
     }
   }
 
   const lastMsg = messages[messages.length - 1];
-  if (lastMsg && lastMsg.role === MessageRole.User) {
+  if (lastMsg?.role === MessageRole.User) {
     groups.push({
       uid: 'loading-group',
       messages: [
@@ -478,7 +478,7 @@ describe('MessageContainer', () => {
       const scrollBtns = wrapper.findAll('.mock-scroll-btn');
       const stopBtn = scrollBtns.find(btn => btn.text().includes('停止生成'));
       expect(stopBtn).toBeTruthy();
-      expect((stopBtn!.element as HTMLElement).style.display).toBe('none');
+      expect((stopBtn?.element as HTMLElement).style.display).toBe('none');
     });
 
     it('点击停止生成按钮应该触发 stopStreaming 事件', async () => {
@@ -571,6 +571,46 @@ describe('MessageContainer', () => {
       await nextTick();
 
       expect(getToolsVisibility(wrapper)).toBe('visible');
+    });
+
+    it('消息组最后一条为 Interrupt 时 mouseenter 不应显示 MessageTools', async () => {
+      const interruptMessage: Message = {
+        id: 'interrupt-1',
+        content: {
+          outcome: {
+            type: 'interrupt',
+            interrupts: [],
+          },
+        },
+        messageId: 2,
+        role: MessageRole.Interrupt,
+        status: MessageStatus.Complete,
+      };
+      const messageGroups: MessageGroup[] = [
+        {
+          uid: 'group-assistant-interrupt',
+          messages: [createAssistantMessage('1', 'Hello', 1), interruptMessage],
+          type: MessageRole.Assistant,
+          isHover: false,
+          checked: false,
+        },
+      ];
+
+      wrapper = mount(MessageContainer, {
+        props: {
+          ...defaultProps,
+          messages: messageGroups[0].messages,
+          messageGroups,
+        },
+      });
+
+      await nextTick();
+
+      const messageGroup = wrapper.find('.message-group');
+      await messageGroup.trigger('mouseenter');
+
+      expect(wrapper.find('.mock-message-tools').exists()).toBe(true);
+      expect(getToolsVisibility(wrapper)).toBe('hidden');
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -191,10 +191,14 @@
   const messageTools = computed(() => {
     return CONST_MESSAGE_TOOLS.filter(tool => props.renderMode !== RenderMode.Test || tool.id !== 'share');
   });
-  const handleMouseEnter = (group: { isHover: boolean }) => {
+  const handleMouseEnter = (group: MessageGroup) => {
+    const lastMessage = group.messages?.at(-1);
+    if (lastMessage?.role === MessageRole.Interrupt) {
+      return;
+    }
     group.isHover = true;
   };
-  const handleMouseLeave = (group: { isHover: boolean }, e: MouseEvent) => {
+  const handleMouseLeave = (group: MessageGroup, e: MouseEvent) => {
     const related = (e as MouseEvent & { toElement?: Element }).toElement ?? e.relatedTarget;
     if (related instanceof Element && related.classList.contains('ai-user-feedback')) {
       return;

--- a/src/frontend/ai-blueking/packages/chat-x/src/icons/index.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/icons/index.ts
@@ -29,6 +29,7 @@ export * from './content';
 export * from './execution';
 export * from './image-preview';
 export * from './input';
+export * from './interrupt';
 export * from './messages';
 export * from './shortcuts';
 export * from './tools';

--- a/src/frontend/ai-blueking/packages/chat-x/src/icons/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/icons/interrupt.ts
@@ -1,0 +1,82 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { h } from 'vue';
+
+import { commonSVGProps } from '../common';
+export const CheckCircleFillIcon = h(
+  'svg',
+  {
+    ...commonSVGProps,
+    class: {
+      [commonSVGProps.class]: true,
+      'ai-check-circle-icon': true,
+    },
+  },
+  [
+    // 图标路径
+    h('path', {
+      d: 'M512 85.333333c235.52 0 426.666667 191.146667 426.666667 426.666667s-191.146667 426.666667-426.666667 426.666667S85.333333 747.52 85.333333 512 276.48 85.333333 512 85.333333m-42.666667 618.666667l298.666667-298.666667-60.16-60.16L469.333333 583.253333l-131.84-131.413333L277.333333 512l192 192z',
+    }),
+  ],
+);
+
+export const TimeIcon = h(
+  'svg',
+  {
+    ...commonSVGProps,
+    class: {
+      [commonSVGProps.class]: true,
+      'ai-time-icon': true,
+    },
+  },
+  [
+    // 外圈路径
+    h('path', {
+      d: 'M512 70.4a441.6 441.6 0 1 0 0 883.2 441.6 441.6 0 0 0 0-883.2z m0 64a377.6 377.6 0 1 1 0 755.2 377.6 377.6 0 0 1 0-755.2z',
+    }),
+    // 时针与分针路径
+    h('path', {
+      d: 'M544 480V256a32 32 0 1 0-64 0v230.4c0 31.7952 25.8048 57.6 57.6 57.6H768a32 32 0 1 0 0-64h-224z',
+    }),
+  ],
+);
+
+export const CloseCircleFillIcon = h(
+  'svg',
+  {
+    ...commonSVGProps,
+    class: {
+      [commonSVGProps.class]: true,
+      'ai-close-circle-icon': true,
+    },
+  },
+  [
+    // 图标路径
+    h('path', {
+      d: 'M85.333333 512C85.333333 276.352 276.352 85.333333 512 85.333333s426.666667 191.018667 426.666667 426.666667-191.018667 426.666667-426.666667 426.666667S85.333333 747.648 85.333333 512z m269.653334-96.661333l96.810666 96.810666-96.810666 96.810667c-16.661333 16.661333-16.384 43.84 0.277333 60.501333l0.512 0.512c16.64 16.64 42.88 16 59.541333-0.682666l96.810667-96.810667 96.832 96.810667c16.64 16.682667 42.88 17.344 59.541333 0.682666l0.512-0.512c16.64-16.64 16.938667-43.84 0.277334-60.501333l-96.810667-96.810667 96.810667-96.810666c16.661333-16.661333 16.384-43.861333-0.277334-60.522667l-0.490666-0.490667c-16.682667-16.661333-42.901333-16-59.562667 0.661334l-96.832 96.810666-96.810667-96.810666c-16.64-16.64-42.88-17.322667-59.541333-0.661334a109.44 109.44 0 0 1-0.512 0.490667c-16.64 16.661333-16.938667 43.861333-0.277333 60.522667z',
+    }),
+  ],
+);

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -37,7 +37,7 @@ export const lang = {
   删除: 'Delete',
   引用: 'Quote',
   重新生成: 'Regenerate',
-  '重新生成将清空下文内容': 'Regenerating will clear the content below',
+  重新生成将清空下文内容: 'Regenerating will clear the content below',
   提交: 'Submit',
   取消: 'Cancel',
   预览内容: 'Preview Content',
@@ -141,6 +141,8 @@ export const lang = {
   请选择以继续: 'Please choose to continue',
   继续: 'Continue',
   '收到信息：': 'Received: ',
+  待审批: 'Pending',
+  已审批: 'Approved',
 } as const;
 
 export const t = (key: keyof typeof lang) => {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/config.mts
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/.vitepress/config.mts
@@ -219,8 +219,9 @@ function sidebarAPI() {
       collapsed: false,
       items: [
         { text: '概览', link: 'types/' },
-        { text: '消息类型 Messages', link: 'types/messages' },
         { text: '常量枚举 Constants', link: 'types/constants' },
+        { text: '中断类型 Interrupt', link: 'types/interrupt' },
+        { text: '消息类型 Messages', link: 'types/messages' },
       ],
     },
     {
@@ -267,7 +268,9 @@ function sidebarComponents() {
         { text: 'ToolMessage 工具消息', link: 'molecular/tool-message' },
         { text: 'ActivityMessage 活动消息', link: 'molecular/activity-message' },
         { text: 'InfoMessage 信息消息', link: 'molecular/info-message' },
+        { text: 'InterruptMessage 中断消息', link: 'molecular/interrupt-message' },
         { text: 'LoadingMessage 加载消息', link: 'molecular/loading-message' },
+        { text: 'ToolApprovalCard 审批卡片', link: 'molecular/tool-approval-card' },
       ],
     },
     {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/interrupt-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/interrupt-message.md
@@ -1,0 +1,257 @@
+---
+name: InterruptMessage 中断消息
+slug: interrupt-message
+category: molecular
+description: human-in-the-loop 中断消息渲染器，按 Interrupt.reason 派发专用卡片或兜底文案。
+aiSummary: >
+  InterruptMessageRender 读取 content.outcome.interrupts，展示 content.message 说明，并按 reason 映射 ToolApprovalCard 等子组件；
+  未注册 reason 时展示兜底文案。由 MessageRender 在 interrupt 角色下调用，导出名为 InterruptMessageRender。
+relatedComponents:
+  - slug: message-render
+    relation: role 为 interrupt 时渲染本组件
+  - slug: tool-approval-card
+    relation: AIDevToolApproval 专用子卡片
+  - slug: message-container
+    relation: 透传 onInterruptResume；末条为 interrupt 时不触发组 hover
+sinceVersion: 2.0.0
+domain: message
+---
+
+<script lang="ts" setup>
+  import InterruptMessageRender from '../../../src/components/chat-message/interrupt-message/interrupt-message.vue'
+  import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus } from '../../../src/ag-ui/types/constants'
+
+  const pendingMessage = {
+    id: 'demo-interrupt-pending',
+    messageId: 'demo-interrupt-pending',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      message: '算法方案评审单需要您关注',
+      outcome: {
+        type: 'interrupt' as const,
+        interrupts: [
+          {
+            id: 'interrupt_demo_pending',
+            reason: InterruptReason.AIDevToolApproval,
+            toolCallId: 'tool_call_demo_pending',
+            message: '算法方案评审单需要您关注',
+            metadata: {
+              ticket: {
+                approvers: ['张三', '李四'],
+                sn: 'REV-2026-04-24-001',
+                status: APPROVAL_STATUS.PENDING,
+                submit_time: '2026-04-24 14:30:15',
+                title: '算法方案评审单',
+                url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+              },
+            },
+          },
+        ],
+      },
+    },
+  }
+
+  const unsupportedMessage = {
+    id: 'demo-interrupt-fallback',
+    messageId: 'demo-interrupt-fallback',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Complete,
+    content: {
+      message: '以下中断类型暂未实现专用卡片：',
+      outcome: {
+        type: 'interrupt' as const,
+        interrupts: [
+          {
+            id: 'interrupt_unsupported',
+            reason: 'unknown_reason' as InterruptReason,
+            toolCallId: 'tool_call_unsupported',
+            message: '暂不支持的中断类型示例',
+          },
+        ],
+      },
+    },
+  }
+
+  const resumedMessage = {
+    id: 'demo-interrupt-resumed',
+    messageId: 'demo-interrupt-resumed',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Complete,
+    content: {
+      message: '您已确认关注该评审单',
+      outcome: { type: 'success' as const },
+      result: { interruptId: 'interrupt_resumed', status: 'acknowledged' },
+    },
+  }
+
+  const handleInterruptResume = async (interrupt: { id: string }, payload?: Record<string, unknown>) => {
+    console.log('resume', interrupt.id, payload)
+  }
+</script>
+
+# InterruptMessage 中断消息
+
+> **层级**：分子组件 · **功能域**：消息展示
+
+human-in-the-loop 中断消息渲染器（导出名 **`InterruptMessageRender`**）。对应 `MessageRole.Interrupt`，解析 `content.outcome` 渲染审批卡片或兜底提示。
+
+> 通常由 [MessageRender](./message-render.md) 自动调用，无需业务侧直接引入。
+
+## 渲染架构
+
+```
+InterruptMessageRender
+├── content.message（可选）→ 顶部说明文案
+└── content.outcome.type === 'interrupt'
+      └── v-for interrupts
+            ├── reason === aidev:tool_approval → ToolApprovalCard
+            └── 未注册 reason → 兜底块（item.message 或「暂不支持的中断消息」）
+
+content.outcome.type === 'success' → 不渲染任何中断卡片
+```
+
+| `InterruptReason`              | 子组件              |
+| ------------------------------ | ------------------- |
+| `aidev:tool_approval`          | `ToolApprovalCard`  |
+| 其他 / 未注册                  | 兜底文案区域        |
+
+## 基础用法（待审批）
+
+```vue
+<template>
+  <InterruptMessageRender
+    :id="message.id"
+    :message-id="message.messageId"
+    :role="message.role"
+    :status="message.status"
+    :content="message.content"
+    :on-interrupt-resume="handleInterruptResume"
+  />
+</template>
+
+<script setup lang="ts">
+  import {
+    InterruptMessageRender,
+    APPROVAL_STATUS,
+    InterruptReason,
+    MessageRole,
+    MessageStatus,
+    type InterruptMessage,
+  } from '@blueking/chat-x';
+
+  const message: InterruptMessage = {
+    id: 'msg_interrupt',
+    messageId: 'msg_interrupt',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      message: '算法方案评审单需要您关注',
+      outcome: {
+        type: 'interrupt',
+        interrupts: [
+          {
+            id: 'interrupt_1',
+            reason: InterruptReason.AIDevToolApproval,
+            toolCallId: 'tool_call_1',
+            metadata: {
+              ticket: {
+                approvers: ['张三'],
+                sn: 'REV-2026-04-24-001',
+                status: APPROVAL_STATUS.PENDING,
+                submit_time: '2026-04-24 14:30:15',
+                title: '算法方案评审单',
+                url: 'https://example.com/tickets/001',
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  const handleInterruptResume = async (interrupt, payload) => {
+    console.log(interrupt.id, payload);
+  };
+</script>
+```
+
+**渲染效果**
+
+<div class="demo">
+  <InterruptMessageRender
+    v-bind="pendingMessage"
+    :on-interrupt-resume="handleInterruptResume"
+  />
+</div>
+
+## 已 resume（outcome.success）
+
+`outcome.type === 'success'` 时不渲染中断卡片，仅保留可选顶部 `content.message`：
+
+```vue
+<InterruptMessageRender
+  :content="{ message: '您已确认关注该评审单', outcome: { type: 'success' } }"
+  role="interrupt"
+/>
+```
+
+**渲染效果**
+
+<div class="demo">
+  <InterruptMessageRender v-bind="resumedMessage" />
+</div>
+
+## 不支持的中断类型（兜底）
+
+```vue
+<InterruptMessageRender :content="unsupportedContent" role="interrupt" />
+```
+
+**渲染效果**
+
+<div class="demo">
+  <InterruptMessageRender v-bind="unsupportedMessage" />
+</div>
+
+## 在 MessageContainer 中使用
+
+配置 `onInterruptResume`，由容器经 `MessageRender` 透传到本组件：
+
+```vue
+<MessageContainer
+  :messages="messages"
+  :on-interrupt-resume="handleInterruptResume"
+/>
+```
+
+当消息组**最后一条**为 `role: 'interrupt'` 时，容器**不会**在鼠标移入时设置 `isHover`，避免误显 AI 工具栏遮挡审批卡片。
+
+## API
+
+### Props
+
+继承 `Partial<InterruptMessage>` 的字段（`id`、`messageId`、`role`、`content`、`status` 等），并额外支持：
+
+| 属性名            | 类型               | 默认值 | 说明                                      |
+| ----------------- | ------------------ | ------ | ----------------------------------------- |
+| content           | `InterruptMessage['content']` | — | 含 `message`、`outcome`、`result` 等      |
+| onInterruptResume | `OnInterruptResume` | —     | 用户完成中断操作后的回调（可选）          |
+
+### Events / Slots / Expose
+
+无。
+
+## 类型定义
+
+```typescript
+import type { Interrupt, InterruptMessage, OnInterruptResume } from '@blueking/chat-x';
+```
+
+详见 [中断类型 Interrupt](../../types/interrupt.md)。
+
+## 关联组件
+
+- [ToolApprovalCard](./tool-approval-card.md) — AI Dev 审批单卡片
+- [MessageRender](./message-render.md) — 按 `role` 派发
+- [MessageContainer](./message-container.md) — 列表容器与 `onInterruptResume` 透传

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-container.md
@@ -14,6 +14,8 @@ relatedComponents:
     relation: 常与 ChatInput 组合构成完整对话界面
   - slug: loading-message
     relation: 末尾为用户消息时自动追加 Loading 消息组
+  - slug: interrupt-message
+    relation: 透传 onInterruptResume；末条 interrupt 消息不触发组 hover
 sinceVersion: 1.0.0
 domain: message
 ---
@@ -386,6 +388,7 @@ domain: message
 - 每个消息组外层 DOM 的 `id` 为 **`MessageGroup.uid`**（由 `useMessageGroup` 生成），供执行摘要「在对话中定位」、侧栏自定义 Tab 等场景滚动锚定
 - `role: 'tool'` 消息**不会独立渲染**，而是被注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段
 - 若 `toolMessage.error` 存在，AssistantMessage 的 `status` 会被强制设为 `MessageStatus.Error`
+- 当消息组**最后一条**消息的 `role === 'interrupt'` 时，`mouseenter` **不会**设置 `isHover`，避免 AI 工具栏在审批卡片上误显
 - `MessageTools` 工具栏只在 `type === 'assistant'` 的消息组底部渲染（不依赖鼠标悬停，始终可见），且满足以下条件时**不渲染**：
   - `renderMode === RenderMode.Share`（分享预览模式）
   - 消息组的 `pause` 为 `true`（来源于 `message.property?.extra?.pause`）
@@ -916,6 +919,7 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 | onUserAction             | `(tool: IToolBtn, message: Message) => Promise<string[] \| void>`                            | —       | 用户消息工具操作回调                                                                                                                     |
 | onUserInputConfirm       | `(message: Message, content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | —       | 用户编辑消息确认回调                                                                                                                     |
 | onUserShortcutConfirm    | `(message: Message, formModel: Record<string, unknown>) => Promise<void>`                    | —       | 用户快捷指令表单提交回调                                                                                                                 |
+| onInterruptResume        | `OnInterruptResume`                                                                          | —       | AG-UI human-in-the-loop 中断响应回调，透传给 `MessageRender` → `InterruptMessageRender`                                                  |
 | renderMode               | `RenderMode`                                                                                 | —       | 渲染模式。`Share` 模式下启用多选样式并隐藏工具栏；`Test` 模式下过滤掉「分享」按钮；不传或 `Chat` 为默认行为                              |
 
 ### v-model
@@ -966,6 +970,7 @@ enum MessageRole {
   Reasoning = 'reasoning',
   Activity = 'activity',
   Info = 'info',
+  Interrupt = 'interrupt',
   Loading = 'loading',
 }
 
@@ -983,5 +988,6 @@ enum MessageStatus {
 ## 关联组件
 
 - [MessageRender](./message-render.md) — 按组渲染每条消息时委托使用
+- [InterruptMessage 中断消息](./interrupt-message.md) — `role: 'interrupt'` 的渲染与 `onInterruptResume` 透传
 - [ChatInput](./chat-input.md) — 常与输入区组合构成完整对话界面
 - [LoadingMessage](./loading-message.md) — 末尾为用户消息时自动追加加载组

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/message-render.md
@@ -14,6 +14,8 @@ relatedComponents:
     relation: role 为 assistant 时渲染 AI 回复与工具调用
   - slug: user-message
     relation: role 为 user 时渲染用户消息
+  - slug: interrupt-message
+    relation: role 为 interrupt 时渲染 InterruptMessageRender
 sinceVersion: 1.0.0
 domain: message
 ---
@@ -506,3 +508,5 @@ enum MessageToolsStatus {
 - [MessageContainer](./message-container.md) — 内部按组调用以渲染每条消息
 - [AssistantMessage](./assistant-message.md) — assistant 角色派发目标
 - [UserMessage](./user-message.md) — user 角色派发目标
+- [InterruptMessage 中断消息](./interrupt-message.md) — interrupt 角色派发目标
+- [ToolApprovalCard 审批卡片](./tool-approval-card.md) — AI Dev 审批中断子卡片

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/tool-approval-card.md
@@ -1,0 +1,192 @@
+---
+name: ToolApprovalCard 审批卡片
+slug: tool-approval-card
+category: molecular
+description: AI Dev 工具审批中断专用卡片，展示评审单状态、处理人与详情/复制操作。
+aiSummary: >
+  接收 AIDevToolApprovalInterrupt，从 metadata.ticket 渲染标题、状态徽章、单据编号、提交时间、当前处理人；
+  支持打开详情链接与复制 url/sn。由 InterruptMessageRender 在 reason 为 aidev:tool_approval 时挂载。
+relatedComponents:
+  - slug: interrupt-message
+    relation: InterruptMessageRender 按 reason 派发渲染
+sinceVersion: 2.0.0
+domain: message
+---
+
+<script lang="ts" setup>
+  import ToolApprovalCard from '../../../src/components/chat-message/interrupt-message/tool-approval-card.vue'
+  import { APPROVAL_STATUS, InterruptReason } from '../../../src/ag-ui/types/constants'
+
+  const pendingInterrupt = {
+    id: 'interrupt_pending',
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: 'tool_call_pending',
+    metadata: {
+      ticket: {
+        approvers: ['张三', '李四', '王五'],
+        sn: 'REV-2026-04-24-001',
+        status: APPROVAL_STATUS.PENDING,
+        submit_time: '2026-04-24 14:30:15',
+        title: '算法方案评审单',
+        url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+      },
+    },
+  }
+
+  const approvedInterrupt = {
+    id: 'interrupt_approved',
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: 'tool_call_approved',
+    metadata: {
+      ticket: {
+        approvers: ['张三'],
+        sn: 'REV-2026-04-24-002',
+        status: APPROVAL_STATUS.APPROVED,
+        submit_time: '2026-04-24 15:00:00',
+        title: '算法方案评审单',
+        url: 'https://example.com/review-tickets/REV-2026-04-24-002',
+      },
+    },
+  }
+
+  const rejectedInterrupt = {
+    id: 'interrupt_rejected',
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: 'tool_call_rejected',
+    metadata: {
+      ticket: {
+        approvers: ['李四'],
+        sn: 'REV-2026-04-24-003',
+        status: APPROVAL_STATUS.REJECTED,
+        submit_time: '2026-04-24 16:00:00',
+        title: '算法方案评审单',
+        url: 'https://example.com/review-tickets/REV-2026-04-24-003',
+      },
+    },
+  }
+</script>
+
+# ToolApprovalCard 审批卡片
+
+> **层级**：分子组件 · **功能域**：消息展示
+
+AI Dev 第三方工具审批（`InterruptReason.AIDevToolApproval`）专用卡片，由 [InterruptMessageRender](./interrupt-message.md) 按 `reason` 动态挂载。
+
+> **通常不需要单独引入**；仅在需要独立预览卡片样式时使用。
+
+## 渲染结构
+
+```
+ToolApprovalCard
+├── 标题栏：左侧色条 + 单据标题 + 状态徽章（待审批/已审批/已拒绝等）
+├── 字段区：单据编号、提交时间
+├── 处理人：当前处理人（overflow-tips 省略）
+└── 操作区：查看单据详情（新窗口打开 url）、复制单据（url 或 sn）
+```
+
+状态徽章样式：
+
+| `ticket.status`                         | 视觉     |
+| --------------------------------------- | -------- |
+| `pending`、`draft`                      | 橙色待办 |
+| `approved`                              | 绿色通过 |
+| `rejected`、`cancelled`、`expired`、`abandoned` | 红色终态 |
+
+## 基础用法（待审批）
+
+> `ToolApprovalCard` 为 `InterruptMessageRender` 内部子组件，**未从 `@blueking/chat-x` 包入口导出**。业务侧通过构造 `InterruptMessage` 触发渲染即可；下方为类型与数据结构参考。
+
+```vue
+<template>
+  <!-- 业务侧推荐：由 MessageRender / MessageContainer 自动渲染 -->
+  <InterruptMessageRender
+    :content="interruptMessage.content"
+    role="interrupt"
+    :status="interruptMessage.status"
+  />
+</template>
+
+<script setup lang="ts">
+  import {
+    InterruptMessageRender,
+    APPROVAL_STATUS,
+    InterruptReason,
+    MessageRole,
+    MessageStatus,
+    type InterruptMessage,
+    type AIDevToolApprovalInterrupt,
+  } from '@blueking/chat-x';
+
+  const interrupt: AIDevToolApprovalInterrupt = {
+    id: 'interrupt_1',
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: 'tool_call_1',
+    metadata: {
+      ticket: {
+        approvers: ['张三', '李四'],
+        sn: 'REV-2026-04-24-001',
+        status: APPROVAL_STATUS.PENDING,
+        submit_time: '2026-04-24 14:30:15',
+        title: '算法方案评审单',
+        url: 'https://example.com/tickets/001',
+      },
+    },
+  };
+
+  const interruptMessage: InterruptMessage = {
+    id: 'msg_1',
+    messageId: 'msg_1',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      outcome: { type: 'interrupt', interrupts: [interrupt] },
+    },
+  };
+</script>
+```
+
+**渲染效果**（文档站直接挂载 `ToolApprovalCard` 预览卡片 UI）
+
+<div class="demo">
+  <ToolApprovalCard :interrupt="pendingInterrupt" />
+</div>
+
+## 已审批 / 已拒绝
+
+```vue
+<InterruptMessageRender
+  :content="{ outcome: { type: 'interrupt', interrupts: [approvedInterrupt] } }"
+  role="interrupt"
+/>
+```
+
+**渲染效果**
+
+<div class="demo" style="display: flex; flex-direction: column; gap: 12px;">
+  <ToolApprovalCard :interrupt="approvedInterrupt" />
+  <ToolApprovalCard :interrupt="rejectedInterrupt" />
+</div>
+
+## API
+
+### Props
+
+| 属性名    | 类型                         | 默认值 | 说明                           |
+| --------- | ---------------------------- | ------ | ------------------------------ |
+| interrupt | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket` |
+
+### Events / Slots / Expose
+
+无。交互通过按钮点击在组件内部完成（打开链接、复制剪贴板）。
+
+## 依赖
+
+- `bkui-vue`：`Button`、`Loading`
+- `useClipboard` — 复制单据
+- `v-overflow-tips` — 处理人超长省略
+
+## 关联组件
+
+- [InterruptMessage 中断消息](./interrupt-message.md)
+- [中断类型 Interrupt](../../types/interrupt.md)
+- [常量枚举 Constants](../../types/constants.md) — `APPROVAL_STATUS`、`APPROVAL_STATUS_MAP`

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
@@ -84,7 +84,7 @@ human-in-the-loop 中断原因枚举，用于 `Interrupt.reason` 区分中断类
 
 ```typescript
 enum InterruptReason {
-  AIDevToolApproval = 'ai_dev:tool_approval',
+  AIDevToolApproval = 'aidev:tool_approval',
   HumanApproval = 'human_approval',
   UserMultiChoice = 'user_multi_choice',
   UserSingleChoice = 'user_single_choice',
@@ -100,11 +100,38 @@ enum APPROVAL_STATUS {
   ABANDONED = 'abandoned',
   APPROVED = 'approved',
   CANCELLED = 'cancelled',
+  DRAFT = 'draft',
   EXPIRED = 'expired',
   PENDING = 'pending',
   REJECTED = 'rejected',
 }
 ```
+
+### APPROVAL_STATUS_MAP
+
+审批单状态到展示文案的映射，供 `ToolApprovalCard` 等组件使用：
+
+```typescript
+const APPROVAL_STATUS_MAP: Record<APPROVAL_STATUS, string> = {
+  [APPROVAL_STATUS.ABANDONED]: '已废弃',
+  [APPROVAL_STATUS.APPROVED]: '已审批',
+  [APPROVAL_STATUS.CANCELLED]: '已取消',
+  [APPROVAL_STATUS.DRAFT]: '待审批',
+  [APPROVAL_STATUS.EXPIRED]: '已过期',
+  [APPROVAL_STATUS.PENDING]: '待审批',
+  [APPROVAL_STATUS.REJECTED]: '已拒绝',
+};
+```
+
+| 状态值      | 展示文案 |
+| ----------- | -------- |
+| `pending`   | 待审批   |
+| `draft`     | 待审批   |
+| `approved`  | 已审批   |
+| `rejected`  | 已拒绝   |
+| `cancelled` | 已取消   |
+| `expired`   | 已过期   |
+| `abandoned` | 已废弃   |
 
 ### RunFinishedOutcome
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
@@ -1,0 +1,170 @@
+---
+name: 中断类型 Interrupt
+slug: interrupt
+category: type
+description: AG-UI human-in-the-loop 中断相关类型，含 Interrupt、InterruptMessage 与 resume 回调。
+aiSummary: >
+  定义 RunFinishedOutcome、BaseInterrupt、AIDevToolApprovalInterrupt、InterruptMessage 与 OnInterruptResume。
+  与 MessageRole.Interrupt 及 InterruptMessageRender 组件配合，对应 RUN_FINISHED outcome.type === interrupt。
+relatedComponents:
+  - slug: interrupt-message
+    relation: 根据 outcome.interrupts 与 reason 渲染中断 UI
+  - slug: tool-approval-card
+    relation: AIDevToolApproval 专用卡片
+  - slug: message-render
+    relation: role 为 interrupt 时派发 InterruptMessageRender
+sinceVersion: 2.0.0
+domain: message
+---
+
+# 中断类型 Interrupt
+
+> **分类**：type
+
+AG-UI [Interrupts](https://docs.ag-ui.com/drafts/interrupts) 协议相关类型，定义在 `src/ag-ui/types/interrupt.ts`，由 `@blueking/chat-x` 导出。
+
+## RunFinishedOutcome
+
+`RUN_FINISHED` 事件的 `outcome` 联合类型：
+
+```typescript
+type RunFinishedOutcome =
+  | { interrupts: Interrupt[]; type: 'interrupt' }
+  | { type: 'success' };
+```
+
+| `type`        | 说明                                                                 |
+| ------------- | -------------------------------------------------------------------- |
+| `'interrupt'` | 等待用户响应；`interrupts` 驱动 UI 渲染审批卡片等                     |
+| `'success'`   | 用户已通过 `resume` 处理；`InterruptMessageRender` 不渲染中断卡片 |
+
+## BaseInterrupt
+
+所有中断项的公共结构：
+
+```typescript
+type BaseInterrupt<T extends InterruptReason, M extends Record<string, any>> = {
+  expiresAt?: string;
+  id: string;
+  message?: string;
+  metadata?: M;
+  properties?: Record<string, any>;
+  reason: T;
+  toolCallId: string;
+};
+```
+
+## AIDevToolApprovalInterrupt
+
+AI Dev 第三方工具审批中断，`reason` 为 `InterruptReason.AIDevToolApproval`（`'aidev:tool_approval'`）：
+
+```typescript
+type AIDevToolApprovalInterrupt = BaseInterrupt<
+  InterruptReason.AIDevToolApproval,
+  {
+    ticket: {
+      approvers: string[];
+      sn: string;
+      status: APPROVAL_STATUS;
+      submit_time: string;
+      title: string;
+      url: string;
+    };
+  }
+>;
+```
+
+## Interrupt
+
+当前支持的中断联合类型（可扩展）：
+
+```typescript
+type Interrupt =
+  | AIDevToolApprovalInterrupt
+  | BaseInterrupt<InterruptReason, Record<string, any>>;
+```
+
+## InterruptMessage
+
+`MessageRole.Interrupt` 对应的消息类型，`content` 承载 outcome 与可选说明文案：
+
+```typescript
+type InterruptMessage = BaseMessage<
+  MessageRole.Interrupt,
+  {
+    message?: string;
+    outcome?: RunFinishedOutcome;
+    result?: unknown;
+    runId?: string;
+    threadId?: string;
+  }
+>;
+```
+
+| 字段       | 说明                                                         |
+| ---------- | ------------------------------------------------------------ |
+| `message`  | 消息组顶部可选说明文案，由 `InterruptMessageRender` 展示     |
+| `outcome`  | `type: 'interrupt'` 时从 `interrupts` 渲染卡片；`success` 时不渲染 |
+| `result`   | 用户 resume 后回传的 payload，便于持久化与回放                 |
+| `runId`    | 关联 AG-UI run 标识                                          |
+| `threadId` | 关联会话线程标识                                             |
+
+## OnInterruptResume
+
+用户完成中断操作后的回调（由 `MessageContainer` / `MessageRender` 透传）：
+
+```typescript
+type OnInterruptResume = (
+  interrupt: Interrupt,
+  payload?: Record<string, any>,
+) => Promise<void> | void;
+```
+
+## 使用示例
+
+```typescript
+import {
+  APPROVAL_STATUS,
+  InterruptReason,
+  MessageRole,
+  MessageStatus,
+  type InterruptMessage,
+} from '@blueking/chat-x';
+
+const message: InterruptMessage = {
+  id: 'msg_interrupt_1',
+  messageId: 'msg_interrupt_1',
+  role: MessageRole.Interrupt,
+  status: MessageStatus.Pending,
+  content: {
+    message: '算法方案评审单需要您关注',
+    outcome: {
+      type: 'interrupt',
+      interrupts: [
+        {
+          id: 'interrupt_1',
+          reason: InterruptReason.AIDevToolApproval,
+          toolCallId: 'tool_call_1',
+          metadata: {
+            ticket: {
+              approvers: ['张三'],
+              sn: 'REV-2026-04-24-001',
+              status: APPROVAL_STATUS.PENDING,
+              submit_time: '2026-04-24 14:30:15',
+              title: '算法方案评审单',
+              url: 'https://example.com/tickets/REV-2026-04-24-001',
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+## 关联文档
+
+- [常量枚举 Constants](./constants.md) — `InterruptReason`、`APPROVAL_STATUS`
+- [消息类型 Messages](./messages.md) — `InterruptMessage` 在消息联合类型中的位置
+- [InterruptMessage 中断消息](../components/molecular/interrupt-message.md)
+- [ToolApprovalCard 审批卡片](../components/molecular/tool-approval-card.md)

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -347,47 +347,52 @@ const knowledgeRagMessage: ActivityMessage = {
 
 ### InterruptMessage
 
-human-in-the-loop 中断消息，对应 AG-UI `RUN_FINISHED` 事件的 `outcome` 对象结构。`type: 'interrupt'` 时，组件从 `outcome.interrupts` 渲染中断卡片；`type: 'success'` 表示 resume 后的成功结果，不渲染中断卡片。
+human-in-the-loop 中断消息，对应 AG-UI `RUN_FINISHED` 事件的 `outcome` 对象结构。`content.outcome.type === 'interrupt'` 时，[InterruptMessageRender](../components/molecular/interrupt-message.md) 从 `interrupts` 渲染审批卡片；`type: 'success'` 表示 resume 后的成功结果，不渲染中断卡片。类型详见 [中断类型 Interrupt](./interrupt.md)。
 
 ```typescript
 type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
 
-interface InterruptMessage extends BaseMessage<MessageRole.Interrupt, string> {
-  message?: string;
-  outcome?: RunFinishedOutcome;
-  result?: unknown;
-  runId?: string;
-  threadId?: string;
-}
+type InterruptMessage = BaseMessage<
+  MessageRole.Interrupt,
+  {
+    message?: string;
+    outcome?: RunFinishedOutcome;
+    result?: unknown;
+    runId?: string;
+    threadId?: string;
+  }
+>;
 
 const interruptMessage: InterruptMessage = {
   id: 'interrupt-message-1',
   messageId: 'interrupt-message-1',
   role: MessageRole.Interrupt,
-  content: '',
-  status: MessageStatus.Complete,
-  runId: 'run_ai_dev_tool_approval',
-  threadId: 'thread_ai_dev_tool_approval',
-  outcome: {
-    type: 'interrupt',
-    interrupts: [
-      {
-        id: 'interrupt_ai_dev_tool_approval',
-        reason: InterruptReason.AIDevToolApproval,
-        toolCallId: 'tool_call_review_ticket',
-        message: '算法方案评审单正在评审中',
-        metadata: {
-          ticket: {
-            approvers: ['张三', '李四'],
-            sn: 'REV-2026-04-24-001',
-            status: APPROVAL_STATUS.PENDING,
-            submit_time: '2026-04-24 14:30:15',
-            title: '算法方案评审单',
-            url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+  status: MessageStatus.Pending,
+  content: {
+    message: '算法方案评审单需要您关注',
+    runId: 'run_ai_dev_tool_approval',
+    threadId: 'thread_ai_dev_tool_approval',
+    outcome: {
+      type: 'interrupt',
+      interrupts: [
+        {
+          id: 'interrupt_ai_dev_tool_approval',
+          reason: InterruptReason.AIDevToolApproval,
+          toolCallId: 'tool_call_review_ticket',
+          message: '算法方案评审单需要您关注',
+          metadata: {
+            ticket: {
+              approvers: ['张三', '李四'],
+              sn: 'REV-2026-04-24-001',
+              status: APPROVAL_STATUS.PENDING,
+              submit_time: '2026-04-24 14:30:15',
+              title: '算法方案评审单',
+              url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+            },
           },
         },
-      },
-    ],
+      ],
+    },
   },
 };
 ```


### PR DESCRIPTION
- 类型：InterruptMessage.content 承载 outcome/message/result 等
- 常量：aidev:tool_approval、DRAFT、审批状态文案
- UI：ToolApprovalCard 状态/时钟图标；末条 interrupt 不触发组 hover
- mock/docs/单测同步 BREAKING: 根级 outcome 字段废弃；InterruptReason 枚举值变更
# Reviewed, transaction id: 80796