### PR TITLE
fix(chat-x): 已选快捷指令 tag 补充 hover 底色

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -399,14 +399,25 @@ Use Shift + Enter to enter a new line`
         padding: 8px 8px 0;
       }
 
+      // 已选快捷指令 tag：默认态与 bkui Tag 一致，hover 使用 shortcut 语义色
       .selected-shortcut-btn {
         height: 24px;
         padding: 0 10px;
         color: #3a84ff;
         background: #e1ecff;
+        transition: background-color 0.2s, color 0.2s;
 
         .ai-common-icon {
           color: #3a84ff;
+        }
+
+        &:hover {
+          color: #1768ef;
+          background: #cddffe;
+
+          .ai-common-icon {
+            color: #3a84ff;
+          }
         }
       }
     }


### PR DESCRIPTION
## 背景
【小鲸走查】输入框底部已选快捷指令 tag（如「深度思考」）缺少 hover 底色，需与 bkui Tag 组件一致（`#cddffe`）。

根因：`.selected-shortcut-btn` 仅定义默认态 `#e1ecff`，未覆盖 `ShortcutBtn` 默认灰色 hover（`#f0f1f5`）。

## 改动
- `chat-input.vue`：为 `.selected-shortcut-btn` 补充 `:hover` 态（背景 `#cddffe`、文字 `#1768ef`）及过渡动画

## 影响面
- `ChatInput` 主输入区已选快捷指令 tag
- `UserMessage` 编辑态（复用 `ChatInput`）
- `ai-blueking/ChatBot` 透传，无需额外改动

## 测试
- [ ] 选中快捷指令（如「深度思考」）后，鼠标悬停 tag 背景变为 `#cddffe`
- [ ] 关闭按钮仍可正常点击
- [ ] 未选中快捷指令时列表按钮 hover 行为不受影响

Made with [Cursor](https://cursor.com)