### PR TITLE
fix(chat-x): 修复输入框输入内容后高度抖动问题

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
@@ -475,8 +475,11 @@
     }
 
     .ai-slash-input {
+      box-sizing: border-box;
       width: 100%;
-      min-height: 100%;
+
+      // 默认保持 4 行高度，避免输入内容后 placeholder 消失导致高度抖动
+      min-height: calc(var(--ai-line-height-compact, 20px) * 4 + var(--ai-spacing-comfortable, 8px) * 2);
       padding: var(--ai-spacing-comfortable, 8px);
       font-size: var(--ai-font-size, 12px);
       line-height: var(--ai-line-height-compact, 20px);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -296,6 +296,11 @@
       align-items: flex-end;
       margin-bottom: 12px;
 
+      // 编辑态输入框贴合内容高度，不沿用主输入区的 4 行最小高度
+      .ai-slash-input {
+        min-height: auto;
+      }
+
       .user-edit-footer {
         display: flex;
         gap: 8px;


### PR DESCRIPTION
## 背景

TAPD 走查单：[【小鲸走查】输入框的高度，默认给 4 行，现在输入 / 会有高度变化](https://tapd.tencent.com/tapd_fe/70093903/story/detail/1070093903135141927)

输入框默认 placeholder 为 4 行提示文案，会把编辑区撑到 4 行高；一旦输入任意内容（如 `/`），placeholder 消失，编辑区回落到内容自身高度，整体高度从约 140px 跳到 110px，产生明显抖动。

## 改动

- `ai-slash-input.vue`：给编辑区 `.ai-slash-input` 增加 `box-sizing: border-box` 并设置基于行高/间距主题变量计算的 **4 行最小高度**，使空状态（placeholder）与输入内容后的高度保持一致，消除抖动。中英文行高/间距通过 `--ai-line-height-compact`、`--ai-spacing-comfortable` 自动适配。
- `user-message.vue`：编辑态 `.user-edit-input` 下覆盖 `.ai-slash-input { min-height: auto }`，保证编辑短消息时输入框仍贴合内容、不被强制撑到 4 行。

## 影响面

`ChatInput` 仅两处实例化：主输入区（`chat-container`，应用 4 行最小高度）与编辑态（`user-message`，覆盖为紧凑），无其他场景受影响。

## 测试

- [ ] 主输入框默认展示 4 行高度
- [ ] 输入 `/`、`@`、`\` 或普通文本后输入框高度不再跳变
- [ ] 用户消息编辑态输入框仍贴合内容、保持紧凑

Made with [Cursor](https://cursor.com)