### PR TITLE
refactor(chat-x): UserQuestion 输入框发送改为 skip resume，onSendMessage 支持第三参数

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/package.json
+++ b/src/frontend/ai-blueking/packages/chat-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/chat-x",
-  "version": "0.0.45-beta.3",
+  "version": "0.0.45-beta.5",
   "description": "蓝鲸智云 AI Chat 组件库 —— 遵循 AG-UI，为 AI Agent 和人类开发者共同设计的对话 UI 组件库。",
   "main": "index.js",
   "scripts": {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -391,13 +391,11 @@ vi.mock('../chat-input/input-info-alert.vue', () => ({
 }));
 
 vi.mock('../chat-message/interrupt-message/user-question', () => ({
-  buildUserQuestionFreeTextResume: (interrupt: UserQuestionInterrupt, text: string) => ({
-    interruptId: interrupt.id,
+  buildSkipResumePayload: (interrupt?: UserQuestionInterrupt) => ({
+    interruptId: interrupt?.id ?? '',
     reason: InterruptReason.UserQuestion,
-    status: 'resolved',
-    payload: {
-      answers: [{ question: '', answer: [{ label: 'others', description: text }] }],
-    },
+    status: 'cancelled',
+    payload: { answers: [] },
   }),
   UserQuestionCard: defineComponent({
     name: 'UserQuestionCard',
@@ -767,7 +765,7 @@ describe('ChatContainer', () => {
       expect(wrapper.find('.mock-input-info-alert').text()).toBe('当前会话有 2 个待审批单，如需继续，请先取消审批');
     });
 
-    it('存在 UserQuestion 且未配置 onInterruptResume 时，应按普通消息发送且不清空输入', async () => {
+    it('存在 UserQuestion 时，发送消息应附带 skip resume 选项且不清空输入', async () => {
       const messages = [createUserQuestionInterruptMessage('user-question-1')];
       const onSendMessage = vi.fn();
 
@@ -776,37 +774,43 @@ describe('ChatContainer', () => {
       });
 
       const ci = wrapper.findComponent({ name: 'ChatInput' });
-      const send = ci.props('onSendMessage') as (content: string, docSchema: Record<string, unknown>) => Promise<void>;
+      const send = ci.props('onSendMessage') as (
+        content: string,
+        docSchema: Record<string, unknown>,
+        options?: { interrupt?: UserQuestionInterrupt; payload?: unknown },
+      ) => Promise<void>;
       const docSchema = {};
       await send('自由文本', docSchema);
 
-      expect(onSendMessage).toHaveBeenCalledWith('自由文本', docSchema);
+      expect(onSendMessage).toHaveBeenCalledWith('自由文本', docSchema, {
+        payload: expect.objectContaining({
+          interruptId: 'user-question-1-interrupt',
+          reason: InterruptReason.UserQuestion,
+          status: 'cancelled',
+          payload: { answers: [] },
+        }),
+        interrupt: expect.objectContaining({ id: 'user-question-1-interrupt' }),
+      });
       expect(wrapper.emitted('update:modelValue')).toBeUndefined();
     });
 
-    it('存在 UserQuestion 且配置 onInterruptResume 时，应将自由文本转为 resume 并清空输入', async () => {
-      const messages = [createUserQuestionInterruptMessage('user-question-1')];
+    it('无 UserQuestion 时，发送消息不应附带第三参数 options', async () => {
       const onSendMessage = vi.fn();
-      const onInterruptResume = vi.fn();
 
       wrapper = mount(ChatContainer, {
-        props: { ...defaultProps, messages, modelValue: '自由文本', onInterruptResume, onSendMessage },
+        props: { ...defaultProps, modelValue: '普通消息', onSendMessage },
       });
 
       const ci = wrapper.findComponent({ name: 'ChatInput' });
-      const send = ci.props('onSendMessage') as (content: string, docSchema: Record<string, unknown>) => Promise<void>;
-      await send('自由文本', {});
+      const send = ci.props('onSendMessage') as (
+        content: string,
+        docSchema: Record<string, unknown>,
+        options?: unknown,
+      ) => Promise<void>;
+      const docSchema = {};
+      await send('普通消息', docSchema);
 
-      expect(onInterruptResume).toHaveBeenCalledWith(
-        expect.objectContaining({
-          interruptId: 'user-question-1-interrupt',
-          reason: InterruptReason.UserQuestion,
-          status: 'resolved',
-        }),
-        expect.objectContaining({ id: 'user-question-1-interrupt' }),
-      );
-      expect(onSendMessage).not.toHaveBeenCalled();
-      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['', []]);
+      expect(onSendMessage).toHaveBeenCalledWith('普通消息', docSchema, undefined);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -307,7 +307,7 @@
   import ContentRender from '../chat-content/content-render/content-render.vue';
   import ChatInput, { type ChatInputEmits, type ChatInputProps } from '../chat-input/chat-input.vue';
   import InputInfoAlert from '../chat-input/input-info-alert.vue';
-  import { buildUserQuestionFreeTextResume, UserQuestionCard } from '../chat-message/interrupt-message/user-question';
+  import { buildSkipResumePayload, UserQuestionCard } from '../chat-message/interrupt-message/user-question';
   import MessageContainer, {
     type MessageContainerEmits,
     type MessageContainerProps,
@@ -548,12 +548,16 @@
    */
   const handleSendMessage = async (content: UserMessage['content'], docSchema: TagSchema) => {
     const activeQuestion = activeUserQuestionInterrupt.value;
-    if (props.onInterruptResume && activeQuestion && typeof content === 'string' && content.trim()) {
-      await props.onInterruptResume(buildUserQuestionFreeTextResume(activeQuestion, content.trim()), activeQuestion);
-      handleUpdateModelValue('', []);
-      return;
-    }
-    return props.onSendMessage?.(content, docSchema);
+    return props.onSendMessage?.(
+      content,
+      docSchema,
+      activeQuestion
+        ? {
+            payload: buildSkipResumePayload(activeQuestion), // 跳过中断时回传空答案
+            interrupt: activeQuestion, // 跳过中断时回传中断对象
+          }
+        : undefined,
+    );
   };
 
   const handleCollapse = () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -89,7 +89,13 @@
 
   import { Message } from 'bkui-vue';
 
-  import { type UserMessage, MessageContentType, MessageStatus } from '../../ag-ui/types';
+  import {
+    type Interrupt,
+    type InterruptResume,
+    type UserMessage,
+    MessageContentType,
+    MessageStatus,
+  } from '../../ag-ui/types';
   import { CHAT_Z_INDEX, isEn, MAX_UPLOAD_FILE_SIZE, MAX_UPLOAD_FILES } from '../../common';
   import { type KeyboardPayload, docToString } from '../../edix';
   import { CloseIcon } from '../../icons';
@@ -128,7 +134,11 @@
     inputMaxHeight?: number;
     messageStatus?: MessageStatus;
     modelValue: string | TagSchema;
-    onSendMessage?: (message: UserMessage['content'], docSchema: TagSchema) => Promise<void>;
+    onSendMessage?: (
+      message: UserMessage['content'],
+      docSchema: TagSchema,
+      options?: { interrupt?: Interrupt; payload?: InterruptResume },
+    ) => Promise<void>;
     onStopSending?: () => Promise<void>;
     onUpload?: (files: File) => Promise<{
       download_url?: string;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts
@@ -90,12 +90,7 @@ export const useUserQuestion = (getInterrupt: () => undefined | UserQuestionInte
   });
 
   /** 跳过：cancelled + 空答案 */
-  const buildSkipPayload = (): UserQuestionResume => ({
-    interruptId: getInterrupt()?.id ?? '',
-    reason: InterruptReason.UserQuestion,
-    status: 'cancelled',
-    payload: { answers: [] },
-  });
+  const buildSkipPayload = (): UserQuestionResume => buildSkipResumePayload(getInterrupt());
 
   return {
     questions,
@@ -113,14 +108,9 @@ export const useUserQuestion = (getInterrupt: () => undefined | UserQuestionInte
  * 自由文本 resume（用户在 chat-input 直接输入而非走结构化选择）。
  * 多题场景下信息有损：统一作为单条 Others 自由文本回传。
  */
-export const buildUserQuestionFreeTextResume = (
-  interrupt: UserQuestionInterrupt,
-  text: string,
-): UserQuestionResume => ({
-  interruptId: interrupt.id,
+export const buildSkipResumePayload = (interrupt?: UserQuestionInterrupt): UserQuestionResume => ({
+  interruptId: interrupt?.id ?? '',
   reason: InterruptReason.UserQuestion,
-  status: 'resolved',
-  payload: {
-    answers: [{ question: '', answer: [{ label: OTHERS_OPTION_LABEL, description: text }] }],
-  },
+  status: 'cancelled',
+  payload: { answers: [] },
 });

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
@@ -94,7 +94,7 @@ sinceVersion: 1.0.0
 - **自定义作答形态**：通过 `#question` slot 可替换默认选择题，渲染任意表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
 - **完成校验**：所有题目均已作答（`setAnswer` 收到有效答案）后才允许点击「完成」。
 - **跳过**：点击「跳过」返回 `status: 'cancelled'` 与空 `answers`。
-- **自由文本兜底**：当存在待回答 UserQuestion 且业务配置了 `onInterruptResume` 时，用户也可以直接在 `ChatInput` 输入文本；容器会将文本转换为单条 Others 回答。
+- **输入框发送**：存在待回答 UserQuestion 时，用户也可在 `ChatInput` 直接发送；`ChatContainer` 会调用 `onSendMessage` 并在第三参数附带与「跳过」等价的 skip `payload` 及 `interrupt`，输入框内容不会自动清空。
 
 ## 数据协议
 
@@ -220,7 +220,24 @@ const payload = {
 />
 ```
 
-如果没有配置 `onInterruptResume`，自由文本输入不会被截获，仍按普通 `onSendMessage` 发送，避免用户输入被静默清空。
+- 卡片内「完成 / 跳过」→ `onInterruptResume(payload, interrupt)`
+- 输入框直接发送 → `onSendMessage(content, docSchema, { interrupt, payload })`，其中 `payload` 由 `buildSkipResumePayload(interrupt)` 生成（`status: 'cancelled'`）
+
+## 工具函数 buildSkipResumePayload
+
+从 `@blueking/chat-x` 导出，用于构造 UserQuestion 的 skip resume（与卡片「跳过」及输入框发送时容器注入的 `options.payload` 一致）：
+
+```typescript
+import { buildSkipResumePayload, InterruptReason } from '@blueking/chat-x';
+
+const payload = buildSkipResumePayload(interrupt);
+// {
+//   interruptId: interrupt.id,
+//   reason: InterruptReason.UserQuestion,
+//   status: 'cancelled',
+//   payload: { answers: [] },
+// }
+```
 
 ## 自定义题目渲染（#question slot）
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -168,6 +168,31 @@ chat-input-container
 
 > **实现细节**：组件内部用 `messageState` 计算属性决定实际按钮状态：当 `messageStatus` 为 `pending`、`streaming` 或 `fetching` 时直接使用该状态（确保停止按钮始终可用）；否则当输入为空或仅含空白字符时强制为 `disabled`，其余情况使用 `messageStatus` 的值。`fetching` 时按 Enter **不会**触发发送（避免请求中与 Loading 占位阶段重复提交）。
 
+### onSendMessage 第三参数 options（UserQuestion 上下文）
+
+`ChatInput` 自身调用 `onSendMessage` 时只传前两个参数。当组件被 [ChatContainer](/components/setup/chat-container) 包裹且存在待回答 `UserQuestion` 中断时，容器会在用户点击发送时注入第三个参数：
+
+| 字段        | 类型               | 说明                                                                 |
+| ----------- | ------------------ | -------------------------------------------------------------------- |
+| `interrupt` | `Interrupt`        | 当前激活的 `UserQuestionInterrupt`                                   |
+| `payload`   | `InterruptResume`  | skip resume（`status: 'cancelled'`，`payload.answers` 为空数组）     |
+
+此场景下容器**不会**自动清空 `modelValue`，业务侧需在 `onSendMessage` 内自行处理消息发送与 `resumeAgent` 的先后顺序。结构化作答仍通过 `UserQuestionCard` → `onInterruptResume` 完成。
+
+```typescript
+const handleSendMessage = async (
+  content: UserMessage['content'],
+  docSchema: TagSchema,
+  options?: { interrupt?: Interrupt; payload?: InterruptResume },
+) => {
+  if (options?.interrupt && options?.payload) {
+    await resumeAgent({ interruptId: options.interrupt.id, resume: options.payload });
+    return;
+  }
+  await sendMessage(content, docSchema);
+};
+```
+
 ### sendDisabledTip（业务阻塞发送）
 
 当业务侧需要临时阻止发送但仍允许用户输入时，可传入 `sendDisabledTip`。组件会置灰发送按钮，按钮 tooltip 展示该文案，并拦截点击发送、按 Enter 发送和 `triggerSendMessage()`：
@@ -693,7 +718,7 @@ chat-input-container
 | sendDisabledTip    | `string`                                                                   | -        | -    | 业务阻塞发送时的 tooltip 提示；传入后发送按钮置灰，点击、Enter 与 `triggerSendMessage()` 均不会发送 |
 | supportUpload      | `boolean`                                                                  | `true`   | -    | 是否显示文件上传按钮                                    |
 | tippyOptions       | `AITippyProps`                                                             | —        | -    | 透传给 FileUploadBtn 和 InputAttachment 的 tooltip 配置 |
-| onSendMessage      | `(content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | -        | -    | 发送消息回调，无文件时 content 为字符串，有文件时为数组 |
+| onSendMessage      | `(content: UserMessage['content'], docSchema: TagSchema, options?: { interrupt?: Interrupt; payload?: InterruptResume }) => Promise<void>` | -        | -    | 发送消息回调，无文件时 content 为字符串，有文件时为数组；经 [ChatContainer](/components/setup/chat-container) 使用时，存在待回答 UserQuestion 会传入第三参数 `options` |
 | onStopSending      | `() => Promise<void>`                                                      | -        | -    | 停止发送回调，点击停止按钮时触发                        |
 | onUpload           | `(file: File) => Promise<{ download_url?: string }>`                       | -        | -    | 文件上传回调（每次单文件）                              |
 
@@ -789,6 +814,13 @@ type SendContent =
       // 有文件时：数组
       { type: 'binary'; url?: string; mimeType: string; filename: string } | { type: 'text'; text: string }
     >;
+
+// onSendMessage 完整签名（第三参数由 ChatContainer 在 UserQuestion 场景注入）
+type OnSendMessage = (
+  content: SendContent,
+  docSchema: TagSchema,
+  options?: { interrupt?: Interrupt; payload?: InterruptResume },
+) => Promise<void>;
 ```
 
 ## 完整集成示例

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -234,7 +234,7 @@ sinceVersion: 1.0.0
 - **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
 - **输入区状态推导**：传给 `MessageContainer` 与 `ChatInput` 的 `messageStatus` 为内部计算值 `inputStatus`：当分组中存在 id 为 `LOADING_MESSAGE_ID`（`'__loading__'`，由 `useMessageGroup` 注入的占位 Loading 消息）时，对内使用 `MessageStatus.Fetching`；否则使用外部传入的 `messageStatus`。用于在「已发用户消息、尚未流式」阶段与流式中一致地展示停止能力，并避免输入区重复发送
 - **待审批发送阻塞**：当消息中存在 `AIDevToolApproval` 且状态为 `pending` / `draft` 的中断项时，`useMessageGroup` 会返回待审批提示，容器在输入区上方展示提示并通过 `ChatInput.sendDisabledTip` 禁止继续发送
-- **用户问题中断**：当消息中存在待回答 `UserQuestion` 中断时，容器会在输入区上方挂载 `UserQuestionCard`；若配置了 `onInterruptResume`，用户也可直接在输入框输入自由文本并作为 Others 回答 resume
+- **用户问题中断**：当消息中存在待回答 `UserQuestion` 中断时，容器会在输入区上方挂载 `UserQuestionCard`；结构化作答走 `onInterruptResume`，用户在输入框直接发送时走 `onSendMessage` 并在第三参数附带 skip 用的 `payload`（`status: 'cancelled'`）与 `interrupt`，且不会自动清空输入框
 - **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
 - **侧栏全屏**：Tab 栏右侧提供全屏/退出全屏按钮，基于 `useFullScreen` 将侧栏区域（`.ai-full-screen-wrapper`）以浏览器原生全屏展示；全屏时 Tippy 的 `appendTo` 自动切换为全屏容器，避免 tooltip 被遮挡
 - **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
@@ -760,7 +760,10 @@ ai-chat-container（:data-ai-size="size"）
 
 ## 用户问题中断
 
-当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)。用户完成或跳过后通过 `onInterruptResume(payload, interrupt)` 通知业务侧继续 Agent。
+当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)。
+
+- **结构化作答**：用户在卡片内完成选择或点击「跳过」后，通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
+- **输入框发送**：用户也可在输入框直接点击发送；容器会调用 `onSendMessage(content, docSchema, options)`，其中 `options.interrupt` 为当前激活的 UserQuestion，`options.payload` 为 `buildSkipResumePayload` 生成的 skip resume（`status: 'cancelled'`，`answers: []`）。此时**不会自动清空**输入框，由业务侧在 `onSendMessage` 内决定如何处理 `content` 与中断恢复。
 
 ```vue
 <template>
@@ -774,17 +777,34 @@ ai-chat-container（:data-ai-size="size"）
 </template>
 
 <script setup lang="ts">
-  import { type OnInterruptResume } from '@blueking/chat-x';
+  import {
+    type OnInterruptResume,
+    type UserMessage,
+    type TagSchema,
+    type Interrupt,
+    type InterruptResume,
+  } from '@blueking/chat-x';
 
   const handleInterruptResume: OnInterruptResume = async (payload, interrupt) => {
-    // UserQuestion 完成时 payload 为 UserQuestionResume
-    // 自由文本输入也会转换为 label: 'others' 的单条回答
+    // UserQuestionCard 完成 / 跳过时 payload 为 UserQuestionResume
     await resumeAgent({ interruptId: interrupt.id, resume: payload });
+  };
+
+  const handleSendMessage = async (
+    content: UserMessage['content'],
+    docSchema: TagSchema,
+    options?: { interrupt?: Interrupt; payload?: InterruptResume },
+  ) => {
+    if (options?.interrupt && options?.payload) {
+      // 存在 UserQuestion 时发送：附带 skip resume，content 仍为输入框文本
+      await resumeAgent({ interruptId: options.interrupt.id, resume: options.payload });
+      // 业务侧自行决定是否将 content 作为新用户消息继续发送
+      return;
+    }
+    await sendMessage(content, docSchema);
   };
 </script>
 ```
-
-如果没有传入 `onInterruptResume`，输入框自由文本不会被中断逻辑截获，仍然走普通 `onSendMessage`，避免输入被静默清空。
 
 ## 自定义消息组渲染
 


### PR DESCRIPTION
- ChatContainer 存在待回答 UserQuestion 时，输入框发送走 onSendMessage 并附带 skip payload 与 interrupt，不再自动清空输入
- 移除 buildUserQuestionFreeTextResume 自由文本转 Others 逻辑，新增导出 buildSkipResumePayload
- ChatInput onSendMessage 签名扩展第三参数 options（interrupt / payload）
- 更新 chat-container 单测及 user-question-card、chat-input、chat-container wiki 文档
- 版本号 0.0.45-beta.3 → 0.0.45-beta.5