### PR TITLE
fix(chat-x): 统一工具与 MCP 调用耗时格式中间不留空格 --story=3135141346

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/utils.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/utils.spec.ts
@@ -25,7 +25,20 @@
  */
 import { describe, expect, it } from 'vitest';
 
-import { formatElapsedTime } from './utils';
+import { formatDuration, formatElapsedTime } from './utils';
+
+describe('formatDuration', () => {
+  it('数字与单位之间、各段之间均不留空格', () => {
+    expect(formatDuration(90500)).toBe('1m30s500ms');
+    expect(formatDuration(30000)).toBe('30s');
+    expect(formatDuration(60000)).toBe('1m');
+  });
+
+  it('不足 1 秒时应展示毫秒', () => {
+    expect(formatDuration(0)).toBe('0ms');
+    expect(formatDuration(500)).toBe('500ms');
+  });
+});
 
 describe('formatElapsedTime', () => {
   it('不足 1 秒时应返回 <1s', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/utils.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/utils.ts
@@ -30,9 +30,9 @@ export const getCookieByName = (name: string) => {
 };
 
 /**
- *
+ * 将毫秒耗时格式化为紧凑字符串（数字与单位之间不留空格）
  * @param duration 耗时，单位：毫秒
- * @returns 返回格式化后的耗时字符串，如：1m 30s 500ms
+ * @returns 如 1m30s500ms；与 formatElapsedTime 风格一致
  */
 export const formatDuration = (duration: number) => {
   const minutes = Math.floor(duration / 60000);
@@ -42,18 +42,18 @@ export const formatDuration = (duration: number) => {
   const parts: string[] = [];
 
   if (minutes > 0) {
-    parts.push(`${minutes} m`);
+    parts.push(`${minutes}m`);
   }
 
   if (seconds > 0) {
-    parts.push(`${seconds} s`);
+    parts.push(`${seconds}s`);
   }
 
   if (milliseconds > 0 || parts.length === 0) {
-    parts.push(`${milliseconds} ms`);
+    parts.push(`${milliseconds}ms`);
   }
 
-  return parts.join(' ');
+  return parts.join('');
 };
 
 export const generateUUID = () => {


### PR DESCRIPTION
## 背景
TAPD: 【小鲸走查】调用工具和 mcp等显示的耗时格式统一中间不留空格

工具/MCP 调用耗时通过 `formatDuration` 展示，原格式为 `1 m 30 s 500 ms`（数字与单位、各段之间均有空格），与 flow-agent 节点耗时的 `formatElapsedTime`（如 `1m30s`）风格不一致。

## 改动
- 修改 `packages/chat-x/src/utils/utils.ts` 中 `formatDuration`：输出改为 `1m30s500ms` 紧凑格式
- 补充 `formatDuration` 单测

## 影响面
- `ToolcallRender`：工具调用与 MCP 调用头部耗时展示
- `ReasoningMessage`：思考完成态耗时展示（同样使用 `formatDuration`）

## 测试
- [x] `pnpm exec vitest run src/utils/utils.spec.ts` 通过

Made with [Cursor](https://cursor.com)