### PR TITLE
fix(chat-x): 修复审批单字段标签在 normal 字号下换行

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -278,9 +278,9 @@
       min-width: 0;
 
       dt {
-        width: 50px;
-        min-width: 50px;
+        flex-shrink: 0;
         color: #979ba5;
+        white-space: nowrap;
       }
 
       dd {


### PR DESCRIPTION
## 背景
TAPD: 【小鲸走查】审批单字体换行了 (#1070093903135141727)

`ToolApprovalCard` 字段标签 `dt` 固定 `width: 50px`，在 `data-ai-size="normal"`（14px）下，「提交时间」「单据编号」等 4 字中文标签宽度不足导致换行。

## 改动
- 移除 `dt` 固定 50px 宽度
- 增加 `flex-shrink: 0` + `white-space: nowrap`，标签按内容自适应且不换行

## 影响面
- `packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue`
- 仅影响 AI Dev 工具审批单卡片（`InterruptReason.AIDevToolApproval`）的字段标签展示
- 由 `InterruptMessage` 按 reason 派发，无其他实例化位置

## 测试
- [ ] `data-ai-size="small"` 下字段标签正常单行显示
- [ ] `data-ai-size="normal"` 下「提交时间」「单据编号」不再换行
- [ ] 右侧值区域 ellipsis 截断行为不变

Made with [Cursor](https://cursor.com)