### PR TITLE
fix(chat-x): 优化 AssistantMessage 工具调用状态与空内容渲染

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
@@ -1,6 +1,9 @@
 <template>
   <div class="ai-assistant-message">
-    <div class="ai-assistant-message-content">
+    <div
+      v-if="content"
+      class="ai-assistant-message-content"
+    >
       <slot
         v-bind="{
           content,
@@ -19,7 +22,7 @@
         :key="toolCall.id"
       >
         <ToolCallRender
-          :status="status"
+          :status="toolCall.toolMessage?.status ?? status"
           :tool-call="toolCall"
         />
       </template>


### PR DESCRIPTION
- assistant-message-content 增加 v-if=content，无正文时跳过内容区渲染
- ToolCallRender 优先使用 toolCall.toolMessage?.status，回退至消息级 status