### PR TITLE
feat(chat-x): 支持 AIDevToolApproval resume 后会话内只读回显审批单

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
@@ -27,8 +27,10 @@ import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus } from '..
 
 import type {
   AIDevToolApprovalInterrupt,
+  AIDevToolApprovalResume,
   Interrupt,
   InterruptMessage,
+  InterruptResult,
   Message,
   RunFinishedOutcome,
   UserQuestionInterrupt,
@@ -82,7 +84,7 @@ const createInterruptScenario = (params: {
   interrupt: Interrupt;
   intro: string;
   outcome: RunFinishedOutcome;
-  result?: unknown;
+  result?: InterruptResult;
   scenarioId: string;
   status?: MessageStatus;
 }): Message[] => {
@@ -194,8 +196,19 @@ const resumedScenario = createInterruptScenario({
     interruptId: 'interrupt_resumed',
     reason: InterruptReason.AIDevToolApproval,
     status: 'resolved',
-    payload: { action: 'view_ticket' },
-  },
+    payload: {
+      metaData: {
+        ticket: {
+          approvers: ['张三', '李四', '王五'],
+          sn: 'REV-2026-04-24-006',
+          status: APPROVAL_STATUS.APPROVED,
+          submit_time: '2026-04-24 14:30:15',
+          title: '算法方案评审单',
+          url: 'https://example.com/review-tickets/REV-2026-04-24-006',
+        },
+      },
+    },
+  } satisfies AIDevToolApprovalResume,
 });
 
 // —— 场景 7：不支持的中断类型（走兜底文案）——

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
@@ -49,22 +49,33 @@ export enum InterruptResumeOperation {
  */
 export type AIDevToolApprovalInterrupt = BaseInterrupt<
   InterruptReason.AIDevToolApproval,
-  {
-    ticket: {
-      // approvers 审批人
-      approvers: string[];
-      // 单据编号
-      sn: string;
-      // 单据状态
-      status: APPROVAL_STATUS;
-      // 提交时间
-      submit_time: string;
-      // 单据标题
-      title: string;
-      // 单据链接
-      url: string;
-    };
-  }
+  AIDevToolApprovalInterruptPayloadMetaData
+>;
+
+export type AIDevToolApprovalInterruptPayloadMetaData = {
+  ticket: {
+    // approvers 审批人
+    approvers: string[];
+    // 单据编号
+    sn: string;
+    // 单据状态
+    status: APPROVAL_STATUS;
+    // 提交时间
+    submit_time: string;
+    // 单据标题
+    title: string;
+    // 单据链接
+    url: string;
+  };
+};
+
+/**
+ * AI Dev 第三方工具审批中断响应（resume 后用于 outcome.success 时会话内回显审批单）。
+ * payload 透传中断时的 metaData（含 ticket），以便复用 ToolApprovalCard 渲染。
+ */
+export type AIDevToolApprovalResume = BaseResume<
+  InterruptReason.AIDevToolApproval,
+  { metaData: AIDevToolApprovalInterruptPayloadMetaData }
 >;
 
 export type BaseInterrupt<T extends InterruptReason, M extends Record<string, any>> = {
@@ -119,12 +130,19 @@ export type InterruptMessage = BaseMessage<
     message?: string;
     /** 是否已被用户响应（resume）过，用于 UI 区分"等待响应 / 已处理"两种态 */
     outcome?: RunFinishedOutcome;
-    /** outcome.type === success 用户 resume 时回传给 Agent 的 payload，便于回放与持久化 */
-    result?: BaseResume<InterruptReason>; // 用户回答问题中断响应负载
+    /** outcome.type === success 用户 resume 后回传/持久化的结果，用于会话内按 reason 回显 */
+    result?: InterruptResult;
     runId?: string;
     threadId?: string;
   }
 >;
+
+/**
+ * 中断处理结果（resume 后回传/持久化，用于 outcome.success 时会话内回显）。
+ * 按 reason 区分不同结果形态，统一具备 BaseResume 的 { interruptId, reason, status }；
+ * 新增中断类型的回显结果只需在此联合扩展。
+ */
+export type InterruptResult = AIDevToolApprovalResume | UserQuestionResume;
 
 export type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestionResume;
 
@@ -137,7 +155,6 @@ export type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestion
 export type OnInterruptResume = (payload: InterruptResume, interrupt?: Interrupt) => Promise<void> | void;
 
 export type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
-
 /**
  * 第三方工具审批中断的响应负载（取消审批等动作）
  */
@@ -145,6 +162,7 @@ export type ToolApprovalResume = {
   operation: InterruptResumeOperation.ApprovalCancel;
   payload: { interrupt_id: number | string };
 };
+
 /**
  * 用户对单个问题的回答
  */

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -33,6 +33,7 @@ import InterruptMessage from './interrupt-message.vue';
 
 import type {
   AIDevToolApprovalInterrupt,
+  AIDevToolApprovalResume,
   Interrupt,
   UserQuestionAnswerItem,
   UserQuestionResume,
@@ -95,6 +96,15 @@ const userQuestionResume: UserQuestionResume = {
   status: 'resolved',
   payload: {
     answers: userQuestionAnswers,
+  },
+};
+
+const approvalResume: AIDevToolApprovalResume = {
+  interruptId: 'interrupt-1',
+  reason: InterruptReason.AIDevToolApproval,
+  status: 'resolved',
+  payload: {
+    metaData: approvalInterrupt.metadata!,
   },
 };
 
@@ -256,6 +266,22 @@ describe('InterruptMessage', () => {
     expect(wrapper.text()).toContain('请选择语言');
     expect(wrapper.text()).toContain('Java');
     expect(wrapper.text()).toContain('Rust');
+  });
+
+  it('success outcome 存在 AIDevToolApproval resume 时应只读回显审批单', () => {
+    wrapper = mount(InterruptMessage, {
+      props: {
+        content: {
+          outcome: { type: 'success' },
+          result: approvalResume,
+        },
+      },
+    });
+
+    expect(wrapper.find('.ai-tool-approval-card').exists()).toBe(true);
+    expect(wrapper.find('.ai-tool-approval-card__title').text()).toBe('算法方案评审单');
+    expect(wrapper.text()).toContain('REV-2026-04-24-001');
+    expect(wrapper.find('.ai-tool-approval-card__cancel').exists()).toBe(false);
   });
 
   it('content.message 存在时应渲染提示文案', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
@@ -24,12 +24,13 @@
         {{ item.message || t('暂不支持的中断消息') }}
       </div>
     </template>
-    <!-- outcome.success 时在会话内回显用户已回答内容（含跳过=已取消态） -->
-    <UserQuestionAnsweredCard
-      v-if="userQuestionResume"
-      :answers="answeredUserQuestion"
-      :status="userQuestionResume.status"
+    <!-- outcome.success 时按 reason 在会话内回显 resume 结果（审批单 / 已回答内容等） -->
+    <component
+      :is="resultRender.component"
+      v-if="resultRender"
+      v-bind="resultRender.props"
     >
+      <!-- #answer 仅 UserQuestionAnsweredCard 消费，其它结果卡片忽略此 slot -->
       <template
         v-if="$slots.answeredQuestion"
         #answer="slotProps"
@@ -39,7 +40,7 @@
           v-bind="slotProps"
         />
       </template>
-    </UserQuestionAnsweredCard>
+    </component>
   </div>
 </template>
 
@@ -53,10 +54,13 @@
   import { UserQuestionAnsweredCard } from './user-question';
 
   import type {
+    AIDevToolApprovalInterrupt,
+    AIDevToolApprovalResume,
     Interrupt,
     InterruptMessage,
+    InterruptResult,
     OnInterruptResume,
-    UserQuestionAnswerItem,
+    UserQuestionResume,
   } from '../../../ag-ui/types/interrupt';
   import type { UserQuestionAnsweredCardSlots } from './user-question/user-question-answered-card.vue';
 
@@ -67,6 +71,31 @@
 
   const interruptRenderers: Partial<Record<InterruptReason, Component>> = {
     [InterruptReason.AIDevToolApproval]: ToolApprovalCard,
+  };
+
+  // 由审批结果还原出 interrupt 形态，复用 ToolApprovalCard 渲染（回显态只读）
+  const toApprovalInterrupt = (result: AIDevToolApprovalResume): AIDevToolApprovalInterrupt => ({
+    id: result.interruptId,
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: '',
+    metadata: result.payload.metaData,
+  });
+
+  // outcome.success 时按 reason 分发 result 渲染：component + 组件 props 适配
+  // 新增结果类型只需在此扩展一条映射，模板与透传链路保持不变
+  type ResultRenderer = (result: InterruptResult) => { component: Component; props: Record<string, unknown> };
+  const resultRenderers: Partial<Record<InterruptReason, ResultRenderer>> = {
+    [InterruptReason.AIDevToolApproval]: result => ({
+      component: ToolApprovalCard,
+      props: { interrupt: toApprovalInterrupt(result as AIDevToolApprovalResume), readonly: true },
+    }),
+    [InterruptReason.UserQuestion]: result => ({
+      component: UserQuestionAnsweredCard,
+      props: {
+        answers: (result as UserQuestionResume).payload?.answers ?? [],
+        status: result.status,
+      },
+    }),
   };
 
   // 这些中断类型的交互 UI 不在会话内渲染（如 UserQuestion 渲染在 chat-input 上方）
@@ -82,17 +111,13 @@
   const getRenderer = (item: Interrupt) => interruptRenderers[item.reason];
   const isSlotRenderedInterrupt = (item: Interrupt) => slotRenderedReasons.has(item.reason);
 
-  // outcome.success 时定位 UserQuestion 的 resume 结果（用于回显问题与 已回复/已取消 状态）
-  const userQuestionResume = computed(() => {
+  // outcome.success 时按 reason 解析 result，得到要渲染的组件与其 props
+  const resultRender = computed(() => {
     if (props.content?.outcome?.type !== 'success') return undefined;
     const result = props.content?.result;
-    return result?.reason === InterruptReason.UserQuestion ? result : undefined;
+    if (!result) return undefined;
+    return resultRenderers[result.reason]?.(result);
   });
-
-  // 从 resume 结果中提取用户对各问题的回答用于回显（跳过态为空数组）
-  const answeredUserQuestion = computed<UserQuestionAnswerItem[]>(
-    () => (userQuestionResume.value?.payload?.answers ?? []) as UserQuestionAnswerItem[],
-  );
 </script>
 
 <style lang="scss">

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -71,7 +71,7 @@
         <span class="ai-tool-approval-card__detail-icon" />
       </Button>
       <Button
-        v-if="isPendingApproval"
+        v-if="isPendingApproval && !readonly"
         class="ai-tool-approval-card__cancel"
         outline
         theme="primary"
@@ -103,6 +103,8 @@
   const props = defineProps<{
     interrupt: AIDevToolApprovalInterrupt;
     onInterruptResume?: OnInterruptResume;
+    // 只读回显态（outcome.success 结果回显）：隐藏取消审批按钮，不接受交互
+    readonly?: boolean;
   }>();
 
   const commonTippyOptions = useCommonTippyInject();

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
@@ -3,9 +3,9 @@ name: InterruptMessage 中断消息
 slug: interrupt-message
 kind: component
 domain: agent
-description: 渲染 human-in-the-loop 中断消息，分发工具审批，并回显用户问题回答结果。
+description: 渲染 human-in-the-loop 中断消息，分发工具审批，并按 reason 回显 resume 结果。
 aiSummary: >
-  渲染 human-in-the-loop 中断消息，分发工具审批，并回显用户问题回答结果。
+  渲染 human-in-the-loop 中断消息，分发工具审批，并按 reason 回显 resume 结果（审批单 / 用户回答）。
   源码位置：src/components/chat-message/interrupt-message/interrupt-message.vue。
 relatedComponents:
   - slug: message-render
@@ -87,7 +87,18 @@ sinceVersion: 1.0.0
         interruptId: 'interrupt_resumed',
         reason: InterruptReason.AIDevToolApproval,
         status: 'resolved',
-        payload: {},
+        payload: {
+          metaData: {
+            ticket: {
+              approvers: ['张三', '李四'],
+              sn: 'REV-2026-04-24-001',
+              status: APPROVAL_STATUS.APPROVED,
+              submit_time: '2026-04-24 14:30:15',
+              title: '算法方案评审单',
+              url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+            },
+          },
+        },
       },
     },
   }
@@ -160,7 +171,7 @@ sinceVersion: 1.0.0
 
 - **源码位置**：`src/components/chat-message/interrupt-message/interrupt-message.vue`
 - **能力域**：Agent 能力
-- **能力说明**：渲染 human-in-the-loop 中断消息，分发工具审批，并回显用户问题回答结果。
+- **能力说明**：渲染 human-in-the-loop 中断消息，分发工具审批，并按 `result.reason` 回显 resume 结果。
 
 
 
@@ -169,7 +180,7 @@ sinceVersion: 1.0.0
 human-in-the-loop 中断消息渲染器（导出名 **`InterruptMessageRender`**）。对应 `MessageRole.Interrupt`，解析 `content.outcome` 渲染审批卡片或兜底提示。
 
 > 通常由 [MessageRender](/components/message/message-render) 自动调用，无需业务侧直接引入。
-> `UserQuestion` 的待回答卡片由 [ChatContainer](/components/setup/chat-container) 放在输入区上方，本组件只负责 success 后的会话内回答回显。
+> `UserQuestion` 的待回答卡片由 [ChatContainer](/components/setup/chat-container) 放在输入区上方，本组件在 `outcome.success` 时按 `result.reason` 回显审批单或用户回答。
 
 ## 渲染架构
 
@@ -183,12 +194,15 @@ InterruptMessageRender
             └── 未注册 reason → 兜底块（item.message 或「暂不支持的中断消息」）
 
 content.outcome.type === 'success'
-└── result.reason === aidev:user_question → UserQuestionAnsweredCard 回显回答（支持 #answeredQuestion 透传 #answer）
+└── resultRenderers[result.reason]
+      ├── aidev:tool_approval → ToolApprovalCard（readonly，隐藏取消审批）
+      └── aidev:user_question → UserQuestionAnsweredCard（支持 #answeredQuestion 透传 #answer）
 ```
 
 | `InterruptReason`              | 子组件              |
 | ------------------------------ | ------------------- |
-| `aidev:tool_approval`          | `ToolApprovalCard`  |
+| `aidev:tool_approval`（待审批） | `ToolApprovalCard`  |
+| `aidev:tool_approval`（已处理） | `ToolApprovalCard`（`readonly`，只读回显） |
 | `aidev:user_question`（待回答） | 输入区 `UserQuestionCard`，本组件不渲染 |
 | `aidev:user_question`（已回答） | `UserQuestionAnsweredCard` |
 | 其他 / 未注册                  | 兜底文案区域        |
@@ -280,6 +294,23 @@ content.outcome.type === 'success'
   <InterruptMessageRender v-bind="userQuestionMessage" />
 </div>
 
+## AIDevToolApproval 已处理回显（outcome.success）
+
+`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以只读 `ToolApprovalCard` 回显审批单。`result.payload.metaData` 需透传中断时的 `metadata`（含 `ticket`）：
+
+```vue
+<InterruptMessageRender
+  :content="resumedMessage.content"
+  role="interrupt"
+/>
+```
+
+**渲染效果**
+
+<div class="demo">
+  <InterruptMessageRender v-bind="resumedMessage" />
+</div>
+
 ## UserQuestion 已回答回显（outcome.success）
 
 `outcome.type === 'success'` 且 `result.reason === InterruptReason.UserQuestion` 时，会话内回显用户回答。可通过 `#answeredQuestion` slot 自定义单题回显：
@@ -299,14 +330,6 @@ content.outcome.type === 'success'
 
 <div class="demo">
   <InterruptMessageRender v-bind="userQuestionAnsweredMessage" />
-</div>
-
-## 其他已 resume（outcome.success）
-
-非 `UserQuestion` 的 success 态不渲染中断卡片，仅保留可选顶部 `content.message`：
-
-<div class="demo">
-  <InterruptMessageRender v-bind="resumedMessage" />
 </div>
 
 ## 不支持的中断类型（兜底）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -3,9 +3,9 @@ name: ToolApprovalCard 工具审批卡片
 slug: tool-approval-card
 kind: component
 domain: agent
-description: 渲染 AIDevToolApproval 中断的审批信息与取消操作。
+description: 渲染 AIDevToolApproval 中断的审批信息与取消操作，支持只读回显态。
 aiSummary: >
-  渲染 AIDevToolApproval 中断的审批信息与取消操作。
+  渲染 AIDevToolApproval 中断的审批信息与取消操作；outcome.success 回显时以 readonly 只读展示。
   源码位置：src/components/chat-message/interrupt-message/tool-approval-card.vue。
 relatedComponents:
   - slug: interrupt-message
@@ -91,7 +91,7 @@ sinceVersion: 1.0.0
 
 - **源码位置**：`src/components/chat-message/interrupt-message/tool-approval-card.vue`
 - **能力域**：Agent 能力
-- **能力说明**：渲染 AIDevToolApproval 中断的审批信息与取消操作。
+- **能力说明**：渲染 AIDevToolApproval 中断的审批信息与取消操作；`readonly` 时用于 outcome.success 只读回显。
 
 
 
@@ -108,8 +108,10 @@ ToolApprovalCard
 ├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
 ├── 处理人：当前处理人（overflow-tips 省略）
-└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft）
+└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly）
 ```
+
+`readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏「取消审批」按钮，不接受审批取消交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
 
 状态徽章样式：
 
@@ -214,6 +216,26 @@ ToolApprovalCard
   <ToolApprovalCard :interrupt="revokedInterrupt" />
 </div>
 
+## 只读回显（readonly）
+
+`outcome.success` 时 [InterruptMessageRender](/components/agent/interrupt-message) 会将 `AIDevToolApprovalResume.payload.metaData` 还原为 `interrupt` 形态，并以 `readonly` 挂载本组件：
+
+```vue
+<ToolApprovalCard
+  :interrupt="approvedInterrupt"
+  readonly
+/>
+```
+
+**渲染效果**（待审批态下 readonly 不展示「取消审批」）
+
+<div class="demo">
+  <ToolApprovalCard
+    :interrupt="pendingInterrupt"
+    readonly
+  />
+</div>
+
 ## API
 
 ### Props
@@ -222,6 +244,7 @@ ToolApprovalCard
 | ----------------- | ---------------------------- | ------ | -------------------------------------------- |
 | interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`               |
 | onInterruptResume | `OnInterruptResume`          | —      | 取消审批时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id } }` |
+| readonly          | `boolean`                    | —      | 只读回显态（`outcome.success` 结果回显）：隐藏取消审批按钮，不接受交互 |
 
 ### Events / Slots / Expose
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
@@ -4,11 +4,11 @@ slug: interrupt
 category: type
 description: AG-UI human-in-the-loop 中断相关类型，含 Interrupt、UserQuestion、InterruptMessage 与 resume 回调。
 aiSummary: >
-  定义 RunFinishedOutcome、BaseInterrupt、AIDevToolApprovalInterrupt、UserQuestionInterrupt、BaseResume、InterruptMessage 与 OnInterruptResume。
+  定义 RunFinishedOutcome、BaseInterrupt、AIDevToolApprovalInterrupt、AIDevToolApprovalResume、UserQuestionInterrupt、InterruptResult、BaseResume、InterruptMessage 与 OnInterruptResume。
   与 MessageRole.Interrupt、InterruptMessageRender、UserQuestionCard、ToolApprovalCard 配合，对应 RUN_FINISHED outcome。
 relatedComponents:
   - slug: interrupt-message
-    relation: 根据 outcome.interrupts 与 reason 渲染中断 UI，success 时回显 UserQuestion 回答
+    relation: 根据 outcome.interrupts 与 reason 渲染中断 UI，success 时按 result.reason 回显审批单或用户回答
   - slug: user-question-card
     relation: UserQuestion 交互面板，挂载在 ChatInput 上方
   - slug: tool-approval-card
@@ -60,7 +60,7 @@ type RunFinishedOutcome =
 | `type`        | 说明                                                                 |
 | ------------- | -------------------------------------------------------------------- |
 | `'interrupt'` | 等待用户响应；`interrupts` 驱动 UI 渲染审批卡片、用户问题面板等       |
-| `'success'`   | 用户已通过 `resume` 处理；若 `result.reason === UserQuestion` 则回显回答内容 |
+| `'success'`   | 用户已通过 `resume` 处理；按 `result.reason` 在会话内回显审批单（`AIDevToolApproval`）或用户回答（`UserQuestion`） |
 
 ## BaseInterrupt
 
@@ -83,18 +83,31 @@ type BaseInterrupt<T extends InterruptReason, M extends Record<string, any>> = {
 AI Dev 第三方工具审批中断，`reason` 为 `InterruptReason.AIDevToolApproval`（`'aidev:tool_approval'`）：
 
 ```typescript
+type AIDevToolApprovalInterruptPayloadMetaData = {
+  ticket: {
+    approvers: string[];
+    sn: string;
+    status: APPROVAL_STATUS;
+    submit_time: string;
+    title: string;
+    url: string;
+  };
+};
+
 type AIDevToolApprovalInterrupt = BaseInterrupt<
   InterruptReason.AIDevToolApproval,
-  {
-    ticket: {
-      approvers: string[];
-      sn: string;
-      status: APPROVAL_STATUS;
-      submit_time: string;
-      title: string;
-      url: string;
-    };
-  }
+  AIDevToolApprovalInterruptPayloadMetaData
+>;
+```
+
+## AIDevToolApprovalResume
+
+AI Dev 第三方工具审批中断响应（resume 后用于 `outcome.success` 时会话内回显审批单）。`payload.metaData` 透传中断时的 `metadata`（含 `ticket`），以便复用 `ToolApprovalCard` 只读渲染：
+
+```typescript
+type AIDevToolApprovalResume = BaseResume<
+  InterruptReason.AIDevToolApproval,
+  { metaData: AIDevToolApprovalInterruptPayloadMetaData }
 >;
 ```
 
@@ -142,7 +155,17 @@ type Interrupt =
   | BaseInterrupt<InterruptReason, Record<string, any>>;
 ```
 
+## InterruptResult
+
+中断处理结果（resume 后回传/持久化，用于 `outcome.success` 时会话内回显）。按 `reason` 区分不同结果形态，统一具备 `BaseResume` 的 `{ interruptId, reason, status }`；新增中断类型的回显结果只需在此联合扩展：
+
+```typescript
+type InterruptResult = AIDevToolApprovalResume | UserQuestionResume;
+```
+
 ## InterruptResume 联合类型
+
+用户操作后通过 `onInterruptResume` 回传的负载（与 `InterruptResult` 用途不同：`InterruptResume` 侧重**动作回传**，`InterruptResult` 侧重**success 态会话内回显**）：
 
 ```typescript
 type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestionResume;
@@ -235,7 +258,7 @@ type InterruptMessage = BaseMessage<
   {
     message?: string;
     outcome?: RunFinishedOutcome;
-    result?: BaseResume<InterruptReason>;
+    result?: InterruptResult;
     runId?: string;
     threadId?: string;
   }
@@ -246,7 +269,7 @@ type InterruptMessage = BaseMessage<
 | ---------- | ------------------------------------------------------------ |
 | `message`  | 消息组顶部可选说明文案，由 `InterruptMessageRender` 展示     |
 | `outcome`  | `type: 'interrupt'` 时从 `interrupts` 渲染交互；`success` 时进入已处理态 |
-| `result`   | 用户 resume 后回传的单对象 payload；`UserQuestion` 会用于会话内回显 |
+| `result`   | 用户 resume 后回传/持久化的 `InterruptResult`；按 `reason` 在会话内回显审批单或用户回答 |
 | `runId`    | 关联 AG-UI run 标识                                          |
 | `threadId` | 关联会话线程标识                                             |
 


### PR DESCRIPTION
- 新增 AIDevToolApprovalResume、InterruptResult 联合类型，result 由 BaseResume 收窄为 InterruptResult
- InterruptMessage 引入 resultRenderers 按 reason 分发 success 态结果渲染
- outcome.success 且 reason 为 aidev:tool_approval 时以 readonly ToolApprovalCard 回显审批单
- playground resumed 场景对齐新 payload 结构，补充 interrupt-message 单测
- 更新 interrupt-message / tool-approval-card / interrupt 类型 wikis 文档