### PR TITLE
feat(chat-x): 走查对齐输入框发送按钮尺寸与设计稿 --story=135141249

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
@@ -80,17 +80,17 @@
 
     .send-message-icon {
       display: flex;
-      flex: 0 0 24px;
+      flex: 0 0 32px;
       align-items: center;
       justify-content: center;
-      width: 24px;
-      height: 24px;
+      width: 32px;
+      height: 32px;
       margin-left: auto;
-      font-size: 14px;
+      font-size: 16px;
       color: #fff;
       cursor: pointer;
       background: #3a84ff;
-      border-radius: 4px;
+      border-radius: 8px;
 
       // &__active {
       //   color: #fff;


### PR DESCRIPTION
## 背景
TAPD: 【小鲸走查】发送图标尺寸调整（story 135141249）
走查发现输入框右下角发送按钮的尺寸与设计稿（Figma 469:15321）不一致，需对齐设计稿。

## 改动
- `input-attachment.vue` 的 `.send-message-icon`：
  - 容器尺寸 24×24 → 32×32
  - 圆角 4px → 8px
  - 发送图标 font-size 14px → 16px（驱动 `.ai-common-icon` 的 1em）
- 背景色（默认/禁用 `#f0f1f5`、可发送 `#3a84ff`）与设计稿一致，未改动

## 影响面
`.send-message-icon` 为全局样式，经 `InputAttachment` 作用于所有使用 `ChatInput` 的位置：
- 主输入区（chat-container）
- 用户消息编辑态（user-message）
- 中断/追问卡片（interrupt-message / user-question-card）

外层 `.ai-input-attachment` 高 40px，可容纳 32px 按钮居中，布局不受影响。

## 测试
- [ ] 主输入区发送按钮尺寸/圆角/图标对齐设计稿
- [ ] 用户消息编辑态发送按钮一致
- [ ] 禁用态与可发送态背景色正常切换

Made with [Cursor](https://cursor.com)