### PR TITLE
docs(chat-x): 修复 wikis 文档链接并 bump 至 0.0.45-beta.3

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/package.json
+++ b/src/frontend/ai-blueking/packages/chat-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/chat-x",
-  "version": "0.0.45-beta.2",
+  "version": "0.0.45-beta.3",
   "description": "蓝鲸智云 AI Chat 组件库 —— 遵循 AG-UI，为 AI Agent 和人类开发者共同设计的对话 UI 组件库。",
   "main": "index.js",
   "scripts": {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-message.md
@@ -136,7 +136,7 @@ export type ContentMap = AIBluekingContentMap & {
 
 ### 推荐写法（含 `codeHeader`）
 
-Playground [`chat-bot-new.vue`](../../playground/chat-bot-new.vue) 与 ai-blueking `ChatBot` 均采用此模式：
+Playground `playground/chat-bot-new.vue` 与 ai-blueking `ChatBot` 均采用此模式：
 
 ```vue
 <ChatContainer :messages="messages" ...>
@@ -333,7 +333,7 @@ Flow / KnowledgeRag 等子组件的外框：
 - **默认详情组件**：`BkFlowNodeDetail`（需 `<slot name="locateButton" />`）
 - **应用覆盖**：`ChatContainer` 的 `getSideRenderComponent` / `onCustomTabChange`（详见侧栏文档）
 
-KnowledgeRag / ReferenceDoc 模式见 [ActivityMessage](../components/molecular/activity-message.md)。
+KnowledgeRag / ReferenceDoc 模式见 [ActivityMessage](../components/message/activity-message.md)。
 
 ## 侧栏自定义 Tab（与消息联动）
 
@@ -361,8 +361,8 @@ Activity（尤其 FlowAgent）可在对话区点击「详情」等操作，通�
 
 - [自定义侧栏 Tab 标签](./custom-side-tab.md)
 - [自定义侧栏内容](./custom-side-content.md)
-- [ChatContainer](../components/molecular/chat-container.md)
-- [ActivityMessage](../components/molecular/activity-message.md)
+- [ChatContainer](../components/setup/chat-container.md)
+- [ActivityMessage](../components/message/activity-message.md)
 - [useCustomTab](../composables/use-custom-tab.md)
 - [架构总览](../architecture.md)
 - [最佳实践](./best-practices.md)

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-content.md
@@ -182,12 +182,12 @@ type GetSideRenderComponent = (
 
 ### Playground：CustomTabContent
 
-[`playground/custom-tab-content.vue`](../../playground/custom-tab-content.vue) 演示业务自定义侧栏：
+`playground/custom-tab-content.vue` 演示业务自定义侧栏：
 
 - 头部保留 **`<slot name="locateButton" />`**，由容器注入定位按钮
 - 根据 `loading` / `taskId` / `nodeName` 等 props 展示骨架或元数据
 
-[`playground/chat-bot-new.vue`](../../playground/chat-bot-new.vue) 中 `getSideRenderComponent` 将 `tab.data.props` 映射为组件 camelCase props：
+`playground/chat-bot-new.vue` 中 `getSideRenderComponent` 将 `tab.data.props` 映射为组件 camelCase props：
 
 ```typescript
 const getSideRenderComponent = (createElement: typeof h, props?: Record<string, unknown>) => {
@@ -298,5 +298,5 @@ const getSideRenderComponent = (createElement: typeof h, props?: Record<string, 
 
 - [自定义侧栏 Tab 标签](./custom-side-tab.md) — `getSideTabRenderComponent`
 - [useCustomTab](../composables/use-custom-tab.md) — Provider / Consumer API
-- [ChatContainer](../components/molecular/chat-container.md) — 侧栏、expose、`collapseChange`
+- [ChatContainer](../components/setup/chat-container.md) — 侧栏、expose、`collapseChange`
 - [自定义消息类型](./custom-message.md) — Activity / FlowAgent 与 `addCustomTab` 关系

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/ai/custom-side-tab.md
@@ -150,7 +150,7 @@ const getSideTabRenderComponent = (createElement, tab, { removeCustomTab }) => {
 
 ## Playground 参考
 
-[`playground/chat-bot-new.vue`](../../playground/chat-bot-new.vue) 中注册了 `getSideTabRenderComponent`：当 `tab.name === '634859'` 时返回简单文本节点，用于验证「覆盖默认标签」路径；其余 Tab 返回 `undefined` 走默认 UI。
+`playground/chat-bot-new.vue` 中注册了 `getSideTabRenderComponent`：当 `tab.name === '634859'` 时返回简单文本节点，用于验证「覆盖默认标签」路径；其余 Tab 返回 `undefined` 走默认 UI。
 
 ```typescript
 const getSideTabRenderComponent = (createElement: typeof h, tab: CustomTab<Record<string, unknown>>) => {
@@ -185,5 +185,5 @@ const getSideTabRenderComponent = (createElement: typeof h, tab: CustomTab<Recor
 
 - [自定义侧栏内容](./custom-side-content.md) — `getSideRenderComponent`、`onCustomTabChange`、`locateButton`
 - [useCustomTab](../composables/use-custom-tab.md) — `addCustomTab` / `removeCustomTab` / Provider-Consumer
-- [ChatContainer](../components/molecular/chat-container.md) — 侧栏整体行为与 expose API
+- [ChatContainer](../components/setup/chat-container.md) — 侧栏整体行为与 expose API
 - [自定义消息类型](./custom-message.md) — FlowAgent 内 `addCustomTab` 场景

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-full-screen.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-full-screen.md
@@ -100,7 +100,7 @@ useFullScreen(target?)
 
 `ChatContainer` 将侧栏包裹在 `.ai-full-screen-wrapper` 中，通过 `useFullScreen(fullScreenRef)` 控制侧栏全屏；Tab 栏 `#setting` 插槽内的 `ToolBtn` 使用自定义插槽渲染 `FullScreenIcon` / `UnFullScreenIcon`。
 
-详见 [ChatContainer 侧栏全屏](../components/molecular/chat-container.md#侧栏全屏)。
+详见 [ChatContainer 侧栏全屏](../components/setup/chat-container.md#侧栏全屏)。
 
 ## API
 
@@ -145,5 +145,5 @@ declare function useFullScreen(target?: MaybeRef<HTMLElement | null>): UseFullSc
 
 ## 关联组件
 
-- [ChatContainer](../components/molecular/chat-container.md) — 内置侧栏全屏按钮
-- [ToolBtn](../components/atomic/tool-btn.md) — 全屏按钮自定义插槽
+- [ChatContainer](../components/setup/chat-container.md) — 内置侧栏全屏按钮
+- [ToolBtn](../components/feedback/tool-btn.md) — 全屏按钮自定义插槽

--- a/src/frontend/ai-blueking/tsconfig.json
+++ b/src/frontend/ai-blueking/tsconfig.json
@@ -6,9 +6,6 @@
     },
     {
       "path": "./packages/chat-helper/tsconfig.json"
-    },
-    {
-      "path": "./packages/mcp/tsconfig.json"
     }
   ]
 }


### PR DESCRIPTION
组件文档目录由 molecular/atomic 调整为 setup/message/feedback 后， 同步更正 AI 指南与 composable 文档中的交叉引用；playground 示例改为
纯文本路径，避免 VitePress 解析相对链接失败。顺带移除 tsconfig 中
已不使用的 mcp 工程引用。