### PR TITLE
feat(chat-x): MessageContainer/ChatContainer 支持 #group 插槽

### DIFF
--- a/src/frontend/ai-blueking/biome.json
+++ b/src/frontend/ai-blueking/biome.json
@@ -10,6 +10,10 @@
         "noUnusedVariables": {
           "fix": "none",
           "level": "error"
+        },
+        "noUnusedImports": {
+          "fix": "none",
+          "level": "error"
         }
       }
     }

--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -39,50 +39,82 @@
       @stop-streaming="handleStopStreaming"
       @update:model-value="handleUpdateInputValue"
     >
-      <template #message="{ message, messageToolsStatus, onInterruptResume }">
-        <template
-          v-if="
-            message.role === MessageRole.Interrupt && message.content.result?.reason === InterruptReason.UserQuestion
-          "
+      <template #group="{ group }">
+        <div class="group-messagesxxxx">
+          <div
+            v-for="(message, index) in group.messages"
+            :key="index"
+          >
+            <MessageRender
+              :key="index"
+              :message="message"
+              :on-input-confirm="
+                (content: UserMessage['content'], docSchema: TagSchema) =>
+                  handleUserInputConfirm(message, content, docSchema)
+              "
+              :on-shortcut-confirm="
+                (formModel: Record<string, unknown>) => handleUserShortcutConfirm(message, formModel)
+              "
+            >
+              <template #answeredQuestion="{ item }">
+                <div>{{ JSON.stringify(item) }}</div>
+              </template>
+            </MessageRender>
+          </div>
+        </div>
+      </template>
+      <!-- <template #message="{ message, messageToolsStatus, onInterruptResume }">
+        <template v-if="message.role === MessageRole.User">
+          <MessageRender :message="message"> </MessageRender>
+        </template>
+        <div
+          v-else
+          class="xxxxx"
         >
-          <InterruptMessageRender
-            v-bind="message"
+          <template
+            v-if="
+              message.role === MessageRole.Interrupt && message.content.result?.reason === InterruptReason.UserQuestion
+            "
+          >
+            <InterruptMessageRender
+              v-bind="message"
+              :on-interrupt-resume="onInterruptResume"
+            >
+              <template #answeredQuestion="{ item }">
+                <div>
+                  <div>
+                    <span> -------- {{ JSON.stringify(item) }} </span>
+                  </div>
+                </div>
+              </template>
+            </InterruptMessageRender>
+          </template>
+          <MessageRender
+            v-else
+            :message="message"
+            :message-tools-status="messageToolsStatus"
             :on-interrupt-resume="onInterruptResume"
           >
-            <template #answeredQuestion="{ item }">
-              <div>
-                <div>
-                  <span> -------- {{ JSON.stringify(item) }} </span>
-                </div>
-              </div>
+            <template #codeHeader="{ language }">
+              <span
+                class="code-header-action"
+                @click="handleCodeInsert(language)"
+              >
+                插入
+              </span>
+              <span
+                class="code-header-action"
+                @click="handleCodeApply(language)"
+              >
+                应用
+              </span>
             </template>
-          </InterruptMessageRender>
-        </template>
-        <MessageRender
-          v-else
-          :message="message"
-          :message-tools-status="messageToolsStatus"
-          :on-interrupt-resume="onInterruptResume"
-        >
-          <template #codeHeader="{ language }">
-            <span
-              class="code-header-action"
-              @click="handleCodeInsert(language)"
-            >
-              插入
-            </span>
-            <span
-              class="code-header-action"
-              @click="handleCodeApply(language)"
-            >
-              应用
-            </span>
-          </template>
-        </MessageRender>
-      </template>
+          </MessageRender>
+        </div>
+      </template> -->
       <!-- 自定义作答态：用下拉选择替代默认的选项列表，选中后通过 setAnswer 回传已组装答案 -->
       <template #interruptQuestion="{ question, setAnswer, answer }">
-        <div>
+        <div v-if="question.multiSelect">
           <Select
             :model-value="answer?.answer.at(0)?.label"
             @change="
@@ -107,6 +139,12 @@
             </Select.Option>
           </Select>
         </div>
+        <div v-else>
+          <UserQuestionChoice
+            :on-answer="setAnswer"
+            :question="question"
+          />
+        </div>
       </template>
     </ChatContainer>
   </div>
@@ -128,14 +166,14 @@
     ChatContainer,
     CopyIcon,
     EditIcon,
-    InterruptMessageRender,
-    InterruptReason,
     MessageContentType,
     MessageRender,
     MessageRole,
     MessageStatus,
     RenderMode,
+    UserQuestionChoice,
   } from '../src';
+  // import QuestionsContainer from '../src/components/ai-questions/questions-container.vue';
   import { MOCK_INTERRUPT_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
   import { MOCK_PROMPTS, MOCK_RESOURCES } from './mock';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -41,6 +41,8 @@ const mockMessageGroupsRef = vi.hoisted(() => {
   return ref<
     Array<{
       messages: Array<{ id?: string }>;
+      type?: string;
+      uid?: string;
     }>
   >([]);
 });
@@ -57,11 +59,7 @@ vi.mock('bkui-vue', () => {
     emits: ['click'],
     setup(_, { slots, emit }) {
       return () =>
-        h(
-          'button',
-          { class: 'mock-bk-button', type: 'button', onClick: () => emit('click') },
-          slots.default?.(),
-        );
+        h('button', { class: 'mock-bk-button', type: 'button', onClick: () => emit('click') }, slots.default?.());
     },
   });
 
@@ -139,9 +137,7 @@ vi.mock('../../composables', () => ({
       }, 0),
     );
     const pendingApprovalTipText = computed(() =>
-      pendingApprovalCount.value
-        ? `当前会话有 ${pendingApprovalCount.value} 个待审批单，如需继续，请先取消审批`
-        : '',
+      pendingApprovalCount.value ? `当前会话有 ${pendingApprovalCount.value} 个待审批单，如需继续，请先取消审批` : '',
     );
     const activeUserQuestionInterrupt = computed(() => {
       for (let index = _options.messages.value.length - 1; index >= 0; index--) {
@@ -366,8 +362,19 @@ vi.mock('../chat-message/message-container/message-container.vue', () => ({
       renderMode: String,
     },
     emits: ['stopStreaming', 'update:selectedUserMessages'],
-    setup(props) {
-      return () => h('div', { class: 'mock-message-container', 'data-render-mode': props.renderMode });
+    setup(props, { slots }) {
+      return () =>
+        h(
+          'div',
+          { class: 'mock-message-container', 'data-render-mode': props.renderMode },
+          (
+            props.messageGroups as Array<{
+              messages: Array<{ id?: string }>;
+              type: string;
+              uid: string;
+            }>
+          )?.map(group => slots.group?.({ group }) ?? h('div', { class: 'default-group-fallback' })),
+        );
     },
   }),
 }));
@@ -423,64 +430,66 @@ const createAssistantMessage = (id: string, content: string): AssistantMessage =
   status: MessageStatus.Complete,
 });
 
-const createApprovalInterruptMessage = (id: string, status: APPROVAL_STATUS): Message => ({
-  id,
-  messageId: id,
-  role: MessageRole.Interrupt,
-  status: MessageStatus.Complete,
-  content: {
-    outcome: {
-      type: 'interrupt',
-      interrupts: [
-        {
-          id: `${id}-interrupt`,
-          reason: InterruptReason.AIDevToolApproval,
-          toolCallId: `${id}-tool`,
-          metadata: {
-            ticket: {
-              approvers: ['张三'],
-              sn: `REV-${id}`,
-              status,
-              submit_time: '2026-04-24 14:30:15',
-              title: '算法方案评审单',
-              url: 'https://example.com/ticket',
+const createApprovalInterruptMessage = (id: string, status: APPROVAL_STATUS): Message =>
+  ({
+    id,
+    messageId: id,
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Complete,
+    content: {
+      outcome: {
+        type: 'interrupt',
+        interrupts: [
+          {
+            id: `${id}-interrupt`,
+            reason: InterruptReason.AIDevToolApproval,
+            toolCallId: `${id}-tool`,
+            metadata: {
+              ticket: {
+                approvers: ['张三'],
+                sn: `REV-${id}`,
+                status,
+                submit_time: '2026-04-24 14:30:15',
+                title: '算法方案评审单',
+                url: 'https://example.com/ticket',
+              },
             },
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-} as Message);
+  }) as Message;
 
-const createUserQuestionInterruptMessage = (id: string): Message => ({
-  id,
-  messageId: id,
-  role: MessageRole.Interrupt,
-  status: MessageStatus.Pending,
-  content: {
-    outcome: {
-      type: 'interrupt',
-      interrupts: [
-        {
-          id: `${id}-interrupt`,
-          reason: InterruptReason.UserQuestion,
-          toolCallId: `${id}-tool`,
-          message: '请回答问题',
-          metadata: {
-            questions: [
-              {
-                header: '请回答问题',
-                multiSelect: false,
-                question: '请选择语言',
-                options: [{ label: 'A', description: 'Java' }],
-              },
-            ],
+const createUserQuestionInterruptMessage = (id: string): Message =>
+  ({
+    id,
+    messageId: id,
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      outcome: {
+        type: 'interrupt',
+        interrupts: [
+          {
+            id: `${id}-interrupt`,
+            reason: InterruptReason.UserQuestion,
+            toolCallId: `${id}-tool`,
+            message: '请回答问题',
+            metadata: {
+              questions: [
+                {
+                  header: '请回答问题',
+                  multiSelect: false,
+                  question: '请选择语言',
+                  options: [{ label: 'A', description: 'Java' }],
+                },
+              ],
+            },
           },
-        },
-      ],
+        ],
+      },
     },
-  },
-} as Message);
+  }) as Message;
 
 describe('ChatContainer', () => {
   let wrapper: VueWrapper;
@@ -597,6 +606,29 @@ describe('ChatContainer', () => {
 
       expect(wrapper.find('.ai-welcome-remark').exists()).toBe(true);
       expect(wrapper.find('.mock-content-render').text()).toBe('欢迎使用');
+    });
+
+    it('应该支持 group 插槽自定义消息组渲染', () => {
+      const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      mockMessageGroupsRef.value = [
+        { messages: [{ id: '1' }], type: MessageRole.User, uid: 'group-user-1' },
+        { messages: [{ id: '2' }], type: MessageRole.Assistant, uid: 'group-assistant-2' },
+      ];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages },
+        slots: {
+          group: ({ group }: { group: { type: string; uid: string } }) =>
+            h('div', { class: 'custom-group', 'data-uid': group.uid, 'data-type': group.type }, 'Custom Group'),
+        },
+      });
+
+      const customGroups = wrapper.findAll('.custom-group');
+      expect(customGroups.length).toBe(2);
+      expect(customGroups[0].attributes('data-uid')).toBe('group-user-1');
+      expect(customGroups[0].attributes('data-type')).toBe(MessageRole.User);
+      expect(customGroups[1].attributes('data-uid')).toBe('group-assistant-2');
+      expect(customGroups[1].attributes('data-type')).toBe(MessageRole.Assistant);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -147,6 +147,12 @@
             :render-mode="renderMode"
             @stop-streaming="emits('stopStreaming')"
           >
+            <template #group="{ group }">
+              <slot
+                name="group"
+                v-bind="{ group }"
+              />
+            </template>
             <template #default="{ message, messageToolsStatus, onInterruptResume: slotOnInterruptResume }">
               <slot
                 name="message"
@@ -252,7 +258,7 @@
 
   import { type Message, type UserMessage, MessageStatus } from '../../ag-ui/types';
   import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
-  import { useMessageGroup } from '../../composables';
+  import { type MessageGroup, useMessageGroup } from '../../composables';
   import { useCommonTippyProvider, useRenderModeProvider } from '../../composables/use-common';
   import { EXECUTION_TAB_NAME, useCustomTabProvider } from '../../composables/use-custom-tab';
   import { useGlobalConfig } from '../../composables/use-global-config';
@@ -316,6 +322,7 @@
       onUserShortcutConfirm?: (message: Message, formModel: Record<string, unknown>) => Promise<void>;
       selectedUserMessages: Message[];
     }) => null | undefined | VNode;
+    group: (props: { group: MessageGroup }) => unknown;
     interruptQuestion: UserQuestionCardSlots['question'];
     message: (props: {
       message: Message;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -631,6 +631,50 @@ describe('MessageContainer', () => {
       expect(wrapper.find('.custom-message').exists()).toBe(true);
       expect(wrapper.find('.custom-message').text()).toBe('Custom: Hello');
     });
+
+    it('应该支持 group 插槽自定义整组渲染', async () => {
+      const messages: Message[] = [createAssistantMessage('1', 'Hello', 1)];
+      const messageGroups = buildGroups(messages);
+
+      wrapper = mount(MessageContainer, {
+        props: { ...defaultProps, messages, messageGroups },
+        slots: {
+          group: ({ group }: { group: MessageGroup }) =>
+            h('div', { class: 'custom-group', 'data-uid': group.uid, 'data-type': group.type }, 'Custom Group'),
+        },
+      });
+
+      await nextTick();
+
+      expect(wrapper.find('.custom-group').exists()).toBe(true);
+      expect(wrapper.find('.custom-group').attributes('data-uid')).toBe('group-1');
+      expect(wrapper.find('.custom-group').attributes('data-type')).toBe(MessageRole.Assistant);
+      expect(wrapper.find('.mock-message-render').exists()).toBe(false);
+      expect(wrapper.find('.mock-message-tools').exists()).toBe(false);
+    });
+
+    it('group 插槽应接收完整的消息组数据', async () => {
+      const messages: Message[] = [createUserMessage('1', 'Hello', 1), createAssistantMessage('2', 'Hi!', 2)];
+      const messageGroups = buildGroups(messages);
+
+      wrapper = mount(MessageContainer, {
+        props: { ...defaultProps, messages, messageGroups },
+        slots: {
+          group: ({ group }: { group: MessageGroup }) =>
+            h('div', { class: 'custom-group', 'data-messages-count': group.messages.length }, group.type),
+        },
+      });
+
+      await nextTick();
+
+      const customGroups = wrapper.findAll('.custom-group');
+      // 用户组 + 助手组（末条为助手消息时不追加 Loading 组）
+      expect(customGroups.length).toBe(2);
+      expect(customGroups[0].attributes('data-messages-count')).toBe('1');
+      expect(customGroups[0].text()).toBe(MessageRole.User);
+      expect(customGroups[1].attributes('data-messages-count')).toBe('1');
+      expect(customGroups[1].text()).toBe(MessageRole.Assistant);
+    });
   });
 
   describe('Actions 测试', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -14,76 +14,81 @@
       @mouseenter="handleMouseEnter(group)"
       @mouseleave="e => handleMouseLeave(group, e)"
     >
-      <Checkbox
-        v-if="enableSelection && group.type !== MessageRole.Loading"
-        class="message-group-checkbox"
-        :model-value="group.checked"
-        @update:model-value="(checked: boolean) => handleCheckboxChange(group, checked)"
-      />
-      <div
-        class="message-group-messages"
-        :class="{
-          'message-group-enabled-selection':
-            renderMode === RenderMode.Share || (enableSelection && group.type !== MessageRole.Loading),
-        }"
-        :style="{
-          width: enableSelection && group.type !== MessageRole.Loading ? 'calc(100% - 16px)' : '100%',
-        }"
+      <slot
+        name="group"
+        v-bind="{ group }"
       >
-        <template
-          v-for="(message, index) in group.messages"
-          :key="index"
-        >
-          <slot
-            name="default"
-            v-bind="{ message, messageToolsStatus, onInterruptResume: props.onInterruptResume }"
-          >
-            <MessageRender
-              :key="index"
-              :message="message"
-              :message-tools-status="messageToolsStatus"
-              :on-action="(tool: IToolBtn) => handleUserAction(tool, message)"
-              :on-input-confirm="
-                (content: UserMessage['content'], docSchema: TagSchema) =>
-                  handleUserInputConfirm(message, content, docSchema)
-              "
-              :on-interrupt-resume="props.onInterruptResume"
-              :on-shortcut-confirm="
-                (formModel: Record<string, unknown>) => handleUserShortcutConfirm(message, formModel)
-              "
-              :tippy-options="messageToolsTippyOptions"
-            >
-              <template
-                v-if="$slots.answeredQuestion"
-                #answeredQuestion="slotProps"
-              >
-                <slot
-                  name="answeredQuestion"
-                  v-bind="slotProps"
-                />
-              </template>
-            </MessageRender>
-          </slot>
-        </template>
-        <MessageTools
-          v-if="
-            renderMode !== RenderMode.Share &&
-            !(enableSelection && group.type !== MessageRole.Loading) &&
-            !group.pause &&
-            group.type === MessageRole.Assistant &&
-            messageToolsStatus !== MessageToolsStatus.Hidden
-          "
-          :message-tools="messageTools"
-          :message-tools-status="messageToolsStatus"
-          :on-action="(tool: IToolBtn) => handleAgentAction(tool, group.messages)"
-          :style="{ visibility: group.isHover ? 'visible' : 'hidden' }"
-          :tippy-options="props.messageToolsTippyOptions"
-          @feedback="
-            (tool: IToolBtn, reasonList: string[], otherReason: string) =>
-              props.onAgentFeedback?.(tool, group.messages, reasonList, otherReason)
-          "
+        <Checkbox
+          v-if="enableSelection && group.type !== MessageRole.Loading"
+          class="message-group-checkbox"
+          :model-value="group.checked"
+          @update:model-value="(checked: boolean) => handleCheckboxChange(group, checked)"
         />
-      </div>
+        <div
+          class="message-group-messages"
+          :class="{
+            'message-group-enabled-selection':
+              renderMode === RenderMode.Share || (enableSelection && group.type !== MessageRole.Loading),
+          }"
+          :style="{
+            width: enableSelection && group.type !== MessageRole.Loading ? 'calc(100% - 16px)' : '100%',
+          }"
+        >
+          <template
+            v-for="(message, index) in group.messages"
+            :key="index"
+          >
+            <slot
+              name="default"
+              v-bind="{ message, messageToolsStatus, onInterruptResume: props.onInterruptResume }"
+            >
+              <MessageRender
+                :key="index"
+                :message="message"
+                :message-tools-status="messageToolsStatus"
+                :on-action="(tool: IToolBtn) => handleUserAction(tool, message)"
+                :on-input-confirm="
+                  (content: UserMessage['content'], docSchema: TagSchema) =>
+                    handleUserInputConfirm(message, content, docSchema)
+                "
+                :on-interrupt-resume="props.onInterruptResume"
+                :on-shortcut-confirm="
+                  (formModel: Record<string, unknown>) => handleUserShortcutConfirm(message, formModel)
+                "
+                :tippy-options="messageToolsTippyOptions"
+              >
+                <template
+                  v-if="$slots.answeredQuestion"
+                  #answeredQuestion="slotProps"
+                >
+                  <slot
+                    name="answeredQuestion"
+                    v-bind="slotProps"
+                  />
+                </template>
+              </MessageRender>
+            </slot>
+          </template>
+          <MessageTools
+            v-if="
+              renderMode !== RenderMode.Share &&
+              !(enableSelection && group.type !== MessageRole.Loading) &&
+              !group.pause &&
+              group.type === MessageRole.Assistant &&
+              messageToolsStatus !== MessageToolsStatus.Hidden
+            "
+            :message-tools="messageTools"
+            :message-tools-status="messageToolsStatus"
+            :on-action="(tool: IToolBtn) => handleAgentAction(tool, group.messages)"
+            :style="{ visibility: group.isHover ? 'visible' : 'hidden' }"
+            :tippy-options="props.messageToolsTippyOptions"
+            @feedback="
+              (tool: IToolBtn, reasonList: string[], otherReason: string) =>
+                props.onAgentFeedback?.(tool, group.messages, reasonList, otherReason)
+            "
+          />
+        </div>
+      </slot>
     </div>
     <div
       ref="messageContainerBottomRef"
@@ -134,8 +139,8 @@
   import MessageRender from '../message-render/message-render.vue';
 
   import type { OnInterruptResume } from '../../../ag-ui/types/interrupt';
-  import type { UserQuestionAnsweredCardSlots } from '../interrupt-message/user-question/user-question-answered-card.vue';
   import type { IToolBtn, TagSchema } from '../../../types';
+  import type { UserQuestionAnsweredCardSlots } from '../interrupt-message/user-question/user-question-answered-card.vue';
 
   export type MessageContainerEmits = {
     (e: 'stopStreaming'): void;
@@ -192,14 +197,15 @@
   defineEmits<MessageContainerEmits>();
 
   defineSlots<{
+    // 中断消息「已回答内容」回显的自定义 slot，透传给内部 MessageRender
+    answeredQuestion: UserQuestionAnsweredCardSlots['answer'];
     // 自定义单条消息渲染（默认回退到内部 MessageRender）
     default: (props: {
       message: Message;
       messageToolsStatus?: MessageToolsStatus;
       onInterruptResume?: OnInterruptResume;
     }) => unknown;
-    // 中断消息「已回答内容」回显的自定义 slot，透传给内部 MessageRender
-    answeredQuestion: UserQuestionAnsweredCardSlots['answer'];
+    group: (props: { group: MessageGroup }) => unknown;
   }>();
 
   const messageContainerRef = useTemplateRef<HTMLElement>('messageContainerRef');

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/index.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/index.ts
@@ -31,12 +31,14 @@ import ShortcutRender from './ai-shortcut/shortcut-render/shortcut-render.vue';
 import ChatContainer from './chat-container/chat-container.vue';
 import ContentRender from './chat-content/content-render/content-render.vue';
 import ChatInput from './chat-input/chat-input.vue';
-import {
-  InterruptMessageRender,
-  UserQuestionAnsweredCard,
-  UserQuestionCard,
-  UserQuestionOption,
-} from './chat-message/interrupt-message';
+// import {
+//   InterruptMessageRender,
+//   UserQuestionAnsweredCard,
+//   UserQuestionCard,
+//   UserQuestionChoice,
+//   UserQuestionOption,
+// } from './chat-message/interrupt-message';
+export * from './chat-message/interrupt-message';
 import MessageContainer from './chat-message/message-container/message-container.vue';
 import MessageRender from './chat-message/message-render/message-render.vue';
 import ExecutionSummary from './execution-summary/execution-summary.vue';
@@ -60,7 +62,6 @@ export {
   HighlightKeyword,
   ImagePreview,
   ImagePreviewGroup,
-  InterruptMessageRender,
   MessageContainer,
   MessageLoading,
   MessageRender,
@@ -71,7 +72,4 @@ export {
   ShortcutBtns,
   ShortcutRender,
   ToolCallRender,
-  UserQuestionAnsweredCard,
-  UserQuestionCard,
-  UserQuestionOption,
 };

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -254,6 +254,8 @@ ai-chat-container
     │   └── collapse-button（折叠按钮）
     └── main（主内容区）
         ├── MessageContainer（有消息时）
+        │   ├── #group 插槽（可选，自定义消息组内容）
+        │   ├── #message 插槽（可选，自定义单条消息）
         │   └── 消息列表 + 工具栏
         ├── 欢迎页（无消息时，容器 .ai-welcome-content）
         │   └── welcome 插槽（默认：Banner + 欢迎标题 + 开场白 ContentRender；自定义则整块替换）
@@ -669,6 +671,25 @@ ai-chat-container
 
 如果没有传入 `onInterruptResume`，输入框自由文本不会被中断逻辑截获，仍然走普通 `onSendMessage`，避免输入被静默清空。
 
+## 自定义消息组渲染
+
+通过 `#group` 插槽可替换单个消息组的默认内容，透传至内部 `MessageContainer`。外层消息组容器（`id`、hover、选中背景）仍由 `MessageContainer` 管理。
+
+> **注意**：提供 `#group` 后需自行编排组内全部 UI（Checkbox、消息列表、`MessageTools`）；若只需替换单条消息，请使用 `#message` 插槽。详见 [MessageContainer 自定义消息组渲染](/components/setup/message-container#自定义消息组渲染)。
+
+```vue
+<ChatContainer
+  v-model="inputValue"
+  :messages="messages"
+  message-status="complete"
+  :on-send-message="handleSendMessage"
+>
+  <template #group="{ group }">
+    <MyCustomGroup :group="group" />
+  </template>
+</ChatContainer>
+```
+
 ### 自定义题目渲染
 
 通过 `#interruptQuestion` slot 可覆盖输入区上方 `UserQuestionCard` 的默认选择题渲染，参数与 [UserQuestionCard](/components/agent/user-question-card) 的 `#question` 一致：
@@ -820,6 +841,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | ----------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | codeHeader        | `{ language: string; token: Token[] }`                                                                            | 代码块头部自定义操作区域，透传给 MessageRender → ContentRender → MarkdownContent → CodeContent |
 | default           | 消息列表相关绑定（messages 等）                                                                                   | 自定义消息列表区域                                                                             |
+| group             | `{ group: MessageGroup }`                                                                                         | 自定义单个消息组内容，透传至 MessageContainer 的 `#group`；替换默认 Checkbox、消息列表与工具栏   |
 | interruptQuestion | `{ question, qIndex, answer, setAnswer, confirm }`                                                                  | 自定义 UserQuestion 单题渲染，透传至输入区上方 UserQuestionCard 的 `#question`                 |
 | message           | `{ message, messageToolsStatus, onInterruptResume }`                                                              | 自定义单条消息渲染；自定义渲染中断消息时需继续透传 `onInterruptResume`                         |
 | welcome           | `{ openingRemark: string }`                                                                                       | 无消息时自定义欢迎页；传入则替换默认 Banner、标题与开场白区域（整块替换）                      |
@@ -867,7 +889,19 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 ## 类型定义
 
 ```typescript
-import { ChatContainer, RenderMode, type CustomTab, type Shortcut, type Message } from '@blueking/chat-x';
+import { ChatContainer, RenderMode, MessageRole, type CustomTab, type MessageGroup, type Shortcut, type Message } from '@blueking/chat-x';
+
+// 消息组（由 useMessageGroup 生成）
+interface MessageGroup {
+  checked: boolean;
+  isHover: boolean;
+  messages: Message[];
+  pause?: boolean;
+  startTime?: number;
+  type: MessageRole;
+  uid: string;
+  userMessageTitle?: number | string;
+}
 
 // 自定义 Tab（data 可与 messageUid 组合，供侧栏定位主对话）
 interface CustomTab<T = Record<string, unknown>> {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
@@ -813,9 +813,69 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
   </div>
 </div>
 
+## 自定义消息组渲染
+
+使用 `#group` 插槽可替换单个消息组的默认内容（Checkbox、消息列表、`MessageTools`）。外层 `.message-group` 容器（含 `id`、hover 状态、选中背景色）仍由 `MessageContainer` 管理。
+
+> **注意**：提供 `#group` 后需自行编排组内全部 UI；若只需替换单条消息，请使用 `#default` 插槽。
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-groups="messageGroups"
+    message-status="complete"
+    :on-agent-action="handleAgentAction"
+    @stop-streaming="handleStopStreaming"
+  >
+    <template #group="{ group }">
+      <div class="custom-group">
+        <span class="custom-group-label">{{ group.type }}</span>
+        <div
+          v-for="message in group.messages"
+          :key="message.id"
+          class="custom-group-message"
+        >
+          {{ typeof message.content === 'string' ? message.content : JSON.stringify(message.content) }}
+        </div>
+      </div>
+    </template>
+  </MessageContainer>
+</template>
+```
+
+**渲染效果**（简化自定义组布局，不含默认 Checkbox 与工具栏）
+
+<div class="demo">
+  <div style="height: 300px; border: 1px solid #eaebf0; border-radius: 8px; overflow: hidden;">
+    <MessageContainerComp
+      :messages="messagesBasic"
+      :message-groups="groupsBasic"
+      message-status="complete"
+      :on-agent-action="handleAgentAction"
+      :on-agent-feedback="handleAgentFeedback"
+      :on-user-action="handleUserAction"
+      @stop-streaming="handleStopStreaming"
+    >
+      <template #group="{ group }">
+        <div style="display: flex; flex-direction: column; gap: 8px; width: 100%;">
+          <span style="font-size: 12px; color: #979ba5;">{{ group.type }}</span>
+          <div
+            v-for="message in group.messages"
+            :key="message.id"
+            style="padding: 8px 12px; background: #f5f7fa; border-radius: 4px; font-size: 13px;"
+          >
+            {{ typeof message.content === 'string' ? message.content.slice(0, 80) + (message.content.length > 80 ? '…' : '') : JSON.stringify(message.content) }}
+          </div>
+        </div>
+      </template>
+    </MessageContainerComp>
+  </div>
+</div>
+
 ## 自定义消息渲染
 
-使用默认插槽替换单条消息的渲染，插槽参数包含 `message` 和 `messageToolsStatus`：
+使用默认插槽替换单条消息的渲染，插槽参数包含 `message`、`messageToolsStatus` 和 `onInterruptResume`：
 
 ```vue
 <template>
@@ -826,10 +886,11 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
     :on-user-action="handleUserAction"
     @stop-streaming="handleStopStreaming"
   >
-    <template #default="{ message, messageToolsStatus }">
+    <template #default="{ message, messageToolsStatus, onInterruptResume }">
       <MyCustomMessage
         :message="message"
         :message-tools-status="messageToolsStatus"
+        :on-interrupt-resume="onInterruptResume"
       />
     </template>
   </MessageContainer>
@@ -942,15 +1003,28 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 
 ### Slots
 
-| 插槽名           | 参数                                                                        | 说明                                                                                     |
-| ---------------- | --------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
-| answeredQuestion | `{ item, index, status }`                                                   | 自定义 UserQuestion 已回答回显，透传给 MessageRender → InterruptMessageRender            |
-| default          | `{ message: Message, messageToolsStatus: MessageToolsStatus \| undefined }` | 自定义单条消息渲染，消息分组和工具栏仍由容器管理                                         |
+| 插槽名           | 参数                                                                                                        | 说明                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| answeredQuestion | `{ item, index, status }`                                                                                   | 自定义 UserQuestion 已回答回显，透传给 MessageRender → InterruptMessageRender            |
+| default          | `{ message: Message, messageToolsStatus?: MessageToolsStatus, onInterruptResume?: OnInterruptResume }`     | 自定义单条消息渲染；消息分组外层容器与 `#group` 未覆盖时的工具栏仍由容器管理             |
+| group            | `{ group: MessageGroup }`                                                                                   | 自定义单个消息组内容，替换默认 Checkbox、消息列表与 `MessageTools`；外层组容器仍由组件管理 |
 
 ## 类型定义
 
 ```typescript
-import { MessageRole, MessageStatus, MessageToolsStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+import { MessageRole, MessageStatus, MessageToolsStatus, type Message, type MessageGroup, type IToolBtn } from '@blueking/chat-x';
+
+// 消息组（由 useMessageGroup 生成，也可手动传入 messageGroups）
+interface MessageGroup {
+  checked: boolean;
+  isHover: boolean;
+  messages: Message[];
+  pause?: boolean;
+  startTime?: number;
+  type: MessageRole;
+  uid: string;
+  userMessageTitle?: number | string;
+}
 
 // onAgentAction 回调类型
 // messages 为当前消息组全部消息（可含 reasoning / activity 等）


### PR DESCRIPTION
- MessageContainer 将默认组内布局包裹为 #group 插槽并提供 fallback
- ChatContainer 透传 #group 至 MessageContainer
- 补充单测、wikis 文档与 playground 示例
- interrupt-message 改为 export * 统一导出
- biome 启用 noUnusedImports 规则