### PR TITLE
fix(chat-x): 引用文档 icon 与标题间距调整为 8px --story=3135141677

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/reference-content/reference-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/reference-content/reference-content.vue
@@ -89,6 +89,13 @@
       }
     }
 
+    .ai-doc-link-icon {
+      flex: 0 0 14px;
+      width: 14px;
+      height: 14px;
+      margin-right: 8px;
+    }
+
     .ai-common-icon:not(.ai-doc-link-icon) {
       display: none;
       flex: 0 0 14px;


### PR DESCRIPTION
## 背景
TAPD: 【小鲸走查】引用文档间距调整
引用文档列表中 DocLinkIcon 与标题文字之间缺少间距，设计稿要求 8px。原 img 图标有 margin-right: 4px，替换为 DocLinkIcon 后未补充对应样式。

## 改动
- `ReferenceContent` 为 `.ai-doc-link-icon` 补充 14px 尺寸与 `margin-right: 8px`

## 影响面
- `ReferenceDocContent`（reference_document 消息）
- `KnowledgeRagContent`（知识库 RAG 检索引用列表）
- `ActivityMessage` 中的引用文档展示

## 测试
- [ ] 知识库问答检索完成后，引用列表 icon 与标题间距为 8px
- [ ] hover 行时预览/跳转图标布局正常
- [ ] 多条引用文档列表显示正常

Made with [Cursor](https://cursor.com)