### PR TITLE
fix(chat-x): 修正 InterruptMessage 单测 AIDevToolApproval resume payload 字段名

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -104,7 +104,7 @@ const approvalResume: AIDevToolApprovalResume = {
   reason: InterruptReason.AIDevToolApproval,
   status: 'resolved',
   payload: {
-    metaData: approvalInterrupt.metadata!,
+    metadata: approvalInterrupt.metadata!,
   },
 };
 


### PR DESCRIPTION
## Summary

- 修正 `interrupt-message.spec.ts` 中 `approvalResume` 测试数据的 payload 字段名：`metaData` → `metadata`
- 与 `AIDevToolApprovalResume` 接口契约对齐，避免单测 mock 与真实 resume 结构不一致

## Test plan

- [ ] `pnpm test:ui` 中 `interrupt-message.spec.ts` 用例通过
- [ ] 审批中断 resume 后会话内只读回显逻辑无回归

## TAPD

--story=135288049


Made with [Cursor](https://cursor.com)