### PR TITLE
feat: 【chat-x】沉淀消费方 skill --story=135442643

### DIFF
--- a/src/frontend/ai-blueking/AGENTS.md
+++ b/src/frontend/ai-blueking/AGENTS.md
@@ -11,6 +11,7 @@
 - `requestOptions.data` 对 POST/PUT/PATCH/DELETE 合并进 body；对 GET/HEAD/OPTIONS 合并进 query（params）
 - `supportUpload` 需从 `ChatContainer -> MessageContainer -> MessageRender -> UserMessage` 全链路透传；否则用户消息编辑态 `ChatInput` 会回退到默认 `true` 与主输入区配置不一致
 - 自定义 `ChatContainer` 的 `#message` 插槽渲染 `MessageRender` 时，必须透传 `on-action`、`on-input-confirm`、`on-shortcut-confirm`、`tippy-options`；否则用户消息的工具操作（删除/编辑/复制/引用）全部失效，而 AI 消息的工具操作不受影响（AI 的 `MessageTools` 在 `MessageContainer` 内部渲染，不经过 `#message` 插槽）
+- `ChatInput` 发送按钮图标尺寸由 `input-attachment.vue` 的全局类 `.send-message-icon` 控制，图标走 `.ai-common-icon`（全局 `width/height:1em`），故尺寸由 `font-size` 驱动；该全局类经 `InputAttachment` 作用于所有 `ChatInput` 实例（主输入区 chat-container、用户消息编辑态 user-message、中断/追问卡片 interrupt-message / user-question-card），改一处全量生效
 
 ## Selection & Share Flow
 
@@ -25,6 +26,32 @@
 ## TypeScript Patterns
 
 - 避免 `IShortcut & Shortcut` 整块交叉类型，当两个接口同名字段类型冲突（如 `fillRegx: RegExp` vs `string`、`components` 结构差异）时会产生 `never`；改用 `Shortcut & Pick<IShortcut, 'supportUpload'>` 只扩展所需字段
+
+## 编码约定（详见 chat-x-dev skill）
+
+- `.ts` 文件顶部带项目 MIT license 头，`.vue` 文件不带；SFC 顺序固定 `template → script setup → style`，import 分组 vue → 三方 → 内部相对 → `import type`
+- 样式统一 `&-element` 嵌套（不用 `&__element`），class 一律 `ai-` 前缀 BEM + `&.is-xxx` 状态；字号用 `var(--ai-font-size, 12px)` 必带兜底；语义色 `@use styles/variables.scss`；禁止 `:deep`
+- composable 用箭头函数 + `Symbol` token 的 `useXxx`(provide)/`injectXxx`(inject 兜底 undefined)；只放数据逻辑，UI 交互态留组件本地；优先 `shallowRef`/`shallowReactive`
+- 类型扩展走 `declare global` 声明合并（`AIBluekingMessageMap`/`AIBluekingContentMap`），不加组件泛型逐层透传；i18n 所有可见文案走 `t('中文')` 并同步 `src/lang/lang.ts`（漏加会类型报错）
+
+## Skills 与文档体系
+
+- 项目已沉淀 4 个 skill：`.agents/skills/chat-x-dev`（库内编码规范）、`skills/blueking-chat-x`（消费方使用导航，注意在 `skills/` 而非 `.agents/skills/`）、`.agents/skills/chat-x-update-docs`（提交前同步 test+wiki）、`.agents/skills/chat-x-tapd-dev`（TAPD 开发闭环）
+- 组件 API 真相源是 `wikis/` + chat-x MCP（`chat-x-mcp`：`list_components`/`get_component_doc`/`search_docs`，由 `mcp/scripts/build-index.ts` 从 wikis 构建索引）；不要凭记忆臆测 props/events/slots
+- `wikis/components/` 已按能力域目录组织（agent/feedback/helper/input/medias/message/rendering/setup），文档带 frontmatter；源码↔文档映射见 `wikis/components/inventory.md`，VitePress 侧边栏在 `wikis/.vitepress/config.mts` 手动维护
+
+## Git 与提交校验
+
+- `.git` 在 monorepo 根 `liang-ai-agent/.git`（workspace 为 `packages/chat-x`），沙箱内 `git commit`/`git push`/`gh pr create` 会报 `index.lock: Operation not permitted`，需 `required_permissions: ["all"]`；`git fetch` 用 `["network"]`
+- git remote：origin = 个人 fork `liangling0628/bk-aidev-agent`，upstream = `TencentBlueKing/bk-aidev-agent`；本仓库未启用 GPG 签名，可直接代提交
+- commit-msg 走 `@blueking/bkui-lint/verify-commit.mjs`：`type: subject` 的 subject（含 `--story=`/`--bug=` 后缀）须 1–50 字符；任何情况不得用 `--no-verify`
+- pre-commit `scripts/pre-commit-test.mjs`：staged 的 `packages/chat-x/src` 改动，若对应 colocated `*.spec.ts` 或 `wikis/components/**` 已存在却未一并 stage 则拦截提交，并自动跑相关 vitest（测试不过无法提交）；slug override `components/image-preview/image.vue → ai-image`
+- TAPD 单据 workspace_id 固定 `70093903`（蓝鲸开发工具）；19 位 ID = `10`+workspace_id(8 位)+短 ID(9 位)，分支名用完整 ID、commit/PR title 后缀用短 ID
+
+## Figma 设计稿开发
+
+- Figma MCP（`user-figma`）默认可能未连接当前工作区，可检查 `~/.cursor/projects/<proj>/mcps/` 是否出现 `user-figma` 目录来判断；未连接时需让用户在 Cursor 启用后再继续
+- 读取设计稿规格优先用 `get_design_context`（传 fileKey + nodeId），比 `get_metadata` 更有用（后者只给结构）；首次调用若要求 Code Connect 映射，确认不需要时传 `disableCodeConnect: true` 直接拿设计上下文，避免循环
 
 ## Workflow Preferences
 

--- a/src/frontend/ai-blueking/packages/chat-x/.gitignore
+++ b/src/frontend/ai-blueking/packages/chat-x/.gitignore
@@ -1,0 +1,1 @@
+skills-lock.json

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/SKILL.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: blueking-chat-x
+description: >-
+  Use when 在消费方项目中接入 / 使用 @blueking/chat-x 对话组件库（已 npm 安装、非改库源码），
+  涉及「某组件怎么用、有哪些 props / events / slots / expose / v-model、怎么搭 AI 对话界面、
+  流式输出、停止生成、工具调用 ToolCall、快捷指令、文件上传、@ 资源、自定义消息或侧栏 Tab、
+  分享多选、HITL 中断审批、Markdown / 代码 / 公式 / 图表渲染、字号与主题 CSS 变量」等问题时优先使用。
+  若是在 packages/chat-x/src 内改库源码（写组件 / composable / 样式 / 测试），改用 chat-x-dev skill。
+---
+
+# 使用 @blueking/chat-x
+
+帮助**消费方项目**（已 `npm i @blueking/chat-x`）快速理解组件库、查清每个组件的用法与 API，并写出正确的接入代码。
+
+本 skill 的组件资料在 `references/` 下，由 `scripts/generate-references.mjs` 从库的 `wikis/` 文档自动生成（剥离演示噪音、保留完整 API 与示例）。**它就是组件 API 的真相源**——不要凭记忆臆测 props/事件/插槽名。
+
+## 信息源优先级（先查再写）
+
+| 想知道什么 | 去哪里查（按优先级） |
+| --- | --- |
+| 某组件的 Props / Events / Slots / Expose / v-model / 用法 | ① `references/_index.md` 定位 slug → ② `references/components/<slug>.md`；③ 若项目装了 chat-x MCP，可用 `get_component_doc` / `search_docs` 交叉验证 |
+| 有哪些组件、按能力域怎么选 | `references/_index.md`（能力地图） |
+| composable / 类型 / 主题（字号、CSS 变量） | `references/composables/*`、`references/types/*`、`references/theme/*` |
+| 最小接入怎么写 | 本文「快速接入」一节 |
+
+> references 缺失或过期时，按本文「再生成 references」一节重新生成。
+
+## 心智模型（一句话）
+
+**消息驱动 + 角色分发**：业务维护一份 `Message[]` → `ChatContainer`（或 `useMessageGroup`）分组 → `MessageRender` 按 `message.role` 分发到具体消息组件 → `ContentRender` 按内容类型分发 → `MarkdownContent` 按 token 分发。
+
+接入心智：**你只负责维护 `messages` 数组和实现 `onSendMessage` 等回调**，组件负责渲染与交互。
+
+## 快速接入（ChatContainer 一站式，推荐入口）
+
+```vue
+<template>
+  <ChatContainer
+    v-model="input"
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatContainer, MessageRole, MessageStatus, type Message, type TagSchema, type UserMessage } from '@blueking/chat-x';
+
+  const input = ref('');
+  const messages = ref<Message[]>([]);
+  const messageStatus = ref(MessageStatus.Complete);
+
+  const handleSendMessage = async (content: UserMessage['content'], docSchema: TagSchema) => {
+    messages.value.push({ id: `u_${Date.now()}`, messageId: `u_${Date.now()}`, role: MessageRole.User, content, status: MessageStatus.Complete });
+    const ai: Message = { id: `a_${Date.now()}`, messageId: `a_${Date.now()}`, role: MessageRole.Assistant, content: '', status: MessageStatus.Streaming };
+    messages.value.push(ai);
+    messageStatus.value = MessageStatus.Streaming;
+    // 接你的 SSE / WebSocket，把增量写入 ai.content
+    ai.status = MessageStatus.Complete;
+    messageStatus.value = MessageStatus.Complete;
+  };
+  const handleStopSending = async () => { messageStatus.value = MessageStatus.Stop; };
+  const handleStopStreaming = () => { messageStatus.value = MessageStatus.Stop; };
+</script>
+```
+
+前置依赖：`vue >= 3.5`、`bkui-vue 2.x`；样式随导入自动加载，无需手动引入。
+需要完全控制布局时改用「`MessageContainer` + `ChatInput` + `useMessageGroup`」组合——细节查 `references/components/message-container.md` 与 `chat-input.md`。
+
+## 怎么查一个组件（标准流程）
+
+1. 在 `references/_index.md` 里按名称/能力域找到组件，拿到它的 `path`。
+2. 读 `references/components/<slug>.md`：顶部是能力域 + 导入符号 + 概述 + 关联组件，正文含「核心能力 / 基础用法 / API（Props/Events/Slots/Expose/v-model）/ 类型定义」。
+3. 按 API 表格落地代码，需要的类型与常量从 `@blueking/chat-x` 具名导入。
+
+> 接入逻辑常跨多个组件（如 `ChatContainer` 透传 `ChatInput` / `MessageContainer` 的 props，自定义 `#message` 插槽需透传 `onAction` 等回调）。遇到「透传到底要带哪些参数」时，连同关联组件文档一起读。
+
+## 常见坑（消费方高频，先看再调）
+
+| 症状 | 原因 / 修法 |
+| --- | --- |
+| 自定义 `#message` 插槽后，用户消息的工具（删除/编辑/复制/引用）全失效，但 AI 消息工具正常 | 自定义 `#message` 渲染 `MessageRender` 时漏透传 `on-action` / `on-input-confirm` / `on-shortcut-confirm` / `tippy-options`；AI 消息工具在 `MessageContainer` 内部渲染不经过该插槽，故不受影响 |
+| 用户消息编辑态的 `ChatInput` 上传配置与主输入区不一致 | `supportUpload` 需全链路透传 `ChatContainer → MessageContainer → MessageRender → UserMessage`，否则回退默认 `true` |
+| 想自定义代码块头部动作（插入/应用代码）无从下手 | 用 `codeHeader` 插槽，参数为 `{ language, token }`（`AIBlueking/ChatBot` 已支持透传） |
+| `requestOptions.data` 不知道进 body 还是 query | POST/PUT/PATCH/DELETE 合并进 body；GET/HEAD/OPTIONS 合并进 query（params） |
+
+## 常见任务 → 入口
+
+| 任务 | 入口组件 / 文档 |
+| --- | --- |
+| 搭完整对话界面 | `components/chat-container.md` |
+| 自定义布局（自己拼消息列表 + 输入框） | `components/message-container.md` + `components/chat-input.md` + `composables/use-message-group.md` |
+| `/` Prompt、`@` 资源、文件上传 | `components/chat-input.md` |
+| 流式输出 / 停止生成 | `components/chat-container.md`（`messageStatus` + `@stop-streaming`） |
+| 工具调用 / ToolCall 渲染 | `components/toolcall-render.md`、`components/tool-message.md` |
+| HITL 中断 / 工具审批 / 用户提问 | `components/interrupt-message.md`、`components/tool-approval-card.md`、`components/user-question-card.md` |
+| FlowAgent 执行 / 知识召回展示 | `components/flow-agent-content.md`、`components/knowledge-rag-content.md` |
+| 渲染 Markdown / 代码 / 公式 / 图表 | `components/content-render.md`、`components/markdown-content.md`、`components/code-content.md` |
+| 图片预览 / 文件展示 | `components/ai-image.md`、`components/image-preview-group.md`、`components/file-content.md` |
+| 快捷指令表单 | `components/shortcut-render.md`、`components/chat-input.md` |
+| 分享 / 多选 | `components/chat-container.md`、`components/selection-footer.md` |
+| 自定义消息类型 / 侧栏 Tab | `composables/use-custom-tab.md` + `components/chat-container.md` |
+| 字号 / 主题 CSS 变量 | `theme/theme.md` |
+
+## 类型与常量速查
+
+```typescript
+// 类型按需具名导入
+import type { Message, UserMessage, AssistantMessage, ToolMessage, IToolBtn, Shortcut, TagSchema } from '@blueking/chat-x';
+
+// 枚举 / 预置工具
+import {
+  MessageRole, MessageStatus, MessageContentType,
+  CONST_MESSAGE_TOOLS,       // AI 消息默认工具：复制 / 引用 / 重新生成 / 分享
+  CONST_USER_MESSAGE_TOOLS,  // 用户消息默认工具：复制 / 引用 / 编辑 / 删除
+} from '@blueking/chat-x';
+```
+
+更全的类型/常量定义查 `references/types/*`。
+
+## 再生成 references
+
+references 由脚本从 `wikis/` 生成。当库升级、wikis 更新，或 references 缺失/过期时重新生成（**运行脚本前需经用户同意**）：
+
+```bash
+# 在 packages/chat-x 下执行（依赖 glob / gray-matter 已在 devDependencies）
+node skills/blueking-chat-x/scripts/generate-references.mjs
+```
+
+脚本会全量重建 `references/`：`glob wikis` → `gray-matter` 解析 frontmatter → 清洗正文（去 VitePress demo `<script>` / `<div class="demo">` / 内联 style，保留代码围栏与 API 表格）→ 按组件能力域 + composables/types/theme 写出 + 生成 `_index.md`。
+
+## 通用项目规则
+
+中文回复、不擅自处理 eslint/格式、运行脚本需先经同意、git 提交禁用 `--no-verify`、不确定先问——见仓库 `AGENTS.md` 与 `.cursor/rules/project.mdc`。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/_index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/_index.md
@@ -1,0 +1,125 @@
+# @blueking/chat-x 能力地图（自动生成）
+
+> 由 `scripts/generate-references.mjs` 从 `wikis/` 生成，请勿手改。
+> 查某个能力时：先在本索引定位 slug，再读对应 `path` 的 reference 文档。
+
+> 生成时间：2026-06-23T01:47:26.937Z
+
+## 组件（按能力域）
+
+### 对话搭建
+
+- **ChatContainer 聊天容器** — 完整对话容器，组合消息列表、输入区、快捷指令、执行摘要、分享选择和自定义 Tab。 → `components/chat-container.md`
+- **MessageContainer 消息列表容器** — 负责消息分组渲染、滚动控制、工具栏和消息插槽透传。 → `components/message-container.md`
+
+### 消息系统
+
+- **ActivityMessage 活动消息** — 按 activityType 分发 FlowAgent、知识召回、引用文档等活动内容。 → `components/activity-message.md`
+- **AssistantMessage AI 助手消息** — 渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。 → `components/assistant-message.md`
+- **InfoMessage 信息消息** — 渲染居中的系统信息提示。 → `components/info-message.md`
+- **LoadingMessage 加载消息** — 消息列表中的加载占位，默认使用 AiLoading，也支持默认插槽覆盖。 → `components/loading-message.md`
+- **MessageRender 消息渲染器** — 按 message.role 分发到用户、助手、工具、推理、活动、中断等消息组件。 → `components/message-render.md`
+- **ReasoningMessage 推理消息** — 渲染推理过程，覆盖加载、错误与 Markdown 内容展示。 → `components/reasoning-message.md`
+- **ToolMessage 工具消息** — 渲染工具返回内容，JSON 场景交给 DescPanel 展示。 → `components/tool-message.md`
+- **UserMessage 用户消息** — 渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。 → `components/user-message.md`
+
+### 内容渲染
+
+- **AnimationText 动画文本** — 按文本增量播放流式动画。 → `components/animation-text.md`
+- **CiteContent 引用内容** — 渲染输入或消息中的引用片段。 → `components/cite-content.md`
+- **CodeContent 代码块** — 渲染 Markdown 代码块，支持高亮、复制和 header 插槽。 → `components/code-content.md`
+- **CommonErrorContent 错误内容** — 展示统一错误提示内容。 → `components/common-error-content.md`
+- **ContentRender 内容渲染器** — 按 MessageContentType 分发 Markdown、文本、引用、键值、图片等内容。 → `components/content-render.md`
+- **DescPanel 描述面板** — 将文本或 JSON 内容降级为可读描述面板。 → `components/desc-panel.md`
+- **KeyValueContent 键值内容** — 以键值列表展示结构化内容。 → `components/key-value-content.md`
+- **LatexContent LaTeX 公式** — 使用 KaTeX 渲染 LaTeX 公式内容。 → `components/latex-content.md`
+- **MarkdownContent Markdown 内容渲染** — Markdown 主渲染器，集成代码块、公式、错误降级和 codeHeader 插槽。 → `components/markdown-content.md`
+- **MermaidContent Mermaid 图表** — 渲染 Mermaid 图表并处理渲染事件。 → `components/mermaid-content.md`
+- **ReferenceContent 引用来源** — 渲染引用文档/来源列表。 → `components/reference-content.md`
+- **TextContent 文本内容** — 渲染纯文本内容。 → `components/text-content.md`
+
+### 媒体文件
+
+- **AiImage 图片展示** — 图片展示组件，组合加载、错误、预览和 extra 插槽。 → `components/ai-image.md`
+- **FileContent 文件内容** — 渲染文件附件，支持图片预览和下载事件。 → `components/file-content.md`
+- **ImageContent 图片内容** — 渲染 Markdown 图片 token。 → `components/image-content.md`
+- **ImagePreview 图片预览** — 图片全屏预览容器，支持缩放、旋转、下载工具栏。 → `components/image-preview.md`
+- **ImagePreviewGroup 图片预览组** — 通过 provide/inject 管理同组图片预览。 → `components/image-preview-group.md`
+- **PreviewToolbar 图片预览工具栏** — 图片预览的缩放、旋转、下载等工具按钮。 → `components/preview-toolbar.md`
+
+### 输入交互
+
+- **AiPromptList Prompt 列表** — / Prompt 选择列表，供 AiSlashInput 插入模板文本。 → `components/ai-prompt-list.md`
+- **AiSelection 划词选择** — 监听选中文本并展示快捷操作浮窗。 → `components/ai-selection.md`
+- **AiSlashEditor 富文本编辑器** — 旧版富文本编辑器实现，封装 command selection 与提示菜单。 → `components/ai-slash-editor.md`
+- **AiSlashInput 富文本命令输入** — ChatInput 内部富文本输入，支持 / Prompt 与 @ 资源标签。 → `components/ai-slash-input.md`
+- **AiSlashMenu 资源菜单** — @ 资源选择菜单，展示资源项供 AiSlashInput 插入标签。 → `components/ai-slash-menu.md`
+- **ChatInput 聊天输入框** — 聊天输入区，组合富文本输入、快捷指令、附件、引用、发送/停止等交互。 → `components/chat-input.md`
+- **FileUploadBtn 文件上传按钮** — 文件选择按钮，封装 input[type=file] 并输出选择事件。 → `components/file-upload-btn.md`
+- **InputAttachment 输入附件区** — ChatInput 底部附件区布局，承载快捷按钮、文件与发送图标。 → `components/input-attachment.md`
+- **InputInfoAlert 输入提示条** — ChatInput 上方的信息提示条。 → `components/input-info-alert.md`
+- **SelectionFooter 多选操作栏** — 消息多选/分享模式下的底部操作栏。 → `components/selection-footer.md`
+- **ShortcutBtn 快捷指令按钮** — 单个快捷指令按钮，支持默认/append 插槽和 expose focus。 → `components/shortcut-btn.md`
+- **ShortcutBtns 快捷指令按钮组** — 快捷指令列表入口，内部组合多个 ShortcutBtn。 → `components/shortcut-btns.md`
+- **ShortcutRender 快捷指令表单** — 渲染快捷指令 components 表单并回传确认数据。 → `components/shortcut-render.md`
+
+### Agent 能力
+
+- **DetailSection 详情分段** — FlowAgent 节点详情中的标题/内容分段容器。 → `components/detail-section.md`
+- **ExecutionSummary 执行摘要** — 按消息流提取执行摘要，支持关键词定位和消息渲染。 → `components/execution-summary.md`
+- **FlowAgentContent FlowAgent 执行内容** — 渲染 FlowAgent 任务/节点执行状态、耗时、详情入口和自定义 Tab 联动。 → `components/flow-agent-content.md`
+- **FlowAgentNodeDetail FlowAgent 节点详情** — 展示 FlowAgent 节点输入、输出、异常、耗时等详情。 → `components/flow-agent-node-detail.md`
+- **InterruptMessage 中断消息** — 渲染 human-in-the-loop 中断消息，分发工具审批，并按 reason 回显 resume 结果。 → `components/interrupt-message.md`
+- **KnowledgeRagContent 知识召回内容** — 渲染知识召回活动，包含加载态、Markdown 内容与引用来源。 → `components/knowledge-rag-content.md`
+- **ReferenceDocContent 引用文档活动** — 渲染引用文档类活动内容，复用 ActivityLayout 与 ReferenceContent。 → `components/reference-doc-content.md`
+- **SimpleTable 简易表格** — FlowAgent 节点详情中的轻量表格展示组件。 → `components/simple-table.md`
+- **ToolApprovalCard 工具审批卡片** — 渲染 AIDevToolApproval 中断的审批信息与取消操作，支持只读回显态。 → `components/tool-approval-card.md`
+- **ToolcallRender 工具调用渲染器** — 渲染 assistant toolCalls，展示工具调用状态、参数和结果。 → `components/toolcall-render.md`
+- **UserQuestionAnsweredCard 用户问题回答回显** — 在 UserQuestion resume 成功后回显用户回答或取消状态。 → `components/user-question-answered-card.md`
+- **UserQuestionCard 用户问题中断** — 渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。 → `components/user-question-card.md`
+- **UserQuestionChoice 用户问题选择题** — UserQuestionCard 默认的选择题渲染组件，封装单选/多选、Others 输入与答案组装。 → `components/user-question-choice.md`
+- **UserQuestionOption 用户问题选项** — UserQuestionChoice 内部选项行，处理单选/多选状态和 Others 输入。 → `components/user-question-option.md`
+
+### 工具与反馈
+
+- **DeleteTool 删除确认按钮** — 消息删除二次确认工具。 → `components/delete-tool.md`
+- **MessageTools 消息工具栏** — 消息悬浮工具栏，组合复制、删除、反馈等工具按钮。 → `components/message-tools.md`
+- **ScrollBtn 滚动按钮** — 停止生成或返回底部等滚动/状态按钮。 → `components/scroll-btn.md`
+- **ToolBtn 工具按钮** — 工具栏图标按钮。 → `components/tool-btn.md`
+- **UserFeedback 用户反馈** — 用户反馈弹层，提交踩/反馈原因。 → `components/user-feedback.md`
+
+### 辅助能力
+
+- **ActivityLayout 活动布局** — 活动消息的折叠布局容器，提供 title/default 插槽。 → `components/activity-layout.md`
+- **AiLoading 三点加载** — 小尺寸 AI 加载动效。 → `components/ai-loading.md`
+- **HighlightKeyword 关键词高亮** — 根据注入关键词高亮文本片段。 → `components/highlight-keyword.md`
+- **MessageLoading 品牌加载** — 带品牌图标和逐字渐变动画的加载组件。 → `components/message-loading.md`
+- **QuestionsContainer 问题容器占位** — 源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。 → `components/questions-container.md`
+- **SelectionQuestion 选择问题占位** — 源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。 → `components/selection-question.md`
+- **VNodeRenderer VNode 渲染器** — 将 Markdown token 转成 VNode 的内部渲染桥。 → `components/vnode-renderer.md`
+
+## Composables 组合式函数
+
+- **useAnimationText** — 文本淡入动画的组合式函数。将响应式文本按**增量**拆分为独立 chunk，每个新增 chunk 对应一次淡入动画，适用于 AI 流式输出的逐段渐显效果。 → `composables/use-animation-text.md`
+- **useClipboard** — 复制文本到剪贴板的组合式函数。内置两级降级策略，并自动通过 bkui-vue `Message` 提示复制结果，调用方无需关心成功/失败处理。 → `composables/use-clipboard.md`
+- **useCommandSelection** — 为 `edix` 富文本编辑器提供光标位置追踪能力的组合式函数。内部封装一个 `EditorCommand`，由编辑器调用后将光标的行列信息存入响应式变量，供后续编辑命令（如插入 tag、删除关键词）精确定位。 → `composables/use-command-selection.md`
+- **useContainerScroll** — 为消息容器提供滚动控制的组合式函数对，通过 **Provider/Consumer** 模式在父子组件间共享滚动状态。 → `composables/use-container-scroll.md`
+- **useCustomTab** — Provider/Consumer 模式的自定义 Tab 管理，用于 `ChatContainer` 侧边栏的 Tab 动态管理。Provider 在 `ChatContainer` 中创建，Consumer 在任意后代组件中注入使用。 → `composables/use-custom-tab.md`
+- **useFlowNodeActions** — 聚合 FlowAgent 节点行尾操作（详情 / 重试 / 跳过）为声明式视图模型列表，显隐与 resume 回调收敛于此。 → `composables/use-flow-node-actions.md`
+- **useFullScreen** — 基于浏览器原生 Fullscreen API 的全屏控制组合式函数，自动嗅探标准与 WebKit 前缀，状态与 ESC 退出保持同步。 → `composables/use-full-screen.md`
+- **useGlobalConfig** — 在聊天根容器与子组件之间通过 provide/inject 共享全局展示配置（字号主题档位、是否支持上传等）。 → `composables/use-global-config.md`
+- **useMenuKeydown** — 为弹出菜单提供键盘导航能力的组合式函数。在 `onMounted` 时于 **`window` 捕获阶段**注册 `keydown` 监听，在 `onScopeDispose` 时自动移除，通过 `menuRef.offsetParent` 检测菜单可见性来决定是否响应按键。 → `composables/use-menu-keydown.md`
+- **useMessageGroup** — 核心消息分组逻辑，将原始 `Message[]` 数组转换为结构化的 `MessageGroup[]`。处理 Tool 消息合并、Loading 自动注入、执行摘要过滤和消息多选/分享等逻辑。 → `composables/use-message-group.md`
+- **useObserverVisibleList** — 基于 `ResizeObserver` 的容器宽度感知组合式函数：遍历列表项的实际 `offsetWidth`，使用贪心算法计算在容器中能完整显示的项目子集，并为"更多"按钮动态预留空间。 → `composables/use-observer-visible-list.md`
+- **useParentScrolling** — 向上递归查找**最近可滚动祖先**，监听其 `scroll` / `scrollend` 事件，提供 `isScrolling` 状态。常用于滚动时自动关闭浮层、禁用交互等场景。 → `composables/use-parent-scrolling.md`
+
+## 类型定义
+
+- **常量枚举** — `@blueking/chat-x` 导出的常量和枚举类型。 → `types/constants.md`
+- **中断类型 Interrupt** — AG-UI human-in-the-loop 中断相关类型，含 Interrupt、UserQuestion、InterruptMessage 与 resume 回调。 → `types/interrupt.md`
+- **消息类型** — `@blueking/chat-x` 提供了完整的消息类型定义，用于构建 AI 对话消息。 → `types/messages.md`
+- **用户问题 Schema** — 历史 human-in-the-loop 用户问题 JSON Schema 工具；新 UserQuestion 中断协议以 Interrupt 文档为准。 → `types/schema.md`
+
+## 主题
+
+- **主题配置** — `@blueking/chat-x` 使用 SCSS 变量和 CSS 类来控制样式，支持通过覆盖变量或样式来自定义主题。 → `theme/theme.md`

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/activity-layout.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/activity-layout.md
@@ -1,0 +1,134 @@
+# ActivityLayout 活动布局
+
+> 能力域：辅助能力 ｜ 导入：`import { ActivityLayout } from '@blueking/chat-x'` ｜ since 1.0.0
+
+活动消息的折叠布局容器，提供 title/default 插槽。 源码位置：src/components/chat-content/activity-layout/activity-layout.vue。
+
+**关联**：activity-message（活动消息通过本组件承载标题栏与内容区）、knowledge-rag-content（知识召回活动复用本组件展示加载标题与正文）、reference-doc-content（引用文档活动复用本组件展示文档数量与引用列表）、flow-agent-content（FlowAgent 活动复用本组件，但隐藏默认折叠箭头）
+
+---
+
+# ActivityLayout 活动布局
+
+> **能力域**：辅助能力
+
+`ActivityLayout` 是活动消息的通用折叠布局容器，负责渲染标题栏、折叠箭头和内容区域。它不关心活动内容类型本身，标题和正文均通过插槽传入，因此常被 `KnowledgeRagContent`、`ReferenceDocContent`、`FlowAgentContent` 等活动组件复用。
+
+通常不需要业务侧直接使用；如果要新增一种活动消息内容，可以用它作为标题/内容外壳。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/activity-layout/activity-layout.vue`
+- **能力说明**：活动消息的折叠布局容器，提供 `title` / `default` 插槽。
+
+## 核心能力
+
+- **标题栏点击折叠**：点击标题栏切换 `collapsed`，内容区通过 `v-show="!collapsed"` 显示或隐藏
+- **双向绑定**：通过 `v-model:collapsed` 让父组件控制展开/收起状态，默认展开
+- **标题插槽透传状态**：`title` 插槽会收到 `{ collapsed }`，可根据折叠状态调整标题内容
+- **默认折叠箭头**：非 FlowAgent 活动自动在标题右侧显示折叠箭头
+- **FlowAgent 特例**：`activityType === MessageContentType.FlowAgent` 时隐藏默认折叠箭头，由 FlowAgent 自己渲染标题交互
+
+## 基础用法
+
+```vue
+<template>
+  <ActivityLayout v-model:collapsed="collapsed">
+    <template #title="{ collapsed }">
+      <span class="ai-activity-message-title-icon">
+        <DocumentIcon style="font-size: 12px" />
+      </span>
+      <span class="ai-activity-message-title-text">
+        {{ collapsed ? '已折叠' : '引用 2 篇资料作为参考' }}
+      </span>
+    </template>
+
+    <div style="padding: 0 14px;">
+      活动内容
+    </div>
+  </ActivityLayout>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import ActivityLayout from '@blueking/chat-x/src/components/chat-content/activity-layout/activity-layout.vue';
+  import { DocumentIcon } from '@blueking/chat-x/src/icons/content';
+
+  const collapsed = ref(false);
+</script>
+```
+
+**渲染效果**
+
+## 折叠状态
+
+`collapsed` 默认为 `false`。设置为 `true` 时只展示标题栏，正文内容保留在 DOM 中但通过 `v-show` 隐藏。
+
+## FlowAgent 活动
+
+传入 `activityType="flow_agent"` 时，`ActivityLayout` 不渲染右侧默认折叠箭头。该场景下标题栏通常由 `FlowAgentContent` 自己展示状态统计、加载图标和展开箭头。
+
+```vue
+<ActivityLayout
+  v-model:collapsed="collapsed"
+  :activity-type="MessageContentType.FlowAgent"
+>
+  <template #title>
+    <span>执行情况: 成功 2 / 失败 1</span>
+  </template>
+  <div>FlowAgent 节点列表</div>
+</ActivityLayout>
+```
+
+## 组件结构
+
+```
+.ai-activity-message
+├── .ai-activity-message-title（点击切换 collapsed）
+│   ├── title slot（slot props: { collapsed }）
+│   └── CollapsedIcon（activityType !== flow_agent 时显示）
+└── .ai-activity-message-content（v-show="!collapsed"）
+    └── default slot
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                 | 必填 | 默认值 | 说明                                          |
+| ------------ | -------------------- | ---- | ------ | --------------------------------------------- |
+| activityType | `MessageContentType` | 否   | —      | 活动类型；为 `flow_agent` 时隐藏默认折叠箭头 |
+
+### Models
+
+| 名称      | 类型      | 默认值  | 说明             |
+| --------- | --------- | ------- | ---------------- |
+| collapsed | `boolean` | `false` | 活动内容是否折叠 |
+
+### Emits
+
+- 无显式 emits；`v-model:collapsed` 会产生 `update:collapsed`。
+
+### Slots
+
+| 插槽名  | 参数                    | 说明       |
+| ------- | ----------------------- | ---------- |
+| title   | `{ collapsed: boolean }` | 标题栏内容 |
+| default | —                       | 活动正文   |
+
+### Expose
+
+- 无。
+
+## 使用建议
+
+- 适合作为活动消息内部布局外壳，不建议替代通用卡片、面板或页面 Section。
+- 标题栏点击区域会整体触发折叠，标题插槽内如有按钮或链接，需要自行处理事件冒泡。
+- `default` 内容使用 `v-show` 控制可见性，折叠时不会卸载内部组件。
+
+## 关联组件
+
+- [ActivityMessage](../message/activity-message.md) — 活动消息分发入口。
+- [KnowledgeRagContent](../agent/knowledge-rag-content.md) — 知识召回活动。
+- [ReferenceDocContent](../agent/reference-doc-content.md) — 引用文档活动。
+- [FlowAgentContent](../agent/flow-agent-content.md) — FlowAgent 执行活动。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/activity-message.md
@@ -1,0 +1,464 @@
+# ActivityMessage 活动消息
+
+> 能力域：消息系统 ｜ 导入：`import { ActivityMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+按 activityType 分发 FlowAgent、知识召回、引用文档等活动内容。 源码位置：src/components/chat-message/activity-message/activity-message.vue。
+
+**关联**：message-render（由 MessageRender 在 role 为 activity 时创建）、assistant-message（常与助手回复相邻，描述检索或执行背景）
+
+---
+
+# ActivityMessage 活动消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/activity-message/activity-message.vue`
+- **能力域**：消息系统
+- **能力说明**：按 activityType 分发 FlowAgent、知识召回、引用文档等活动内容。
+
+> **能力域**：消息系统
+
+活动消息组件，用于展示 AI 的知识检索（Knowledge RAG）过程、参考文档引用列表和 FlowAgent 流程执行情况。通过 `activityType` 切换三种工作模式，点击标题栏可折叠/展开内容区域。
+
+组件会将父级传入消息上的 **`uid`** 以 **`message-uid`** 形式透传给各活动子组件（`FlowAgentContent` / `KnowledgeRagContent` / `ReferenceDocContent`），用于侧栏自定义 Tab、`addCustomTab` 的 `data.messageUid` 与主对话区「在对话中定位」联动（详见 [ChatContainer](/components/setup/chat-container)）。
+
+`onInterruptResume` 仅由 `FlowAgentContent` 消费（失败节点「重试 / 跳过」），由 `MessageRender` 从 `ChatContainer` 透传；知识检索、引用文档等活动子组件忽略该 prop。
+
+## 三种工作模式
+
+组件根据 `activityType` 的值决定渲染模式：
+
+| `activityType`    | 模式           | 标题文案                             | 图标             | 内容区                              |
+| ----------------- | -------------- | ------------------------------------ | ---------------- | ----------------------------------- |
+| `'knowledge_rag'` | 知识检索模式   | 检索中 / 检索完成（随 status 切换）  | Loading / 文档   | Markdown 检索摘要 + 引用列表        |
+| `'flow_agent'`    | FlowAgent 模式 | 执行情况: 成功 N / 失败 N / 执行中 N | Loading / 箭头   | 任务节点树 + 节点详情（自定义 Tab） |
+| 其他任意值        | 引用文档模式   | 引用 N 篇资料作为参考                | 文档图标（固定） | 引用文档列表                        |
+
+> **注意：** 只有值严格等于 `'knowledge_rag'` 才进入知识检索模式；严格等于 `'flow_agent'`（`MessageContentType.FlowAgent`）才进入 FlowAgent 模式；其他值均按引用文档模式处理。
+
+## 引用文档模式
+
+`activityType` 传入 `MessageContentType.ReferenceDocument`（`'reference_document'`）或任意非 `'knowledge_rag'` 的值，`content` 传入文档对象数组。
+
+标题自动显示文档数量，始终展示文档图标，`status` 不影响标题和图标。
+
+```vue
+<template>
+  <ActivityMessage
+    v-model:collapsed="collapsed"
+    :content="docs"
+    status="complete"
+    :activity-type="MessageContentType.ReferenceDocument"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+
+  const docs = [
+    {
+      name: 'Vue 3 组合式 API 指南',
+      url: 'https://cn.vuejs.org/guide/extras/composition-api-faq.html',
+      originFile: 'composition-api.md',
+    },
+    { name: 'TypeScript 高级类型手册', url: 'https://www.typescriptlang.org/docs/', originFile: 'ts-advanced.pdf' },
+    { name: '蓝鲸前端开发规范 v2.0', url: 'https://example.com/bk-standard', originFile: 'bk-standard.docx' },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 知识检索模式
+
+`activityType` 设为 `MessageContentType.KnowledgeRag`（`'knowledge_rag'`），`content` 传入包含 `content`（检索摘要）和 `referenceDocument`（引用文档列表）的对象。
+
+标题和图标随 `status` 动态变化：
+
+| `status`                | 图标     | 标题     |
+| ----------------------- | -------- | -------- |
+| `pending` / `streaming` | Loading  | 检索中   |
+| 其他（`complete` 等）   | 文档图标 | 检索完成 |
+
+```vue
+<template>
+  <ActivityMessage
+    v-model:collapsed="collapsed"
+    :content="ragContent"
+    :status="status"
+    :activity-type="MessageContentType.KnowledgeRag"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+  const status = ref(MessageStatus.Complete);
+
+  const ragContent = {
+    // 检索摘要（支持 Markdown）
+    content: '根据知识库检索，Vue 3 引入了 Composition API...',
+    // 引用文档列表
+    referenceDocument: [
+      { name: '知识库文档：Composition API 详解', url: 'https://example.com/kb1', originFile: 'kb1.md' },
+    ],
+  };
+</script>
+```
+
+**渲染效果（检索完成 + 单引用）**
+
+**渲染效果（检索完成 + 多引用 + Markdown 摘要）**
+
+## 状态变化（知识检索模式）
+
+`knowledge_rag` 模式下，`status` 决定图标和标题文案：
+
+**检索中（`pending`）**
+
+**检索中（`streaming`）**
+
+**检索完成（`complete`）**
+
+> **引用文档模式**不受 `status` 影响，始终显示文档图标和文档数量，不会出现 Loading 动画。
+
+## 折叠/展开
+
+通过 `v-model:collapsed` 控制内容区的折叠状态，点击整个标题栏均可切换。默认为 `false`（展开）。
+
+```vue
+<template>
+  <!-- 默认展开 -->
+  <ActivityMessage
+    v-model:collapsed="collapsed"
+    :content="docs"
+    status="complete"
+    activity-type="reference_document"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ActivityMessage } from '@blueking/chat-x';
+
+  const collapsed = ref(false); // false = 展开，true = 折叠
+  const docs = [{ name: '参考文档', url: 'https://example.com/doc', originFile: 'doc.pdf' }];
+</script>
+```
+
+**渲染效果（展开状态）**
+
+**渲染效果（折叠状态）**
+
+## FlowAgent 执行情况模式
+
+`activityType` 设为 `MessageContentType.FlowAgent`（`'flow_agent'`），`content` 传入 `BkFlowMessageContent` 任务数组。用于展示一个或多个蓝鲸标准运维（BkFlow）任务的执行状态、节点列表和统计信息。
+
+### 核心交互
+
+- **标题栏**：显示「执行情况」+ 所有任务聚合后的各状态计数（执行中 / 成功 / 失败 / 挂起），颜色区分
+- **任务组**：逐个展示任务行，带状态图标、总耗时；点击箭头图标可折叠/展开节点列表
+- **有效证据**：`task.has_confidence === true` 时，任务行右侧展示「有效证据」按钮，点击后在侧栏打开置信度/证据详情 Tab（`props.has_confidence: true`）
+- **默认激活**：当 `MessageContainer` 已注入滚动上下文（`useContainerScrollProvider`，供 `FlowAgentContent` 内 `useContainerScrollConsumer` 读取）时，组件挂载后若存在 `task.is_active === true` 且 `task.has_confidence === true` 的任务，会自动在侧栏打开该任务的「有效证据」Tab；无滚动 Provider（例如独立演示）时不做自动打开。用户手动切换 Tab 后不再沿用 `is_active` 默认高亮
+- **选中态**：当前侧栏 Tab 与任务行 / 节点行联动高亮（`is-selected`）；任务 Tab 与「有效证据」Tab 均视为该任务的选中态
+- **节点列表**：每个节点显示状态圆点、名称和耗时；hover 时出现行尾操作按钮组
+- **失败节点操作**：失败且 `retryable` / `skippable` 为 `true` 的节点，hover 时额外展示「重试」「跳过」按钮，点击后通过 `onInterruptResume` 回传 Agent（不传 `interrupt`）
+- **节点详情**：点击「详情」会通过 `useCustomTabConsumer` 在 `ChatContainer` 侧边栏新增自定义 Tab，展示节点配置（基础信息、输入参数、输出参数）
+
+> `FlowAgentContent` 会读取 `ChatContainer` 注入的 `renderMode`。当 `renderMode === RenderMode.Share` 时，任务行不展示总耗时与「有效证据」，节点列表不展示耗时与「详情」按钮，避免分享预览中出现可交互入口。独立使用 `ActivityMessage` 且没有上层 Provider 时，默认按 `Chat` 模式渲染。
+
+### 内部渲染结构
+
+```
+FlowAgentContent（activityType = 'flow_agent'）
+├── ActivityLayout（公共折叠布局容器）
+│   └── #title
+│       ├── Loading / ArrowIcon（随 status 切换）
+│       └── 执行情况：执行中 N / 成功 N / 失败 N / 挂起 N
+└── #default
+    └── TaskGroup × N
+        ├── TaskHeader（is-selected / has-confidence；箭头点击折叠）
+        │   ├── 状态图标（running=Loading / success / failed / suspended）
+        │   ├── task_name（HighlightKeyword 支持搜索高亮）
+        │   └── trailing：总耗时 + 「有效证据」（has_confidence 时）
+        └── NodeList
+            └── NodeItem × N（is-selected 与侧栏 Tab 联动）
+                ├── 状态圆点（颜色对应状态）
+                ├── node.name（HighlightKeyword 支持搜索高亮）
+                ├── node.elapsed_time
+                └── 行尾操作按钮组（hover 显示）
+                    ├── 重试（失败 + retryable）→ onInterruptResume
+                    ├── 跳过（失败 + skippable）→ onInterruptResume
+                    └── 详情 → 打开节点详情 Tab
+```
+
+### 用法示例
+
+```vue
+<template>
+  <ActivityMessage
+    v-model:collapsed="collapsed"
+    :content="flowContent"
+    :status="status"
+    :activity-type="MessageContentType.FlowAgent"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
+  import type { BkFlowMessageContent } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+  const status = ref(MessageStatus.Complete);
+
+  const flowContent: BkFlowMessageContent = [
+    {
+      task_id: 100,
+      task_name: '数据清洗流程',
+      task_state: 'FINISHED',
+      task_outputs: [],
+      statistics: {
+        total: 3,
+        state_counts: { FINISHED: 2, FAILED: 1 },
+      },
+      nodes: {
+        node1: {
+          id: 'node1',
+          name: '数据拉取',
+          state: 'FINISHED',
+          elapsed_time: 12,
+          start_time: '2025-01-01 10:00:00',
+          finish_time: '2025-01-01 10:00:12',
+          loop: 1,
+          retry: 0,
+          skip: false,
+          type: 'ServiceActivity',
+        },
+        node2: {
+          id: 'node2',
+          name: '数据转换',
+          state: 'FINISHED',
+          elapsed_time: 45,
+          start_time: '2025-01-01 10:00:12',
+          finish_time: '2025-01-01 10:00:57',
+          loop: 1,
+          retry: 0,
+          skip: false,
+          type: 'ServiceActivity',
+        },
+        node3: {
+          id: 'node3',
+          name: '结果写入',
+          state: 'FAILED',
+          elapsed_time: 3,
+          start_time: '2025-01-01 10:00:57',
+          finish_time: '2025-01-01 10:01:00',
+          loop: 1,
+          retry: 0,
+          skip: false,
+          type: 'ServiceActivity',
+        },
+      },
+    },
+  ];
+</script>
+```
+
+### 在 MessageContainer 中自动渲染
+
+```typescript
+const messages = [
+  {
+    id: '3',
+    role: 'activity',
+    activityType: MessageContentType.FlowAgent, // 'flow_agent'
+    status: MessageStatus.Streaming,
+    content: [
+      {
+        task_id: 100,
+        task_name: '数据清洗流程',
+        task_state: 'RUNNING',
+        task_outputs: [],
+        statistics: { total: 3, state_counts: { RUNNING: 1, FINISHED: 2 } },
+        nodes: {
+          /* ... */
+        },
+      },
+    ],
+  },
+];
+```
+
+### 节点状态映射
+
+组件内部将 BkFlow 原始状态归并为四种显示状态：
+
+| 归并状态    | 原始状态                                                                            | 颜色    |
+| ----------- | ----------------------------------------------------------------------------------- | ------- |
+| `running`   | CREATED / LOOP_READY / READY / RUNNING / BLOCKED / ROLLING_BACK / ROLL_BACK_SUCCESS | #3A84FF |
+| `success`   | FINISHED                                                                            | #18B456 |
+| `failed`    | FAILED / REVOKED / ROLL_BACK_FAILED                                                 | #EA3636 |
+| `suspended` | SUSPENDED                                                                           | #F59500 |
+| `pending`   | PENDING                                                                             | #DCDEE5 |
+
+### 侧栏 Tab 命名规则
+
+| 场景       | `tab.name` 格式                          |
+| ---------- | ---------------------------------------- |
+| 任务详情   | `{task_id}`                              |
+| 有效证据   | `{task_id}`（与任务 Tab 同名，label 为「有效证据」） |
+| 节点详情   | `{task_id}\|{node.id}\|{node.name}`      |
+
+`CustomBkFlowTabData` 支持 `has_confidence?: boolean`，用于侧栏详情组件区分证据视图与节点视图。应用层可通过 `ChatContainer` 的 `getSideRenderComponent` 覆盖渲染组件。
+
+### 节点详情 Tab
+
+点击节点的「详情」按钮，内部调用 `useCustomTabConsumer().addCustomTab()` 在 `ChatContainer` 侧边栏新开一个 Tab，渲染 `BkFlowNodeDetail`（或 `getSideRenderComponent` 返回的自定义组件），该组件提供：
+
+- **节点配置** Tab：基础信息表单（流程模板、节点名称、步骤名称、失败处理、超时控制）+ 输入参数表 + 输出参数表
+- **节点输出** Tab：结构化输出参数表
+- **骨架屏**：`loading` 为 `true` 时展示骨架屏占位
+
+### 相关类型定义
+
+```typescript
+import { MessageContentType, type BkFlowMessageContent, type BkFlowNode, type BkFlowTask } from '@blueking/chat-x';
+
+type BkFlowMessageContent = BkFlowTask[];
+
+type BkFlowTask = {
+  has_confidence?: boolean; // 是否展示「有效证据」入口；与 is_active 同时为 true 且在消息容器滚动上下文中时，挂载后自动打开「有效证据」侧栏 Tab
+  is_active?: boolean; // 是否默认激活；需配合 has_confidence 且存在滚动 Provider 才会自动打开侧栏「有效证据」Tab
+  nodes: Record<string, BkFlowNode>;
+  statistics: { state_counts: Record<string, number>; total: number };
+  task_id: number;
+  task_name: string;
+  task_outputs: unknown;
+  task_state: string;
+};
+
+type BkFlowNode = {
+  elapsed_time: number;
+  finish_time: string;
+  id: string;
+  loop: number;
+  name: string;
+  retry: number;
+  retryable?: boolean;
+  skip: boolean;
+  skippable?: boolean;
+  start_time: string;
+  state: string;
+  type: string;
+};
+
+enum MessageContentType {
+  FlowAgent = 'flow_agent',
+  KnowledgeRag = 'knowledge_rag',
+  ReferenceDocument = 'reference_document',
+  // ...
+}
+```
+
+## 在 MessageContainer 中使用
+
+`ActivityMessage` 通常不需要单独使用，`MessageContainer` 会对 `role: 'activity'` 的消息自动渲染：
+
+```vue
+<template>
+  <MessageContainer :messages="messages" />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer, MessageContentType, MessageStatus } from '@blueking/chat-x';
+
+  const messages = [
+    // 知识检索消息
+    {
+      id: '1',
+      role: 'activity',
+      activityType: MessageContentType.KnowledgeRag, // 'knowledge_rag'
+      status: MessageStatus.Complete,
+      content: {
+        content: '根据知识库检索到以下相关信息...',
+        referenceDocument: [{ name: '文档A', url: 'https://example.com/a', originFile: 'a.md' }],
+      },
+    },
+    // 引用文档消息
+    {
+      id: '2',
+      role: 'activity',
+      activityType: MessageContentType.ReferenceDocument, // 'reference_document'
+      status: MessageStatus.Complete,
+      content: [
+        { name: '参考文档1', url: 'https://example.com/doc1', originFile: 'doc1.pdf' },
+        { name: '参考文档2', url: 'https://example.com/doc2', originFile: 'doc2.pdf' },
+      ],
+    },
+  ];
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                                                                        | 默认值 | 说明                                                      |
+| ------------ | --------------------------------------------------------------------------- | ------ | --------------------------------------------------------- |
+| content      | `ReferenceDocumentContent[] \| KnowledgeRagContent \| BkFlowMessageContent` | -      | 内容数据，格式随 `activityType` 不同                      |
+| activityType | `'knowledge_rag' \| 'flow_agent' \| 'reference_document' \| string`         | -      | 活动类型，决定渲染模式（知识检索 / FlowAgent / 引用文档） |
+| status       | `MessageStatus`                                                             | -      | 消息状态；在 `knowledge_rag` 模式下影响标题和图标，在 `flow_agent` 模式下影响标题 Loading 状态 |
+| id           | `string \| number`                                                          | -      | 消息 ID                                                   |
+| messageId    | `string \| number`                                                          | -      | 消息唯一标识                                              |
+| onInterruptResume | `OnInterruptResume`                                                    | -      | 仅 `flow_agent` 子组件消费；失败节点「重试 / 跳过」回调，由 `MessageRender` 透传 |
+
+### v-model
+
+| 属性名    | 类型      | 默认值  | 说明                        |
+| --------- | --------- | ------- | --------------------------- |
+| collapsed | `boolean` | `false` | 内容折叠状态，`true` 为折叠 |
+
+## 类型定义
+
+```typescript
+import { MessageContentType } from '@blueking/chat-x';
+
+// 引用文档条目
+type ReferenceDocumentContent = {
+  name: string; // 文档名称（显示文本）
+  url: string; // 文档访问链接
+  originFile: string; // 原始文件名
+};
+
+// 知识检索内容（knowledge_rag 模式）
+interface KnowledgeRagContent {
+  content: string; // 检索摘要，支持 Markdown
+  referenceDocument: ReferenceDocumentContent[]; // 引用文档列表
+}
+
+// activityType 枚举值
+enum MessageContentType {
+  FlowAgent = 'flow_agent',
+  KnowledgeRag = 'knowledge_rag',
+  ReferenceDocument = 'reference_document',
+  // ...
+}
+```
+
+## 使用场景
+
+- **知识检索过程**：以 `knowledge_rag` 模式展示 RAG 检索全过程，从"检索中"到"检索完成"的状态流转
+- **参考资料引用**：以 `reference_document` 模式展示 AI 回复所引用的参考文档列表
+- **FlowAgent 执行监控**：以 `flow_agent` 模式展示 BkFlow 流程执行状态、节点列表和详情
+- **流式场景**：`pending` → `streaming` → `complete` 状态变化配合流式响应实时更新
+- **自动渲染**：通过 `MessageContainer` 或 `MessageRender` 自动处理 `role: 'activity'` 消息，无需手动引入
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — activity 角色由其实例化
+- [AssistantMessage](/components/message/assistant-message) — 常与助手主回复配合出现

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-image.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-image.md
@@ -1,0 +1,230 @@
+# AiImage 图片展示
+
+> 能力域：媒体文件 ｜ 导入：`import { AiImage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+图片展示组件，组合加载、错误、预览和 extra 插槽。 源码位置：src/components/image-preview/image.vue。
+
+**关联**：image-preview（独立模式下内嵌全屏预览，单图预览入口）、image-preview-group（组内注册子图并统一打开多图预览）
+
+---
+
+# AiImage 图片展示
+## 源码事实
+
+- **源码位置**：`src/components/image-preview/image.vue`
+- **能力域**：媒体文件
+- **能力说明**：图片展示组件，组合加载、错误、预览和 extra 插槽。
+
+> **能力域**：媒体文件
+
+图片展示组件，支持加载状态、加载失败重试、懒加载、点击预览等功能。可独立使用（单图预览），也可配合 `ImagePreviewGroup` 实现多图预览。
+
+## 组件结构
+
+```
+.ai-image（display: inline-block，border-radius: 4px）
+├── <img>（v-if status !== 'error' && actualSrc，object-fit: cover）
+├── .ai-image-error（v-if status === 'error'）
+│     └── ImageErrorIcon（24×24，color: #c4c6cc）
+├── .ai-image-error-overlay（v-if status === 'error'，hover 时显示）
+│     ├── ReloadIcon（16×16）
+│     └── <span>"重新加载"</span>
+├── <slot />
+└── ImagePreview（v-if !groupContext && preview && previewVisible）
+      独立模式下的内置全屏预览
+```
+
+## 基础用法
+
+```vue
+<template>
+  <AiImage
+    src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=400&h=300&fit=crop"
+    :width="200"
+    :height="150"
+    alt="风景图"
+    @load="handleLoad"
+    @error="handleError"
+    @preview="handlePreview"
+  />
+</template>
+
+<script setup lang="ts">
+  import { AiImage } from '@blueking/chat-x';
+
+  const handleLoad = (ev: Event) => {
+    console.log('图片加载成功', ev);
+  };
+
+  const handleError = (ev: Event) => {
+    console.log('图片加载失败', ev);
+  };
+
+  const handlePreview = () => {
+    console.log('触发预览');
+  };
+</script>
+```
+
+## 加载失败与重新加载
+
+当图片加载失败时，显示错误占位图标，鼠标悬停后出现"重新加载"遮罩，点击可重新加载（内部通过追加时间戳参数实现缓存破坏）：
+
+```vue
+<template>
+  <AiImage
+    src="https://invalid-url.example.com/not-exist.png"
+    :width="200"
+    :height="150"
+  />
+</template>
+```
+
+## 禁用预览
+
+将 `preview` 设为 `false` 可禁用点击预览功能，此时图片不显示 `zoom-in` 光标：
+
+```vue
+<template>
+  <AiImage
+    src="https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&h=300&fit=crop"
+    :width="200"
+    :height="150"
+    :preview="false"
+  />
+</template>
+```
+
+## 预览属性配置
+
+通过 `previewProps` 可为预览弹窗配置不同的图片源（如高清原图）、名称、尺寸信息等：
+
+```vue
+<template>
+  <AiImage
+    src="https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=400&h=300&fit=crop"
+    :width="200"
+    :height="150"
+    :preview-props="{
+      src: 'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=1920',
+      name: '森林.jpg',
+      width: 1920,
+      resolution: '1920×1080',
+    }"
+    :show-info="true"
+  />
+</template>
+```
+
+## 多图预览（配合 ImagePreviewGroup）
+
+将多个 `AiImage` 放在 `ImagePreviewGroup` 中，点击任意图片会打开多图预览模式，支持左右切换：
+
+```vue
+<template>
+  <ImagePreviewGroup>
+    <AiImage
+      v-for="(src, i) in images"
+      :key="i"
+      :src="src"
+      :width="160"
+      :height="120"
+    />
+  </ImagePreviewGroup>
+</template>
+
+<script setup lang="ts">
+  import { AiImage, ImagePreviewGroup } from '@blueking/chat-x';
+
+  const images = [
+    'https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=400&h=300&fit=crop',
+    'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&h=300&fit=crop',
+    'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=400&h=300&fit=crop',
+  ];
+</script>
+```
+
+## 自定义下载
+
+通过 `onDownload` 自定义下载行为（例如调用后端接口），不传时使用默认的 `<a>` 标签下载：
+
+```vue
+<template>
+  <AiImage
+    src="https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=400&h=300&fit=crop"
+    :width="200"
+    :height="150"
+    :on-download="handleDownload"
+  />
+</template>
+
+<script setup lang="ts">
+  import { AiImage } from '@blueking/chat-x';
+
+  const handleDownload = (url: string) => {
+    console.log('自定义下载:', url);
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                    | 默认值  | 说明                                                            |
+| ------------ | ----------------------- | ------- | --------------------------------------------------------------- |
+| src          | `string`                | —       | **必填**，图片地址                                              |
+| alt          | `string`                | `''`    | 图片 alt 属性                                                   |
+| width        | `number \| string`      | —       | 容器宽度，数字时单位为 px                                       |
+| height       | `number \| string`      | —       | 容器高度，数字时单位为 px                                       |
+| lazy         | `boolean`               | `false` | 是否懒加载（IntersectionObserver，rootMargin: 200px）           |
+| preview      | `boolean`               | `true`  | 是否启用点击预览；为 `true` 且图片加载成功时显示 `zoom-in` 光标 |
+| previewProps | `ImagePreviewConfig`    | —       | 预览弹窗配置（可指定高清源、名称、尺寸等）                      |
+| showInfo     | `boolean`               | `false` | 预览工具栏是否显示图片尺寸信息                                  |
+| onDownload   | `(url: string) => void` | —       | 自定义下载回调；不传时使用默认 `<a>` 标签下载                   |
+
+### Events
+
+| 事件名  | 参数          | 说明               |
+| ------- | ------------- | ------------------ |
+| load    | `(ev: Event)` | 图片加载成功时触发 |
+| error   | `(ev: Event)` | 图片加载失败时触发 |
+| preview | —             | 点击触发预览时触发 |
+
+### Slots
+
+| 插槽名  | 说明                                            |
+| ------- | ----------------------------------------------- |
+| default | 覆盖在图片上方的自定义内容                      |
+| extra   | 预览工具栏的额外操作区域（透传给 ImagePreview） |
+
+### Expose
+
+| 属性名         | 类型           | 说明                             |
+| -------------- | -------------- | -------------------------------- |
+| previewVisible | `Ref<boolean>` | 当前预览弹窗是否可见（独立模式） |
+
+## 类型定义
+
+```typescript
+interface ImagePreviewConfig {
+  src?: string;
+  name?: string;
+  width?: number;
+  height?: number;
+  resolution?: string;
+  downloadUrl?: string;
+}
+```
+
+## 使用场景
+
+- AI 对话中的图片消息展示
+- 需要点击放大查看的缩略图
+- 多图浏览场景（配合 `ImagePreviewGroup`）
+- 懒加载长列表中的图片
+
+## 关联组件
+
+- [ImagePreview](/components/medias/image-preview) — 独立模式下的全屏预览
+- [ImagePreviewGroup](/components/medias/image-preview-group) — 多图注册与预览上下文

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-loading.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-loading.md
@@ -1,0 +1,131 @@
+# AiLoading 三点加载
+
+> 能力域：辅助能力 ｜ 导入：`import { AiLoading } from '@blueking/chat-x'` ｜ since 1.0.0
+
+小尺寸 AI 加载动效。 源码位置：src/components/ai-loading/ai-loading.vue。
+
+**关联**：loading-message（列表末尾加载占位）、reasoning-message（推理进行中的加载指示）、activity-message（活动消息加载态指示）
+
+---
+
+# AiLoading AI 加载动画
+## 源码事实
+
+- **源码位置**：`src/components/ai-loading/ai-loading.vue`
+- **能力域**：辅助能力
+- **能力说明**：小尺寸 AI 加载动效。
+
+> **能力域**：辅助能力
+
+AI 加载动画基础组件。由两层 SVG 叠加构成：外层旋转光环（带渐变弧线）+ 内层脉冲星形图标，两者共用同一套蓝→紫→粉渐变色。
+
+## 组件结构
+
+```
+.ai-loading（inline-flex，position: relative，width/height 由 size prop 控制）
+│   CSS 同时定义 width/height: 1em 兜底，inline style 优先
+│
+├── .ai-loading-ring（position: absolute，svg 100%×100%）
+│     旋转弧线：ai-loading-rotate 0.8s linear infinite
+│     渐变：#235DFA → #8A77EC → #EB8CEC（蓝 → 紫 → 粉）
+│
+└── .ai-loading-star（position: absolute，svg 100%×100%）
+      脉冲星形：ai-loading-pulse 0.8s ease-in-out infinite
+      关键帧：scale(0.5) → scale(1) → scale(0.5)（小→大→小）
+      渐变：同上
+
+stopLoading=true → 根元素加 .ai-loading-stopped
+  → .ai-loading-stopped .ai-loading-ring { animation-play-state: paused }
+  → .ai-loading-stopped .ai-loading-star { animation-play-state: paused }
+```
+
+## 基础用法
+
+```vue
+<template>
+  <AiLoading />
+</template>
+
+<script setup lang="ts">
+  import { AiLoading } from '@blueking/chat-x';
+</script>
+```
+
+## 自定义尺寸
+
+通过 `size` 属性控制图标大小（单位 px），默认 `16`：
+
+```vue
+<template>
+  <AiLoading />
+  <!-- 16px（默认） -->
+  <AiLoading :size="24" />
+  <AiLoading :size="32" />
+  <AiLoading :size="48" />
+</template>
+```
+
+## 暂停动画
+
+`stopLoading` 为 `true` 时，组件根元素添加 `.ai-loading-stopped` class，两层动画同时进入 `paused` 状态（不移除元素，仅冻结帧）：
+
+```vue
+<template>
+  <AiLoading :stop-loading="isPaused" />
+  <button @click="isPaused = !isPaused">
+    {{ isPaused ? '恢复' : '暂停' }}
+  </button>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiLoading } from '@blueking/chat-x';
+
+  const isPaused = ref(false);
+</script>
+```
+
+## 多实例渐变隔离
+
+每个 `AiLoading` 实例通过**模块级 `uid` 计数器**生成唯一的 SVG 渐变 ID：
+
+```
+ai-loading-ring-{instanceId}
+ai-loading-star-{instanceId}
+```
+
+同一页面挂载多个实例时，渐变互不影响。ring 和 star 的 `instanceId` 始终相同（同一组件内），SVG `<path fill="url(#...)" />` 正确引用各自实例的渐变定义。
+
+## 动画规格
+
+| 层                 | 动画名              | 时长 | 缓动        | 关键帧                                  |
+| ------------------ | ------------------- | ---- | ----------- | --------------------------------------- |
+| `.ai-loading-ring` | `ai-loading-rotate` | 0.8s | linear      | `0deg → 360deg` 匀速旋转                |
+| `.ai-loading-star` | `ai-loading-pulse`  | 0.8s | ease-in-out | `0%/100%: scale(0.5)` → `50%: scale(1)` |
+
+脉冲动画节奏：以**半尺寸**起始 → 膨胀至**全尺寸**（0.4s）→ 收缩回**半尺寸**（0.4s），循环往复。
+
+## API
+
+### Props
+
+| 属性名      | 类型      | 默认值  | 说明                                               |
+| ----------- | --------- | ------- | -------------------------------------------------- |
+| size        | `number`  | `16`    | 图标尺寸（px），应用为 inline style，覆盖 CSS 默认 |
+| stopLoading | `boolean` | `false` | `true` 时两层动画均 `paused`，图标停在当前帧       |
+
+## 使用场景
+
+组件库内部以下场景自动使用 `AiLoading`：
+
+| 使用方             | 触发时机                                       | 固定尺寸  |
+| ------------------ | ---------------------------------------------- | --------- |
+| `LoadingMessage`   | 等待 AI 首次响应（loading 消息占位）           | 18px      |
+| `ReasoningMessage` | `status` 为 `pending`/`streaming` 时（思考中） | 默认 16px |
+| `ActivityMessage`  | 活动消息加载状态                               | 默认 16px |
+
+## 关联组件
+
+- [LoadingMessage](/components/message/loading-message) — 对话加载消息
+- [ReasoningMessage](/components/message/reasoning-message) — 推理加载态
+- [ActivityMessage](/components/message/activity-message) — 活动加载态

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-prompt-list.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-prompt-list.md
@@ -1,0 +1,42 @@
+# AiPromptList Prompt 列表
+
+> 能力域：输入交互 ｜ 导入：`import { AiPromptList } from '@blueking/chat-x'` ｜ since 1.0.0
+
+/ Prompt 选择列表，供 AiSlashInput 插入模板文本。 源码位置：src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.vue。
+
+---
+
+# AiPromptList Prompt 列表
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.vue`
+- **能力说明**：/ Prompt 选择列表，供 AiSlashInput 插入模板文本。
+
+## API 摘要
+
+### Props
+
+- `{ onSelect: (prompt: string) =`
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-selection.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-selection.md
@@ -1,0 +1,439 @@
+# AiSelection 划词选择
+
+> 能力域：输入交互 ｜ 导入：`import { AiSelection } from '@blueking/chat-x'` ｜ since 1.0.0
+
+监听选中文本并展示快捷操作浮窗。 源码位置：src/components/ai-selection/ai-selection.vue。
+
+**关联**：shortcut-btn（弹窗内快捷指令按钮/菜单项由该基础组件渲染）、chat-input（划词结果常回填或触发与输入框联动的快捷指令）
+
+---
+
+# AiSelection AI 划词选择弹窗
+## 源码事实
+
+- **源码位置**：`src/components/ai-selection/ai-selection.vue`
+- **能力域**：输入交互
+- **能力说明**：监听选中文本并展示快捷操作浮窗。
+
+> **能力域**：输入交互
+
+AI 划词选择组件，监听用户在页面中的文本选区，在选区附近弹出快捷操作菜单。支持自定义快捷指令列表、数量限制、垂直偏移以及完全自定义插槽内容。
+
+> **注意**：`AiSelection` 通过 `document.addEventListener` 监听全局事件（`selectionchange`、`mouseup`、`mousedown`、`scroll`），**同一页面中只应挂载一个实例**，避免多实例同时响应导致事件重复和弹窗叠加。
+
+## 工作原理
+
+```
+用户选中文本
+   ↓  mouseup（200ms 防抖）/ selectionchange（300ms 防抖）
+获取选区文本 & 坐标 → 计算弹窗位置
+   ↓
+通过 <Teleport to="body"> 将弹窗渲染到 <body> 末尾
+   ↓
+用户点击快捷指令 → 触发 selectShortcut 事件 → 关闭弹窗
+```
+
+弹窗渲染在 `<body>` 顶层，不受父级 `overflow: hidden` / `z-index` 影响，定位坐标基于视口（`position: fixed`）。
+
+## 弹窗关闭时机
+
+| 触发条件           | 说明                             |
+| ------------------ | -------------------------------- |
+| 点击弹窗外部区域   | `mousedown` 事件，弹窗外任意位置 |
+| 滚动包含选区的容器 | `scroll` 事件捕获阶段            |
+| 窗口大小改变       | `window.resize`                  |
+| 窗口失去焦点       | `window.blur`                    |
+| 点击快捷指令       | 触发后立即关闭并清除选区         |
+
+## 基础用法
+
+不传 `shortcuts` 时，使用内置默认快捷指令"问问小鲸"（`id: 'ai-chat'`）：
+
+```vue
+<template>
+  <AiSelection v-model:visible="selectionVisible" />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+</script>
+```
+
+**渲染效果**（选中下方文字后弹出快捷操作菜单）
+
+## 自定义快捷指令
+
+通过 `shortcuts` 属性传入自定义快捷指令列表：
+
+```vue
+<template>
+  <AiSelection
+    v-model:visible="selectionVisible"
+    :shortcuts="shortcuts"
+    @select-shortcut="handleSelectShortcut"
+    @selection-change="handleSelectionChange"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection, type Shortcut } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ai-chat', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释' },
+  ];
+
+  const handleSelectShortcut = (shortcut: Shortcut, selectedText: string) => {
+    console.log('触发指令:', shortcut.name, '选中文本:', selectedText);
+  };
+
+  const handleSelectionChange = (text: string) => {
+    console.log('选区变化:', text);
+  };
+</script>
+```
+
+**渲染效果**（选中文字后弹出 3 个快捷操作按钮）
+
+## 快捷指令数量限制
+
+当快捷指令数量超过 `maxShortcutCount`（默认 `3`）时，多余的指令会收起到「更多」菜单（点击 `›` 箭头展开）。
+
+### `maxShortcutCount = 3`（默认）
+
+6 个指令中前 3 个直接展示，其余 3 个收起：
+
+```vue
+<template>
+  <AiSelection
+    v-model:visible="selectionVisible"
+    :shortcuts="shortcuts"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection, type Shortcut } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ai-chat', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释' },
+    { id: 'summarize', name: '总结' },
+    { id: 'improve', name: '改进' },
+    { id: 'code', name: '生成代码' },
+  ];
+</script>
+```
+
+**渲染效果**（展示 3 个，其余 3 个收起到「更多」菜单）
+
+### `maxShortcutCount = 5`
+
+前 5 个直接展示，仅最后 1 个收起：
+
+```vue
+<AiSelection v-model:visible="selectionVisible" :shortcuts="shortcuts" :max-shortcut-count="5" />
+```
+
+**渲染效果**（展示 5 个，仅「生成代码」收起）
+
+## 带图标的快捷指令
+
+`icon` 属性支持三种形式：
+
+| 类型                              | 说明            | 示例                             |
+| --------------------------------- | --------------- | -------------------------------- |
+| `string`（emoji）                 | 直接渲染文本    | `'🌐'`                           |
+| `string`（HTTP URL）              | 渲染为 `<img>`  | `'https://example.com/icon.svg'` |
+| `VNode \| (c: typeof h) => VNode` | 渲染为 Vue 组件 | `ThinkingIcon`（内置图标组件）   |
+
+```vue
+<script setup lang="ts">
+  import { h } from 'vue';
+  import { AiSelection, type Shortcut } from '@blueking/chat-x';
+
+  const shortcuts: Shortcut[] = [
+    {
+      id: 'ai-chat',
+      name: '问问小鲸',
+      // VNode 渲染函数
+      icon: c => c('span', { style: 'font-size: 14px;' }, '🐳'),
+    },
+    {
+      id: 'translate',
+      name: '翻译',
+      icon: '🌐', // Emoji 字符串
+    },
+    {
+      id: 'search',
+      name: '搜索',
+      icon: 'https://example.com/search-icon.svg', // URL（渲染为 img）
+    },
+  ];
+</script>
+```
+
+## 事件回调
+
+`selectShortcut` 在用户点击快捷指令后触发，携带指令对象和选中文本；`selectionChange` 在选区文字内容变化时触发：
+
+```vue
+<template>
+  <div>
+    <p>选中文字后点击快捷指令，观察下方回调信息。</p>
+
+    <AiSelection
+      v-model:visible="selectionVisible"
+      :shortcuts="shortcuts"
+      @select-shortcut="handleSelectShortcut"
+      @selection-change="handleSelectionChange"
+    />
+
+    <div
+      v-if="selectedInfo.shortcut"
+      class="callback-info"
+    >
+      <p>触发指令：{{ selectedInfo.shortcut }}</p>
+      <p>选中文本：{{ selectedInfo.text }}</p>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection, type Shortcut } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+  const selectedInfo = ref({ shortcut: '', text: '' });
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ai-chat', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释' },
+  ];
+
+  const handleSelectShortcut = (shortcut: Shortcut, selectedText: string) => {
+    selectedInfo.value = { shortcut: shortcut.name, text: selectedText };
+  };
+
+  const handleSelectionChange = (text: string) => {
+    console.log('选区变化:', text);
+  };
+</script>
+```
+
+**渲染效果**（点击快捷指令后下方显示回调信息）
+
+## 自定义垂直偏移
+
+`offset` 控制弹窗与选区之间的垂直距离（单位 px），默认 `10`。弹窗优先显示在选区**上方**，空间不足时自动显示在**下方**：
+
+```vue
+<!-- 间距 20px -->
+<AiSelection v-model:visible="selectionVisible" :offset="20" />
+
+<!-- 紧贴选区（间距 0） -->
+<AiSelection v-model:visible="selectionVisible" :offset="0" />
+```
+
+## 自定义插槽
+
+默认插槽替换整个弹窗内容区，插槽参数 `shortcuts` 为**完整**快捷指令列表（未经 `maxShortcutCount` 截断）：
+
+```vue
+<template>
+  <AiSelection
+    v-model:visible="selectionVisible"
+    :shortcuts="shortcuts"
+  >
+    <template #default="{ shortcuts }">
+      <div class="my-menu">
+        <button
+          v-for="shortcut in shortcuts"
+          :key="shortcut.id"
+          @click="handleClick(shortcut)"
+        >
+          {{ shortcut.name }}
+        </button>
+      </div>
+    </template>
+  </AiSelection>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection, type Shortcut } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ai-chat', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+  ];
+
+  const handleClick = (shortcut: Shortcut) => {
+    const text = window.getSelection()?.toString() || '';
+    console.log(shortcut.name, text);
+  };
+</script>
+```
+
+> **注意**：使用默认插槽后，`maxShortcutCount` 不再生效，「更多」菜单也不会出现，需要自行处理超出逻辑。
+
+## 排除区域
+
+通过 `excludeSelectors` 指定 CSS 选择器列表，当选区位于这些选择器匹配的元素内部时，弹窗不会弹出。适用于代码块、表单输入等不需要划词弹窗的区域：
+
+```vue
+<template>
+  <AiSelection
+    v-model:visible="selectionVisible"
+    :exclude-selectors="['.code-block', '.no-selection']"
+  />
+
+  <div class="code-block">这里选中文字不会弹出操作菜单</div>
+  <div class="no-selection">这里也不会弹出</div>
+  <p>这里选中文字正常弹出操作菜单</p>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+</script>
+```
+
+## Input / Textarea 支持
+
+组件对 `<input>` 和 `<textarea>` 中的选区进行了特殊处理：原生 Range 在这两类元素中无法获取准确坐标，组件会降级使用**输入框自身的 `getBoundingClientRect()`** 作为弹窗位置参考。
+
+## 与 ChatBot 联动
+
+选中文本后触发快捷指令，自动将选中内容作为上下文发送到聊天窗口：
+
+```vue
+<template>
+  <div class="page">
+    <article>文章内容...</article>
+
+    <AiSelection
+      v-model:visible="selectionVisible"
+      :shortcuts="shortcuts"
+      @select-shortcut="handleSelectShortcut"
+    />
+
+    <ChatBot ref="chatBotRef" />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { AiSelection, ChatBot, type Shortcut } from '@blueking/chat-x';
+
+  const selectionVisible = ref(false);
+  const chatBotRef = ref();
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ai-chat', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释' },
+  ];
+
+  const handleSelectShortcut = (shortcut: Shortcut, selectedText: string) => {
+    const prompts: Record<string, string> = {
+      translate: `请翻译以下内容：\n${selectedText}`,
+      explain: `请解释以下内容：\n${selectedText}`,
+    };
+    chatBotRef.value?.sendMessage(prompts[shortcut.id] ?? selectedText);
+  };
+</script>
+```
+
+<!-- 全页唯一的 AiSelection 实例，通过各演示区的 mousedown 切换当前配置 -->
+
+<AiSelectionComp
+v-model:visible="selectionVisible"
+:shortcuts="currentConfig.shortcuts"
+:max-shortcut-count="currentConfig.maxShortcutCount"
+@select-shortcut="handleSelectShortcut"
+/>
+
+## API
+
+### Props
+
+| 属性名           | 类型         | 默认值              | 必填 | 说明                                                    |
+| ---------------- | ------------ | ------------------- | ---- | ------------------------------------------------------- |
+| visible          | `boolean`    | -                   | ✅   | 控制弹窗显示，必须使用 `v-model:visible`                |
+| shortcuts        | `Shortcut[]` | `DEFAULT_SHORTCUTS` | -    | 快捷指令列表，默认为内置「问问小鲸」                    |
+| maxShortcutCount | `number`     | `3`                 | -    | 直接展示的最大指令数，超出收起到「更多」菜单            |
+| offset           | `number`     | `10`                | -    | 弹窗与选区的垂直间距（px）                              |
+| excludeSelectors | `string[]`   | `[]`                | -    | 排除的 CSS 选择器数组，选区在这些选择器内部时不显示弹窗 |
+
+### Events
+
+| 事件名          | 参数                                 | 说明                                    |
+| --------------- | ------------------------------------ | --------------------------------------- |
+| selectShortcut  | `(shortcut: Shortcut, text: string)` | 点击快捷指令时触发，`text` 为选中的文本 |
+| selectionChange | `(text: string)`                     | 选区文本内容发生变化时触发              |
+
+### Slots
+
+| 插槽名  | 参数                        | 说明                                           |
+| ------- | --------------------------- | ---------------------------------------------- |
+| default | `{ shortcuts: Shortcut[] }` | 自定义弹窗内容，`shortcuts` 为完整快捷指令列表 |
+
+## 定位逻辑
+
+| 方向     | 规则                                                                                 |
+| -------- | ------------------------------------------------------------------------------------ |
+| 水平方向 | 弹窗居中对齐选区，超出视口左/右边界时自动贴边（保留 8px 间距）                       |
+| 垂直方向 | 优先显示在选区**上方**，上方空间不足时显示在**下方**；两侧均不足时选择空间较大的一侧 |
+
+## 默认快捷指令
+
+```typescript
+const DEFAULT_SHORTCUTS: Shortcut[] = [{ id: 'ai-chat', name: '问问小鲸' }];
+```
+
+## Shadow DOM 支持
+
+组件会递归查找当前 `document.activeElement` 下的 Shadow DOM，兼容 Web Components 场景。若 Shadow DOM 中存在有效文本选区，弹窗同样会正常弹出并定位。
+
+## 类型定义
+
+```typescript
+import { type Component, type VNode, h } from 'vue';
+
+interface Shortcut {
+  id: string;
+  name: string;
+  key?: string;
+  icon?: ((c: typeof h) => Component | VNode) | string | VNode;
+  components?: ShortcutComponent[];
+  // ... 其余字段参见 ShortcutRender 文档
+}
+```
+
+## 使用场景
+
+- **文章阅读划词**：选中内容后弹出「问问小鲸」「翻译」「解释」等快捷入口
+- **代码解释**：在代码区块中选中代码片段，触发「解释代码」「优化建议」等操作
+- **文本处理**：对选中内容进行翻译、总结、改写等 AI 增强处理
+- **与 ChatBot 联动**：选中文本后将内容作为上下文自动填入聊天输入框
+
+## 关联组件
+
+- [ShortcutBtn](/components/input/shortcut-btn) — 弹窗内快捷指令按钮单元
+- [ChatInput](/components/input/chat-input) — 选区文本常回填到聊天输入框

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-editor.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-editor.md
@@ -1,0 +1,43 @@
+# AiSlashEditor 富文本编辑器
+
+> 能力域：输入交互 ｜ 导入：`import { AiSlashEditor } from '@blueking/chat-x'` ｜ since 1.0.0
+
+旧版富文本编辑器实现，封装 command selection 与提示菜单。 源码位置：src/components/chat-input/ai-slash-editor/ai-slash-editor.vue。
+
+---
+
+# AiSlashEditor 富文本编辑器
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/ai-slash-editor/ai-slash-editor.vue`
+- **能力说明**：旧版富文本编辑器实现，封装 command selection 与提示菜单。
+
+## API 摘要
+
+### Props
+
+- `{ disabled?: boolean; modelValue?: string; placeholder?: string; prompts?: string[]; }`
+
+### Emits
+
+- `{ (e: 'update:modelValue', value: string): void; (e: 'focus'): void; (e: 'keydown', event: IKeyboardEvent): void; (e: 'layoutChange', layoutInfo: monacoEditor.EditorLayoutInfo): void; }`
+
+### Slots
+
+- 无。
+
+### Expose
+
+- `{ get editor(`
+
+## 组件依赖
+
+- `AiPromptList`
+- `AiSlashMenu`
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-input.md
@@ -1,0 +1,43 @@
+# AiSlashInput 富文本命令输入
+
+> 能力域：输入交互 ｜ 导入：`import { AiSlashInput } from '@blueking/chat-x'` ｜ since 1.0.0
+
+ChatInput 内部富文本输入，支持 / Prompt 与 @ 资源标签。 源码位置：src/components/chat-input/ai-slash-input/ai-slash-input.vue。
+
+---
+
+# AiSlashInput 富文本命令输入
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/ai-slash-input/ai-slash-input.vue`
+- **能力说明**：ChatInput 内部富文本输入，支持 / Prompt 与 @ 资源标签。
+
+## API 摘要
+
+### Props
+
+- `{ modelValue: string | TagSchema; placeholder?: string; prompts?: string[]; resources?: IAiSlashMenuItem[]; }`
+
+### Emits
+
+- `{ (e: 'update:modelValue', value: TagSchema, selectedResourceList: IAiSlashMenuItem[]): void; (e: 'keydown', event: KeyboardEvent & KeyboardPayload): void; (e: 'upload', files: File[]): void; }`
+
+### Slots
+
+- 无。
+
+### Expose
+
+- `{ cleanup: (`
+
+## 组件依赖
+
+- `AiPromptList`
+- `AiSlashMenu`
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-menu.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/ai-slash-menu.md
@@ -1,0 +1,42 @@
+# AiSlashMenu 资源菜单
+
+> 能力域：输入交互 ｜ 导入：`import { AiSlashMenu } from '@blueking/chat-x'` ｜ since 1.0.0
+
+@ 资源选择菜单，展示资源项供 AiSlashInput 插入标签。 源码位置：src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.vue。
+
+---
+
+# AiSlashMenu 资源菜单
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.vue`
+- **能力说明**：@ 资源选择菜单，展示资源项供 AiSlashInput 插入标签。
+
+## API 摘要
+
+### Props
+
+- `{ onSelect: (item: IAiSlashMenuItem) =`
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/animation-text.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/animation-text.md
@@ -1,0 +1,202 @@
+# AnimationText 动画文本
+
+> 能力域：内容渲染 ｜ 导入：`import { AnimationText } from '@blueking/chat-x'` ｜ since 1.0.0
+
+按文本增量播放流式动画。 源码位置：src/components/animation-text/animation-text.vue。
+
+**关联**：use-animation-text（提供 chunk 拆分与 animationStyle 的 composable）、markdown-content（流式 Markdown 中可与渐显策略配合）
+
+---
+
+# AnimationText 动画文本
+## 源码事实
+
+- **源码位置**：`src/components/animation-text/animation-text.vue`
+- **能力域**：内容渲染
+- **能力说明**：按文本增量播放流式动画。
+
+> **能力域**：内容渲染
+
+动画文本基础组件，将文本以**淡入（fade-in）**方式渐显。内部由 `useAnimationText` composable 驱动，核心能力是将增量文本拆分为独立 chunk，每个 chunk 单独触发一次淡入动画，适用于流式文本的逐段渐显效果。
+
+## 组件结构
+
+```
+AnimationText
+└── <span v-for="chunk in chunks" :style="animationStyle">
+       {{ chunk }}
+    </span>
+
+animationStyle = {
+  animation: `ai-markdown-fade-in {fadeDuration}ms {easing} forwards`,
+  color: 'inherit',
+}
+
+@keyframes ai-markdown-fade-in {
+  0%   { opacity: 0; }
+  100% { opacity: 1; }
+}
+```
+
+> **注意**：`AnimationText` 组件将 `props.text`（字符串原始值）传给 `useAnimationText`，watch 只触发一次（挂载时），**prop 变化后不会触发新动画**。若需响应式流式效果，请直接使用 `useAnimationText` composable，并传入 `Ref<string>`。
+
+## 基础用法
+
+挂载时文本以淡入方式显示，适合一次性展示的短文本动画：
+
+```vue
+<template>
+  <AnimationText text="这是一段带动画效果的文本" />
+</template>
+
+<script setup lang="ts">
+  import { AnimationText } from '@blueking/chat-x';
+</script>
+```
+
+## 流式文本（推荐使用 composable）
+
+对于流式输出场景，需直接使用 `useAnimationText` 并传入响应式 `Ref<string>`：
+
+```vue
+<template>
+  <span
+    v-for="(chunk, index) in streamChunks"
+    :key="index"
+    :style="streamAnimStyle"
+    >{{ chunk }}</span
+  >
+</template>
+
+<script setup lang="ts">
+  import { ref, watch } from 'vue';
+
+  const streamText = ref('');
+  const streamChunks = ref<string[]>([]);
+  const streamAnimStyle = {
+    animation: 'ai-markdown-fade-in 200ms ease-in-out forwards',
+    color: 'inherit',
+  };
+
+  // 直接 watch Ref（Vue 自动追踪 .value 变化）
+  // ⚠️ 不能写成 watch(() => streamText, ...)，那样 getter 每次返回同一个 Ref 引用，永远不触发
+  watch(streamText, (newVal, oldVal) => {
+    if (!oldVal || !newVal.startsWith(oldVal)) {
+      streamChunks.value = [newVal]; // 内容替换 → 整体重置
+    } else {
+      const chunk = newVal.slice(oldVal.length);
+      if (chunk) streamChunks.value = [...streamChunks.value, chunk]; // 追加 → 新 chunk 淡入
+    }
+  });
+
+  // 模拟流式追加
+  async function receiveStream() {
+    streamText.value = '';
+    streamChunks.value = [];
+    for (const char of '来自 AI 的流式回复内容...') {
+      streamText.value += char;
+      await new Promise(r => setTimeout(r, 80));
+    }
+  }
+</script>
+```
+
+**效果演示**（点击按钮触发流式输出）
+
+## chunk 增量算法
+
+`useAnimationText` 内部通过**前缀检测**将文本变化拆分为增量 chunk：
+
+```
+新文本以旧文本为前缀（即纯追加）→ 截取增量部分 → 追加新 chunk（触发新动画）
+新文本与旧文本无前缀关系（内容替换）→ 清空所有 chunk → 用完整新文本创建单一 chunk
+```
+
+```typescript
+// watch 内部逻辑（简化）
+if (newText === prevText) return; // 无变化，跳过
+
+if (prevText && newText.startsWith(prevText)) {
+  // 追加模式：只有新增部分触发淡入
+  const newChunk = newText.slice(prevText.length);
+  chunks.value = [...chunks.value, newChunk];
+} else {
+  // 重置模式：内容替换，整体重新淡入
+  chunks.value = [newText];
+}
+prevText = newText;
+```
+
+| 场景            | 示例                                       | 行为                           |
+| --------------- | ------------------------------------------ | ------------------------------ |
+| 流式追加（SSE） | `"Hello"` → `"Hello Wo"` → `"Hello World"` | 每次增量部分单独淡入           |
+| 内容完全替换    | `"旧文本"` → `"新文本"`                    | 清空所有 chunk，新文本整体淡入 |
+| 相同内容        | `"文本"` → `"文本"`                        | 不做任何处理，跳过             |
+
+## 自定义动画参数
+
+`useAnimationText` 支持通过第二个参数自定义动画时长和缓动：
+
+```typescript
+import { ref } from 'vue';
+import { useAnimationText } from '@blueking/chat-x';
+
+const text = ref('');
+const { chunks, animationStyle } = useAnimationText(text, {
+  fadeDuration: 400, // 动画时长（ms），默认 200
+  easing: 'ease-out', // CSS easing，默认 'ease-in-out'
+});
+```
+
+生成的 `animationStyle`：
+
+```typescript
+// animationStyle 是 computed，格式为：
+{
+  animation: `ai-markdown-fade-in ${fadeDuration}ms ${easing} forwards`,
+  color: 'inherit',
+}
+```
+
+> **关键帧**：`ai-markdown-fade-in` 定义在库的全局样式中，仅做透明度变化（`opacity: 0 → 1`），无位移或缩放。
+
+## API
+
+### AnimationText Props
+
+| 属性名 | 类型     | 必填 | 说明                                            |
+| ------ | -------- | ---- | ----------------------------------------------- |
+| text   | `string` | ✓    | 要显示的文本；仅挂载时触发动画，prop 更新后无效 |
+
+### useAnimationText
+
+```typescript
+function useAnimationText(
+  text: MaybeRef<string>, // 字符串或 Ref<string>，传 Ref 才能响应变化
+  options?: AnimationConfig,
+): {
+  chunks: Ref<string[]>; // 分割后的文本块数组，v-for 遍历渲染
+  animationStyle: ComputedRef<{
+    // 应用到每个 <span> 的 inline style
+    animation: string;
+    color: 'inherit';
+  }>;
+};
+
+interface AnimationConfig {
+  fadeDuration?: number; // 动画时长（ms），默认 200
+  easing?: string; // CSS easing，默认 'ease-in-out'
+}
+```
+
+## 注意事项
+
+1. **`AnimationText` 不响应 prop 更新**：组件内部传的是字符串原始值，若需动态响应，直接用 `watch(myRef, ...)` 手动实现 chunk 逻辑
+2. **流式场景不要使用 `useAnimationText`**：该 composable 内部使用 `watch(() => text, ...)` 的 getter 形式，当传入 `Ref<string>` 时，getter 每次返回同一个 Ref 引用，Vue 无法检测到 `.value` 变化，watch 只触发一次（immediate）。正确做法是直接 `watch(streamText, callback)` 绑定 Ref
+3. **动画 keyframe 依赖全局样式**：使用 `@blueking/chat-x` 时会自动引入；独立使用时需确保 `ai-markdown-fade-in` 已定义
+4. **chunks 只增不减**（追加模式下）：流式结束后 chunks 保留所有历史分段，若需复用，手动清空 `chunks.value = []` 再重置文本即可
+
+## 关联组件
+
+- [useAnimationText](../../composables/use-animation-text.md) — chunk 与动画样式逻辑
+- [MarkdownContent](/components/rendering/markdown-content) — 流式正文渲染时可配合渐显

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/assistant-message.md
@@ -1,0 +1,426 @@
+# AssistantMessage AI 助手消息
+
+> 能力域：消息系统 ｜ 导入：`import { AssistantMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。 源码位置：src/components/chat-message/assistant-message/assistant-message.vue。
+
+**关联**：message-render（由 MessageRender 在 role 为 assistant 时创建）、tool-message（工具结果通过 toolCall.toolMessage 内联或独立 tool 消息关联展示）、toolcall-render（多条工具调用由 ToolcallRender 统一渲染）
+
+---
+
+# AssistantMessage AI 助手消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/assistant-message/assistant-message.vue`
+- **能力域**：消息系统
+- **能力说明**：渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。
+
+> **能力域**：消息系统
+
+AI 助手消息展示组件，负责渲染 AI 回复的文本内容和工具调用（Tool Calls）结果。
+
+## 渲染管线
+
+```
+AssistantMessage（根类名：ai-assistant-message）
+├── ai-assistant-message-content（内容区）
+│   └── [default slot] 或 ContentRender → MarkdownContent（Markdown 渲染）
+└── ToolCallRender × N（每个 toolCall 独立渲染，不受 slot 影响）
+```
+
+- **内容区**：`content` 字符串传入 `ContentRender`，内部固定使用 `MessageContentType.Text` 类型，最终由 `MarkdownContent` 渲染 Markdown
+- **工具调用区**：`toolCalls` 数组中每一项渲染一个 `ToolCallRender`，位于内容区**下方**，与 slot 无关
+
+## 基础用法
+
+```vue
+<template>
+  <AssistantMessage
+    :content="content"
+    :status="status"
+  />
+</template>
+
+<script setup lang="ts">
+  import { AssistantMessage, MessageStatus } from '@blueking/chat-x';
+
+  const content = '你好！我是 AI 助手，有什么可以帮助你的吗？';
+  const status = MessageStatus.Complete;
+</script>
+```
+
+**渲染效果**
+
+## Markdown 内容渲染
+
+`content` 支持 Markdown 格式，组件内部通过 `MarkdownContent` 自动渲染标题、列表、代码块、链接等：
+
+```vue
+<template>
+  <AssistantMessage
+    :content="markdownContent"
+    status="complete"
+  />
+</template>
+
+<script setup lang="ts">
+  import { AssistantMessage } from '@blueking/chat-x';
+
+  const markdownContent = `## Vue 3 核心特性
+
+Vue 3 引入了多项重要更新：
+
+1. **Composition API**：提供更灵活的逻辑组织方式
+2. **性能优化**：虚拟 DOM 重写，编译时优化
+3. **TypeScript 支持**：内置完整的类型定义
+
+\\\`\\\`\\\`typescript
+import { ref, computed } from 'vue';
+
+const count = ref(0);
+const doubled = computed(() => count.value * 2);
+\\\`\\\`\\\`
+
+> 更多详情请参考 [Vue 3 官方文档](https://vuejs.org)。`;
+</script>
+```
+
+**渲染效果**
+
+## 消息状态
+
+`status` 影响两处渲染：**内容区**和**工具调用状态标题**。
+
+| `status`    | 内容区效果                          | ToolCallRender 标题 |
+| ----------- | ----------------------------------- | ------------------- |
+| `pending`   | 正常渲染（通常 content 为空）       | Loading + "调用中"  |
+| `streaming` | Markdown 自动补全未闭合语法         | Loading + "调用中"  |
+| `complete`  | 正常渲染完整 Markdown               | "调用成功" + 耗时   |
+| `error`     | 红色错误图标 + content 作为错误提示 | "调用失败"          |
+| `stop`      | 正常渲染（内容停留在中止时的状态）  | "调用成功"          |
+
+### Pending
+
+### Streaming
+
+流式输出中，`MarkdownContent` 自动补全未闭合的 Markdown 语法（代码块、列表等），适合逐字/逐段追加内容：
+
+### Complete
+
+### Error
+
+渲染为错误信息样式（红色错误图标），`content` 作为错误提示文案展示：
+
+### Stop
+
+用户手动中止生成，内容停留在中止时的状态，与 `complete` 表现相同：
+
+## 工具调用
+
+当 AI 回复中包含工具调用时，传入 `toolCalls` 数组，每项自动渲染为 `ToolCallRender`，位于内容区下方。`status` 会同步传递给每个 `ToolCallRender` 以反映调用状态。
+
+### 单个工具调用
+
+```vue
+<template>
+  <AssistantMessage
+    content="让我帮你查询一下天气信息。"
+    :status="MessageStatus.Complete"
+    :tool-calls="toolCalls"
+  />
+</template>
+
+<script setup lang="ts">
+  import { AssistantMessage, MessageStatus } from '@blueking/chat-x';
+
+  const toolCalls = [
+    {
+      id: 'call_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city": "北京", "unit": "celsius"}',
+        description: '获取指定城市的天气信息',
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+### 多个工具调用
+
+AI 可在一次回复中发起多个工具调用，组件依次渲染：
+
+```vue
+<script setup lang="ts">
+  const toolCalls = [
+    {
+      id: 'call_1',
+      type: 'function',
+      function: {
+        name: 'search_documents',
+        arguments: '{"query": "Vue 3 Composition API"}',
+        description: '搜索知识库中的相关文档',
+      },
+    },
+    {
+      id: 'call_2',
+      type: 'function',
+      function: {
+        name: 'get_code_snippet',
+        arguments: '{"language": "typescript", "topic": "ref vs reactive"}',
+        description: '获取代码示例片段',
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+### MCP 工具调用
+
+`function.mcpName` 标识 MCP 服务名称，`ToolCallRender` 的标题会显示为「调用 MCP：{mcpName} / {name}」：
+
+```vue
+<script setup lang="ts">
+  const toolCalls = [
+    {
+      id: 'call_mcp_1',
+      type: 'function',
+      function: {
+        name: 'query_database',
+        arguments: '{"sql": "SELECT * FROM users LIMIT 10"}',
+        description: '执行数据库查询',
+        mcpName: 'database-server', // MCP 服务名
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+### 携带执行结果
+
+`toolMessage` 字段包含工具的执行结果；`ToolCallRender` 会展示返回内容（JSON 自动解析为键值对）和执行耗时：
+
+```vue
+<script setup lang="ts">
+  const toolCalls = [
+    {
+      id: 'call_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city": "北京"}',
+        description: '获取天气信息',
+      },
+      toolMessage: {
+        role: 'tool',
+        content: '{"weather":"晴","temperature":"22°C","humidity":"45%","wind":"东北风 3 级"}',
+        status: 'complete',
+        duration: 1200, // 毫秒
+        toolCallId: 'call_1',
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**（点击展开箭头可查看返回结果）
+
+### 工具调用失败
+
+`toolMessage.error` 不为空时，`ToolCallRender` 显示错误信息：
+
+```vue
+<script setup lang="ts">
+  const toolCalls = [
+    {
+      id: 'call_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city": "北京"}',
+        description: '获取天气信息',
+      },
+      toolMessage: {
+        role: 'tool',
+        content: '',
+        status: 'error',
+        error: 'API rate limit exceeded',
+        duration: 350,
+        toolCallId: 'call_1',
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+### 工具调用状态随消息状态变化
+
+`ToolCallRender` 的状态标题直接来自 `AssistantMessage` 的 `status` prop：
+
+**调用中**（`status = "streaming"`）：
+
+**调用成功**（`status = "complete"` + `toolMessage`）：
+
+## 自定义内容渲染
+
+默认插槽替换**内容区**的渲染（即 `ContentRender` 部分），工具调用仍在内容区外独立渲染，不受插槽影响：
+
+```
+[自定义 slot 内容]   ← 替换 ai-assistant-message-content 内默认渲染
+[ToolCallRender]     ← 不受影响，仍正常渲染
+[ToolCallRender]
+```
+
+```vue
+<template>
+  <AssistantMessage
+    :content="content"
+    :tool-calls="toolCalls"
+  >
+    <template #default="{ content }">
+      <div style="padding: 12px; background: #f0f9ff; border-left: 3px solid #3a84ff; border-radius: 4px;">
+        🤖 {{ content }}
+      </div>
+    </template>
+  </AssistantMessage>
+</template>
+```
+
+> **注意**：使用默认插槽后，内置的 `MarkdownContent`（Markdown 渲染）被替换，需要自行处理内容格式化。
+
+**渲染效果**
+
+## 在 MessageContainer 中使用
+
+`AssistantMessage` 通常不需要单独引入，`MessageContainer` 会对 `role: 'assistant'` 的消息自动渲染：
+
+```vue
+<template>
+  <MessageContainer :messages="messages" />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer } from '@blueking/chat-x';
+
+  const messages = [
+    {
+      id: '1',
+      messageId: '1',
+      role: 'user',
+      content: '北京今天天气怎么样？',
+      status: 'complete',
+    },
+    {
+      id: '2',
+      messageId: '2',
+      role: 'assistant',
+      content: '让我帮你查询一下天气信息。',
+      status: 'complete',
+      toolCalls: [
+        {
+          id: 'call_1',
+          type: 'function',
+          function: {
+            name: 'get_weather',
+            arguments: '{"city": "北京"}',
+            description: '获取天气',
+          },
+          toolMessage: {
+            role: 'tool',
+            content: '{"weather":"晴","temperature":"22°C"}',
+            status: 'complete',
+            duration: 800,
+            toolCallId: 'call_1',
+          },
+        },
+      ],
+    },
+    {
+      id: '3',
+      messageId: '3',
+      role: 'assistant',
+      content: '北京今天天气晴朗，气温 22°C，适合出行。',
+      status: 'complete',
+    },
+  ];
+</script>
+```
+
+## API
+
+### Props
+
+组件 Props 来自 `Partial<AssistantMessage>`（所有字段均可选）：
+
+| 属性名    | 类型                    | 说明                                                           |
+| --------- | ----------------------- | -------------------------------------------------------------- |
+| content   | `string`                | AI 回复的文本内容，支持 Markdown，`undefined` 时渲染为空字符串 |
+| status    | `MessageStatus`         | 消息状态，影响 Markdown 渲染模式和 ToolCallRender 的状态标题   |
+| toolCalls | `ToolCall[]`            | 工具调用列表，每项渲染一个 `ToolCallRender`                    |
+| id        | `number \| string`      | 消息 ID                                                        |
+| messageId | `number \| string`      | 消息唯一标识                                                   |
+| name      | `string`                | 消息发送者名称（可选）                                         |
+| role      | `MessageRole.Assistant` | 消息角色，固定为 `'assistant'`                                 |
+| property  | `object`                | 消息附加属性，本组件不使用，由父组件（`MessageContainer`）消费 |
+
+### Slots
+
+| 插槽名  | 参数                  | 说明                                                 |
+| ------- | --------------------- | ---------------------------------------------------- |
+| default | `{ content: string }` | 替换内容区渲染，toolCalls 在内容区外独立渲染不受影响 |
+
+## 类型定义
+
+```typescript
+import type { AssistantMessage, ToolCall, FunctionCall, ToolMessage } from '@blueking/chat-x';
+
+interface AssistantMessage extends BaseMessage<MessageRole.Assistant> {
+  toolCalls?: ToolCall[];
+}
+
+// 工具调用
+type ToolCall = {
+  id: string;
+  type: MessageContentType.Function; // 固定为 'function'
+  function: FunctionCall;
+  toolMessage?: Partial<ToolMessage>; // 工具执行结果（可选）
+};
+
+// 函数调用信息
+type FunctionCall = {
+  name: string; // 函数名
+  arguments: string; // JSON 字符串格式的参数
+  description?: string; // 函数描述
+  mcpName?: string; // MCP 服务名（存在时标题显示 "调用 MCP"）
+};
+
+// 工具执行结果
+interface ToolMessage extends BaseMessage<MessageRole.Tool, string> {
+  toolCallId: string; // 对应的 ToolCall.id
+  duration: number; // 执行耗时（ms）
+  error?: string; // 错误信息（存在时 ToolCallRender 显示失败状态）
+}
+```
+
+## 使用场景
+
+- **文本消息展示**：聊天界面渲染 AI 回复的 Markdown 文本
+- **工具调用过程展示**：展示 Function Call / MCP 调用的参数、状态和返回结果
+- **流式输出**：`streaming` 状态下 Markdown 自动补全未闭合语法，配合流式响应实时更新
+- **自动渲染**：通过 `MessageContainer` 对 `role: 'assistant'` 消息自动处理，无需手动引入
+- **自定义内容渲染**：通过默认插槽替换内置 Markdown 渲染器，保留工具调用渲染
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — assistant 角色由其实例化
+- [ToolMessage](/components/message/tool-message) — 工具执行结果可通过 toolCall.toolMessage 内联
+- [ToolcallRender](/components/agent/toolcall-render) — 工具调用列表渲染

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
@@ -1,0 +1,655 @@
+# ChatContainer 聊天容器
+
+> 能力域：对话搭建 ｜ 导入：`import { ChatContainer } from '@blueking/chat-x'` ｜ since 1.0.0
+
+完整对话容器，组合消息列表、输入区、快捷指令、执行摘要、分享选择和自定义 Tab。 源码位置：src/components/chat-container/chat-container.vue。
+
+**关联**：message-container（消息列表与滚动区域）、chat-input（对话输入与快捷指令入口）、shortcut-render（快捷指令表单浮层）、execution-summary（执行摘要侧栏与定位）、selection-footer（多选分享底部操作栏）
+
+---
+
+# ChatContainer 聊天容器
+## 源码事实
+
+- **源码位置**：`src/components/chat-container/chat-container.vue`
+- **能力域**：对话搭建
+- **能力说明**：完整对话容器，组合消息列表、输入区、快捷指令、执行摘要、分享选择和自定义 Tab。
+
+> **能力域**：对话搭建
+
+顶层聊天容器组件，整合了 `MessageContainer`（消息列表）、`ChatInput`（输入框）、`ExecutionSummary`（执行摘要面板）、`ShortcutRender`（快捷指令表单）和 `SelectionFooter`（多选操作栏）。提供完整的 AI 对话界面布局能力。
+
+## 核心能力
+
+- **分栏布局**：基于 `ResizeLayout` 的可拖拽分栏；**侧栏是否展示 Tab / 执行摘要、以及分栏是否进入折叠样式（`ai-is-collapse`）以 `executionGroups` 与执行情况搜索关键词 `keyword` 共同决定**（`executionGroups` 由 `useMessageGroup` 从消息中过滤工具调用与 FlowAgent 记录；`keyword` 来自 `ExecutionSummary` 的 `@update-keyword`）。当 `executionGroups` 为空且未输入搜索词时，侧栏 Tab 与执行摘要不展示；**用户正在搜索执行情况时（`keyword` 非空），即使暂无执行类消息也会保留侧栏**，避免搜索态被折叠
+- **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
+- **输入区状态推导**：传给 `MessageContainer` 与 `ChatInput` 的 `messageStatus` 为内部计算值 `inputStatus`：当分组中存在 id 为 `LOADING_MESSAGE_ID`（`'__loading__'`，由 `useMessageGroup` 注入的占位 Loading 消息）时，对内使用 `MessageStatus.Fetching`；否则使用外部传入的 `messageStatus`。用于在「已发用户消息、尚未流式」阶段与流式中一致地展示停止能力，并避免输入区重复发送
+- **待审批发送阻塞**：当消息中存在 `AIDevToolApproval` 且状态为 `pending` / `draft` 的中断项时，`useMessageGroup` 会返回待审批提示，容器在输入区上方展示提示并通过 `ChatInput.sendDisabledTip` 禁止继续发送
+- **用户问题中断**：当消息中存在待回答 `UserQuestion` 中断时，容器会在输入区上方挂载 `UserQuestionCard`；结构化作答走 `onInterruptResume`，用户在输入框直接发送时走 `onSendMessage` 并在第三参数附带 skip 用的 `payload`（`status: 'cancelled'`）与 `interrupt`，且不会自动清空输入框
+- **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
+- **侧栏全屏**：Tab 栏右侧提供全屏/退出全屏按钮，基于 `useFullScreen` 将侧栏区域（`.ai-full-screen-wrapper`）以浏览器原生全屏展示；全屏时 Tippy 的 `appendTo` 自动切换为全屏容器，避免 tooltip 被遮挡
+- **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
+- **分享模式**：内置消息多选分享流程，选中用户消息后确认分享
+- **渲染模式注入**：`renderMode` 会通过内部 Provider 下传给后代内容组件；例如 FlowAgent 节点在 `Share` 模式下隐藏耗时和「详情」入口
+- **字号主题**：通过 `size` 控制 `small`（默认 12px）/ `normal`（14px）两档字号；根节点设置 `data-ai-size`，子组件通过 CSS 变量（`--ai-font-size` 等）响应式缩放；浮层（Tippy / Teleport）会同步 `document.body.dataset.aiSize`，卸载时自动清理
+- **空状态欢迎页**：无消息时展示欢迎语和开场白
+
+## 组件结构
+
+```
+ai-chat-container（:data-ai-size="size"）
+├── Loading（chatLoading 时）
+└── ResizeLayout
+    ├── aside（侧边栏）
+    │   ├── .ai-full-screen-wrapper（全屏目标容器，ref=fullScreenRef）
+    │   │   ├── Tab 标签页
+    │   │   │   ├── 执行情况（默认 Tab）
+    │   │   │   ├── 自定义 Tab × N（可关闭；标签可由 `getSideTabRenderComponent` 自定义）
+    │   │   │   └── #setting 插槽 → 全屏/退出全屏 ToolBtn（FullScreenIcon / UnFullScreenIcon）
+    │   │   ├── ExecutionSummary（执行情况 Tab 内容）
+    │   │   └── 自定义 Tab 组件（`getSideRenderComponent` 优先，否则 `data.component`；可向子组件注入 #locateButton）
+    │   └── collapse-button（折叠按钮，CollapsedIcon；折叠时图标旋转，hover 高亮 #3a84ff）
+    └── main（主内容区）
+        ├── MessageContainer（有消息时）
+        │   ├── #group 插槽（可选，自定义消息组内容）
+        │   ├── #message 插槽（可选，自定义单条消息）
+        │   └── 消息列表 + 工具栏
+        ├── 欢迎页（无消息时，容器 .ai-welcome-content）
+        │   └── welcome 插槽（默认：Banner + 欢迎标题 + 开场白 ContentRender；自定义则整块替换）
+        ├── SelectionFooter（分享模式时）
+        ├── ShortcutRender（有快捷指令时）
+        └── ChatInput（默认状态，待审批时通过 interrupt slot 展示 InputInfoAlert）
+```
+
+## 基础用法
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    :on-agent-action="handleAgentAction"
+    :on-agent-feedback="handleAgentFeedback"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatContainer, MessageStatus, type Message, type IToolBtn, type TagSchema } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+  const messages = ref<Message[]>([]);
+
+  const handleSendMessage = async (content: string, docSchema: TagSchema) => {
+    messageStatus.value = MessageStatus.Streaming;
+    // ... 发送 AI 请求
+    messageStatus.value = MessageStatus.Complete;
+  };
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+  const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面', '表达清晰'];
+    }
+  };
+  const handleAgentFeedback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList, otherReason);
+  };
+  const handleUserAction = async (tool: IToolBtn, message: Message) => {
+    console.log('用户操作:', tool.id);
+  };
+  const handleStopStreaming = () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+**渲染效果**
+
+## 字号主题
+
+通过 `size` 切换两档字号主题。未传时默认为 `small`（12px 基准字号）；设为 `normal` 时使用 14px 基准字号，并联动行高、间距与图标尺寸。
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    message-status="complete"
+    size="normal"
+    :on-send-message="handleSendMessage"
+  />
+</template>
+```
+
+**渲染效果**（左右对比 `size="small"` 与 `size="normal"`）
+
+> CSS 变量与档位取值详见 [主题配置 — 字号主题](../../theme/theme#字号主题)。
+
+## 侧边栏与执行摘要
+
+侧边栏默认包含「执行情况」Tab，展示所有工具调用和 FlowAgent 类型的 Activity 消息。支持关键词搜索过滤和点击定位到对话中的消息位置。
+
+**展示条件**：当 `executionGroups` 为空且 `keyword` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。用户在执行情况中输入搜索词后，侧栏会保持展示以显示「搜索结果为空」等状态。`renderMode === Share` 时侧栏隐藏，且分栏会应用与折叠一致的样式。
+
+**自定义 Tab 联动**：当 `executionGroups` 变为空且搜索词已清空时，容器会**自动重置自定义 Tab**（`resetCustomTab`），避免残留节点详情等 Tab；若用户仍在搜索（`keyword` 非空），不会触发重置。
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    :message-status="messageStatus"
+    placement="left"
+    :on-send-message="handleSendMessage"
+    :on-agent-action="handleAgentAction"
+    @stop-streaming="handleStopStreaming"
+    @collapse-change="handleCollapseChange"
+  />
+</template>
+
+<script setup lang="ts">
+  const handleCollapseChange = (isCollapse: boolean, resizeAsideWidth: number) => {
+    console.log('侧边栏折叠:', isCollapse, '宽度:', resizeAsideWidth);
+  };
+</script>
+```
+
+**渲染效果**（包含工具调用消息时，侧边栏自动展示「执行情况」）
+
+侧边栏放置方向通过 `placement` 控制：
+
+| `placement` | 侧边栏位置   | 折叠按钮位置 | 折叠图标旋转 |
+| ----------- | ------------ | ------------ | ------------ |
+| `left`      | 左侧（默认） | 主区域左边缘 | 折叠时旋转 180° |
+| `right`     | 右侧         | 主区域右边缘 | 默认旋转 180°，折叠时恢复 0° |
+
+> 折叠按钮仅展示 `CollapsedIcon`（不再显示「执行情况」文案），通过图标旋转方向指示展开/折叠状态。
+
+**placement 对比**（左右两种布局）
+
+## 侧栏全屏
+
+当侧栏 Tab 区域可见时，Tab 栏右侧（`#setting` 插槽）内置全屏切换按钮：
+
+- 点击 **全屏** 图标：调用 `useFullScreen(fullScreenRef).enter()`，将 `.ai-full-screen-wrapper` 进入浏览器原生全屏
+- 点击 **退出全屏** 图标：调用 `exit()` 退出；用户按 ESC 退出时 `isFullScreen` 也会自动同步
+- 全屏状态下，侧栏内 `v-overflow-tips` 的 `appendTo` 会指向全屏容器，避免 tooltip 挂载到 `document.body` 后被全屏层遮挡
+
+该能力由内部 `useFullScreen` composable 提供，详见 [useFullScreen](../../composables/use-full-screen.md)。
+
+## 自定义 Tab
+
+通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab。若 **`executionGroups` 变为空且搜索词已清空**，容器会清空自定义 Tab 状态（与侧栏执行数据联动，见上文「侧边栏与执行摘要」）。
+
+### 侧栏渲染扩展
+
+应用层可通过以下 Props 覆盖默认 Tab 标签与侧栏内容区的渲染逻辑（例如 FlowAgent 节点详情使用业务自定义组件）：
+
+| Prop | 说明 |
+| ---- | ---- |
+| `getSideTabRenderComponent` | `(h, tab, { removeCustomTab }) => VNode \| undefined`。返回自定义 Tab 标签 VNode；未返回时使用默认图标 + `tab.label` + 关闭按钮 |
+| `getSideRenderComponent` | `(h, props) => VNode \| undefined`。返回侧栏内容区组件 VNode；未返回时使用 `selectedTab.data.component` |
+
+侧栏内容区实现上会以 **`selectedTab.name` 作为外层 `key`**，切换 Tab 时重建子树，避免插槽与局部状态残留；当前 Tab 的 `:is` 由内部 **`computed`** 根据 `getSideRenderComponent(h, selectedTab.data.props)` 与 `data.component` 解析，保证 Tab 切换或 `onCustomTabChange` 异步更新 props 后内容类型与数据一致。
+
+```vue
+<template>
+  <ChatContainer
+    :get-side-tab-render-component="renderSideTab"
+    :get-side-render-component="renderSidePanel"
+    ...
+  />
+</template>
+
+<script setup lang="ts">
+  import { h } from 'vue';
+  import type { CustomTab } from '@blueking/chat-x';
+
+  const renderSideTab = (createElement, tab, { removeCustomTab }) => {
+    if (tab.name.startsWith('custom-')) {
+      return createElement('span', {}, tab.label);
+    }
+    return undefined; // 走默认 Tab 标签
+  };
+
+  const renderSidePanel = (createElement, props) => {
+    if (props?.has_confidence) {
+      return createElement(MyConfidencePanel, props);
+    }
+    return undefined; // 走 tab.data.component
+  };
+</script>
+```
+
+### 自定义 Tab 与「在对话中定位」
+
+`addCustomTab` 的 `data` 可携带 **`messageUid`**（与对应活动消息的 `message.uid` 一致）。`ChatContainer` 在侧栏用 `<component :is="sideRenderComponent">`（内部计算属性，见上文「侧栏渲染扩展」）渲染自定义 Tab 时，会向子组件提供 **`locateButton` 插槽**：默认渲染「在对话中定位」按钮，点击后调用内部 `handleLocateMessageGroup(messageUid)`，优先滚动到主区域 `document.getElementById(messageUid)`；若不存在该节点，则在当前 `messageGroups` 中查找包含 `message.uid === messageUid` 的消息组，并滚动到该组的容器（`MessageGroup.uid` 作为组级 `id`）。
+
+子组件若需展示该按钮，请在模板中声明 `<slot name="locateButton" />`（例如 FlowAgent 节点详情标题栏）。`FlowAgentContent` 等会在打开节点详情 Tab 时将 `messageUid` 写入 `data`，与 `ActivityMessage` 下传给内容区的 `message-uid` 对齐。
+
+```vue
+<template>
+  <ChatContainer
+    ref="chatContainerRef"
+    v-model="inputValue"
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-custom-tab-change="handleCustomTabChange"
+    :on-send-message="handleSendMessage"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { useTemplateRef } from 'vue';
+  import { ChatContainer, type CustomTab } from '@blueking/chat-x';
+
+  const chatContainerRef = useTemplateRef<InstanceType<typeof ChatContainer>>('chatContainerRef');
+
+  // 添加自定义 Tab（如 FlowAgent 节点详情）
+  const addNodeDetailTab = (nodeId: string, nodeName: string, messageUid?: string) => {
+    chatContainerRef.value?.addCustomTab({
+      name: `node-${nodeId}`,
+      label: nodeName,
+      data: {
+        component: MyNodeDetail, // 自定义组件（模板内需 <slot name="locateButton" /> 以展示侧栏「在对话中定位」）
+        props: { loading: true, data: {} },
+        messageUid, // 与活动消息 message.uid 一致时可省略；用于主对话定位
+      },
+    });
+  };
+
+  // Tab 切换时加载数据
+  const handleCustomTabChange = async (tab: CustomTab) => {
+    const data = await fetchTabData(tab.name);
+    return data;
+  };
+</script>
+```
+
+## 开场白
+
+无消息时展示欢迎页，通过 `openingRemark` 设置开场白内容（支持 Markdown）：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="[]"
+    :message-status="messageStatus"
+    opening-remark="你好！我是 AI 小鲸 🐳，可以帮你：\n\n- 编写和优化代码\n- 解答技术问题\n- 分析和调试错误"
+    :on-send-message="handleSendMessage"
+  />
+</template>
+```
+
+### 自定义欢迎内容
+
+通过 `welcome` 插槽可完全自定义欢迎页内容，插槽参数 `openingRemark` 为传入的开场白文本：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="[]"
+    :message-status="messageStatus"
+    opening-remark="欢迎使用 AI 助手"
+    :on-send-message="handleSendMessage"
+  >
+    <template #welcome="{ openingRemark }">
+      <div class="my-welcome">
+        <h3>{{ openingRemark }}</h3>
+        <div class="quick-actions">
+          <button @click="handleQuickAction('code')">写代码</button>
+          <button @click="handleQuickAction('debug')">调试</button>
+          <button @click="handleQuickAction('explain')">解释</button>
+        </div>
+      </div>
+    </template>
+  </ChatContainer>
+</template>
+```
+
+> **注意**：使用 `welcome` 插槽后，将**整块替换**默认欢迎区（含 Banner 图标、默认欢迎标题与 `openingRemark` 的 `ContentRender` 渲染），需自行编排完整欢迎页；插槽参数 `openingRemark` 仍可用于读取传入的开场白文本。
+
+**渲染效果**
+
+## 加载状态
+
+`chatLoading` 为 `true` 时，整个容器显示 Loading 遮罩，适用于初始化加载场景（如拉取历史消息）：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="[]"
+    :chat-loading="true"
+  />
+</template>
+```
+
+**渲染效果**
+
+## 流式输出
+
+`messageStatus` 为 `streaming` 时，底部固定区域显示「停止生成」按钮，点击后触发 `@stop-streaming` 事件：
+
+## 待审批阻塞发送
+
+当会话中存在待审批的 AI Dev 工具审批中断时，`ChatContainer` 会在输入框上方展示提示，并禁用发送按钮。用户需要在审批卡片中点击「取消审批」或等待状态变化后，才能继续发送新消息。
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    message-status="complete"
+    :on-interrupt-resume="handleInterruptResume"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  />
+</template>
+```
+
+**渲染效果**（待审批单存在时，输入区上方展示提示，发送按钮置灰）
+
+## 用户问题中断
+
+当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)。
+
+- **结构化作答**：用户在卡片内完成选择或点击「跳过」后，通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
+- **输入框发送**：用户也可在输入框直接点击发送；容器会调用 `onSendMessage(content, docSchema, options)`，其中 `options.interrupt` 为当前激活的 UserQuestion，`options.payload` 为 `buildSkipResumePayload` 生成的 skip resume（`status: 'cancelled'`，`answers: []`）。此时**不会自动清空**输入框，由业务侧在 `onSendMessage` 内决定如何处理 `content` 与中断恢复。
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    message-status="complete"
+    :on-interrupt-resume="handleInterruptResume"
+    :on-send-message="handleSendMessage"
+  />
+</template>
+
+<script setup lang="ts">
+  import {
+    type OnInterruptResume,
+    type UserMessage,
+    type TagSchema,
+    type Interrupt,
+    type InterruptResume,
+  } from '@blueking/chat-x';
+
+  const handleInterruptResume: OnInterruptResume = async (payload, interrupt) => {
+    // UserQuestionCard 完成 / 跳过时 payload 为 UserQuestionResume
+    await resumeAgent({ interruptId: interrupt.id, resume: payload });
+  };
+
+  const handleSendMessage = async (
+    content: UserMessage['content'],
+    docSchema: TagSchema,
+    options?: { interrupt?: Interrupt; payload?: InterruptResume },
+  ) => {
+    if (options?.interrupt && options?.payload) {
+      // 存在 UserQuestion 时发送：附带 skip resume，content 仍为输入框文本
+      await resumeAgent({ interruptId: options.interrupt.id, resume: options.payload });
+      // 业务侧自行决定是否将 content 作为新用户消息继续发送
+      return;
+    }
+    await sendMessage(content, docSchema);
+  };
+</script>
+```
+
+## 自定义消息组渲染
+
+通过 `#group` 插槽可替换单个消息组的默认内容，透传至内部 `MessageContainer`。外层消息组容器（`id`、hover、选中背景）仍由 `MessageContainer` 管理。
+
+> **注意**：提供 `#group` 后需自行编排组内全部 UI（Checkbox、消息列表、`MessageTools`）；若只需替换单条消息，请使用 `#message` 插槽。详见 [MessageContainer 自定义消息组渲染](/components/setup/message-container#自定义消息组渲染)。
+
+```vue
+<ChatContainer
+  v-model="inputValue"
+  :messages="messages"
+  message-status="complete"
+  :on-send-message="handleSendMessage"
+>
+  <template #group="{ group }">
+    <MyCustomGroup :group="group" />
+  </template>
+</ChatContainer>
+```
+
+### 自定义题目渲染
+
+通过 `#interruptQuestion` slot 可覆盖输入区上方 `UserQuestionCard` 的默认选择题渲染，参数与 [UserQuestionCard](/components/agent/user-question-card) 的 `#question` 一致：
+
+```vue
+<ChatContainer
+  v-model="inputValue"
+  :messages="messages"
+  :on-interrupt-resume="handleInterruptResume"
+  :on-send-message="handleSendMessage"
+>
+  <template #interruptQuestion="{ question, qIndex, answer, setAnswer, confirm }">
+    <MyCustomForm
+      :model="question"
+      @change="setAnswer"
+      @submit="confirm"
+    />
+  </template>
+</ChatContainer>
+```
+
+## 分享模式
+
+点击消息工具栏的「分享」按钮后进入分享模式，底部出现 `SelectionFooter` 操作栏：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-agent-action="handleAgentAction"
+    @confirm-share="handleConfirmShare"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { type Message } from '@blueking/chat-x';
+
+  const handleConfirmShare = (selectedMessages: Message[]) => {
+    console.log('分享消息:', selectedMessages);
+  };
+</script>
+```
+
+**渲染效果**（点击 AI 回复工具栏中的「分享」按钮进入多选模式）
+
+**分享流程**：
+
+1. 用户点击消息工具栏中的「分享」按钮
+2. 进入多选模式，用户勾选要分享的消息
+3. 底部 `SelectionFooter` 提供全选、取消、确认操作
+4. 确认后触发 `confirmShare` 事件，携带选中的消息列表
+
+## 快捷指令
+
+通过 `v-model:selectedShortcut` 管理快捷指令选中状态：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    v-model:selected-shortcut="selectedShortcut"
+    :messages="messages"
+    :message-status="messageStatus"
+    :shortcuts="shortcuts"
+    :on-send-message="handleSendMessage"
+    @shortcut-close="handleShortcutClose"
+    @shortcut-submit="handleShortcutSubmit"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { type Shortcut } from '@blueking/chat-x';
+
+  const selectedShortcut = ref<Shortcut | null>(null);
+
+  const handleShortcutClose = () => {
+    selectedShortcut.value = null;
+  };
+  const handleShortcutSubmit = (formModel: Record<string, unknown>) => {
+    console.log('快捷指令提交:', formModel);
+  };
+</script>
+```
+
+## API
+
+### Props
+
+ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`（排除 `enableSelection` 和 `messageGroups`），另外新增：
+
+| 属性名             | 类型                                                                         | 默认值   | 说明                                                                                                                                          |
+| ------------------ | ---------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| chatLoading                 | `boolean`                                                                    | —        | 整体加载状态，`true` 时显示 Loading 遮罩                                                                                                      |
+| commonTippyOptions          | `AITippyProps`                                                               | —        | 通用 Tippy 配置（`appendTo` / `placement` / `zIndex`），传入的选项会注入到所有使用 `v-overflow-tips` 的子组件中                                 |
+| getSideRenderComponent      | `(h, props?) => VNode \| undefined`                                          | —        | 自定义侧栏内容区渲染；未返回时使用 `selectedTab.data.component`                                                                               |
+| getSideTabRenderComponent   | `(h, tab, { removeCustomTab }) => VNode \| undefined`                        | —        | 自定义侧栏 Tab 标签渲染；未返回时使用默认图标 + 文案 + 关闭按钮                                                                               |
+| openingRemark               | `string`                                                                     | —        | 开场白，无消息时显示，支持 Markdown                                                                                                           |
+| placement          | `'left' \| 'right'`                                                          | `'left'` | 侧边栏位置                                                                                                                                    |
+| size               | `'normal' \| 'small'`                                                        | `'small'` | 字号主题档位：`small` 为 12px 基准，`normal` 为 14px 基准；根节点设置 `data-ai-size` 并注入 `useGlobalConfig`                                |
+| resizeProps        | `{ disabled?: boolean; initialDivide?: number \| string; max?: number; min?: number }` | —        | 透传给内部 `ResizeLayout` 的可选配置，与默认 `collapsible: false`、`immediate: true`、`min: 400` 合并；`placement` 始终取自本组件 `placement`；`initialDivide` 可为像素数字或百分比等字符串（与 bkui ResizeLayout 一致） |
+| onCustomTabChange  | `(tab: CustomTab) => Promise<any>`                                           | —        | 自定义 Tab 切换回调，返回值作为 Tab 组件 props                                                                                                |
+
+> 完整 Props 列表请参考 [ChatInput](/components/input/chat-input) 和 [MessageContainer](/components/setup/message-container) 文档。
+
+### v-model
+
+| 属性名           | 类型                  | 说明                                                         |
+| ---------------- | --------------------- | ------------------------------------------------------------ |
+| modelValue       | `string \| TagSchema` | 输入框内容，支持纯文本或标签结构                             |
+| selectedShortcut | `Shortcut \| null`    | 当前选中的快捷指令                                           |
+| cite             | `string`              | 引用内容                                                     |
+| renderMode       | `RenderMode`          | 渲染模式（默认 `Chat`）。`Share` 模式隐藏侧边栏和折叠按钮；`Test` 模式隐藏分享按钮 |
+
+### Events
+
+| 事件名         | 参数                                   | 说明                                 |
+| -------------- | -------------------------------------- | ------------------------------------ |
+| stopStreaming  | —                                      | 点击「停止生成」按钮                 |
+| shortcutClose  | —                                      | 关闭快捷指令表单                     |
+| shortcutSubmit | `(formModel: Record<string, unknown>)` | 提交快捷指令表单                     |
+| confirmShare   | `(messages: Message[])`                | 确认分享，携带选中的消息             |
+| collapseChange | `(isCollapse: boolean, width: number)` | 侧边栏折叠/展开状态变化              |
+| selectShortcut | `(shortcut: Shortcut)`                 | 选择快捷指令（继承自 ChatInput）     |
+| deleteShortcut | —                                      | 删除已选快捷指令（继承自 ChatInput） |
+
+### Slots
+
+| 插槽名            | 参数                                                                                                              | 说明                                                                                           |
+| ----------------- | ----------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| codeHeader        | `{ language: string; token: Token[] }`                                                                            | 代码块头部自定义操作区域，透传给 MessageRender → ContentRender → MarkdownContent → CodeContent |
+| default           | 消息列表相关绑定（messages 等）                                                                                   | 自定义消息列表区域                                                                             |
+| group             | `{ group: MessageGroup }`                                                                                         | 自定义单个消息组内容，透传至 MessageContainer 的 `#group`；替换默认 Checkbox、消息列表与工具栏   |
+| interruptQuestion | `{ question, qIndex, answer, setAnswer, confirm }`                                                                  | 自定义 UserQuestion 单题渲染，透传至输入区上方 UserQuestionCard 的 `#question`                 |
+| message           | `{ message, messageToolsStatus, onInterruptResume }`                                                              | 自定义单条消息渲染；自定义渲染中断消息时需继续透传 `onInterruptResume`                         |
+| welcome           | `{ openingRemark: string }`                                                                                       | 无消息时自定义欢迎页；传入则替换默认 Banner、标题与开场白区域（整块替换）                      |
+
+### Expose
+
+| 方法/属性名     | 类型                        | 说明           |
+| --------------- | --------------------------- | -------------- |
+| selectedTab     | `Ref<CustomTab>`            | 当前选中的 Tab |
+| addCustomTab    | `(tab: CustomTab) => void`  | 添加自定义 Tab |
+| removeCustomTab | `(tabName: string) => void` | 移除自定义 Tab |
+| selectCustomTab | `(tab: CustomTab) => void`  | 切换到指定 Tab |
+| enterShareMode  | `() => void`                | 手动进入分享多选模式 |
+| exitShareMode   | `() => void`                | 退出分享多选模式，并清空已选消息 |
+
+## 渲染模式
+
+通过 `v-model:render-mode` 控制容器的渲染行为。`ChatContainer` 会把当前 `renderMode` 注入给后代组件，供内容渲染根据场景收敛交互能力。
+
+| `renderMode` | 侧边栏 Tab / 折叠按钮 | 底部输入区域                      | MessageTools 工具栏   | 说明                             |
+| ------------ | ---------------------- | --------------------------------- | --------------------- | -------------------------------- |
+| `Chat`       | 正常显示               | 正常显示（ChatInput / ShortcutRender / SelectionFooter） | 全部工具按钮          | 默认对话模式                     |
+| `Share`      | **隐藏**               | **隐藏**                          | **隐藏**（多选模式）  | 分享预览模式，仅展示消息；FlowAgent 节点会隐藏耗时和「详情」入口 |
+| `Test`       | 正常显示               | 正常显示                          | 过滤掉「分享」按钮    | 测试/嵌入模式，隐藏分享入口     |
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    v-model:render-mode="renderMode"
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+  />
+</template>
+
+<script setup lang="ts">
+  import { shallowRef } from 'vue';
+  import { ChatContainer, RenderMode } from '@blueking/chat-x';
+
+  const renderMode = shallowRef<RenderMode>(RenderMode.Chat);
+</script>
+```
+
+## 类型定义
+
+```typescript
+import { ChatContainer, RenderMode, MessageRole, type CustomTab, type MessageGroup, type Shortcut, type Message } from '@blueking/chat-x';
+
+// 消息组（由 useMessageGroup 生成）
+interface MessageGroup {
+  checked: boolean;
+  isHover: boolean;
+  messages: Message[];
+  pause?: boolean;
+  startTime?: number;
+  type: MessageRole;
+  uid: string;
+  userMessageTitle?: number | string;
+}
+
+// 自定义 Tab（data 可与 messageUid 组合，供侧栏定位主对话）
+interface CustomTab<T = Record<string, unknown>> {
+  label: string;
+  name: string;
+  data?: T & { messageUid?: string };
+}
+
+// 快捷指令
+interface Shortcut {
+  id: string;
+  name: string;
+  components?: ShortcutComponent[];
+}
+```
+
+## 关联组件
+
+- [MessageContainer](/components/setup/message-container) — 消息列表区域
+- [ChatInput](/components/input/chat-input) — 输入与快捷指令
+- [ShortcutRender](/components/input/shortcut-render) — 快捷指令表单
+- [ExecutionSummary](/components/agent/execution-summary) — 执行摘要侧栏
+- [SelectionFooter](/components/input/selection-footer) — 多选操作栏
+- [ToolBtn](/components/feedback/tool-btn) — 侧栏全屏按钮（自定义插槽）
+- [useFullScreen](/composables/use-full-screen) — 侧栏全屏控制
+- [useGlobalConfig](/composables/use-global-config) — 注入 `size` 与 `supportUpload`
+- [主题配置](/theme/theme) — 字号主题 CSS 变量

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
@@ -1,0 +1,698 @@
+# ChatInput 聊天输入框
+
+> 能力域：输入交互 ｜ 导入：`import { ChatInput } from '@blueking/chat-x'` ｜ since 1.0.0
+
+聊天输入区，组合富文本输入、快捷指令、附件、引用、发送/停止等交互。 源码位置：src/components/chat-input/chat-input.vue。
+
+**关联**：shortcut-btns（底部附件区默认展示的快捷指令列表）、shortcut-btn（已选快捷指令以单按钮形式展示并可关闭）、shortcut-render（快捷指令含 components 时由外层唤起表单渲染）、chat-container（顶层聊天布局中作为输入区子组件）、cite-content（消息引用区展示选中的上下文片段）
+
+---
+
+# ChatInput 聊天输入框
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/chat-input.vue`
+- **能力域**：输入交互
+- **能力说明**：聊天输入区，组合富文本输入、快捷指令、附件、引用、发送/停止等交互。
+
+> **能力域**：输入交互
+
+聊天消息输入框组件，支持快捷指令选择、资源 `@` 引用、Prompt `/` 模板、消息引用、文件上传（拖拽/粘贴/点击）等功能。
+
+## 组件结构
+
+```
+chat-input-container
+├── slot#top（容器顶部，在输入框框体外侧）
+├── slot#interrupt（容器顶部，在输入框框体外侧，通常展示中断/审批提示）
+└── chat-input（框体，受 inputMaxHeight 控制）
+    ├── slot#input-header（默认：cite 不为空时渲染引用区）
+    ├── slot#files（默认：有上传文件时渲染文件预览区）
+    ├── AiSlashInput（富文本编辑器，/ 触发 Prompt，@ 触发资源）
+    └── InputAttachment（底部工具栏，高度固定 40px）
+        ├── FileUploadBtn（仅当 supportUpload 为 true 时显示，在 slot#attachment 外部）
+        ├── 分隔线（仅当 supportUpload 为 true 且有快捷指令时显示）
+        ├── slot#attachment（默认：ShortcutBtns 或已选 ShortcutBtn + 关闭图标）
+        └── slot#send-icon（默认：发送/停止图标，仅替换图标，按钮容器保留）
+```
+
+> **注意**：`slot#attachment` 只替换快捷指令区，`FileUploadBtn` 在其外部，使用该 slot 不会移除上传按钮。`slot#send-icon` 只替换图标，按钮的点击处理和样式仍由组件控制。
+
+### AiSlashInput 与 modelValue 同步
+
+内部编辑器 `AiSlashInput` 在 **`modelValue` 由外部异步更新**（例如从历史会话回填、父组件重置）且与当前文档不一致时，会通过 `useCommandSelection` 提供的 `GetDocSnapshot` 读取编辑器快照，与 `docToString(modelValue)` 比对后，必要时执行 `ReplaceAll` 将编辑器内容同步为新的 `modelValue`，避免内外状态脱节。
+
+## 基础用法
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type TagSchema } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+
+  const handleSendMessage = async (content: string, docSchema: TagSchema) => {
+    // content：纯文本字符串（无文件时）或 InputContent[] 数组（有文件时）
+    messageStatus.value = MessageStatus.Streaming;
+    // ... 发送 AI 请求
+    messageStatus.value = MessageStatus.Complete;
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+**渲染效果**（输入 `/` 唤出 Prompt，输入 `@` 唤出资源菜单）
+
+## 发送状态（messageStatus）
+
+`messageStatus` 控制底部工具栏的按钮渲染，但**输入框为空时始终自动置灰禁用**，无论 `messageStatus` 传入什么值。
+
+| `messageStatus`               | 输入框有内容时按钮表现                                 | 输入框空时               |
+| ----------------------------- | ------------------------------------------------------ | ------------------------ |
+| `complete` / `stop` / `error` | 蓝色发送按钮，点击触发 `onSendMessage`                 | 灰色禁用                 |
+| `streaming` / `pending` / `fetching` | 蓝色停止按钮（Loading 图标），点击触发 `onStopSending` | 蓝色停止按钮（仍可点击） |
+| `disabled`                    | 灰色禁用，点击无效                                     | 灰色禁用                 |
+
+> **实现细节**：组件内部用 `messageState` 计算属性决定实际按钮状态：当 `messageStatus` 为 `pending`、`streaming` 或 `fetching` 时直接使用该状态（确保停止按钮始终可用）；否则当输入为空或仅含空白字符时强制为 `disabled`，其余情况使用 `messageStatus` 的值。`fetching` 时按 Enter **不会**触发发送（避免请求中与 Loading 占位阶段重复提交）。
+
+### onSendMessage 第三参数 options（UserQuestion 上下文）
+
+`ChatInput` 自身调用 `onSendMessage` 时只传前两个参数。当组件被 [ChatContainer](/components/setup/chat-container) 包裹且存在待回答 `UserQuestion` 中断时，容器会在用户点击发送时注入第三个参数：
+
+| 字段        | 类型               | 说明                                                                 |
+| ----------- | ------------------ | -------------------------------------------------------------------- |
+| `interrupt` | `Interrupt`        | 当前激活的 `UserQuestionInterrupt`                                   |
+| `payload`   | `InterruptResume`  | skip resume（`status: 'cancelled'`，`payload.answers` 为空数组）     |
+
+此场景下容器**不会**自动清空 `modelValue`，业务侧需在 `onSendMessage` 内自行处理消息发送与 `resumeAgent` 的先后顺序。结构化作答仍通过 `UserQuestionCard` → `onInterruptResume` 完成。
+
+```typescript
+const handleSendMessage = async (
+  content: UserMessage['content'],
+  docSchema: TagSchema,
+  options?: { interrupt?: Interrupt; payload?: InterruptResume },
+) => {
+  if (options?.interrupt && options?.payload) {
+    await resumeAgent({ interruptId: options.interrupt.id, resume: options.payload });
+    return;
+  }
+  await sendMessage(content, docSchema);
+};
+```
+
+### sendDisabledTip（业务阻塞发送）
+
+当业务侧需要临时阻止发送但仍允许用户输入时，可传入 `sendDisabledTip`。组件会置灰发送按钮，按钮 tooltip 展示该文案，并拦截点击发送、按 Enter 发送和 `triggerSendMessage()`：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    message-status="complete"
+    :send-disabled-tip="interruptTip"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  >
+    <template #interrupt>
+      <div class="input-alert">{{ interruptTip }}</div>
+    </template>
+  </ChatInput>
+</template>
+```
+
+**渲染效果**
+
+### Complete（可发送）
+
+### Streaming（流式输出中，显示停止按钮）
+
+### Disabled（禁用）
+
+## 引用消息（v-model:cite）
+
+通过 `v-model:cite` 绑定引用内容，引用区域显示在编辑器上方，用户可点击关闭按钮取消引用。发送时通过 `onSendMessage` 的第一个参数获取输入内容，引用内容需自行通过 `cite` 变量读取：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    v-model:cite="citeContent"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type TagSchema } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const citeContent = ref('被引用的消息内容...');
+  const messageStatus = ref(MessageStatus.Complete);
+
+  const handleSendMessage = async (content: string, docSchema: TagSchema) => {
+    console.log('输入内容:', content);
+    console.log('引用内容:', citeContent.value); // 自行读取引用内容
+    citeContent.value = ''; // 发送后清空引用
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+**渲染效果**（顶部引用区，点击右侧 × 关闭引用）
+
+## Prompt 模板（`/` 触发）
+
+通过 `prompts` 传入字符串数组，用户在编辑器中输入 `/` 唤出 Prompt 菜单，支持模糊搜索，选择后自动填入编辑器：
+
+```vue
+<script setup lang="ts">
+  const prompts = [
+    '帮我写一篇关于 {topic} 的文章',
+    '解释一下这段代码的作用',
+    '请用简洁的语言总结以下内容',
+    '将以下内容翻译成英文',
+    '帮我优化这段代码',
+  ];
+</script>
+```
+
+## 资源 `@` 引用（`@` 触发）
+
+通过 `resources` 传入资源列表，用户输入 `@` 唤出资源选择菜单。资源按 `type` 分组展示，选中后以 Tag 标签形式嵌入编辑器。已选中的资源不会再出现在下拉菜单中（自动去重）。
+
+通过监听 `@update:model-value` 事件的第二个参数 `selectedResourceList` 可以获取当前编辑器中已选中的资源列表：
+
+```vue
+<template>
+  <ChatInput
+    :model-value="inputValue"
+    :message-status="messageStatus"
+    :prompts="prompts"
+    :resources="resources"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    @update:model-value="handleModelValueUpdate"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type TagSchema, type IAiSlashMenuItem } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+
+  const resources: IAiSlashMenuItem[] = [
+    { id: 'tool1', name: '天气查询', type: 'tool', icon: 'icon-tool' },
+    { id: 'tool2', name: '代码执行', type: 'tool', icon: 'icon-tool' },
+    { id: 'mcp1', name: 'db-server', type: 'mcp', icon: 'icon-mcp' },
+    { id: 'doc1', name: 'API 文档', type: 'doc', icon: 'icon-doc' },
+    { id: 'sc1', name: '翻译助手', type: 'shortcut', icon: 'icon-shortcut' },
+  ];
+
+  const handleModelValueUpdate = (value: string | TagSchema, selectedResourceList: IAiSlashMenuItem[]) => {
+    inputValue.value = value;
+    // selectedResourceList 为当前编辑器中已选中的 @ 资源列表
+    console.log('已选资源:', selectedResourceList);
+  };
+
+  const handleSendMessage = async (content: string, docSchema: TagSchema) => {
+    console.log('发送内容（含 @ 引用）:', docSchema);
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+> 基础用法 demo 已集成 Prompt 和资源功能，可在上方输入框中体验 `/` 和 `@` 操作。
+>
+> **注意**：`v-model` 仍可使用（Vue 自动取第一个参数绑定），但如需获取 `selectedResourceList`，应使用 `@update:model-value` 显式监听。
+
+## 快捷指令
+
+通过 `shortcuts` 传入快捷指令列表，底部工具栏展示快捷指令按钮；通过 `shortcutId` + `shortcuts` 配合控制选中状态：
+
+- `shortcutId` 为空 → 显示所有快捷指令按钮列表
+- `shortcutId` 匹配某个 `shortcut.id` → 隐藏列表，显示已选指令 + 关闭图标
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :message-status="messageStatus"
+    :shortcuts="shortcuts"
+    :shortcut-id="selectedShortcutId"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    @select-shortcut="selectedShortcutId = $event.id"
+    @delete-shortcut="selectedShortcutId = ''"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type TagSchema, type Shortcut } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+  const selectedShortcutId = ref('');
+
+  const shortcuts: Shortcut[] = [
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释代码' },
+    { id: 'summarize', name: '总结' },
+  ];
+
+  const handleSendMessage = async (content: string, docSchema: TagSchema) => {
+    console.log('发送内容:', content, '当前快捷指令:', selectedShortcutId.value);
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+**渲染效果**（底部显示快捷指令按钮，点击选中后按钮变为已选状态）
+
+## 文件上传 {#file-upload}
+
+`supportUpload` 默认为 `true`，底部工具栏自动显示文件上传按钮。传入 `onUpload` 回调后即可处理文件上传：
+
+- 底部工具栏出现文件上传按钮（在快捷指令左侧）
+- 支持**点击选择**、**拖拽上传**、**粘贴上传**（Ctrl+V）
+- `onUpload` 每次传入**单个** `File`，返回 `{ download_url?: string }`
+- 文件自动去重（基于 `name + size + lastModified` 复合键），不会重复上传
+- 发送成功后，`uploadFiles` 自动清空
+
+**个数与大小校验（与 `FileUploadBtn` 分工）**：
+
+- 列表最多保留 **`MAX_UPLOAD_FILES`（3）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
+- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）**、或与已有文件重复的项会被跳过；若本轮有任意文件因此未加入列表，会在处理结束后弹出**同一条文案风格**的错误提示，汇总未成功添加的数量。
+- `FileUploadBtn` 仅在按钮层过滤**空文件与单文件超大**，把合法文件以数组形式 `upload` 上来；**个数上限与重复校验**在 `ChatInput` 的 `handleUpload` 中统一处理，避免与按钮层各弹一条提示。
+
+**发送内容格式**（有文件时）：
+
+```typescript
+// onSendMessage 的 content 参数变为数组：
+[
+  { type: 'binary', url: '...', mimeType: 'image/png', filename: 'a.png' },
+  { type: 'binary', url: '...', mimeType: 'application/pdf', filename: 'b.pdf' },
+  // 若输入框也有文字，则最后追加：
+  { type: 'text', text: '请帮我分析这两个文件' },
+];
+```
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    :on-upload="handleUpload"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type UserMessage, type TagSchema } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+
+  const handleSendMessage = async (content: UserMessage['content'], docSchema: TagSchema) => {
+    if (Array.isArray(content)) {
+      // 有文件时 content 为数组
+      content.forEach(item => {
+        if (item.type === 'binary') console.log('文件:', item.filename, item.url);
+        if (item.type === 'text') console.log('文字:', item.text);
+      });
+    } else {
+      // 无文件时 content 为纯字符串
+      console.log('文字:', content);
+    }
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+
+  // 每次传入单个 File，需返回 { download_url: string }
+  const handleUpload = async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/upload', { method: 'POST', body: formData });
+    return res.json(); // { download_url: '...' }
+  };
+</script>
+```
+
+**渲染效果**（底部出现文件上传按钮，支持点击、拖拽、粘贴上传）
+
+## 预设上传文件（defaultUploadFiles）
+
+通过 `defaultUploadFiles` 设置初始已上传的文件列表，文件出现在文件预览区，随下次发送一起携带：
+
+```vue
+<script setup lang="ts">
+  import { type UploadFile, UploadStatus } from '@blueking/chat-x';
+
+  const defaultFiles: UploadFile[] = [
+    {
+      type: 'binary',
+      url: 'https://example.com/report.pdf',
+      filename: 'report.pdf',
+      mimeType: 'application/pdf',
+      status: UploadStatus.Success,
+    },
+  ];
+</script>
+```
+
+## 自定义占位符
+
+通过 `placeholder` 自定义占位符文案，支持多行（换行用 `\n`）：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :message-status="messageStatus"
+    :placeholder="placeholder"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  />
+</template>
+
+<script setup lang="ts">
+  // 多行占位符
+  const placeholder = `你好，我是 AI 小鲸！
+输入 "/" 唤出 Prompt
+输入 "@" 唤出工具
+按 Shift + Enter 换行`;
+</script>
+```
+
+**渲染效果**
+
+## 自定义插槽
+
+组件提供 6 个插槽用于自定义各区域内容：
+
+| 插槽名         | 位置                                       | 默认行为                                   |
+| -------------- | ------------------------------------------ | ------------------------------------------ |
+| `top`          | 框体外部顶部（`.chat-input` 上方）         | 无                                         |
+| `interrupt`    | 框体外部顶部，位于 `top` 之后              | 无，通常用于展示审批/中断提示              |
+| `input-header` | 框体内部顶部（编辑器上方）                 | `cite` 不为空时渲染引用区（`CiteContent`） |
+| `files`        | 文件预览区                                 | 有上传文件时渲染 `FileContent`             |
+| `attachment`   | 底部工具栏快捷指令区（FileUploadBtn 右侧） | 快捷指令按钮列表 / 已选快捷指令            |
+| `send-icon`    | 发送按钮内的图标                           | 发送图标 / 停止图标（按钮容器由组件控制）  |
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :message-status="messageStatus"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+  >
+    <!-- 框体外顶部，适合展示模型信息、Token 消耗等 -->
+    <template #top>
+      <div class="input-tips">当前模型: GPT-4 · 剩余 Token: 12,800</div>
+    </template>
+
+    <!-- 框体外顶部，适合展示中断、审批等业务提示 -->
+    <template #interrupt>
+      <div class="input-alert">当前会话有待审批单，暂时不能继续发送</div>
+    </template>
+
+    <!-- 替换引用区，可自定义引用样式 -->
+    <template #input-header>
+      <div class="custom-header">自定义头部内容</div>
+    </template>
+
+    <!-- 替换文件预览区，接收 files 参数 -->
+    <template #files="{ files }">
+      <div class="custom-files">
+        <span
+          v-for="file in files"
+          :key="file.filename"
+          >{{ file.filename }}</span
+        >
+      </div>
+    </template>
+
+    <!-- 替换快捷指令区（FileUploadBtn 仍在左侧） -->
+    <template #attachment>
+      <button @click="handleCustomAction">🎯 自定义操作</button>
+    </template>
+
+    <!-- 替换发送按钮图标（点击逻辑不变） -->
+    <template #send-icon>
+      <span>🚀</span>
+    </template>
+  </ChatInput>
+</template>
+```
+
+**渲染效果**（顶部自定义模型信息与中断提示）
+
+## Expose（模板引用）
+
+通过 `ref` 获取组件实例后可调用以下方法：
+
+```vue
+<template>
+  <ChatInput
+    ref="chatInputRef"
+    v-model="inputValue"
+    :on-send-message="handleSendMessage"
+  />
+  <button @click="chatInputRef?.focus()">聚焦输入框</button>
+  <button @click="chatInputRef?.triggerSendMessage()">手动发送</button>
+</template>
+
+<script setup lang="ts">
+  import { useTemplateRef } from 'vue';
+  import { ChatInput } from '@blueking/chat-x';
+
+  const chatInputRef = useTemplateRef<InstanceType<typeof ChatInput>>('chatInputRef');
+  const inputValue = ref('');
+  const handleSendMessage = async (content: string) => {
+    /* ... */
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名             | 类型                                                                       | 默认值   | 必填 | 说明                                                    |
+| ------------------ | -------------------------------------------------------------------------- | -------- | ---- | ------------------------------------------------------- |
+| modelValue         | `string \| TagSchema`                                                      | -        | ✅   | 编辑器的值，支持 `v-model`                              |
+| messageStatus      | `MessageStatus`                                                            | -        | -    | 消息状态，控制按钮；输入为空时内部强制 `disabled`       |
+| cite               | `string`                                                                   | `''`     | -    | 引用内容，支持 `v-model:cite`，不为空时显示引用区       |
+| prompts            | `string[]`                                                                 | `[]`     | -    | Prompt 模板列表，输入 `/` 触发                          |
+| resources          | `IAiSlashMenuItem[]`                                                       | `[]`     | -    | 资源列表，输入 `@` 触发，按 `type` 分组展示             |
+| shortcuts          | `Shortcut[]`                                                               | -        | -    | 快捷指令列表，显示在底部工具栏                          |
+| shortcutId         | `string`                                                                   | -        | -    | 当前选中的快捷指令 ID，匹配时列表收起为已选样式         |
+| placeholder        | `string`                                                                   | 见默认值 | -    | 编辑器占位符，支持多行                                  |
+| inputMaxHeight     | `number`                                                                   | `200`    | -    | 框体最大高度（px），有文件时自动加上文件预览区高度      |
+| defaultUploadFiles | `UploadFile[]`                                                             | -        | -    | 预设已上传的文件列表                                    |
+| sendDisabledTip    | `string`                                                                   | -        | -    | 业务阻塞发送时的 tooltip 提示；传入后发送按钮置灰，点击、Enter 与 `triggerSendMessage()` 均不会发送 |
+| supportUpload      | `boolean`                                                                  | `true`   | -    | 是否显示文件上传按钮                                    |
+| tippyOptions       | `AITippyProps`                                                             | —        | -    | 透传给 FileUploadBtn 和 InputAttachment 的 tooltip 配置 |
+| onSendMessage      | `(content: UserMessage['content'], docSchema: TagSchema, options?: { interrupt?: Interrupt; payload?: InterruptResume }) => Promise<void>` | -        | -    | 发送消息回调，无文件时 content 为字符串，有文件时为数组；经 [ChatContainer](/components/setup/chat-container) 使用时，存在待回答 UserQuestion 会传入第三参数 `options` |
+| onStopSending      | `() => Promise<void>`                                                      | -        | -    | 停止发送回调，点击停止按钮时触发                        |
+| onUpload           | `(file: File) => Promise<{ download_url?: string }>`                       | -        | -    | 文件上传回调（每次单文件）                              |
+
+### 默认占位符
+
+```
+输入 "/"唤出 Prompt
+输入"@"唤出工具
+通过 Shift + Enter 进行换行输入
+```
+
+### Events
+
+| 事件名            | 参数                                                                     | 触发时机                                                  |
+| ----------------- | ------------------------------------------------------------------------ | --------------------------------------------------------- |
+| update:modelValue | `(value: string \| TagSchema, selectedResourceList: IAiSlashMenuItem[])` | 编辑器值变化时触发；第二个参数为当前已选中的 `@` 资源列表 |
+| selectShortcut    | `(shortcut: Shortcut)`                                                   | 点击底部快捷指令按钮                                      |
+| deleteShortcut    | -                                                                        | 点击已选快捷指令旁的关闭按钮                              |
+
+### Slots
+
+| 插槽名       | 参数                               | 说明                                                       |
+| ------------ | ---------------------------------- | ---------------------------------------------------------- |
+| top          | -                                  | 框体（`.chat-input`）外部顶部，适合展示模型/Token 信息     |
+| interrupt    | -                                  | 框体外部顶部，位于 `top` 后，适合展示审批/中断提示         |
+| input-header | -                                  | 框体内顶部，替换引用区（`CiteContent`）                    |
+| files        | `{ files: Partial<UploadFile>[] }` | 文件预览区                                                 |
+| attachment   | -                                  | 底部快捷指令区，`FileUploadBtn` 在其左侧，不受此 slot 影响 |
+| send-icon    | -                                  | 发送按钮内图标，按钮的点击逻辑和样式仍由组件控制           |
+
+### Expose
+
+| 方法名             | 类型         | 说明             |
+| ------------------ | ------------ | ---------------- |
+| focus              | `() => void` | 聚焦编辑器       |
+| triggerSendMessage | `() => void` | 手动触发发送逻辑 |
+
+## 键盘快捷键
+
+| 快捷键          | 说明                                     |
+| --------------- | ---------------------------------------- |
+| `Enter`         | 发送消息（输入为空或仅空白字符时不触发） |
+| `Shift + Enter` | 换行                                     |
+| `/`             | 唤出 Prompt 列表                         |
+| `@`             | 唤出资源列表                             |
+| `↑` / `↓`       | 在 Prompt / 资源菜单中导航               |
+| `Esc`           | 关闭 Prompt / 资源菜单                   |
+
+## 类型定义
+
+```typescript
+import type { UserMessage } from '@blueking/chat-x';
+
+// 消息状态
+enum MessageStatus {
+  Pending = 'pending', // 等待中（显示停止按钮）
+  Streaming = 'streaming', // 流式输出中（显示停止按钮）
+  Complete = 'complete', // 完成（显示发送按钮）
+  Error = 'error', // 错误（显示发送按钮）
+  Stop = 'stop', // 已停止（显示发送按钮）
+  Disabled = 'disabled', // 禁用（发送按钮置灰）
+}
+
+// 上传状态
+enum UploadStatus {
+  Pending = 'pending', // 上传中
+  Success = 'success', // 上传成功
+  Error = 'error', // 上传失败
+}
+
+// 上传文件
+type UploadFile = {
+  type: 'binary';
+  url?: string; // 上传成功后的下载地址
+  filename?: string; // 文件名
+  mimeType?: string; // MIME 类型
+  file?: File; // 原始 File 对象
+  status?: UploadStatus; // 上传状态
+};
+
+// 资源菜单项（@ 触发）
+interface IAiSlashMenuItem {
+  id: string;
+  name: string;
+  icon: string;
+  type: 'tool' | 'mcp' | 'doc' | 'shortcut'; // 分组类型
+}
+
+// onSendMessage 的 content 参数
+type SendContent =
+  | string // 无文件时：纯文本
+  | Array<
+      // 有文件时：数组
+      { type: 'binary'; url?: string; mimeType: string; filename: string } | { type: 'text'; text: string }
+    >;
+
+// onSendMessage 完整签名（第三参数由 ChatContainer 在 UserQuestion 场景注入）
+type OnSendMessage = (
+  content: SendContent,
+  docSchema: TagSchema,
+  options?: { interrupt?: Interrupt; payload?: InterruptResume },
+) => Promise<void>;
+```
+
+## 完整集成示例
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    v-model:cite="citeContent"
+    :message-status="messageStatus"
+    :prompts="prompts"
+    :resources="resources"
+    :shortcuts="shortcuts"
+    :shortcut-id="shortcutId"
+    :on-send-message="handleSendMessage"
+    :on-stop-sending="handleStopSending"
+    :on-upload="handleUpload"
+    @select-shortcut="shortcutId = $event.id"
+    @delete-shortcut="shortcutId = ''"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageStatus, type TagSchema, type Shortcut } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const citeContent = ref('');
+  const messageStatus = ref(MessageStatus.Complete);
+  const shortcutId = ref('');
+
+  const prompts = ['帮我写一篇关于 {topic} 的文章', '解释一下这段代码'];
+  const resources = [{ id: 'tool1', name: '天气查询', type: 'tool', icon: '' }];
+  const shortcuts: Shortcut[] = [
+    { id: 'translate', name: '翻译' },
+    { id: 'explain', name: '解释' },
+  ];
+
+  const handleSendMessage = async (content, docSchema: TagSchema) => {
+    messageStatus.value = MessageStatus.Streaming;
+    try {
+      await callAI(content, { cite: citeContent.value, shortcut: shortcutId.value });
+    } finally {
+      messageStatus.value = MessageStatus.Complete;
+      citeContent.value = '';
+    }
+  };
+
+  const handleStopSending = async () => {
+    messageStatus.value = MessageStatus.Stop;
+    abortAICall();
+  };
+
+  const handleUpload = async (file: File) => {
+    const formData = new FormData();
+    formData.append('file', file);
+    const res = await fetch('/api/upload', { method: 'POST', body: formData });
+    return res.json(); // { download_url: '...' }
+  };
+</script>
+```
+
+## 关联组件
+
+- [ShortcutBtns](/components/input/shortcut-btns) — 底部附件区默认快捷指令列表
+- [ShortcutBtn](/components/input/shortcut-btn) — 已选快捷指令单按钮展示
+- [ShortcutRender](/components/input/shortcut-render) — 含表单的快捷指令表单渲染
+- [ChatContainer](/components/setup/chat-container) — 顶层布局中包裹输入区
+- [CiteContent](/components/rendering/cite-content) — 消息引用区内容展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/cite-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/cite-content.md
@@ -1,0 +1,142 @@
+# CiteContent 引用内容
+
+> 能力域：内容渲染 ｜ 导入：`import { CiteContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染输入或消息中的引用片段。 源码位置：src/components/chat-content/cite-content/cite-content.vue。
+
+**关联**：chat-input（输入区展示待发送引用内容）
+
+---
+
+# CiteContent 引用内容
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/cite-content/cite-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：渲染输入或消息中的引用片段。
+
+> **能力域**：内容渲染
+
+展示被引用文本片段的紧凑条带组件。固定高度 28px，左侧引用图标 + 单行截断文本 + 可选关闭图标，背景灰色（`#f5f7fa`）。
+
+常见于两处：
+
+- **`UserMessage`**：`property.extra.cite` 为字符串时，渲染在消息气泡上方
+- **`ChatInput`**：通过 `v-model:cite` 绑定，渲染在输入框顶部，关闭后清空引用
+
+## 组件结构
+
+```
+.ai-cite-content（flex，height: 28px，padding: 0 8px，gap: 4px，bg: #f5f7fa，border-radius: 4px，margin-bottom: 4px）
+├── CiteIcon（14×14px，color: #979ba5，始终显示）
+├── .ai-cite-content-text（flex: 1，单行截断，color: #979ba5，overflow: hidden，text-overflow: ellipsis）
+│     {{ content }}（Vue 文本插值，XSS 安全）
+└── CloseIcon（14×14px，color: #979ba5，v-if="onClose"，hover: #4d4f56）
+      @click → onClose(content)
+```
+
+## 基础用法
+
+```vue
+<template>
+  <CiteContent content="这是一段被引用的文本" />
+</template>
+
+<script setup lang="ts">
+  import { CiteContent } from '@blueking/chat-x';
+</script>
+```
+
+## 可关闭引用
+
+传入 `onClose` 函数后，右侧显示关闭图标；点击时将当前 `content` 作为参数回传给 `onClose`：
+
+```vue
+<template>
+  <CiteContent
+    v-if="showCite"
+    content="这是一段可关闭的引用文本"
+    :on-close="handleClose"
+  />
+</template>
+
+<script setup lang="ts">
+  import { CiteContent } from '@blueking/chat-x';
+
+  const handleClose = (content: string) => {
+    // content 即当前引用文本，可用于日志或状态清除
+    console.log('关闭引用:', content);
+  };
+</script>
+```
+
+## 长文本截断
+
+文本超出容器宽度时自动单行截断（`text-overflow: ellipsis`），始终保持 28px 高度不变形：
+
+## 与 ChatInput 配合
+
+`ChatInput` 通过 `v-model:cite` 内置了 `CiteContent`，当 `cite` 有值时自动渲染在输入框顶部（`input-header` slot 位置）；用户点击关闭时，内部调用 `citeModel.value = ''` 清空引用：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    v-model:cite="citeText"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput } from '@blueking/chat-x';
+
+  const inputValue = ref('');
+  const citeText = ref('');
+
+  // 用户通过 AiSelection 划词后，将选中文本赋值给 citeText
+  // ChatInput 会自动在顶部显示 CiteContent，用户点击关闭时 citeText 自动清空
+  function onUserSelectText(selectedText: string) {
+    citeText.value = selectedText;
+  }
+</script>
+```
+
+## 与 UserMessage 配合
+
+`UserMessage` 在 `property.extra.cite` 为字符串时，自动在气泡上方渲染 `CiteContent`（不带关闭按钮）：
+
+```typescript
+const message = {
+  role: 'user',
+  content: '这段代码有什么性能问题？',
+  property: {
+    extra: {
+      // 字符串类型 → 渲染 CiteContent（气泡外上方）
+      cite: 'for (let i = 0; i < arr.length; i++) {\n  fetch(`/api/${arr[i]}`)\n}',
+    },
+  },
+};
+```
+
+## API
+
+### Props
+
+| 属性名  | 类型                        | 必填 | 说明                                                      |
+| ------- | --------------------------- | ---- | --------------------------------------------------------- |
+| content | `string`                    | ✓    | 引用的文本内容；使用 Vue 文本插值渲染，XSS 安全           |
+| onClose | `(content: string) => void` | —    | 关闭回调；传入后右侧显示关闭图标，点击时将 `content` 回传 |
+
+> **XSS 安全**：`content` 通过 `{{ content }}` 文本插值渲染，不会执行 HTML 标签或脚本。
+
+## 样式说明
+
+| 元素                     | 关键样式                                                                                            |
+| ------------------------ | --------------------------------------------------------------------------------------------------- |
+| `.ai-cite-content`       | `height: 28px`，`padding: 0 8px`，`background: #f5f7fa`，`margin-bottom: 4px`（为下方内容留出间距） |
+| `.ai-cite-content-text`  | `flex: 1`，`white-space: nowrap`，`overflow: hidden`，`text-overflow: ellipsis`，`color: #979ba5`   |
+| `CiteIcon` / `CloseIcon` | `14×14px`，`color: #979ba5`；CloseIcon hover 变为 `#4d4f56`                                         |
+
+## 关联组件
+
+- [ChatInput](/components/input/chat-input) — 引用区常见挂载位置

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/code-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/code-content.md
@@ -1,0 +1,211 @@
+# CodeContent 代码块
+
+> 能力域：内容渲染 ｜ 导入：`import { CodeContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 Markdown 代码块，支持高亮、复制和 header 插槽。 源码位置：src/components/markdown-token/code-content/code-content.vue。
+
+**关联**：markdown-content（解析 Markdown 后生成 fence token 并渲染本组件）
+
+---
+
+# CodeContent 代码块渲染
+## 源码事实
+
+- **源码位置**：`src/components/markdown-token/code-content/code-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：渲染 Markdown 代码块，支持高亮、复制和 header 插槽。
+
+> **能力域**：内容渲染
+
+代码块渲染基础组件，专为 **Markdown 流式输出**设计。接收 `markdown-it` token 数组，基于 `highlight.js`（github-dark 主题）实现逐行语法高亮，顶部固定深色头部展示语言名和复制按钮。
+
+## 组件结构
+
+根类名为 **`.code-content-wrapper`**：外层宽度、下边距以及 **`.code-content-header`**（深色顶栏）在任意父级下均生效。**代码区** `.hljs-pre`、行内高亮等样式选择器为 **`.ai-message-container .code-content-wrapper`**，仅在消息列表（`MessageContainer` 根上的 `ai-message-container`）内与对话区一致。Wiki 与业务中若要完整还原代码区外观，请将 `CodeContent` 包在带 `ai-message-container` 类名的父节点内。
+
+```
+.code-content-wrapper
+├── .code-content-header（深色顶栏；不依赖 .ai-message-container）
+│     ├── .code-header-language（token.info）
+│     ├── slot#header（{ language, token }）
+│     └── ToolBtn id="copy"
+│
+└── .hljs-pre（完整 padding / 背景 / code 字体：需父级为 .ai-message-container .code-content-wrapper）
+      └── <code class="hljs language-{raw-info}">
+            ├── v-for completedLines → <span class="code-line" />
+            └── v-if currentLineText → <span class="code-line current-line" />
+```
+
+## 基础用法
+
+`token` 接收 `markdown-it` 解析生成的 token 数组，组件从中提取第一个 `fence` 或 `code_block` token 渲染：
+
+```vue
+<template>
+  <!-- 代码区 .hljs-pre 的完整样式依赖父级 .ai-message-container（与对话消息区一致）；顶栏单独也可用 -->
+  <div class="ai-message-container">
+    <CodeContent
+      :token="codeTokens"
+      @mounted="handleMounted"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { CodeContent } from '@blueking/chat-x';
+  import type { Token } from 'markdown-it';
+
+  const codeTokens: Token[] = [
+    {
+      type: 'fence',
+      tag: 'code',
+      info: 'typescript',
+      content: 'const greeting = "Hello, World!";\nconsole.log(greeting);',
+    },
+  ];
+
+  const handleMounted = ({ el }: { el: HTMLElement | null }) => {
+    // el 是 <code> 元素的 DOM 引用（通过懒加载 getter 访问）
+    console.log('代码块已渲染:', el);
+  };
+</script>
+```
+
+**TypeScript**
+
+**Python**
+
+**SQL**
+
+## 流式渲染
+
+组件的核心设计场景。流式输入时，每次 `token[].content` 追加新内容，只更新最后一行，已完成的行通过**内容比较复用缓存**，无需重新高亮：
+
+```
+content 变化 → watch(immediate: true, deep: true) → processContent()
+  → split('\n')
+  → 除最后一行：与 completedLines 对比，内容未变则复用，否则重新 highlightLine
+  → 最后一行：highlightLine 并赋值给 currentLineHtml（v-html 渲染）
+```
+
+**注意**：当 content 以 `\n` 结尾时，`split('\n')` 末尾为 `''`，`currentLineText = ''`，`.current-line` 元素不渲染（`v-if="currentLineText"`）。
+
+```vue
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { CodeContent } from '@blueking/chat-x';
+
+  const streamingTokens = ref([{ type: 'fence', tag: 'code', info: 'typescript', content: '' }]);
+
+  async function simulateStream() {
+    let content = '';
+    for (const char of fullCode) {
+      await new Promise(r => setTimeout(r, 20));
+      content += char;
+      // 每次只更新 content，token 数组引用可保持同一个对象（deep watch）
+      streamingTokens.value = [{ type: 'fence', tag: 'code', info: 'typescript', content }];
+    }
+  }
+</script>
+```
+
+## 语言识别
+
+### 内置别名映射
+
+组件在 `MarkdownLanguageMap` 中维护了 3 个常用别名，`info` 字段使用别名时自动映射：
+
+| `info` 值 | 映射后       | 说明 |
+| --------- | ------------ | ---- |
+| `js`      | `javascript` | —    |
+| `ts`      | `typescript` | —    |
+| `py`      | `python`     | —    |
+
+### 解析优先级
+
+```
+1. MarkdownLanguageMap[info] → 尝试别名映射
+2. hljs.getLanguage(mappedLang) → 检查 hljs 是否支持
+3. 提取文件扩展名（如 "index.ts" → "ts"）→ 再次查询 hljs
+4. 均不匹配 → resolveLanguage 返回 null → 对内容进行 HTML 转义（非高亮）
+```
+
+> **注意**：`code` 元素的 class 使用原始 `token.info`（`language-{info}`），不是解析后的语言名。即 `info: 'js'` → `class="language-js"`，但高亮时用 `javascript`。
+
+### 未知语言（HTML 转义）
+
+当语言无法识别时，内容经过 HTML 转义（`&lt;` `&gt;` `&amp;` `&quot;`）后直接渲染，不进行语法高亮：
+
+### 无语言标识
+
+`info` 为空字符串时，语言区域留空，内容同样走 HTML 转义路径：
+
+## 高亮缓存
+
+每行代码的高亮结果缓存在组件实例内部的 `Map<string, string>` 中（key 为 `"${lang}:${lineContent}"`），最大容量 500 条；超限后清除前 250 条（LRU 近似）：
+
+```typescript
+const lineHighlightCache = new Map<string, string>();
+const MAX_CACHE_SIZE = 500;
+
+// 超限时清理前半部分
+if (lineHighlightCache.size > MAX_CACHE_SIZE) {
+  const keys = Array.from(lineHighlightCache.keys()).slice(0, MAX_CACHE_SIZE / 2);
+  keys.forEach(k => lineHighlightCache.delete(k));
+}
+```
+
+## API
+
+### Props
+
+| 属性名 | 类型      | 必填 | 说明                                                                     |
+| ------ | --------- | ---- | ------------------------------------------------------------------------ |
+| token  | `Token[]` | ✓    | markdown-it token 数组；组件提取其中第一个 `fence` 或 `code_block` token |
+
+### Events
+
+| 事件名  | 参数类型                      | 触发时机                                                                          |
+| ------- | ----------------------------- | --------------------------------------------------------------------------------- |
+| mounted | `{ el: HTMLElement \| null }` | 每次 `token` 变化后 `nextTick` 完成时；`el` 为 `<code>` 元素引用（懒加载 getter） |
+
+### Slots
+
+| 插槽名 | 参数                                   | 说明                                                                                       |
+| ------ | -------------------------------------- | ------------------------------------------------------------------------------------------ |
+| header | `{ language: string; token: Token[] }` | 代码块头部自定义内容区域，渲染在语言标签和复制按钮之间，可用于添加"插入"、"应用"等操作按钮 |
+
+> **`mounted` 频率**：由于 `watch` 设置了 `immediate: true` 和 `deep: true`，每次 `token` 内容变化（包括初始化）都会触发 `mounted` 事件。
+
+## Token 结构
+
+组件从 token 数组中提取第一个匹配的 token：
+
+```typescript
+// 组件接受的 token 格式（只使用这 3 个字段）
+interface CodeToken {
+  type: 'fence' | 'code_block'; // 触发提取的条件
+  info: string; // 语言标识（如 'typescript'），显示在头部
+  content: string; // 代码内容（换行符 '\n' 分隔多行）
+}
+```
+
+完整 Token 类型从 `markdown-it` 包引入：
+
+```typescript
+import type { Token } from 'markdown-it';
+```
+
+## 样式说明
+
+| 区域                    | 关键样式                                                                             |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `.code-content-header`  | `height: 40px`，`background: #2f333d`，`border: 1px solid #1a1a1a`，圆角仅顶部 `6px` |
+| `.code-header-language` | `color: #999`，`font-size: 12px`，`margin-right: auto`（推复制按钮到右侧）           |
+| `.hljs-pre`             | `background: #282c34`，`padding: 8px 16px`，`overflow-x: auto`，圆角仅底部 `6px`     |
+| `code`                  | `color: #abb2bf`，`font-size: 13px`，`line-height: 1.5`，等宽字体栈                  |
+| `.code-line`            | `display: inline`（保持行内流式拼接）                                                |
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — 解析并传入 code fence token

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/common-error-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/common-error-content.md
@@ -1,0 +1,73 @@
+# CommonErrorContent 错误内容
+
+> 能力域：内容渲染 ｜ 导入：`import { CommonErrorContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+展示统一错误提示内容。 源码位置：src/components/chat-content/common-error-content/common-error-content.vue。
+
+**关联**：markdown-content（Markdown 渲染错误态展示）、reasoning-message（推理消息错误态展示）
+
+---
+
+# CommonErrorContent 通用错误内容
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/common-error-content/common-error-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：展示统一错误提示内容。
+
+> **能力域**：内容渲染
+
+错误状态消息渲染基础组件。红色 `ErrorIcon`（14×14px，绝对定位）+ 文本区域，`display: flex` 水平排列。
+
+通常由上层组件在 `status === 'error'` 时自动渲染，无需手动使用。
+
+## 组件结构
+
+```
+.ai-error-content（position: relative，display: flex，align-items: center）
+├── ErrorIcon（position: absolute，top: 2px，left: 0，flex: 0 0 14px，14×14px，color: #ea3636）
+└── .ai-error-content-text（flex: 1，margin-left: 20px，font-size: 12px，line-height: 20px，color: #4d4f56）
+      └── {{ content }}（Vue 文本插值，XSS 安全；content 为 undefined 时渲染空文本）
+```
+
+## 基础用法
+
+```vue
+<template>
+  <CommonErrorContent content="请求失败，请稍后重试" />
+</template>
+
+<script setup lang="ts">
+  import { CommonErrorContent } from '@blueking/chat-x';
+</script>
+```
+
+## 典型错误场景
+
+## 不传 content
+
+`content` 为可选，缺省时只渲染 `ErrorIcon`：
+
+## 使用场景
+
+组件库内部有两处自动使用：
+
+| 使用方             | 触发条件             | 传入内容                                      |
+| ------------------ | -------------------- | --------------------------------------------- |
+| `MarkdownContent`  | `status === 'error'` | `content`（字符串）                           |
+| `ReasoningMessage` | `status === 'error'` | `content?.join('\n') \|\| ''`（数组转字符串） |
+
+即 `AssistantMessage` / `ReasoningMessage` 在错误状态时，内容区域会自动替换为此组件，无需手动引入。
+
+## API
+
+### Props
+
+| 属性名  | 类型     | 必填 | 说明                                                            |
+| ------- | -------- | ---- | --------------------------------------------------------------- |
+| content | `string` | —    | 错误提示文本；使用 Vue 文本插值渲染，XSS 安全；缺省时仅显示图标 |
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — Markdown 错误态
+- [ReasoningMessage](/components/message/reasoning-message) — 推理错误态

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/content-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/content-render.md
@@ -1,0 +1,241 @@
+# ContentRender 内容渲染器
+
+> 能力域：内容渲染 ｜ 导入：`import { ContentRender } from '@blueking/chat-x'` ｜ since 1.0.0
+
+按 MessageContentType 分发 Markdown、文本、引用、键值、图片等内容。 源码位置：src/components/chat-content/content-render/content-render.vue。
+
+**关联**：markdown-content（文本类 Markdown 正文的默认渲染实现）、reference-content（引用文档数组类型的列表渲染）、assistant-message（AI 回复中默认通过本组件渲染正文）
+
+---
+
+# ContentRender 内容渲染器
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/content-render/content-render.vue`
+- **能力域**：内容渲染
+- **能力说明**：按 MessageContentType 分发 Markdown、文本、引用、键值、图片等内容。
+
+> **能力域**：内容渲染
+
+消息内容渲染分发组件，根据 `content` 的 JavaScript 类型自动选择渲染方式：字符串 → `MarkdownContent`（Markdown 渲染），数组 → `ReferenceContent`（引用列表）。
+
+## 渲染管线
+
+```
+ContentRender
+├── typeof content === 'string'  →  MarkdownContent（Markdown 渲染）
+│   └── status === 'error'       →  CommonErrorContent（红色错误图标 + 文本）
+├── Array.isArray(content)       →  ReferenceContent（引用文档列表）
+└── 其他                         →  undefined（不渲染，可通过 slot 自定义）
+```
+
+> **注意**：渲染类型由 `content` 的 JavaScript 类型决定（字符串 vs 数组），`type` prop 仅当传入 `MessageContentType.Text` 时才强制走 `MarkdownContent`，通常不需要显式传递。
+
+## 基础用法（Markdown 文本）
+
+字符串内容自动渲染为 Markdown：
+
+```vue
+<template>
+  <ContentRender
+    :content="content"
+    :status="status"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ContentRender, MessageStatus } from '@blueking/chat-x';
+
+  const content = '这是一段 **Markdown** 内容，支持 `代码`、**加粗**、*斜体* 等语法。';
+  const status = MessageStatus.Complete;
+</script>
+```
+
+**渲染效果**
+
+## Markdown 语法支持
+
+`MarkdownContent` 内置了完整的 Markdown 解析能力，使用 `markdown-it` + 多个插件：
+
+### 常用语法（代码、列表、表格）
+
+### 扩展语法
+
+| 语法                  | 效果           | 插件                      |
+| --------------------- | -------------- | ------------------------- |
+| `++文字++`            | 下划线（新增） | markdown-it-ins           |
+| `==文字==`            | 高亮标注       | markdown-it-mark          |
+| `^上标^`              | 上标           | markdown-it-sup           |
+| `~下标~`              | 下标           | markdown-it-sub           |
+| `[^1]` / `[^1]: 内容` | 脚注           | markdown-it-footnote      |
+| `- [x] 任务`          | 任务列表       | markdown-it-task-checkbox |
+
+### LaTeX 数学公式
+
+行内公式 `$...$` 和块级公式 `$$...$$`，由 `katex` 渲染：
+
+```vue
+<ContentRender content="行内公式：$E = mc^2$" status="complete" />
+```
+
+### Mermaid 图表
+
+代码块语言标识为 `mermaid` 时，由 `MermaidContent` 专门渲染：
+
+## 消息状态
+
+`status` 只传递给 `MarkdownContent`，对 `ReferenceContent` 无效。
+
+| `status`    | 渲染行为                                                          |
+| ----------- | ----------------------------------------------------------------- |
+| `complete`  | 正常渲染完整 Markdown                                             |
+| `streaming` | 自动补全未闭合的 Markdown 语法（代码块、列表等），节流解析（5ms） |
+| `pending`   | 同 `complete`（按当前内容渲染）                                   |
+| `error`     | 渲染为 `CommonErrorContent`（红色错误图标 + `content` 文本）      |
+| `stop`      | 同 `complete`                                                     |
+
+**错误状态示例**
+
+## 引用文档列表
+
+`content` 传入 `ReferenceDocumentContent[]` 数组时，自动渲染为 `ReferenceContent`（引用文档列表）：
+
+```vue
+<template>
+  <ContentRender :content="referenceContent" />
+</template>
+
+<script setup lang="ts">
+  import { ContentRender, type ReferenceDocumentContent } from '@blueking/chat-x';
+
+  const referenceContent: ReferenceDocumentContent[] = [
+    {
+      name: 'Vue 3 官方文档',
+      url: 'https://vuejs.org',
+      originFile: 'vue3-guide.md', // 有 originFile 时显示预览和跳转图标
+    },
+    {
+      name: 'TypeScript 手册',
+      url: 'https://www.typescriptlang.org',
+      originFile: '', // 无 originFile 时不显示操作图标
+    },
+  ];
+</script>
+```
+
+**渲染效果**（悬停条目查看图标，有 `originFile` 的条目显示预览和跳转图标）
+
+### ReferenceContent 图标显示规则
+
+| 条件                           | 显示图标                                     |
+| ------------------------------ | -------------------------------------------- |
+| 始终                           | 文档图标（红色）                             |
+| `url` 和 `originFile` 均不为空 | 预览图标（悬停可见）                         |
+| `url` 和 `originFile` 均不为空 | 跳转图标（悬停可见，打开 `originFile` 链接） |
+
+无 `originFile` 时只显示文档图标（点击文档名跳转 `url`）：
+
+## 自定义渲染（默认插槽）
+
+默认插槽接收 `{ content }` 参数（原始 `content` prop 值），替换整个内容渲染：
+
+```vue
+<template>
+  <ContentRender
+    :content="content"
+    :status="status"
+  >
+    <template #default="{ content }">
+      <div class="custom-content">
+        <h3>自定义渲染</h3>
+        <pre>{{ JSON.stringify(content, null, 2) }}</pre>
+      </div>
+    </template>
+  </ContentRender>
+</template>
+
+<script setup lang="ts">
+  import { ContentRender } from '@blueking/chat-x';
+
+  const content = '自定义内容，由 slot 接管渲染。';
+  const status = 'complete';
+</script>
+```
+
+**渲染效果**
+
+## API
+
+### Props
+
+| 属性名  | 类型                                   | 必填 | 说明                                                                                      |
+| ------- | -------------------------------------- | ---- | ----------------------------------------------------------------------------------------- |
+| content | `string \| ReferenceDocumentContent[]` | ✅   | 内容数据，字符串走 Markdown 渲染，数组走引用文档列表渲染                                  |
+| status  | `MessageStatus`                        | -    | 消息状态，只影响 Markdown 渲染（`error` 时渲染错误样式，`streaming` 时补全语法）          |
+| type    | `ContentType`                          | -    | 内容类型提示，传入 `MessageContentType.Text` 可强制走 MarkdownContent；通常不需要显式传递 |
+
+### Slots
+
+| 插槽名     | 参数                                   | 说明                                                                          |
+| ---------- | -------------------------------------- | ----------------------------------------------------------------------------- |
+| codeHeader | `{ language: string; token: Token[] }` | 代码块头部自定义操作区域，透传给 MarkdownContent → CodeContent 的 header 插槽 |
+| default    | `{ content: ContentMap[T] }`           | 自定义渲染，接收原始 content prop 值，替换全部默认逻辑                        |
+
+## 流式渲染机制
+
+`streaming` 状态下，`MarkdownContent` 有以下优化：
+
+1. **语法自动补全**：`completeMarkdownSyntax` 在解析前补全未闭合的代码块、列表等，避免渲染异常
+2. **节流解析**：`parseMarkdownContent` 节流 5ms（leading + trailing），大幅降低流式输入时的解析开销
+3. **不完整状态保护**：当正在输入 LaTeX 命令（如 `$\fra...`）时保持之前的渲染结果，避免闪烁
+4. **CSS contain 性能隔离**：`.ai-markdown-content` 使用 `contain: layout style`，`.ai-markdown-body` 使用 `contain: content`，减少重排影响范围
+5. **自动滚动**：每个 token 挂载后触发 `toScrollBottom()`（节流 100ms），与 `MessageContainer` 配合实现流式自动滚动
+
+## 类型定义
+
+```typescript
+import { MessageContentType, MessageStatus } from '@blueking/chat-x';
+
+// 引用文档内容
+type ReferenceDocumentContent = {
+  name: string; // 显示名称（为空时该条目被过滤，不渲染）
+  url: string; // 文档访问地址（点击文档名跳转）
+  originFile: string; // 原始文件地址（非空时显示预览和跳转图标）
+};
+
+// 内容类型（ContentType = keyof ContentMap）
+enum MessageContentType {
+  Text = 'text', // 字符串，Markdown 渲染
+  ReferenceDocument = 'reference_document', // ReferenceDocumentContent[]，引用列表
+  Binary = 'binary',
+  Function = 'function',
+  KeyValue = 'key_value',
+  KnowledgeRag = 'knowledge_rag',
+  Other = 'other',
+}
+
+// 消息状态
+enum MessageStatus {
+  Pending = 'pending',
+  Streaming = 'streaming',
+  Complete = 'complete',
+  Error = 'error',
+  Stop = 'stop',
+  Disabled = 'disabled',
+}
+```
+
+## 使用场景
+
+- **AI 文本回复渲染**：`AssistantMessage` 内部用 `ContentRender` 渲染 AI 回复内容，`status` 配合流式响应
+- **知识库引用展示**：`ActivityMessage` 内部用 `ContentRender` 渲染引用文档列表
+- **代码展示**：Markdown 代码块由 `CodeContent` 自动高亮（Atom One Dark 主题，支持 180+ 语言）
+- **数学公式**：行内 `$...$` 和块级 `$$...$$`，由 KaTeX 渲染
+- **流程图**：Mermaid 代码块自动渲染为 SVG 图表
+- **自定义渲染**：通过 slot 接管渲染，实现表格、图表等自定义内容展示
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — 字符串 Markdown 正文
+- [ReferenceContent](/components/rendering/reference-content) — 引用文档数组
+- [AssistantMessage](/components/message/assistant-message) — assistant 消息中默认使用

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/delete-tool.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/delete-tool.md
@@ -1,0 +1,191 @@
+# DeleteTool 删除确认按钮
+
+> 能力域：工具与反馈 ｜ 导入：`import { DeleteTool } from '@blueking/chat-x'` ｜ since 1.0.0
+
+消息删除二次确认工具。 源码位置：src/components/message-tools/delete-tool/delete-tool.vue。
+
+**关联**：tool-btn（删除图标与触发入口）、message-tools（delete 工具 id 时自动采用本组件）
+
+---
+
+# DeleteTool 删除确认按钮
+## 源码事实
+
+- **源码位置**：`src/components/message-tools/delete-tool/delete-tool.vue`
+- **能力域**：工具与反馈
+- **能力说明**：消息删除二次确认工具。
+
+> **能力域**：工具与反馈
+
+删除操作的二次确认组件。点击删除图标后弹出确认弹窗，用户需再次点击"删除"按钮才会触发 `confirm` 事件，防止误删。内部由 `ToolBtn`（触发按钮）+ `Tippy`（确认弹窗）组合实现。
+
+> **提示**：此组件通常**不需要手动使用**，`MessageTools` 在工具列表中检测到 `id === 'delete'` 时会自动使用此组件替换普通 `ToolBtn`。
+
+## 组件结构
+
+```
+Tippy（trigger='click'，interactive，appendTo=body）
+  │
+  ├── ToolBtn（触发按钮，id/name/description/disabled 透传）
+  │
+  └── #content: div.ai-delete-confirm（width: 280px）
+        ├── .ai-delete-confirm__title   "确认删除该回答？"（16px, bold）
+        ├── .ai-delete-confirm__desc    "删除操作无法撤回，请谨慎操作！"
+        └── .ai-delete-confirm__actions（justify-content: flex-end，gap: 8px）
+              ├── Button（theme="danger", size="small"）→ 点击触发 confirm + 关闭弹窗
+              └── Button（size="small"）→ 点击触发 cancel + 关闭弹窗
+
+disabled=true 时：Tippy onShow 返回 false，弹窗不打开
+```
+
+## 基础用法
+
+```vue
+<template>
+  <DeleteTool
+    id="delete"
+    name="删除"
+    description="删除消息"
+    @confirm="handleConfirm"
+    @cancel="handleCancel"
+  />
+</template>
+
+<script setup lang="ts">
+  import { DeleteTool } from '@blueking/chat-x';
+
+  const handleConfirm = () => {
+    console.log('用户确认删除，执行删除操作');
+  };
+
+  const handleCancel = () => {
+    console.log('用户取消删除');
+  };
+</script>
+```
+
+## 禁用状态
+
+`disabled=true` 时，点击按钮不弹出确认弹窗：
+
+```vue
+<template>
+  <DeleteTool
+    id="delete"
+    name="删除"
+    description="删除消息"
+    :disabled="true"
+    @confirm="handleConfirm"
+  />
+</template>
+```
+
+## 在 MessageTools 中的自动使用
+
+`MessageTools` 在渲染工具列表时，若检测到 `tool.id === 'delete'`，会自动使用 `DeleteTool` 替换普通 `ToolBtn`，无需手动配置：
+
+```vue
+<template>
+  <MessageTools
+    :update-tools="updateTools"
+    :on-action="handleAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageTools, type IToolBtn } from '@blueking/chat-x';
+
+  // delete 会自动使用 DeleteTool 渲染，点击弹确认框，确认后 onAction 触发
+  const updateTools: IToolBtn[] = [
+    { id: 'like', name: '点赞', description: '点赞' },
+    { id: 'unlike', name: '不满意', description: '不满意' },
+    { id: 'delete', name: '删除', description: '删除消息' },
+  ];
+
+  const handleAction = async (tool: IToolBtn) => {
+    if (tool.id === 'delete') {
+      // 只有用户在弹窗中点击"删除"确认后，才会走到这里
+      console.log('执行删除:', tool.id);
+    }
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                                                                       | 必填 | 默认值 | 说明                                                                 |
+| ------------ | -------------------------------------------------------------------------- | ---- | ------ | -------------------------------------------------------------------- |
+| id           | `string`                                                                   | 是   | —      | 按钮标识，传 `"delete"` 时显示删除图标                               |
+| name         | `string`                                                                   | 否   | —      | 按钮名称，`id` 无对应图标时作为文本内容渲染                          |
+| description  | `string`                                                                   | 否   | —      | `ToolBtn` 的 tooltip 文本；`disabled=true` 时不显示                  |
+| disabled     | `boolean`                                                                  | 否   | —      | 禁用态；`true` 时点击不弹出确认弹窗，`ToolBtn` 同步禁用              |
+| tippyOptions | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>` | 否   | —      | 覆盖确认弹窗（`Tippy`）的默认配置；可覆盖 `placement`、`appendTo` 等 |
+
+### Events
+
+| 事件名  | 参数 | 触发时机                           |
+| ------- | ---- | ---------------------------------- |
+| confirm | —    | 用户在确认弹窗点击"删除"按钮后触发 |
+| cancel  | —    | 用户在确认弹窗点击"取消"按钮后触发 |
+
+## 类型定义
+
+```typescript
+import type { IToolBtn } from '@blueking/chat-x';
+import type { TippyOptions } from 'vue-tippy';
+
+export type DeleteToolProps = IToolBtn & {
+  disabled?: boolean;
+  tippyOptions?: Partial<Omit<TippyOptions, 'getReferenceClientRect' | 'triggerTarget'>>;
+};
+```
+
+## 样式说明
+
+确认弹窗（`.ai-delete-confirm`）样式：
+
+```scss
+.ai-delete-confirm {
+  width: 280px;
+  padding: 16px;
+  font-size: 12px;
+  color: #4d4f56;
+  background: #fff;
+  border: 1px solid #dcdee5;
+  box-shadow: 0 2px 6px 0 #0000001a;
+
+  &__title {
+    margin-bottom: 6px;
+    font-size: 16px;
+    font-weight: 600;
+    line-height: 22px;
+    color: #313238;
+  }
+
+  &__desc {
+    margin-bottom: 16px;
+    line-height: 20px;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+  }
+}
+```
+
+## 注意事项
+
+1. **确认才触发**：`confirm` 事件只在用户点击弹窗内"删除"按钮后触发；直接点击 `ToolBtn` 触发器不会触发任何业务事件
+2. **`disabled` 双重保障**：`disabled=true` 时，`ToolBtn` 的 JS 层拦截 click，且 `Tippy` 的 `onShow` 返回 `false`，弹窗不会弹出
+3. **弹窗挂载至 body**：默认 `appendTo: () => document.body`，避免被父容器 `overflow: hidden` 裁剪
+4. **组件卸载自动关闭**：`onUnmounted` 时调用 `hide()` 关闭弹窗，防止组件销毁后弹窗残留
+5. **`MessageTools` 自动处理**：通常不需要直接使用此组件，`MessageTools` 会在 `id === 'delete'` 时自动替换
+
+## 关联组件
+
+- [ToolBtn](/components/feedback/tool-btn) — 触发按钮
+- [MessageTools](/components/feedback/message-tools) — 工具栏中 delete 替换入口

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/desc-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/desc-panel.md
@@ -1,0 +1,141 @@
+# DescPanel 描述面板
+
+> 能力域：内容渲染 ｜ 导入：`import { DescPanel } from '@blueking/chat-x'` ｜ since 1.0.0
+
+将文本或 JSON 内容降级为可读描述面板。 源码位置：src/components/tool-call/desc-panel/desc-panel.vue。
+
+**关联**：toolcall-render（工具调用详情中渲染描述与参数）、highlight-keyword（键值与文本匹配关键词高亮）
+
+---
+
+# DescPanel 描述面板
+## 源码事实
+
+- **源码位置**：`src/components/tool-call/desc-panel/desc-panel.vue`
+- **能力域**：内容渲染
+- **能力说明**：将文本或 JSON 内容降级为可读描述面板。
+
+> **能力域**：内容渲染
+
+工具调用（ToolCall）详情面板的描述区域组件，主要用于 `ToolcallRender` 内部的折叠面板中。
+
+将 `desc` 字符串尝试解析为 JSON，解析成功且结果为对象/数组时以键值对列表渲染，否则作为纯文本展示。
+
+## 组件结构
+
+```
+.toolcall-desc（flex column，gap: 4px，padding: 12px，background: #f5f7fa）
+├── .desc-title（font-size: 12px，font-weight: bold，color: #313238，margin-bottom: 6px）
+│     └── {{ title }}
+└── .desc-panel（flex column，gap: 4px）
+      ├── [JSON 对象/数组] v-for 逐项渲染 .desc-panel-item
+      │     ├── .desc-label  → HighlightKeyword(key)
+      │     └── .desc-value → HighlightKeyword(值的文本或 JSON 字符串)，`word-break: break-all`
+      └── [非 JSON / 解析失败] HighlightKeyword(data)，`word-break: break-all`
+```
+
+> **说明**：键值与纯文本均通过 `HighlightKeyword` 展示，长内容依赖换行与面板宽度展示，**不再**使用 `v-overflow-tips` 悬停气泡。
+
+## desc 解析规则
+
+`data` 是一个 computed，逻辑如下：
+
+```typescript
+const data = computed(() => {
+  try {
+    return JSON.parse(props.desc || ''); // desc 为 undefined/''/null 时 parse('') 会抛出
+  } catch {
+    return props.desc; // 解析失败，原样返回字符串
+  }
+});
+```
+
+模板通过 `typeof data === 'object'` 分支渲染：
+
+| desc 值            | JSON.parse 结果 | typeof 结果 | 渲染方式                 |
+| ------------------ | --------------- | ----------- | ------------------------ |
+| `'{"a":1}'`        | `{ a: 1 }`      | `'object'`  | 键值对列表               |
+| `'[1,2,3]'`        | `[1, 2, 3]`     | `'object'`  | 索引键值对（0:、1:、2:） |
+| `'{}'`             | `{}`            | `'object'`  | 键值对列表（0 行）       |
+| `'"hello"'`        | `"hello"`       | `'string'`  | 纯文本                   |
+| `'42'`             | `42`            | `'number'`  | 纯文本                   |
+| `'普通文本'`       | 解析抛出        | —           | 纯文本（原始字符串）     |
+| `''` / `undefined` | 解析抛出        | —           | 纯文本（空白）           |
+
+> **嵌套对象**：值本身是对象时，文本区域通过 `JSON.stringify(value)` 展示完整 JSON（`HighlightKeyword` + `word-break: break-all`），不再使用悬停 tooltip。
+
+## 基础用法：JSON 参数
+
+```vue
+<template>
+  <DescPanel
+    title="工具调用参数"
+    desc='{"query": "天气查询", "city": "北京", "unit": "celsius"}'
+  />
+</template>
+
+<script setup lang="ts">
+  import { DescPanel } from '@blueking/chat-x';
+</script>
+```
+
+## 纯文本描述
+
+`desc` 不是合法 JSON 时作为纯文本渲染：
+
+```vue
+<template>
+  <DescPanel
+    title="执行说明"
+    desc="正在查询北京的实时天气，请稍候..."
+  />
+</template>
+```
+
+## JSON 数组
+
+JSON 数组同样被视为 `object`，以数组索引（`0:`、`1:`…）作为键渲染：
+
+```vue
+<template>
+  <DescPanel
+    title="文件列表"
+    desc='["report.pdf", "data.csv", "readme.md"]'
+  />
+</template>
+```
+
+## 嵌套 JSON
+
+嵌套对象的值在文本区域直接渲染为 `JSON.stringify(value)` 字符串，便于在面板内换行阅读：
+
+```vue
+<template>
+  <DescPanel
+    title="API 配置"
+    desc='{"endpoint": "/api/search", "headers": {"Authorization": "Bearer xxx", "Content-Type": "application/json"}, "timeout": 5000}'
+  />
+</template>
+```
+
+## 无 desc
+
+`desc` 为可选，不传时面板仅显示标题，内容区域为空：
+
+## API
+
+### Props
+
+| 属性名 | 类型     | 必填 | 说明                                                                                |
+| ------ | -------- | ---- | ----------------------------------------------------------------------------------- |
+| title  | `string` | ✓    | 面板标题，始终渲染在顶部                                                            |
+| desc   | `string` | —    | 描述内容；尝试 `JSON.parse`，成功且为 `object` 类型时渲染键值对列表，否则渲染纯文本 |
+
+## 使用场景
+
+`DescPanel` 由 `ToolcallRender` 内部在折叠面板中使用，分别用于渲染工具调用的 **输入参数**（`arguments`）和 **输出结果**（`toolMessage.description`）。通常不需要手动引入，如需独立使用，直接传入 `title` 和 `desc` 即可。
+
+## 关联组件
+
+- [ToolcallRender](/components/agent/toolcall-render) — 主要使用场景
+- [HighlightKeyword](/components/helper/highlight-keyword) — 键值高亮

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/detail-section.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/detail-section.md
@@ -1,0 +1,91 @@
+# DetailSection 详情分段
+
+> 能力域：Agent 能力 ｜ 导入：`import { DetailSection } from '@blueking/chat-x'` ｜ since 1.0.0
+
+FlowAgent 节点详情中的标题/内容分段容器。 源码位置：src/components/chat-content/flow-agent-content/detail-section.vue。
+
+**关联**：flow-agent-node-detail（节点详情中用于承载基础信息、输入参数、输出参数等区块）、simple-table（常作为分段内容展示结构化参数表格）
+
+---
+
+# DetailSection 详情分段
+
+> **能力域**：Agent 能力
+
+`DetailSection` 是 FlowAgent 节点详情页中的轻量分段容器，用于给一组相关信息提供统一标题样式。组件自身只负责渲染标题和默认插槽，不处理数据格式、折叠、空态或表格逻辑。
+
+通常不需要单独接入，主要由 `FlowAgentNodeDetail` 内部组合使用。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/flow-agent-content/detail-section.vue`
+- **能力说明**：FlowAgent 节点详情中的标题/内容分段容器。
+
+## 核心能力
+
+- **统一标题样式**：标题前带蓝色竖条，标题文本使用详情页统一字号与字重
+- **内容完全透传**：通过默认插槽承载任意内容，如基础信息表单、`SimpleTable` 或自定义说明
+- **无内部状态**：不维护折叠、加载、选择等状态，适合作为详情页布局基础块
+
+## 基础用法
+
+```vue
+<template>
+  <DetailSection title="基础信息">
+    <div class="info-row">节点名称：采集主机指标</div>
+  </DetailSection>
+</template>
+
+<script setup lang="ts">
+  import DetailSection from '@blueking/chat-x/src/components/chat-content/flow-agent-content/detail-section.vue';
+</script>
+```
+
+**渲染效果**
+
+## 搭配 SimpleTable
+
+`DetailSection` 最常见的用法是包裹结构化内容，由外层负责分段标题，内部组件负责数据展示。
+
+```vue
+<template>
+  <DetailSection title="输入参数">
+    <SimpleTable
+      :columns="columns"
+      :data="data"
+    />
+  </DetailSection>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名 | 类型     | 必填 | 默认值 | 说明     |
+| ------ | -------- | ---- | ------ | -------- |
+| title  | `string` | 是   | —      | 分段标题 |
+
+### Emits
+
+- 无。
+
+### Slots
+
+| 插槽名  | 说明             |
+| ------- | ---------------- |
+| default | 分段主体展示内容 |
+
+### Expose
+
+- 无。
+
+## 使用建议
+
+- 用于详情页内部的短分段，不建议作为通用卡片或页面 Section 使用。
+- 内容空态应由插槽内组件自行处理，`DetailSection` 不会主动显示空态。
+
+## 关联组件
+
+- [FlowAgentNodeDetail](./flow-agent-node-detail.md) — 节点详情主体。
+- [SimpleTable](./simple-table.md) — 分段内常用的轻量表格。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/execution-summary.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/execution-summary.md
@@ -1,0 +1,128 @@
+# ExecutionSummary 执行摘要
+
+> 能力域：Agent 能力 ｜ 导入：`import { ExecutionSummary } from '@blueking/chat-x'` ｜ since 1.0.0
+
+按消息流提取执行摘要，支持关键词定位和消息渲染。 源码位置：src/components/execution-summary/execution-summary.vue。
+
+**关联**：message-render（摘要列表内渲染消息内容）、highlight-keyword（搜索关键词注入与高亮）、chat-container（常与侧栏「执行情况」Tab 组合）
+
+---
+
+# ExecutionSummary 执行摘要
+## 源码事实
+
+- **源码位置**：`src/components/execution-summary/execution-summary.vue`
+- **能力域**：Agent 能力
+- **能力说明**：按消息流提取执行摘要，支持关键词定位和消息渲染。
+
+> **能力域**：Agent 能力
+
+执行摘要面板组件，以时间线形式展示对话中的工具调用和 FlowAgent 活动记录。支持关键词搜索过滤和点击定位到对话中的消息位置。
+
+通常不需要直接使用，`ChatContainer` 会在侧边栏的「执行情况」Tab 中自动渲染。
+
+## 核心能力
+
+- **时间线布局**：每组消息按时间节点排列，带连接线
+- **关键词搜索**：实时过滤匹配的执行记录
+- **对话定位**：hover 显示「在对话中定位」按钮，点击滚动到对应消息
+- **空状态处理**：无数据或搜索无结果时显示空状态提示
+
+## 基础用法
+
+```vue
+<template>
+  <ExecutionSummary
+    :message-groups="executionGroups"
+    @locate-message-group="handleLocate"
+    @update-keyword="handleUpdateKeyword"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ExecutionSummary, type MessageGroup } from '@blueking/chat-x';
+
+  const handleLocate = (uid: string, group: MessageGroup) => {
+    const dom = document.getElementById(uid);
+    dom?.scrollIntoView({ behavior: 'smooth' });
+  };
+
+  const handleUpdateKeyword = (keyword: string) => {
+    console.log('搜索关键词:', keyword);
+  };
+</script>
+```
+
+**渲染效果**（包含搜索过滤和定位功能，hover 消息组可看到「在对话中定位」按钮）
+
+## 组件结构
+
+```
+execution-summary
+├── execution-summary-header
+│   └── Input（关键词搜索框，clearable）
+└── execution-summary-content
+    ├── 有数据时：
+    │   └── content-item × N（时间线节点）
+    │       ├── timeline-dot（时间节点圆点）
+    │       ├── content-item-time（格式化时间）
+    │       ├── content-item-locate（hover 显示定位按钮）
+    │       ├── content-item-messages（MessageRender × N）
+    │       └── timeline-line（连接线，最后一项不显示）
+    └── 无数据时：
+        └── Exception（空状态）+ 清空搜索按钮
+```
+
+## 空状态
+
+当 `messageGroups` 为空数组时，显示空状态提示：
+
+## 与 ChatContainer 配合
+
+`ChatContainer` 通过 `useMessageGroup` 计算 `executionGroups`（仅包含工具调用和 FlowAgent 消息），并传给 `ExecutionSummary`：
+
+```vue
+<!-- ChatContainer 内部 -->
+<ExecutionSummary
+  :message-groups="executionGroups"
+  @locate-message-group="handleLocateMessageGroup"
+  @update-keyword="handleUpdateKeyword"
+/>
+```
+
+## API
+
+### Props
+
+| 属性名        | 类型             | 必填 | 说明             |
+| ------------- | ---------------- | ---- | ---------------- |
+| messageGroups | `MessageGroup[]` | ✓    | 执行摘要消息分组 |
+
+### Events
+
+| 事件名             | 参数                                  | 说明                     |
+| ------------------ | ------------------------------------- | ------------------------ |
+| locateMessageGroup | `(uid: string, group: MessageGroup)` | 点击「在对话中定位」按钮，参数为消息组 `MessageGroup.uid` |
+| updateKeyword      | `(keyword: string)`                   | 搜索关键词变更           |
+
+## 类型定义
+
+```typescript
+import { type MessageGroup } from '@blueking/chat-x';
+
+interface MessageGroup {
+  uid: string;
+  type: MessageRole;
+  messages: Message[];
+  checked: boolean;
+  isHover: boolean;
+  pause?: boolean;
+  startTime?: number;
+}
+```
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — 摘要内消息渲染
+- [HighlightKeyword](/components/helper/highlight-keyword) — 搜索高亮
+- [ChatContainer](/components/setup/chat-container) — 侧栏挂载场景

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
@@ -1,0 +1,303 @@
+# FileContent 文件内容
+
+> 能力域：媒体文件 ｜ 导入：`import { FileContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染文件附件，支持图片预览和下载事件。 源码位置：src/components/chat-content/file-content/file-content.vue。
+
+**关联**：image-preview（点击图片缩略图打开全屏预览）、user-message（用户消息只读展示附件列表）
+
+---
+
+# FileContent 文件内容展示
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/file-content/file-content.vue`
+- **能力域**：媒体文件
+- **能力说明**：渲染文件附件，支持图片预览和下载事件。
+
+> **能力域**：媒体文件
+
+文件列表展示组件，支持图片缩略图预览、点击图片全屏预览（`ImagePreview`）、文档卡片展示（文件名/扩展名/文件大小）、图片加载失败占位和删除操作。
+
+## 渲染决策逻辑
+
+每个文件按以下优先级决定渲染方式：
+
+```
+file.url 存在？
+├── 是 → 图片模式（用 file.url 作为 <img src>，点击可全屏预览）
+│        图片加载失败 → 错误占位（粉色背景 + 红色边框 + 灰色图标）
+└── 否 → 检查 mimeType 或 file.file?.type
+         ├── 以 'image/' 开头 → 图片模式（用 getFilePreviewUrl(file.file) 作为 src，点击可全屏预览）
+         └── 其他            → 文档卡片模式（图标 + 文件名 + 扩展名 + 大小）
+```
+
+> **注意**：`file.url` 存在时**无论文件 MIME 类型是什么**都会走图片模式。若要将 PDF 等非图片文件显示为文档卡片，确保不设置 `url` 字段（或设为 `undefined`）。
+
+## 基础用法（文档文件）
+
+无 `url` 字段、MIME 类型非 `image/*` 的文件，渲染为文档卡片（文档图标 + 文件名 + 扩展名 + 大小）：
+
+```vue
+<template>
+  <FileContent
+    :files="files"
+    @delete-file="handleDeleteFile"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { FileContent, type UploadFile } from '@blueking/chat-x';
+
+  const files = ref<Partial<UploadFile>[]>([
+    { file: new File(['content'], 'report.pdf', { type: 'application/pdf' }) },
+    { file: new File(['content'], 'data.xlsx', { type: 'application/vnd.ms-excel' }) },
+    { file: new File(['readme'], 'README.md', { type: 'text/markdown' }) },
+  ]);
+
+  const handleDeleteFile = (file: Partial<UploadFile>) => {
+    files.value = files.value.filter(f => f !== file);
+  };
+</script>
+```
+
+**渲染效果**（悬停文件卡片，右上角出现删除按钮）
+
+## 图片文件预览
+
+设置了 `url` 字段时，渲染为 48×48 的图片缩略图（`cursor: zoom-in`）。点击图片可打开全屏预览（内部集成 `ImagePreview` 组件），支持缩放、旋转、下载等操作：
+
+```vue
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { type UploadFile } from '@blueking/chat-x';
+
+  const imageFiles = ref<Partial<UploadFile>[]>([
+    {
+      url: 'https://example.com/cat.jpg', // 有 url → 图片模式
+      filename: 'cat.jpg',
+      mimeType: 'image/jpeg',
+      file: new File([''], 'cat.jpg', { type: 'image/jpeg' }),
+    },
+    {
+      url: 'https://example.com/dog.png',
+      filename: 'dog.png',
+      mimeType: 'image/png',
+      file: new File([''], 'dog.png', { type: 'image/png' }),
+    },
+  ]);
+</script>
+```
+
+**渲染效果**
+
+## 图片点击预览
+
+图片模式下点击缩略图会打开全屏预览弹窗。多张图片时支持左右切换。加载失败的图片不会出现在预览列表中：
+
+```vue
+<template>
+  <FileContent :files="imageFiles" />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { FileContent, type UploadFile } from '@blueking/chat-x';
+
+  const imageFiles = ref<Partial<UploadFile>[]>([
+    { url: 'https://example.com/cat.jpg', filename: 'cat.jpg', mimeType: 'image/jpeg' },
+    { url: 'https://example.com/dog.png', filename: 'dog.png', mimeType: 'image/png' },
+  ]);
+</script>
+```
+
+> **预览行为**：组件内部自动维护 `ImagePreview` 实例，无需外部管理预览状态。只有加载成功的图片才会进入预览列表，加载失败的图片被自动过滤。
+
+## 图片加载失败
+
+`<img>` 触发 `onerror` 时，切换为粉色背景 + 红色边框的错误占位：
+
+## 混合文件（图片 + 文档）
+
+同一列表中可同时包含图片和文档文件，横向 flex 布局、换行排列：
+
+```vue
+<script setup lang="ts">
+  const files = [
+    { url: 'https://example.com/photo.jpg', filename: 'photo.jpg', mimeType: 'image/jpeg' },
+    { file: new File(['content'], 'report.pdf', { type: 'application/pdf' }) },
+    { file: new File(['data'], 'data.xlsx', { type: 'application/vnd.ms-excel' }) },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 只读模式（readonly）
+
+传入 `readonly` 时，隐藏删除按钮，适用于用户消息中展示已发送的文件：
+
+```vue
+<FileContent :files="files" :readonly="true" />
+```
+
+**渲染效果**（悬停无删除按钮）
+
+## 仅有 filename（无 File 对象）
+
+从服务端恢复的历史文件没有 `File` 对象时，仍可渲染文档卡片，但**文件大小不显示**，扩展名从 `filename` 或 `mimeType` 推断：
+
+```vue
+<script setup lang="ts">
+  const remoteFiles = [
+    // 无 file 对象，文件大小显示为空
+    { filename: 'server-report.pdf', mimeType: 'application/pdf' },
+    { filename: 'config.json', mimeType: 'application/json' },
+  ];
+</script>
+```
+
+**渲染效果**（大小区域为空）
+
+## 在 ChatInput 中使用
+
+`FileContent` 由 `ChatInput` 内部自动渲染在文件预览区（`slot#files` 的默认内容），通常不需要手动引入。当 `ChatInput` 收到上传文件时，自动更新 `uploadFiles` 并渲染：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :on-send-message="handleSendMessage"
+    :on-upload="handleUpload"
+  />
+</template>
+```
+
+若需自定义文件展示，通过 `slot#files` 替换默认 `FileContent`：
+
+```vue
+<template>
+  <ChatInput
+    v-model="inputValue"
+    :on-upload="handleUpload"
+  >
+    <template #files="{ files }">
+      <!-- 自定义文件列表 UI -->
+      <FileContent
+        :files="files"
+        readonly
+      />
+    </template>
+  </ChatInput>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名   | 类型                    | 默认值  | 必填 | 说明                            |
+| -------- | ----------------------- | ------- | ---- | ------------------------------- |
+| files    | `Partial<UploadFile>[]` | -       | ✅   | 文件列表                        |
+| readonly | `boolean`               | `false` | -    | 只读模式，`true` 时隐藏删除按钮 |
+
+### Events
+
+| 事件名     | 参数                          | 触发时机           |
+| ---------- | ----------------------------- | ------------------ |
+| deleteFile | `(file: Partial<UploadFile>)` | 点击删除按钮时触发 |
+
+## 渲染模式详解
+
+### 图片模式
+
+| 条件                               | 图片 src                         | 点击行为       |
+| ---------------------------------- | -------------------------------- | -------------- |
+| `file.url` 有值（优先）            | `file.url`                       | 打开全屏预览   |
+| MIME 以 `image/` 开头（无 url 时） | `URL.createObjectURL(file.file)` | 打开全屏预览   |
+| 图片加载失败                       | 错误占位                         | 不进入预览列表 |
+
+### 文档卡片模式
+
+| 字段     | 取值优先级                                                                                                   |
+| -------- | ------------------------------------------------------------------------------------------------------------ |
+| 文件名   | `file.filename` → `file.file?.name`                                                                          |
+| 扩展名   | 有 `file.file`：取文件名最后一段 `.xxx` 或 MIME 后缀<br>无 `file.file`：取 `filename` 后缀 → `mimeType` 后缀 |
+| 文件大小 | 仅当有 `file.file`（`File` 对象）时显示，否则为空                                                            |
+
+## 类型定义
+
+```typescript
+import type { UploadFile, BinaryInputContent } from '@blueking/chat-x';
+
+// 上传状态（ChatInput 内部使用，FileContent 不使用此字段）
+enum UploadStatus {
+  Pending = 'pending', // 上传中
+  Success = 'success', // 上传成功
+  Error = 'error', // 上传失败
+}
+
+// 上传文件（FileContent 的 files 数组中每一项）
+type UploadFile = BinaryInputContent & {
+  file?: File; // 原始 File 对象，无则文件大小不显示
+  status?: UploadStatus; // 上传状态（ChatInput 使用，FileContent 不消费）
+};
+
+// 二进制内容基础类型
+interface BinaryInputContent {
+  type: 'binary';
+  url?: string; // 文件访问地址，存在时强制走图片模式
+  filename?: string; // 文件名（用于文档卡片）
+  mimeType?: string; // MIME 类型（用于图片判断和扩展名推断）
+}
+```
+
+## 工具函数（内部使用）
+
+```typescript
+// 判断是否走图片模式
+// ⚠️ file.url 存在时直接返回 true，不判断 MIME 类型
+const isImage = (file: Partial<UploadFile>): boolean => {
+  if (file.url) return true;
+  return isImageFile(file.mimeType || file.file?.type);
+};
+
+// 判断 MIME 类型是否为图片
+const isImageFile = (mimeType?: string): boolean => {
+  if (!mimeType) return false;
+  return mimeType.startsWith('image/');
+};
+
+// 获取 File 对象的临时预览 URL（无 url 时的图片模式备选）
+const getFilePreviewUrl = (file?: File): string => {
+  if (!file) return '';
+  return URL.createObjectURL(file);
+};
+
+// 获取文件扩展名
+const getFileExtension = (file?: File): string => {
+  if (!file) return '';
+  return file.name.split('.').pop() || file.type?.split('/').pop() || '';
+};
+
+// 格式化文件大小（需要 File 对象）
+const formatFileSize = (file?: File): string => {
+  if (!file) return '';
+  const size = file.size;
+  const units = ['B', 'KB', 'M', 'GB'];
+  const index = Math.floor(Math.log2(size || 1) / 10);
+  return `${(size / Math.pow(1024, index)).toFixed(2)} ${units[index]}`;
+};
+```
+
+## 使用场景
+
+- **ChatInput 文件预览区**：上传文件后在编辑器上方展示待发送的文件列表（可删除）
+- **用户消息展示**：`UserMessage` 内部以 `readonly` 模式展示已发送的图片和附件
+- **历史消息回放**：服务端返回的文件信息（无 `File` 对象）也能正常渲染文档卡片
+
+## 关联组件
+
+- [ImagePreview](/components/medias/image-preview) — 图片全屏预览
+- [UserMessage](/components/message/user-message) — 用户消息内附件展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
@@ -1,0 +1,161 @@
+# FileUploadBtn 文件上传按钮
+
+> 能力域：输入交互 ｜ 导入：`import { FileUploadBtn } from '@blueking/chat-x'` ｜ since 1.0.0
+
+文件选择按钮，封装 input[type=file] 并输出选择事件。 源码位置：src/components/ai-buttons/file-upload-btn/file-upload-btn.vue。
+
+**关联**：chat-input（输入区附件上传按钮常见挂载位置）、file-content（选中文件常以列表形式展示待发送内容）
+
+---
+
+# FileUploadBtn 文件上传按钮
+## 源码事实
+
+- **源码位置**：`src/components/ai-buttons/file-upload-btn/file-upload-btn.vue`
+- **能力域**：输入交互
+- **能力说明**：文件选择按钮，封装 input[type=file] 并输出选择事件。
+
+> **能力域**：输入交互
+
+聊天输入框内置的文件上传触发按钮，点击后弹出系统文件选择框。内部包含隐藏的 `<input type="file">` 与可见的图标按钮；在按钮层对**单文件**做大小与空文件过滤，**已选文件个数上限**由上层（如 `ChatInput`）统一校验并提示，避免按钮与输入区各弹一条错误提示。
+
+## 组件结构
+
+```
+.file-upload-btn（display: flex，align-items: center）
+├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
+│     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
+└── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）
+      v-tippy: "上传图片, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
+      @click → fileInputRef.click()
+      └── <slot> 默认：FileUploadIcon
+```
+
+## 文件校验逻辑
+
+```
+用户选择文件
+  │
+  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（约 2.4MB）→ 加入 toEmit
+  │       size 为 0 或 ≥ 上限 → sizeRejected += 1
+  │
+  ├─ sizeRejected > 0 → bkui-vue Message.error（formatUploadNotAddedMessage，说明可能超大或超出个数等）
+  │
+  ├─ toEmit.length > 0 → emit('upload', toEmit)
+  │
+  └─ target.value = ''（重置 input，允许再次选择同一文件）
+```
+
+**关键边界行为**：
+
+| 场景                                                         | 结果                                                                 |
+| ------------------------------------------------------------ | -------------------------------------------------------------------- |
+| 一次多选超过上层允许个数（如 `ChatInput` 内已达 3 个）       | 由 **ChatInput** 侧 toast 并丢弃/不计入，不在本按钮内按个数提前拦截 |
+| 部分文件因空文件或单文件超大被过滤                           | 弹出错误 toast；若仍有合法文件，**仍触发** `upload`（payload 为合法子集） |
+| 全部被过滤（均为空或超大）                                   | 仅 toast，**不触发** `upload`                                        |
+| `file.size === 0`                                          | 计入未添加提示，不进入 `upload` payload                              |
+| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，约 2.4MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
+| 选择后取消                                                   | `files.length === 0`，不触发 `upload`                                |
+
+> `multiple` prop 声明存在但当前模板中 `input` 的 `multiple` 属性为**硬编码**（非 `:multiple="multiple"` 绑定），始终允许多选，该 prop 暂时无实际效果。
+
+> **`maxFiles` prop**：当前版本在按钮内**不参与截断或计数校验**，仅作类型与文档预留；列表最多几个文件由上层（如 `ChatInput` 的 `MAX_UPLOAD_FILES`）控制。详见 [ChatInput 文件上传](/components/input/chat-input#file-upload)。
+
+## 基础用法
+
+```vue
+<template>
+  <FileUploadBtn @upload="handleUpload" />
+</template>
+
+<script setup lang="ts">
+  import { FileUploadBtn } from '@blueking/chat-x';
+
+  const handleUpload = (files: File[]) => {
+    console.log(
+      '选中文件:',
+      files.map(f => `${f.name}(${f.size}B)`),
+    );
+  };
+</script>
+```
+
+## 限制文件类型
+
+通过 `accept` 属性控制系统文件选择框的过滤条件，遵循 `<input type="file">` 的 `accept` 规范：
+
+```vue
+<template>
+  <!-- 仅图片（默认） -->
+  <FileUploadBtn
+    accept="image/*"
+    @upload="handleUpload"
+  />
+
+  <!-- 文档类型 -->
+  <FileUploadBtn
+    accept=".pdf,.doc,.docx,.xlsx,.pptx"
+    @upload="handleUpload"
+  />
+
+  <!-- 不限制类型 -->
+  <FileUploadBtn
+    accept="*/*"
+    @upload="handleUpload"
+  />
+</template>
+```
+
+> `accept` 仅影响文件选择框的过滤 UI，不做服务端验证，请在 `upload` 回调中自行校验 MIME 类型。
+
+## 自定义图标
+
+通过默认插槽替换上传图标：
+
+```vue
+<template>
+  <FileUploadBtn @upload="handleUpload">
+    <span style="font-size: 16px; line-height: 1;">📎</span>
+  </FileUploadBtn>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型           | 默认值      | 说明                                                                 |
+| ------------ | -------------- | ----------- | -------------------------------------------------------------------- |
+| accept       | `string`       | `'image/*'` | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
+| maxFiles     | `number`       | `3`         | 预留字段，**当前不在按钮内生效**；个数上限见 `ChatInput` 与全局常量 |
+| multiple     | `boolean`      | `true`      | 声明属性（当前版本未实际绑定到 input，始终多选）                     |
+| tippyOptions | `AITippyProps` | —           | 扩展 tooltip 配置，会与内置配置合并                                |
+
+### Events
+
+| 事件名 | 参数              | 说明                                                                                      |
+| ------ | ----------------- | ----------------------------------------------------------------------------------------- |
+| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，约 2.4MB）后的数组；个数截断不在此组件内完成 |
+
+### Slots
+
+| 插槽名  | 说明                                            |
+| ------- | ----------------------------------------------- |
+| default | 自定义按钮图标内容，默认为内置 `FileUploadIcon` |
+
+## 使用场景
+
+`FileUploadBtn` 由 `ChatInput` 组件内置，当 `ChatInput` 的 `supportUpload` prop 为 `true`（默认值）时自动渲染。一般不需要单独引入，除非构建完全自定义的输入区域。
+
+## 类型定义
+
+```typescript
+import type { TippyOptions } from 'vue-tippy';
+
+type AITippyProps = Partial<Pick<TippyOptions, 'appendTo' | 'placement' | 'zIndex'>>;
+```
+
+## 关联组件
+
+- [ChatInput](/components/input/chat-input) — 默认内置上传入口
+- [FileContent](/components/medias/file-content) — 选中文件列表展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/flow-agent-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/flow-agent-content.md
@@ -1,0 +1,249 @@
+# FlowAgentContent FlowAgent 执行内容
+
+> 能力域：Agent 能力 ｜ 导入：`import { FlowAgentContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 FlowAgent 任务/节点执行状态、耗时、详情入口和自定义 Tab 联动。 源码位置：src/components/chat-content/flow-agent-content/flow-agent-content.vue。
+
+**关联**：flow-agent-node-detail（详情入口点击后挂载到自定义 Tab 渲染）、activity-layout（提供可折叠的活动容器外壳）、chat-container（通过自定义 Tab 在侧栏展示节点详情）
+
+---
+
+# FlowAgentContent FlowAgent 执行内容
+
+> **能力域**：Agent 能力
+
+渲染 FlowAgent（标准运维 / 流程编排）执行过程的活动组件，以「任务 → 节点」两级结构展示执行状态、耗时统计与详情入口。组件内部消费 `useCustomTabConsumer`，点击节点「详情」会向侧栏的自定义 Tab 注入 `FlowAgentNodeDetail` 渲染节点输入输出。
+
+通常不需要直接使用，`MessageRender` 会根据消息 `content.type === flow_agent` 自动渲染。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/flow-agent-content/flow-agent-content.vue`
+- **能力说明**：渲染 FlowAgent 任务/节点执行状态、耗时、详情入口和自定义 Tab 联动。
+
+## 核心能力
+
+- **状态聚合统计**：汇总所有任务的 `statistics.state_counts`，在标题栏按「执行中 / 成功 / 失败 / 挂起 / 待执行」分类展示带颜色的计数（超过 99 显示 `99+`）
+- **两级折叠**：任务整体由 `ActivityLayout` 折叠；每个任务节点列表可单独展开/收起
+- **耗时格式化**：节点耗时与任务总耗时按 `d/h/m/s` 紧凑展示，小于 1 秒显示 `<1s`
+- **节点行尾操作**：hover 失败节点行显示「重试 / 跳过 / 详情」按钮组（间距 12px）；成功 / 运行中等非失败节点仅显示「详情」。重试 / 跳过依赖节点 `retryable` / `skippable` 能力位，通过 `onInterruptResume` 回传 Agent
+- **详情入口联动**：「详情」按钮点击后通过自定义 Tab 挂载 `FlowAgentNodeDetail`
+- **分享态降级**：`RenderMode.Share` 下隐藏耗时与行尾操作按钮，仅保留只读的执行状态
+
+## 状态映射
+
+组件将后端原始 `state` / `task_state` 归一为 5 类收敛状态（`getConvergedState`），用于图标、颜色与统计分类：
+
+| 收敛状态    | 颜色        | 原始状态                                                                          |
+| ----------- | ----------- | --------------------------------------------------------------------------------- |
+| `success`   | `#18B456`   | `FINISHED`                                                                        |
+| `failed`    | `#EA3636`   | `FAILED`、`REVOKED`、`ROLL_BACK_FAILED`                                            |
+| `suspended` | `#F59500`   | `SUSPENDED`                                                                       |
+| `pending`   | `#4D4F56`   | `PENDING`                                                                         |
+| `running`   | `#3A84FF`   | `CREATED`、`LOOP_READY`、`READY`、`RUNNING`、`BLOCKED`、`ROLLING_BACK`、`ROLL_BACK_SUCCESS` 及未知状态（兜底） |
+
+## 基础用法
+
+`content` 为任务数组 `BkFlowTask[]`；传入单个对象时组件会自动包装为单元素数组。
+
+```vue
+<template>
+  <FlowAgentContent
+    :content="flowContent"
+    :message-uid="messageUid"
+    :on-interrupt-resume="handleInterruptResume"
+    :status="status"
+  />
+</template>
+
+<script setup lang="ts">
+  import { FlowAgentContent } from '@blueking/chat-x';
+  import type { BkFlowMessageContent, OnInterruptResume } from '@blueking/chat-x';
+
+  const messageUid = 'flow-msg-1';
+  const status = 'success';
+  const handleInterruptResume: OnInterruptResume = async payload => {
+    console.log('flow node resume:', payload);
+  };
+  const flowContent: BkFlowMessageContent = [
+    {
+      task_id: 100,
+      task_name: '主机巡检流程',
+      task_state: 'FINISHED',
+      task_outputs: { result: 'ok' },
+      statistics: { state_counts: { FINISHED: 2, FAILED: 1 }, total: 3 },
+      nodes: {
+        n1: { id: 'n1', name: '采集主机指标', state: 'FINISHED', elapsed_time: 12, type: 'task', loop: 0, retry: 0, skip: false, start_time: '', finish_time: '' },
+        n2: { id: 'n2', name: '分析异常项', state: 'FINISHED', elapsed_time: 65, type: 'task', loop: 0, retry: 0, skip: false, start_time: '', finish_time: '' },
+        n3: { id: 'n3', name: '推送告警', state: 'FAILED', elapsed_time: 3, type: 'task', loop: 0, retry: 1, skip: false, retryable: true, skippable: true, start_time: '', finish_time: '' },
+      },
+    },
+  ];
+</script>
+```
+
+**渲染效果**（hover 失败节点行可看到「重试 / 跳过 / 详情」按钮组；点击「详情」会向侧栏自定义 Tab 注入节点详情）
+
+## 执行中状态
+
+`status` 为 `pending` / `streaming` 时，标题栏图标显示为加载动画；运行中的节点显示旋转 Loading，待执行 / 挂起节点显示对应颜色的状态点。
+
+## 失败节点重试 / 跳过
+
+失败节点（`convergedState === 'failed'`）且具备对应能力位时，hover 行尾展示「重试」或「跳过」按钮。点击后调用 `onInterruptResume`，**不传** `interrupt` 参数：
+
+```typescript
+// 重试
+onInterruptResume?.({
+  operation: InterruptResumeOperation.FlowNodeRetry,
+  payload: { node_id: node.id, task_id: task.task_id },
+});
+
+// 跳过
+onInterruptResume?.({
+  operation: InterruptResumeOperation.FlowNodeSkip,
+  payload: { node_id: node.id, task_id: task.task_id },
+});
+```
+
+| 按钮 | 显隐条件                              | `operation`          |
+| ---- | ------------------------------------- | ---------------------- |
+| 重试 | 失败态且 `node.retryable === true`    | `flow_node_retry`      |
+| 跳过 | 失败态且 `node.skippable === true`    | `flow_node_skip`       |
+| 详情 | 始终展示（Share 模式除外）            | —（打开侧栏 Tab，不走 resume） |
+
+行尾操作由内部 composable [`useFlowNodeActions`](/composables/use-flow-node-actions) 聚合为声明式列表，组件层仅遍历渲染。
+
+## 节点详情联动
+
+点击节点「详情」按钮时，组件调用 `addCustomTab` 注入一个以 `${task_id}|${node.id}|${node.name}` 为唯一 `name` 的 Tab，渲染组件为 `FlowAgentNodeDetail`：
+
+```ts
+addCustomTab?.({
+  label: node.name,
+  name: `${task.task_id}|${node.id}|${node.name}`,
+  data: {
+    component: BkFlowNodeDetail,
+    messageUid: props.messageUid,
+    props: {
+      loading: true,
+      node_id: node.id,
+      node_name: node.name,
+      task_id: task.task_id,
+      task_name: task.task_name,
+      data: {},
+    },
+  },
+});
+```
+
+> 实际节点详情数据由应用层在 `ChatContainer` 的 `onCustomTabChange` 中异步拉取后回填，组件本身只负责挂载占位与传参。组件卸载时（在消息容器滚动上下文中）会自动调用 `removeCustomTab` 清理对应 Tab。
+
+## 组件结构
+
+```
+ActivityLayout（activity-type=flow_agent，v-model:collapsed）
+├── #title（执行情况统计栏）
+│   ├── AiLoading / ArrowRightIcon（加载态 / 折叠箭头）
+│   └── flow-agent-stat-item × N（按收敛状态分类的计数）
+└── flow-agent-task-group × N（任务）
+    ├── flow-agent-task-header（点击折叠当前任务）
+    │   ├── task-arrow（任务展开箭头）
+    │   ├── task-state-icon（Loading / 状态图标）
+    │   ├── task-name（HighlightKeyword + 溢出提示）
+    │   └── task-time（任务总耗时 = 各节点耗时累加）
+    └── flow-agent-task-nodes（v-show 折叠）
+        └── flow-agent-node-item × N（节点）
+            ├── node-status（Loading / 状态圆点）
+            ├── node-name（HighlightKeyword + 溢出提示）
+            └── node-trailing（非 Share 态）
+                ├── node-time（节点耗时，hover 时隐藏）
+                └── node-actions（hover 时显示按钮组，间距 12px）
+                    ├── node-action-btn「重试」（失败 + retryable）
+                    ├── node-action-btn「跳过」（失败 + skippable）
+                    └── node-action-btn「详情」（始终，点击挂载详情 Tab）
+```
+
+## API
+
+### Props
+
+| 属性名     | 类型                     | 必填 | 默认值      | 说明                                                                       |
+| ---------- | ------------------------ | ---- | ----------- | -------------------------------------------------------------------------- |
+| content    | `BkFlowMessageContent`   | 否   | `[{}]`      | 任务数组；传入单个 `BkFlowTask` 时自动包装为单元素数组                       |
+| messageUid | `string`                 | 否   | —           | 所属消息唯一标识，注入到节点详情 Tab 的 `data.messageUid`，用于异步回填数据 |
+| onInterruptResume | `OnInterruptResume` | 否   | —           | 节点「重试 / 跳过」与第三方审批取消复用同一回调，按 `payload.operation` 分流；流程节点操作时不传 `interrupt` |
+| status     | `MessageStatus`          | 否   | —           | 消息状态；`pending` / `streaming` 时标题栏显示加载动画                       |
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+// 来自 @blueking/chat-x 导出
+type BkFlowMessageContent = BkFlowTask[];
+
+interface BkFlowTask {
+  task_id: number;
+  task_name: string;
+  task_state: string;          // 原始任务状态，经 getConvergedState 归一
+  task_outputs: unknown;       // 任务输出（当前展示区块已注释，不渲染）
+  statistics: {
+    state_counts: Record<string, number>; // 原始状态 → 数量，用于标题统计聚合
+    total: number;
+  };
+  nodes: Record<string, BkFlowNode>;       // key 为节点 id
+}
+
+interface BkFlowNode {
+  id: string;
+  name: string;
+  state: string;        // 原始节点状态
+  elapsed_time: number; // 耗时（秒）
+  type: string;
+  loop: number;
+  retry: number;
+  retryable?: boolean; // 是否可重试（失败节点「重试」按钮显隐）
+  skip: boolean;
+  skippable?: boolean; // 是否可跳过（失败节点「跳过」按钮显隐）
+  start_time: string;
+  finish_time: string;
+}
+```
+
+## 组件依赖
+
+- `AiLoading` — 标题栏流式加载动画
+- `ActivityLayout` — 可折叠活动容器外壳
+- `BkFlowNodeDetail` — 节点详情面板（经自定义 Tab 挂载）
+- `Loading`（bkui-vue） — 运行中状态的旋转指示
+- `HighlightKeyword` — 任务 / 节点名称的搜索关键词高亮
+
+## 注意事项
+
+1. **依赖自定义 Tab 上下文**：组件内部使用 `useCustomTabConsumer()!`，必须存在 `useCustomTabProvider` 提供者（`ChatContainer` 已内置）。脱离上下文直接使用需自行提供，否则详情入口会报错。
+2. **统计来自 `statistics.state_counts` 而非节点遍历**：标题栏计数直接读取后端下发的统计，不会实时统计 `nodes`；两者不一致时以 `state_counts` 为准。
+3. **任务总耗时为节点累加**：`task-time` 由各节点 `elapsed_time` 求和得到，并非任务级独立字段。
+4. **`task_outputs` 暂不渲染**：模板中任务输出展示区块已注释，传入也不会显示。
+5. **未知状态兜底为 `running`**：`getConvergedState` 对未识别的原始状态统一归为运行中。
+6. **Share 模式降级**：`RenderMode.Share` 下不渲染节点耗时与行尾操作按钮（重试 / 跳过 / 详情），仅保留只读执行状态。
+7. **`onInterruptResume` 透传链路**：`MessageRender` → `ActivityMessage` → `FlowAgentContent`；未传入时重试 / 跳过按钮仍展示但点击无回调。
+
+## 关联组件
+
+- [FlowAgentNodeDetail](/components/agent/flow-agent-node-detail) — 节点详情面板
+- [ActivityLayout](/components/helper/activity-layout) — 可折叠活动容器
+- [ChatContainer](/components/setup/chat-container) — 侧栏自定义 Tab 挂载场景
+- [useFlowNodeActions](/composables/use-flow-node-actions) — 节点行尾操作聚合 composable
+- [中断类型 Interrupt](/types/interrupt) — `InterruptResumeOperation`、`FlowNodeResume`、`OnInterruptResume`
+- [使用建议] 优先通过上层组合组件（`MessageRender`）使用；直接使用前请确认 `content` 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/flow-agent-node-detail.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/flow-agent-node-detail.md
@@ -1,0 +1,236 @@
+# FlowAgentNodeDetail FlowAgent 节点详情
+
+> 能力域：Agent 能力 ｜ 导入：`import { FlowAgentNodeDetail } from '@blueking/chat-x'` ｜ since 1.0.0
+
+展示 FlowAgent 节点输入、输出、异常、耗时等详情。 源码位置：src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue。
+
+**关联**：flow-agent-content（节点详情入口由 FlowAgentContent 挂载到自定义 Tab）、detail-section（详情页内部分段容器）、simple-table（展示输入参数、插件输出定义与结构化输出）、chat-container（应用层通过 onCustomTabChange 拉取节点详情并回填）
+
+---
+
+# FlowAgentNodeDetail FlowAgent 节点详情
+
+> **能力域**：Agent 能力
+
+`FlowAgentNodeDetail` 用于展示 FlowAgent 单个节点的配置与输出详情。它通常被 `FlowAgentContent` 通过自定义 Tab 挂载到侧栏，应用层再根据 `messageUid`、`task_id`、`node_id` 拉取真实节点详情并回填到 `data`。
+
+组件自身只负责详情展示，不负责接口请求、Tab 生命周期或消息定位逻辑。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue`
+- **能力说明**：展示 FlowAgent 节点输入、输出、异常、耗时等详情。
+
+## 核心能力
+
+- **双 Tab 展示**：内置“节点配置”和“节点输出”两个页签，默认展示“节点配置”
+- **配置详情**：展示流程模板、节点名称、步骤名称、是否可选、失败处理和超时控制
+- **参数表格**：使用 `SimpleTable` 展示输入参数、插件输出定义和结构化输出
+- **加载骨架屏**：`loading` 为 `true` 时展示标题和内容骨架，不渲染真实数据
+- **定位插槽**：提供 `locateButton` 插槽，允许侧栏注入“在对话中定位”等操作按钮
+- **值格式化**：`null` / `undefined` 显示为 `--`，对象值通过 `JSON.stringify` 转为字符串
+
+## 基础用法
+
+```vue
+<template>
+  <FlowAgentNodeDetail
+    :data="nodeDetailData"
+    :loading="false"
+    node_id="n1"
+    node_name="采集主机指标"
+    :task_id="100"
+    task_name="主机巡检流程"
+  >
+    <template #locateButton>
+      <button type="button">定位</button>
+    </template>
+  </FlowAgentNodeDetail>
+</template>
+
+<script setup lang="ts">
+  import FlowAgentNodeDetail from '@blueking/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue';
+  import type { NodeDetailData } from '@blueking/chat-x';
+
+  const nodeDetailData: Partial<NodeDetailData> = {
+    basic_info: {
+      node_name: '采集主机指标',
+      template_name: '主机巡检流程',
+      stage_name: '巡检准备',
+      optional: false,
+      skippable: true,
+      retryable: true,
+      error_ignorable: false,
+      auto_retry: { enable: true, interval: 30, times: 2 },
+      timeout_config: { enable: true, seconds: 300, action: 'forced_fail' },
+    },
+    inputs: {
+      bk_host_id: 10001,
+      collect_items: ['cpu', 'memory', 'disk'],
+    },
+    plugin_output: [
+      {
+        key: '${cpu_usage}',
+        name: 'CPU 使用率',
+        type: 'number',
+        schema: { description: '当前主机 CPU 使用率', enum: [], type: 'number' },
+      },
+    ],
+    outputs: [{ key: 'cpu_usage', preset: false, value: 23.5 }],
+  };
+</script>
+```
+
+**渲染效果**
+
+## 加载态
+
+`loading` 为 `true` 时，组件展示骨架屏，标题中的节点名和内容区均不会读取 `data` 展示。
+
+## 空数据
+
+当输入参数、插件输出定义或结构化输出为空时，对应 `SimpleTable` 渲染 `--` 占位行。
+
+## Tab 内容
+
+| Tab        | 内容                                                         |
+| ---------- | ------------------------------------------------------------ |
+| 节点配置   | 基础信息、失败处理、超时控制、输入参数、插件输出定义         |
+| 节点输出   | 结构化输出，来自 `data.outputs`                              |
+
+`activeTab` 是组件内部状态，不通过 prop 或 expose 暴露。
+
+## 字段展示规则
+
+| 区域         | 数据来源                         | 展示规则                                      |
+| ------------ | -------------------------------- | --------------------------------------------- |
+| 流程模板     | `data.basic_info.template_name`   | 空值显示 `--`                                 |
+| 节点名称     | `data.basic_info.node_name`       | 空值显示 `--`                                 |
+| 步骤名称     | `data.basic_info.stage_name`      | 空值显示 `--`                                 |
+| 是否可选     | `data.basic_info.optional`        | `true` 显示“是”，否则显示“否”                 |
+| 失败处理     | `skippable` / `auto_retry.enable` | 支持“手动跳过”和“自动重试”；均无时显示 `--`  |
+| 超时控制     | `timeout_config`                  | 未启用时显示 `--`；`forced_fail` 显示“强制失败” |
+| 输入参数     | `data.inputs`                     | 对象条目转为 `{ key, value }` 表格            |
+| 插件输出定义 | `data.plugin_output`              | 展示名称、变量说明和 KEY                     |
+| 结构化输出   | `data.outputs`                    | 展示输出 key 与格式化后的 value              |
+
+## 自定义 Tab 联动
+
+`FlowAgentContent` 点击节点“详情”时，会将本组件挂载到自定义 Tab，并先传入 `loading: true` 和节点定位参数：
+
+```typescript
+addCustomTab?.({
+  label: node.name,
+  name: `${task.task_id}|${node.id}|${node.name}`,
+  data: {
+    component: BkFlowNodeDetail,
+    messageUid: props.messageUid,
+    props: {
+      loading: true,
+      node_id: node.id,
+      node_name: node.name,
+      task_id: task.task_id,
+      task_name: task.task_name,
+      data: {},
+    },
+  },
+});
+```
+
+应用层通常在 `ChatContainer` 的 `onCustomTabChange` 中读取这些参数，请求节点详情后返回新的 `props.data` 和 `props.loading`。
+
+## API
+
+### Props
+
+| 属性名    | 类型                       | 必填 | 默认值 | 说明                         |
+| --------- | -------------------------- | ---- | ------ | ---------------------------- |
+| data      | `Partial<NodeDetailData>`  | 是   | —      | 节点详情数据                 |
+| loading   | `boolean`                  | 否   | —      | 是否显示骨架屏               |
+| node_id   | `string`                   | 否   | —      | 节点 ID，来自自定义 Tab 参数 |
+| node_name | `string`                   | 否   | —      | 节点名称                     |
+| task_id   | `number`                   | 否   | —      | 任务 ID                      |
+| task_name | `string`                   | 否   | —      | 任务名称                     |
+
+> Props 类型来自 `CustomBkFlowTabData['props'] & { data: Partial<NodeDetailData> }`。
+
+### Emits
+
+- 无。
+
+### Slots
+
+| 插槽名       | 说明                         |
+| ------------ | ---------------------------- |
+| locateButton | 标题栏右侧操作区，如定位按钮 |
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+export type CustomBkFlowTabData = CustomTabData<{
+  data?: Partial<NodeDetailData>;
+  loading?: boolean;
+  node_id?: string;
+  node_name?: string;
+  task_id?: number;
+  task_name?: string;
+}>;
+
+export interface NodeDetailData {
+  inputs: Record<string, unknown>;
+  node_id: string;
+  task_id: number;
+  basic_info: {
+    auto_retry: {
+      enable: boolean;
+      interval: number;
+      times: number;
+    };
+    error_ignorable: boolean;
+    node_name: string;
+    optional: boolean;
+    retryable: boolean;
+    skippable: boolean;
+    stage_name: string;
+    template_name: string;
+    timeout_config: {
+      action: string;
+      enable: boolean;
+      seconds: number;
+    };
+  };
+  outputs: Array<{
+    key: string;
+    preset: boolean;
+    value: unknown;
+  }>;
+  plugin_output: Array<{
+    key: string;
+    name: string;
+    schema: {
+      description: string;
+      enum: unknown[];
+      properties?: Record<string, unknown>;
+      type: string;
+    };
+    type: string;
+  }>;
+}
+```
+
+## 使用建议
+
+- 优先由 [FlowAgentContent](./flow-agent-content.md) 通过自定义 Tab 挂载，不建议业务组件手动拼装 Tab 生命周期。
+- 接口请求与数据回填应放在应用层 `ChatContainer` 的 `onCustomTabChange` 链路中处理。
+- `data` 可传 `Partial<NodeDetailData>`，但真实展示依赖 `basic_info`、`inputs`、`plugin_output`、`outputs` 等字段；缺字段时对应区域会降级为空表格或 `--`。
+
+## 关联组件
+
+- [FlowAgentContent](./flow-agent-content.md) — 节点详情入口。
+- [DetailSection](./detail-section.md) — 详情分段容器。
+- [SimpleTable](./simple-table.md) — 详情表格。
+- [ChatContainer](../setup/chat-container.md) — 自定义 Tab 数据回填入口。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/highlight-keyword.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/highlight-keyword.md
@@ -1,0 +1,146 @@
+# HighlightKeyword 关键词高亮
+
+> 能力域：辅助能力 ｜ 导入：`import { HighlightKeyword } from '@blueking/chat-x'` ｜ since 1.0.0
+
+根据注入关键词高亮文本片段。 源码位置：src/components/highlight-keyword/highlight-keyword.ts。
+
+**关联**：toolcall-render（工具调用标题与状态文案高亮）、desc-panel（工具详情键值与描述文本高亮）、execution-summary（执行摘要搜索过滤与列表高亮）
+
+---
+
+# HighlightKeyword 关键词高亮
+## 源码事实
+
+- **源码位置**：`src/components/highlight-keyword/highlight-keyword.ts`
+- **能力域**：辅助能力
+- **能力说明**：根据注入关键词高亮文本片段。
+
+> **能力域**：辅助能力
+
+函数式组件，用于在文本中高亮匹配的搜索关键词。通过 `useKeywordInject` 从上层注入关键词，自动将匹配部分包裹在带高亮样式的 `<span>` 中。
+
+主要配合 `ExecutionSummary` 的搜索功能使用，实现搜索结果的视觉高亮。
+
+## 工作原理
+
+```
+props.text + inject(keyword)
+        │
+        ├── keyword 为空 → 直接渲染原文本
+        │
+        └── keyword 非空
+            ├── 正则 split 文本为 parts[]
+            ├── parts.length === 1 → 无匹配，渲染原文本
+            └── parts.length > 1 → 匹配部分用 <span class="highlight"> 包裹
+```
+
+组件使用 `defineComponent` + `h()` 渲染函数实现，不依赖模板。
+
+## 基础用法
+
+```vue
+<template>
+  <HighlightKeyword :text="text" />
+</template>
+
+<script setup lang="ts">
+  import { HighlightKeyword } from '@blueking/chat-x';
+
+  const text = '这是一段包含 Vue 3 Composition API 的示例文本';
+</script>
+```
+
+> **注意**：关键词通过 `useKeywordProvider` / `useKeywordInject`（`provide/inject`）注入，不通过 props 传入。上层需先调用 `useKeywordProvider()` 设置关键词。
+
+**渲染效果**（在输入框中输入关键词，观察文本高亮变化）
+
+## 关键词高亮示例
+
+预设关键词为 `API`，文本中所有匹配部分会以高亮背景显示：
+
+## 与 ExecutionSummary 配合
+
+`ExecutionSummary` 内部通过 `useKeywordProvider` 提供搜索关键词，后代组件中的 `HighlightKeyword` 自动响应：
+
+```
+ExecutionSummary
+├── useKeywordProvider(keyword)  ← Input 绑定
+└── MessageRender
+    └── AssistantMessage
+        └── ToolcallRender
+            └── HighlightKeyword(:text)  ← inject(keyword)
+```
+
+## 配套 Composables
+
+### useKeywordProvider
+
+在上层组件中创建关键词并 `provide`，后代组件通过 `useKeywordInject` 消费：
+
+```typescript
+import { useKeywordProvider } from '@blueking/chat-x';
+
+const { keyword } = useKeywordProvider();
+keyword.value = '搜索词';
+```
+
+### useKeywordInject
+
+在后代组件中注入关键词，返回 `ComputedRef<string> | undefined`：
+
+```typescript
+import { useKeywordInject } from '@blueking/chat-x';
+
+const keyword = useKeywordInject();
+console.log(keyword?.value); // 当前搜索关键词
+```
+
+### useKeywordMatch
+
+用于判断组件的可搜索文本是否与当前关键词匹配。内部调用 `useKeywordInject` 获取关键词，根据传入的文本提取函数判断是否命中：
+
+```typescript
+import { useKeywordMatch } from '@blueking/chat-x';
+
+const { keywordMatched } = useKeywordMatch(() => [props.title, props.description, props.content]);
+
+// keywordMatched.value === true 表示命中搜索
+// keywordMatched.value === false 表示未命中（可据此隐藏组件）
+// keyword 为空时始终返回 true
+```
+
+`useKeywordMatch` 的典型用途是在 `ExecutionSummary` 的搜索过滤中，让组件自行判断是否匹配搜索词，与 `HighlightKeyword` 配合实现搜索 + 高亮。
+
+## API
+
+### Props
+
+| 属性名 | 类型     | 必填 | 说明       |
+| ------ | -------- | ---- | ---------- |
+| text   | `string` | ✓    | 待高亮文本 |
+
+### 依赖注入
+
+| 注入项  | 提供方               | 说明                   |
+| ------- | -------------------- | ---------------------- |
+| keyword | `useKeywordProvider` | 搜索关键词，响应式更新 |
+
+### 配套 Composables
+
+| 函数名               | 参数                                            | 返回值                                     | 说明                                          |
+| -------------------- | ----------------------------------------------- | ------------------------------------------ | --------------------------------------------- |
+| `useKeywordProvider` | —                                               | `{ keyword: ShallowRef<string> }`          | 创建并 `provide` 关键词，用于上层组件         |
+| `useKeywordInject`   | —                                               | `ComputedRef<string> \| undefined`         | 注入关键词，用于后代组件                      |
+| `useKeywordMatch`    | `getSearchTexts: () => (string \| undefined)[]` | `{ keywordMatched: ComputedRef<boolean> }` | 判断组件文本是否匹配关键词，空关键词返回 true |
+
+### CSS 类名
+
+| 类名                    | 说明                                |
+| ----------------------- | ----------------------------------- |
+| `.ai-highlight-keyword` | 匹配文本的高亮样式（背景色 + 圆角） |
+
+## 关联组件
+
+- [ToolcallRender](/components/agent/toolcall-render) — 工具调用头部高亮
+- [DescPanel](/components/rendering/desc-panel) — 详情面板键值高亮
+- [ExecutionSummary](/components/agent/execution-summary) — 执行摘要搜索

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-content.md
@@ -1,0 +1,182 @@
+# ImageContent 图片内容
+
+> 能力域：媒体文件 ｜ 导入：`import { ImageContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 Markdown 图片 token。 源码位置：src/components/markdown-token/image-content/image-content.vue。
+
+**关联**：markdown-content（解析图片 token 后挂载本组件）
+
+---
+
+# ImageContent 图片渲染
+## 源码事实
+
+- **源码位置**：`src/components/markdown-token/image-content/image-content.vue`
+- **能力域**：媒体文件
+- **能力说明**：渲染 Markdown 图片 token。
+
+> **能力域**：媒体文件
+
+Markdown Token 层的图片渲染基础组件，被 `MarkdownContent` 在解析到图片 token 时自动调用，通常无需手动引入。
+
+核心能力：**流式 URL 防闪烁**（debounce 稳定判断 + throttle 预加载）、**全局缓存**（模块级 `Set` 跨实例共享）、**三态渲染**（加载中 / 成功 / 失败）。
+
+## 组件结构
+
+```
+span.md-image-wrapper（inline-block，vertical-align: middle）
+├── [showLoading] span.md-image-loading（inline-flex，gap: 6px，padding: 4px 8px，bg: #f5f7fa）
+│     ├── bkui-vue Loading（spin，mini，primary）
+│     └── "图片加载中..."
+├── [showError]  span.md-image-error（同上，color: #ea3636，bg: #fee）
+│     ├── span.md-image-error-icon  →  ⚠️（font-size: 14px）
+│     └── span.md-image-error-text  →  alt || "图片加载失败"
+└── [else]       img.md-image（max-width: 100%，height: auto，loading="lazy"）
+                   :src="src"  :alt="alt"
+```
+
+> **错误文本**：优先显示 `alt`，未传 `alt` 时才显示 "图片加载失败"。
+
+## 状态机
+
+组件内部维护三个 `shallowRef`：`isLoading`、`hasError`、`isUrlStable`，以及两个 computed 控制显示：
+
+```
+showLoading 为 true 的条件（按优先级）：
+  1. isCached（全局缓存命中）→ false，直接显示图片
+  2. !isValidUrl              → true（URL 无效或正在输入中）
+  3. isLoading               → true（正在预加载）
+  4. !isUrlStable && hasError → true（URL 仍在变化，忽略旧错误）
+
+showError 为 true 的条件（需全部满足）：
+  isUrlStable && hasError && !isLoading
+```
+
+### URL 有效性（isValidUrl）
+
+```
+src 被判定为无效的情况（显示 Loading）：
+  · 空字符串 / '#' / '#)'
+  · 以 '#' 或 '#)' 结尾（Markdown 语法补全占位符）
+  · 无协议且不是相对路径/带图片扩展名的路径
+  · https?:// 开头但域名中无 '.' 且不是 localhost
+
+合法 URL 格式：
+  · https?://、//          → 协议 URL（域名需含 '.' 或为 localhost）
+  · data:、blob:           → Data URL / Blob URL
+  · /path 或 ./path       → 绝对/相对路径
+  · image.png、a.jpg?v=1  → 带图片扩展名的文件名
+```
+
+### 流式防抖与节流
+
+| 机制                        | 参数                      | 作用                                                             |
+| --------------------------- | ------------------------- | ---------------------------------------------------------------- |
+| `markUrlStable`（debounce） | 500ms                     | URL 停止变化 500ms 后置 `isUrlStable = true`，此后才允许显示错误 |
+| `preloadImage`（throttle）  | 100ms，leading + trailing | 限制 `new Image()` 预加载频率，流式输入时不会每个字符都发请求    |
+
+### 全局缓存
+
+`loadedImageCache` 是**模块级 `Set<string>`**，所有 `ImageContent` 实例共享：
+
+- 图片加载成功后 → `loadedImageCache.add(url)`
+- 组件初始化时若命中缓存 → `isLoading = false`，`isUrlStable = true`，跳过所有预加载逻辑，直接渲染 `<img>`
+- 页面刷新后缓存清空（仅内存缓存）
+
+## 基础用法
+
+```vue
+<template>
+  <ImageContent
+    src="https://picsum.photos/seed/demo/400/200"
+    alt="示例图片"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ImageContent } from '@blueking/chat-x';
+</script>
+```
+
+## 加载失败
+
+URL 稳定后（500ms 无变化）加载失败，显示 `⚠️ + alt文本`（无 alt 时显示"图片加载失败"）：
+
+## Data URL
+
+支持 Base64 / SVG Data URL，不经过 `isValidUrl` 的网络检测，直接进入预加载：
+
+```vue
+<template>
+  <ImageContent
+    src="data:image/svg+xml,..."
+    alt="内联 SVG"
+  />
+</template>
+```
+
+## 流式输入防闪烁
+
+流式 Markdown 渲染时 URL 逐字符拼接，组件通过 debounce + throttle 避免频繁请求和闪烁：
+
+```vue
+<template>
+  <button
+    @click="simulateStreaming"
+    :disabled="isStreaming"
+  >
+    {{ isStreaming ? '输入中...' : '模拟流式输入' }}
+  </button>
+  <ImageContent
+    :src="streamingUrl"
+    alt="流式图片"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ImageContent } from '@blueking/chat-x';
+
+  const streamingUrl = ref('');
+  const isStreaming = ref(false);
+
+  const simulateStreaming = async () => {
+    const url = 'https://picsum.photos/seed/chat-x-stream/400/200';
+    streamingUrl.value = '';
+    isStreaming.value = true;
+    for (let i = 0; i <= url.length; i++) {
+      await new Promise(r => setTimeout(r, 60));
+      streamingUrl.value = url.slice(0, i);
+    }
+    isStreaming.value = false;
+  };
+</script>
+```
+
+**流式过程中的状态变化**：
+
+```
+URL = ''             → isValidUrl=false  → showLoading=true（Loading）
+URL = 'https://'    → isValidUrl=false  → showLoading=true（域名不完整）
+URL = 'https://p…'  → isValidUrl=false  → showLoading=true（域名无 '.'）
+URL = 完整 URL       → isValidUrl=true   → throttle 触发 preloadImage
+                                           debounce 500ms → isUrlStable=true
+                                           onload → cache → showLoading=false → 显示图片
+```
+
+## API
+
+### Props
+
+| 属性名 | 类型     | 必填 | 说明                                                                         |
+| ------ | -------- | ---- | ---------------------------------------------------------------------------- |
+| src    | `string` | ✓    | 图片 URL，支持 https / http / // / data: / blob: / 相对路径 / 带扩展名文件名 |
+| alt    | `string` | —    | 替代文本；加载失败时优先显示此文本，未传时显示"图片加载失败"                 |
+
+## 使用场景
+
+`ImageContent` 由 `MarkdownContent` 在渲染 `image` token 时自动调用，通常不需要手动引入。如需在 Markdown 以外的场景渲染带流式防抖保护的图片，可单独使用。
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — 图片 token 渲染入口

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-preview-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-preview-group.md
@@ -1,0 +1,184 @@
+# ImagePreviewGroup 图片预览组
+
+> 能力域：媒体文件 ｜ 导入：`import { ImagePreviewGroup } from '@blueking/chat-x'` ｜ since 1.0.0
+
+通过 provide/inject 管理同组图片预览。 源码位置：src/components/image-preview/image-preview-group.vue。
+
+**关联**：ai-image（子级注册并参与多图预览集合）、image-preview（内置实例承载多图切换与工具栏）
+
+---
+
+# ImagePreviewGroup 图片预览组
+## 源码事实
+
+- **源码位置**：`src/components/image-preview/image-preview-group.vue`
+- **能力域**：媒体文件
+- **能力说明**：通过 provide/inject 管理同组图片预览。
+
+> **能力域**：媒体文件
+
+多图预览管理容器。通过 `provide/inject` + `Map<symbol>` 模式管理子级 `AiImage` 的注册与预览状态，点击任意子图片时自动收集所有已注册图片并打开多图预览。
+
+## 组件结构
+
+```
+.ai-image-preview-group
+├── <slot />（放置多个 AiImage）
+└── ImagePreview（内置，按需显示）
+      v-model:visible="previewVisible"
+      v-model:current="activeIndex"
+      :images="previewImages"
+```
+
+## 工作原理
+
+```
+┌─ ImagePreviewGroup ──────────────────────────────────────┐
+│  provide(IMAGE_PREVIEW_GROUP_KEY, { register, unregister, preview })  │
+│                                                                       │
+│  ┌─ AiImage ─┐  ┌─ AiImage ─┐  ┌─ AiImage ─┐                       │
+│  │ uid: sym1 │  │ uid: sym2 │  │ uid: sym3 │                        │
+│  │ onMounted → register(sym, getItem)                                 │
+│  │ onClick  → groupContext.preview(sym)                               │
+│  │ onUnmount → unregister(sym)                                        │
+│  └────────────┘  └────────────┘  └────────────┘                       │
+│                                                                       │
+│  preview(uid) → 收集所有 registry 中的 ImageItem →                    │
+│                  设置 activeIndex → 打开 ImagePreview                  │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+## 基础用法
+
+```vue
+<template>
+  <ImagePreviewGroup>
+    <AiImage
+      v-for="(src, i) in images"
+      :key="i"
+      :src="src"
+      :width="160"
+      :height="120"
+    />
+  </ImagePreviewGroup>
+</template>
+
+<script setup lang="ts">
+  import { AiImage, ImagePreviewGroup } from '@blueking/chat-x';
+
+  const images = [
+    'https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=400&h=300&fit=crop',
+    'https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=400&h=300&fit=crop',
+    'https://images.unsplash.com/photo-1447752875215-b2761acb3c5d?w=400&h=300&fit=crop',
+  ];
+</script>
+```
+
+## 带图片信息
+
+配合 `showInfo` 和 `AiImage` 的 `previewProps`，在预览工具栏显示图片尺寸信息：
+
+```vue
+<template>
+  <ImagePreviewGroup :show-info="true">
+    <AiImage
+      v-for="(img, i) in images"
+      :key="i"
+      :src="img.src"
+      :preview-props="img.previewProps"
+      :width="160"
+      :height="120"
+    />
+  </ImagePreviewGroup>
+</template>
+
+<script setup lang="ts">
+  import { AiImage, ImagePreviewGroup, type ImagePreviewConfig } from '@blueking/chat-x';
+
+  const images = [
+    {
+      src: '...缩略图地址...',
+      previewProps: {
+        src: '...高清原图地址...',
+        name: '湖泊风景.jpg',
+        width: 1920,
+        resolution: '1920×1080',
+      } as ImagePreviewConfig,
+    },
+    // ...更多图片
+  ];
+</script>
+```
+
+## 自定义下载
+
+通过 `onDownload` 统一控制所有子图片的下载行为：
+
+```vue
+<template>
+  <ImagePreviewGroup :on-download="handleDownload">
+    <AiImage
+      v-for="(src, i) in images"
+      :key="i"
+      :src="src"
+      :width="160"
+      :height="120"
+    />
+  </ImagePreviewGroup>
+</template>
+
+<script setup lang="ts">
+  import { AiImage, ImagePreviewGroup } from '@blueking/chat-x';
+
+  const handleDownload = (url: string) => {
+    window.open(`/api/download?url=${encodeURIComponent(url)}`);
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                    | 默认值  | 说明                                          |
+| ------------ | ----------------------- | ------- | --------------------------------------------- |
+| maskClosable | `boolean`               | `true`  | 点击遮罩层是否关闭预览                        |
+| showInfo     | `boolean`               | `false` | 预览工具栏是否显示图片尺寸信息                |
+| onDownload   | `(url: string) => void` | —       | 自定义下载回调；不传时使用默认 `<a>` 标签下载 |
+
+### Slots
+
+| 插槽名  | 说明                                            |
+| ------- | ----------------------------------------------- |
+| default | 放置子级 `AiImage` 组件                         |
+| extra   | 预览工具栏的额外操作区域（透传给 ImagePreview） |
+
+## 类型定义
+
+```typescript
+interface ImagePreviewGroupContext {
+  register: (uid: symbol, getItem: () => ImageItem) => void;
+  unregister: (uid: symbol) => void;
+  preview: (uid: symbol) => void;
+}
+
+const IMAGE_PREVIEW_GROUP_KEY: InjectionKey<ImagePreviewGroupContext>;
+```
+
+## 与 AiImage 的协作关系
+
+| AiImage 场景  | 行为                                                                                     |
+| ------------- | ---------------------------------------------------------------------------------------- |
+| 未在 Group 内 | `inject` 返回 `null`，AiImage 内部自行渲染 `ImagePreview`（独立模式）                    |
+| 在 Group 内   | `inject` 获取 Group 上下文；`onMounted` 注册自身；点击时调用 `groupContext.preview(uid)` |
+
+## 使用场景
+
+- AI 对话中一条消息包含多张图片，需要统一预览
+- 图片画廊场景
+- 任何需要"点击缩略图 → 多图预览切换"的场景
+
+## 关联组件
+
+- [AiImage](/components/medias/ai-image) — 子级缩略图与注册
+- [ImagePreview](/components/medias/image-preview) — 内置全屏预览

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/image-preview.md
@@ -1,0 +1,226 @@
+# ImagePreview 图片预览
+
+> 能力域：媒体文件 ｜ 导入：`import { ImagePreview } from '@blueking/chat-x'` ｜ since 1.0.0
+
+图片全屏预览容器，支持缩放、旋转、下载工具栏。 源码位置：src/components/image-preview/image-preview.vue。
+
+**关联**：ai-image（独立模式下由 AiImage 打开预览）、image-preview-group（组内容器内持有一个实例做多图切换）、file-content（文件列表点击缩略图触发预览）
+
+---
+
+# ImagePreview 图片预览
+## 源码事实
+
+- **源码位置**：`src/components/image-preview/image-preview.vue`
+- **能力域**：媒体文件
+- **能力说明**：图片全屏预览容器，支持缩放、旋转、下载工具栏。
+
+> **能力域**：媒体文件
+
+全屏图片预览组件，通过 `Teleport` 渲染到 `body`，支持缩放、旋转、拖拽、下载、键盘导航等功能。`images` 支持传入 URL 字符串、`ImageItem` 对象或 `File` 对象，File 对象会自动通过 `URL.createObjectURL` 生成预览并在关闭/卸载时回收。通常不直接使用，而是配合 `AiImage`、`ImagePreviewGroup` 或 `FileContent` 自动触发。
+
+## 组件结构
+
+```
+Teleport(to="body")
+└── .ai-image-preview（fixed，z-index: 10000，background: rgba(0,0,0,0.6)）
+    ├── .ai-image-preview-close（右上角关闭按钮）
+    ├── .ai-image-preview-arrow-left（左切换箭头，多图时显示）
+    ├── .ai-image-preview-arrow-right（右切换箭头，多图时显示）
+    ├── .ai-image-preview-body（图片主体区域，支持拖拽/滚轮缩放）
+    │   ├── <img>（currentStatus !== 'error' 时）
+    │   ├── .ai-image-preview-error（加载失败时）
+    │   └── .ai-image-preview-loading（加载中，支持模糊缩略图）
+    └── PreviewToolbar（底部工具栏）
+        ├── 页码（多图时: 1/3）
+        ├── 缩小 / 放大 / 旋转 / 重置 / 下载
+        ├── slot#extra（额外操作区域）
+        └── 图片信息（showInfo 时显示宽度/分辨率）
+```
+
+## 内部子组件
+
+### PreviewToolbar
+
+底部圆角工具栏，包含以下按钮：
+
+| 按钮 | 功能                           | tooltip |
+| ---- | ------------------------------ | ------- |
+| 缩小 | 按 15% 步进缩小（最小 0.1 倍） | 缩小    |
+| 放大 | 按 15% 步进放大（最大 10 倍）  | 放大    |
+| 旋转 | 顺时针旋转 90°                 | 旋转    |
+| 重置 | 重置缩放/旋转/位移             | 重置    |
+| 下载 | 触发下载                       | 下载    |
+
+多图模式下还显示页码（如 "1 / 3"）和分隔线。
+
+### useImageTransform
+
+图片变换 Composable，管理缩放/旋转/平移状态：
+
+- `scale`：缩放比例（0.1 ~ 10，步进 15%）
+- `rotate`：旋转角度（每次 +90°，累加不取模）
+- `translateX / translateY`：拖拽偏移量
+- 支持鼠标滚轮缩放和拖拽平移
+- `resetTransform` 重置时跳过过渡动画（`skipTransition`），避免视觉闪烁
+
+### usePreviewKeyboard
+
+键盘导航 Composable：
+
+| 按键  | 功能               |
+| ----- | ------------------ |
+| `Esc` | 关闭预览           |
+| `←`   | 上一张（多图模式） |
+| `→`   | 下一张（多图模式） |
+
+预览打开时自动锁定 `body` 滚动（`overflow: hidden`），关闭时恢复。
+
+## 基础用法（单图）
+
+```vue
+<template>
+  <button @click="visible = true">预览图片</button>
+  <ImagePreview
+    v-model:visible="visible"
+    :images="images"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ImagePreview } from '@blueking/chat-x';
+
+  const visible = ref(false);
+  const images = ['https://images.unsplash.com/photo-1506744038136-46273834b3fb?w=1920'];
+</script>
+```
+
+## 多图预览
+
+传入多张图片时，左右箭头和页码自动显示，支持循环切换：
+
+```vue
+<template>
+  <button @click="visibleMulti = true">预览多张图片</button>
+  <ImagePreview
+    v-model:visible="visibleMulti"
+    v-model:current="currentIndex"
+    :images="images"
+    :show-info="true"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ImagePreview, type ImageItem } from '@blueking/chat-x';
+
+  const visibleMulti = ref(false);
+  const currentIndex = ref(0);
+  const images: ImageItem[] = [
+    { url: '...', name: '湖泊风景.jpg', width: 1920, resolution: '1920×1080' },
+    { url: '...', name: '山谷日出.jpg', width: 1920, resolution: '1920×1280' },
+    { url: '...', name: '森林小径.jpg', width: 1920, resolution: '1920×1280' },
+  ];
+</script>
+```
+
+## File 对象预览
+
+`images` 数组中可直接传入 `File` 对象，组件会自动通过 `URL.createObjectURL` 生成预览 URL，并在预览关闭或组件卸载时自动调用 `URL.revokeObjectURL` 释放内存：
+
+```vue
+<template>
+  <button @click="visibleFile = true">预览 File 对象</button>
+  <ImagePreview
+    v-model:visible="visibleFile"
+    :images="fileImages"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ImagePreview } from '@blueking/chat-x';
+
+  const visibleFile = ref(false);
+  const fileImages = [
+    new File(['png-data'], 'screenshot.png', { type: 'image/png' }),
+    new File(['jpg-data'], 'photo.jpg', { type: 'image/jpeg' }),
+  ];
+</script>
+```
+
+> **ObjectURL 生命周期管理**：组件内部维护 `objectUrls` 数组，在以下时机自动回收：
+>
+> - `normalizedImages` 计算属性重算时（会先 `revokeObjectUrls`，再按当前 `images` 与 `visible` 生成新列表）
+> - **`visible` 为 `false` 时**：计算属性直接清空并 `revokeObjectURL`，避免仅依赖 `props.images` 时 computed 仍缓存**已失效**的 blob URL，导致关闭预览后再次打开加载失败
+> - 组件 `onBeforeUnmount` 时
+
+## API
+
+### Props
+
+| 属性名       | 类型                              | 默认值  | 说明                                                        |
+| ------------ | --------------------------------- | ------- | ----------------------------------------------------------- |
+| images       | `(File \| ImageItem \| string)[]` | `[]`    | 图片列表；字符串自动转为 `{ url }`，File 自动转为 ObjectURL |
+| maskClosable | `boolean`                         | `true`  | 点击遮罩层是否关闭预览                                      |
+| showInfo     | `boolean`                         | `false` | 工具栏是否显示图片尺寸信息（width / resolution）            |
+| onDownload   | `(url: string) => void`           | —       | 自定义下载回调；不传时使用默认 `<a>` 标签下载               |
+
+### v-model
+
+| 属性名  | 类型      | 必填 | 说明                    |
+| ------- | --------- | ---- | ----------------------- |
+| visible | `boolean` | ✅   | 控制预览弹窗的显示/隐藏 |
+| current | `number`  | —    | 当前展示的图片索引      |
+
+### Slots
+
+| 插槽名 | 说明                                   |
+| ------ | -------------------------------------- |
+| extra  | 工具栏额外操作区域，渲染在下载按钮右侧 |
+
+## 类型定义
+
+```typescript
+interface ImageItem {
+  url: string;
+  thumbnailUrl?: string;
+  name?: string;
+  file?: File;
+  width?: number;
+  height?: number;
+  resolution?: string;
+  downloadUrl?: string;
+}
+
+type ImageLoadingStatus = 'loading' | 'loaded' | 'error';
+```
+
+## 交互说明
+
+| 操作          | 效果                                    |
+| ------------- | --------------------------------------- |
+| 滚轮向上      | 放大图片（15% 步进）                    |
+| 滚轮向下      | 缩小图片（15% 步进）                    |
+| 鼠标左键拖拽  | 平移图片                                |
+| 点击遮罩      | 关闭预览（`maskClosable` 为 `true` 时） |
+| 点击关闭按钮  | 关闭预览                                |
+| 左/右箭头按钮 | 切换上/下一张（多图，循环切换）         |
+| `Esc` 键      | 关闭预览                                |
+| `←` / `→` 键  | 切换上/下一张（多图）                   |
+
+## 使用场景
+
+- 单张或多张图片的全屏预览
+- AI 对话中点击图片放大查看（由 `AiImage` 自动触发）
+- 文件列表中点击图片缩略图预览（由 `FileContent` 内部集成）
+- 用户消息中点击附件图片预览（由 `UserMessage` → `FileContent` 自动触发）
+- 需要旋转/缩放/下载操作的图片查看
+- 传入 `File` 对象直接预览（无需手动管理 ObjectURL）
+
+## 关联组件
+
+- [AiImage](/components/medias/ai-image) — 独立模式触发预览
+- [ImagePreviewGroup](/components/medias/image-preview-group) — 多图预览容器
+- [FileContent](/components/medias/file-content) — 附件列表点击预览

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/info-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/info-message.md
@@ -1,0 +1,127 @@
+# InfoMessage 信息消息
+
+> 能力域：消息系统 ｜ 导入：`import { InfoMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染居中的系统信息提示。 源码位置：src/components/chat-message/info-message/info-message.vue。
+
+**关联**：message-render（由 MessageRender 在 role 为 info 时创建）、message-container（嵌入消息列表时由 MessageContainer 统一布局与滚动）
+
+---
+
+# InfoMessage 信息消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/info-message/info-message.vue`
+- **能力域**：消息系统
+- **能力说明**：渲染居中的系统信息提示。
+
+> **能力域**：消息系统
+
+系统信息分隔组件，在聊天消息列表中以**居中虚线分隔条**的形式展示非对话类信息（会话重置、时间节点、状态变更等）。
+
+## 视觉原理
+
+组件通过 `height: 0` + `border-bottom: 1px dashed #dcdee5` 生成一条贯穿全宽的虚线，内容文字区域设置白色背景"浮"在虚线中央，形成"文字刻在分隔线上"的视觉效果：
+
+```
+───── ─ ─ 以下是新的对话 ─ ─ ─────
+```
+
+## 基础用法
+
+`content` 传入字符串，渲染单行分隔信息：
+
+```vue
+<template>
+  <InfoMessage :content="content" />
+</template>
+
+<script setup lang="ts">
+  import { InfoMessage } from '@blueking/chat-x';
+
+  const content = '以下是新的对话';
+</script>
+```
+
+**渲染效果**
+
+## 多行信息
+
+`content` 传入字符串数组时，每个元素渲染为一个独立的文字浮标，均居中排列在同一条虚线上：
+
+```vue
+<template>
+  <InfoMessage :content="['会话已重置', '以下是新的对话']" />
+</template>
+
+<script setup lang="ts">
+  import { InfoMessage } from '@blueking/chat-x';
+</script>
+```
+
+**渲染效果**
+
+## 典型使用场景
+
+**会话分隔**
+
+**时间节点**
+
+**上下文清除**
+
+## 在 MessageContainer 中使用
+
+`InfoMessage` 通常不需要单独引入，`MessageContainer`（或 `MessageRender`）会对 `role: 'info'` 的消息自动渲染：
+
+```vue
+<template>
+  <MessageContainer :messages="messages" />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer, MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  const messages = [
+    {
+      id: '1',
+      messageId: '1',
+      role: MessageRole.User,
+      content: '请帮我分析一下这份报告。',
+      status: MessageStatus.Complete,
+    },
+    // info 消息：role 为 'info'，content 为字符串
+    {
+      id: '2',
+      messageId: '2',
+      role: MessageRole.Info, // 'info'
+      content: '上下文已达上限，已自动清除历史对话',
+      status: MessageStatus.Complete,
+    },
+    {
+      id: '3',
+      messageId: '3',
+      role: MessageRole.Assistant,
+      content: '好的，我来帮你分析这份报告...',
+      status: MessageStatus.Complete,
+    },
+  ];
+</script>
+```
+
+## API
+
+### Props
+
+组件 Props 继承自 `Partial<InfoMessage>`，所有字段均可选：
+
+| 属性名    | 类型                 | 说明                                                               |
+| --------- | -------------------- | ------------------------------------------------------------------ |
+| content   | `string \| string[]` | 信息内容。字符串渲染单行，数组渲染多个文字浮标，均居中排列在虚线上 |
+| id        | `number \| string`   | 消息 ID（接收但不使用，由 MessageContainer 管理）                  |
+| messageId | `number \| string`   | 消息唯一标识（接收但不使用）                                       |
+| status    | `MessageStatus`      | 消息状态（接收但不使用，组件无状态相关渲染逻辑）                   |
+| role      | `MessageRole.Info`   | 消息角色，固定为 `'info'`                                          |
+
+> **说明**：`content` 的 TypeScript 类型定义为 `string`（与 `BaseMessage` 泛型一致），但组件模板内部通过 `Array.isArray(content) ? content : [content]` 实际兼容字符串数组。
+
+## 安全性

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/input-attachment.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/input-attachment.md
@@ -1,0 +1,43 @@
+# InputAttachment 输入附件区
+
+> 能力域：输入交互 ｜ 导入：`import { InputAttachment } from '@blueking/chat-x'` ｜ since 1.0.0
+
+ChatInput 底部附件区布局，承载快捷按钮、文件与发送图标。 源码位置：src/components/chat-input/input-attachment/input-attachment.vue。
+
+---
+
+# InputAttachment 输入附件区
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/input-attachment/input-attachment.vue`
+- **能力说明**：ChatInput 底部附件区布局，承载快捷按钮、文件与发送图标。
+
+## API 摘要
+
+### Props
+
+- `{ messageState?: MessageStatus; sendDisabledTip?: string; tippyOptions?: AITippyProps; }`
+
+### Emits
+
+- `{ (e: 'sendMessage'): void; (e: 'stopSending'): void; }`
+
+### Slots
+
+- `default`
+- `send-icon`
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/input-info-alert.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/input-info-alert.md
@@ -1,0 +1,42 @@
+# InputInfoAlert 输入提示条
+
+> 能力域：输入交互 ｜ 导入：`import { InputInfoAlert } from '@blueking/chat-x'` ｜ since 1.0.0
+
+ChatInput 上方的信息提示条。 源码位置：src/components/chat-input/input-info-alert.vue。
+
+---
+
+# InputInfoAlert 输入提示条
+
+> **能力域**：输入交互
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-input/input-info-alert.vue`
+- **能力说明**：ChatInput 上方的信息提示条。
+
+## API 摘要
+
+### Props
+
+- `{ content: string; }`
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/interrupt-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/interrupt-message.md
@@ -1,0 +1,212 @@
+# InterruptMessage 中断消息
+
+> 能力域：Agent 能力 ｜ 导入：`import { InterruptMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 human-in-the-loop 中断消息，分发工具审批，并按 reason 回显 resume 结果（审批单 / 用户回答）。 源码位置：src/components/chat-message/interrupt-message/interrupt-message.vue。
+
+**关联**：message-render（role 为 interrupt 时渲染本组件）、user-question-card（UserQuestion 待回答面板与回答回显）、tool-approval-card（AIDevToolApproval 专用子卡片）、message-container（透传 onInterruptResume；末条为 interrupt 时不触发组 hover）
+
+---
+
+# InterruptMessage 中断消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/interrupt-message.vue`
+- **能力域**：Agent 能力
+- **能力说明**：渲染 human-in-the-loop 中断消息，分发工具审批，并按 `result.reason` 回显 resume 结果。
+
+> **能力域**：Agent 能力
+
+human-in-the-loop 中断消息渲染器（导出名 **`InterruptMessageRender`**）。对应 `MessageRole.Interrupt`，解析 `content.outcome` 渲染审批卡片或兜底提示。
+
+> 通常由 [MessageRender](/components/message/message-render) 自动调用，无需业务侧直接引入。
+> `UserQuestion` 的待回答卡片由 [ChatContainer](/components/setup/chat-container) 放在输入区上方，本组件在 `outcome.success` 时按 `result.reason` 回显审批单或用户回答。
+
+## 渲染架构
+
+```
+InterruptMessageRender
+├── content.message（可选）→ 顶部说明文案
+└── content.outcome.type === 'interrupt'
+      └── v-for interrupts
+            ├── reason === aidev:tool_approval → ToolApprovalCard（透传 onInterruptResume，用于取消审批）
+            ├── reason === aidev:user_question → 不在消息内渲染，交由 ChatContainer 输入区挂载
+            └── 未注册 reason → 兜底块（item.message 或「暂不支持的中断消息」）
+
+content.outcome.type === 'success'
+└── resultRenderers[result.reason]
+      ├── aidev:tool_approval → ToolApprovalCard（readonly，隐藏取消审批）
+      └── aidev:user_question → UserQuestionAnsweredCard（支持 #answeredQuestion 透传 #answer）
+```
+
+| `InterruptReason`              | 子组件              |
+| ------------------------------ | ------------------- |
+| `aidev:tool_approval`（待审批） | `ToolApprovalCard`  |
+| `aidev:tool_approval`（已处理） | `ToolApprovalCard`（`readonly`，只读回显） |
+| `aidev:user_question`（待回答） | 输入区 `UserQuestionCard`，本组件不渲染 |
+| `aidev:user_question`（已回答） | `UserQuestionAnsweredCard` |
+| 其他 / 未注册                  | 兜底文案区域        |
+
+## 基础用法（待审批）
+
+```vue
+<template>
+  <InterruptMessageRender
+    :id="message.id"
+    :message-id="message.messageId"
+    :role="message.role"
+    :status="message.status"
+    :content="message.content"
+    :on-interrupt-resume="handleInterruptResume"
+  />
+</template>
+
+<script setup lang="ts">
+  import {
+    InterruptMessageRender,
+    APPROVAL_STATUS,
+    InterruptReason,
+    MessageRole,
+    MessageStatus,
+    type InterruptMessage,
+  } from '@blueking/chat-x';
+
+  const message: InterruptMessage = {
+    id: 'msg_interrupt',
+    messageId: 'msg_interrupt',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      message: '算法方案评审单需要您关注',
+      outcome: {
+        type: 'interrupt',
+        interrupts: [
+          {
+            id: 'interrupt_1',
+            reason: InterruptReason.AIDevToolApproval,
+            toolCallId: 'tool_call_1',
+            metadata: {
+              ticket: {
+                approvers: ['张三'],
+                sn: 'REV-2026-04-24-001',
+                status: APPROVAL_STATUS.PENDING,
+                submit_time: '2026-04-24 14:30:15',
+                title: '算法方案评审单',
+                url: 'https://example.com/tickets/001',
+              },
+            },
+          },
+        ],
+      },
+    },
+  };
+
+  const handleInterruptResume = async (payload, interrupt) => {
+    // ToolApprovalCard 点击「取消审批」时，payload 为 ToolApprovalResume
+    console.log(payload, interrupt?.id);
+  };
+</script>
+```
+
+**渲染效果**
+
+## UserQuestion 待回答
+
+待回答的 `UserQuestion` 不在消息内渲染；`ChatContainer` 会找到最近一条待回答中断，并在 `ChatInput` 上方挂载 [UserQuestionCard](/components/agent/user-question-card)。
+
+```vue
+<InterruptMessageRender
+  :content="userQuestionMessage.content"
+  role="interrupt"
+/>
+```
+
+**渲染效果**
+
+## AIDevToolApproval 已处理回显（outcome.success）
+
+`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以只读 `ToolApprovalCard` 回显审批单。`result.payload.metadata` 需透传中断时的 `metadata`（含 `ticket`）：
+
+```vue
+<InterruptMessageRender
+  :content="resumedMessage.content"
+  role="interrupt"
+/>
+```
+
+**渲染效果**
+
+## UserQuestion 已回答回显（outcome.success）
+
+`outcome.type === 'success'` 且 `result.reason === InterruptReason.UserQuestion` 时，会话内回显用户回答。可通过 `#answeredQuestion` slot 自定义单题回显：
+
+```vue
+<InterruptMessageRender
+  :content="userQuestionAnsweredMessage.content"
+  role="interrupt"
+>
+  <template #answeredQuestion="{ item, index, status }">
+    <MyCustomAnswerView :data="item" :index="index" :status="status" />
+  </template>
+</InterruptMessageRender>
+```
+
+**渲染效果**
+
+## 不支持的中断类型（兜底）
+
+```vue
+<InterruptMessageRender :content="unsupportedContent" role="interrupt" />
+```
+
+**渲染效果**
+
+## 在 MessageContainer 中使用
+
+配置 `onInterruptResume`，由容器经 `MessageRender` 透传到本组件：
+
+```vue
+<MessageContainer
+  :messages="messages"
+  :on-interrupt-resume="handleInterruptResume"
+/>
+```
+
+当消息组**最后一条**为 `role: 'interrupt'` 时，容器**不会**在鼠标移入时设置 `isHover`，避免误显 AI 工具栏遮挡审批卡片。
+
+## API
+
+### Props
+
+继承 `Partial<InterruptMessage>` 的字段（`id`、`messageId`、`role`、`content`、`status` 等），并额外支持：
+
+| 属性名            | 类型               | 默认值 | 说明                                      |
+| ----------------- | ------------------ | ------ | ----------------------------------------- |
+| content           | `InterruptMessage['content']` | — | 含 `message`、`outcome`、`result` 等      |
+| onInterruptResume | `OnInterruptResume` | —     | 用户完成中断操作后的回调（可选）          |
+
+### Slots
+
+| 插槽名           | 参数                                              | 说明                                                                 |
+| ---------------- | ------------------------------------------------- | -------------------------------------------------------------------- |
+| answeredQuestion | `{ item, index, status }`                         | 自定义 UserQuestion 已回答内容回显，透传给 `UserQuestionAnsweredCard` 的 `#answer` |
+
+slot 参数与 [UserQuestionAnsweredCard](/components/agent/user-question-answered-card) 的 `#answer` 一致。
+
+### Events / Expose
+
+无。
+
+## 类型定义
+
+```typescript
+import type { Interrupt, InterruptMessage, OnInterruptResume } from '@blueking/chat-x';
+```
+
+详见 [中断类型 Interrupt](../../types/interrupt.md)。
+
+## 关联组件
+
+- [ToolApprovalCard](/components/agent/tool-approval-card) — AI Dev 审批单卡片
+- [MessageRender](/components/message/message-render) — 按 `role` 派发
+- [MessageContainer](/components/setup/message-container) — 列表容器与 `onInterruptResume` 透传

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/key-value-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/key-value-content.md
@@ -1,0 +1,128 @@
+# KeyValueContent 键值内容
+
+> 能力域：内容渲染 ｜ 导入：`import { KeyValueContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+以键值列表展示结构化内容。 源码位置：src/components/chat-content/key-value-content/key-value-content.vue。
+
+**关联**：user-message（用户消息内展示结构化附加信息）
+
+---
+
+# KeyValueContent 键值对内容
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/key-value-content/key-value-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：以键值列表展示结构化内容。
+
+> **能力域**：内容渲染
+
+键值对列表展示基础组件，每行以 `key : value` 格式渲染一条数据，支持可选标题栏（带 `ThinkingIcon`）。
+
+主要被 `UserMessage` 内部用于渲染结构化引用内容（`property.extra.cite.data`），通常不需要手动引入。
+
+## 组件结构
+
+```
+div.ai-key-value-content（flex column，gap: 8px，font-size: 12px，color: #4d4f56）
+├── [v-if="title"] div.ai-key-value-title（flex，gap: 4px，font-size: 12px，font-weight: 700，color: #3a84ff）
+│     ├── ThinkingIcon（14×14px）
+│     └── {{ title }}
+└── div.ai-key-value-content（flex column，无 gap）   ← 与外层同名嵌套
+      └── div.key-value-item × N（flex row，gap: 3px，min-height: 20px）
+            ├── div.item-key   → {{ item.key }}（flex: 0 0 auto，font-weight: bold，color: #333）
+            ├── "："            → 硬编码文本节点，冒号不属于任何 div
+            └── div.item-value → {{ item.value }}（overflow hidden，ellipsis，`word-break: break-all` 允许多行换行）
+```
+
+> **注意**：内层也是 `.ai-key-value-content` 类（与外层同名），仅用于布局，无额外样式差异。  
+> **注意**：`v-for` 使用 `item.key` 作为 `:key`，`content` 中的 `key` 字段必须唯一，否则触发 Vue 重复 key 警告。  
+> **注意**：`item.value` 在单行方向仍可能因 `text-overflow: ellipsis` 显示省略，但配合 `word-break: break-all` 长串会优先换行展示，**无 tooltip**（与 `DescPanel` 不同）。
+
+## 基础用法
+
+```vue
+<template>
+  <KeyValueContent :content="data" />
+</template>
+
+<script setup lang="ts">
+  import { KeyValueContent } from '@blueking/chat-x';
+
+  const data = [
+    { key: '名称', value: '蓝鲸智云' },
+    { key: '版本', value: 'v3.0' },
+    { key: '状态', value: '运行中' },
+  ];
+</script>
+```
+
+## 带标题
+
+传入 `title` 时，顶部显示 `ThinkingIcon` + 标题文本（蓝色加粗）：
+
+```vue
+<template>
+  <KeyValueContent
+    title="模型参数"
+    :content="[
+      { key: '模型', value: 'GPT-4' },
+      { key: '温度', value: '0.7' },
+      { key: '最大 Token', value: '2048' },
+      { key: '频率惩罚', value: '0.5' },
+    ]"
+  />
+</template>
+```
+
+## 超长 value 换行
+
+`.item-value` 使用 `word-break: break-all`，长 URL 或长文本会在容器内换行；仍保留 `overflow: hidden` 与 `text-overflow: ellipsis` 以约束极端情况，**悬停无 tooltip**：
+
+## API
+
+### Props
+
+| 属性名  | 类型                                | 必填 | 说明                                                              |
+| ------- | ----------------------------------- | ---- | ----------------------------------------------------------------- |
+| content | `{ key: string; value: string; }[]` | ✓    | 键值对数组；`key` 同时作为 `v-for` 的 `:key`，需保证唯一          |
+| title   | `string`                            | —    | 标题文本；传入后在列表上方渲染 `ThinkingIcon + title`（蓝色加粗） |
+
+## 使用场景
+
+`KeyValueContent` 由 `UserMessage` 内部使用，渲染结构化引用内容（`property.extra.cite` 为对象类型时）：
+
+```typescript
+// UserMessage 内部逻辑（简化）
+const citeTitle = computed(() => {
+  const cite = props.property?.extra?.cite;
+  return cite && typeof cite !== 'string' ? cite.title : undefined;
+});
+
+const citeContent = computed(() => {
+  const cite = props.property?.extra?.cite;
+  return cite && typeof cite !== 'string' ? cite.data : cite;
+});
+// citeContent 为数组时 → <KeyValueContent :content="citeContent" :title="citeTitle" />
+// citeContent 为字符串时 → <CiteContent :content="citeContent" />
+```
+
+如需在用户消息中展示结构化引用，将 `property.extra.cite` 设置为以下格式即可：
+
+```typescript
+const message = {
+  // ...
+  property: {
+    extra: {
+      cite: {
+        title: '引用标题',
+        data: [{ key: '字段名', value: '字段值' }],
+      },
+    },
+  },
+};
+```
+
+## 关联组件
+
+- [UserMessage](/components/message/user-message) — 键值气泡展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/knowledge-rag-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/knowledge-rag-content.md
@@ -1,0 +1,122 @@
+# KnowledgeRagContent 知识召回内容
+
+> 能力域：Agent 能力 ｜ 导入：`import { KnowledgeRagContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染知识召回活动，包含加载态、Markdown 内容与引用来源。 源码位置：src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue。
+
+**关联**：activity-message（activityType 为 knowledge_rag 时分发到本组件）、activity-layout（提供可折叠的活动容器外壳）、markdown-content（渲染知识召回摘要正文）、reference-content（渲染召回引用来源列表）
+
+---
+
+# KnowledgeRagContent 知识召回内容
+
+> **能力域**：Agent 能力
+
+`KnowledgeRagContent` 用于渲染知识召回活动内容，包含活动标题、加载态、Markdown 摘要和引用来源列表。它是 `ActivityMessage` 在 `activityType === 'knowledge_rag'` 时使用的具体内容组件。
+
+通常不需要直接使用，`MessageRender -> ActivityMessage` 会根据消息类型自动分发到本组件。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue`
+- **能力说明**：渲染知识召回活动，包含加载态、Markdown 内容与引用来源。
+
+## 核心能力
+
+- **活动外壳**：基于 `ActivityLayout` 渲染可折叠活动区域，默认展开
+- **状态标题**：`status` 为 `pending` / `streaming` 时标题显示“检索中”并展示 Loading；其他状态显示“检索完成”
+- **Markdown 摘要**：使用 `MarkdownContent` 渲染 `content.content`
+- **引用来源**：使用 `ReferenceContent` 渲染 `content.referenceDocument`
+- **空值兜底**：正文缺失时传入空字符串，引用缺失时传入空数组
+
+## 基础用法
+
+```vue
+<template>
+  <KnowledgeRagContent
+    v-model:collapsed="collapsed"
+    :content="content"
+    status="complete"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import KnowledgeRagContent from '@blueking/chat-x/src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue';
+  import type { KnowledgeRagMessageContent } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+
+  const content: KnowledgeRagMessageContent = {
+    content: '根据知识库检索，**蓝鲸智云** 常见 Agent 接入流程包括...',
+    referenceDocument: [
+      { name: 'Agent 接入指南', url: 'https://example.com/agent-guide', originFile: 'https://example.com/docs/agent-guide' },
+    ],
+  };
+</script>
+```
+
+**渲染效果**
+
+## 检索中状态
+
+当消息状态为 `pending` 或 `streaming` 时，标题区域显示 Loading，标题文案为“检索中”。
+
+## 折叠状态
+
+`collapsed` 通过 `v-model:collapsed` 与 `ActivityLayout` 双向绑定，适合由父级活动消息统一控制展开/收起。
+
+## API
+
+### Props
+
+| 属性名     | 类型                         | 必填 | 默认值 | 说明                                     |
+| ---------- | ---------------------------- | ---- | ------ | ---------------------------------------- |
+| content    | `KnowledgeRagMessageContent` | 否   | —      | 知识召回摘要与引用来源                   |
+| messageUid | `string`                     | 否   | —      | 所属消息唯一标识，当前组件暂未直接使用   |
+| status     | `MessageStatus`              | 否   | —      | 消息状态，影响标题文案与 Loading 显示    |
+
+### Models
+
+| 名称      | 类型      | 默认值  | 说明             |
+| --------- | --------- | ------- | ---------------- |
+| collapsed | `boolean` | `false` | 活动内容是否折叠 |
+
+### Emits
+
+- 无显式 emits；`v-model:collapsed` 会产生 `update:collapsed`。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+export type KnowledgeRagMessageContent = {
+  content: string;
+  referenceDocument: ReferenceDocumentContent[];
+};
+
+export type ReferenceDocumentContent = {
+  name: string;
+  originFile: string;
+  url: string;
+};
+```
+
+## 使用建议
+
+- 业务接入时优先通过 [ActivityMessage](../message/activity-message.md) 或完整消息链路使用，避免重复判断 `activityType`。
+- `referenceDocument` 为空时组件仍会渲染正文区域，引用列表由 `ReferenceContent` 处理空数组。
+
+## 关联组件
+
+- [ActivityMessage](../message/activity-message.md) — 活动消息分发入口。
+- [ActivityLayout](../helper/activity-layout.md) — 折叠活动外壳。
+- [MarkdownContent](../rendering/markdown-content.md) — Markdown 摘要渲染。
+- [ReferenceContent](../rendering/reference-content.md) — 引用来源列表。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/latex-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/latex-content.md
@@ -1,0 +1,200 @@
+# LatexContent LaTeX 公式
+
+> 能力域：内容渲染 ｜ 导入：`import { LatexContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+使用 KaTeX 渲染 LaTeX 公式内容。 源码位置：src/components/markdown-token/latex-content/latex-content.vue。
+
+**关联**：markdown-content（插件解析 $...$ / $$...$$ 后生成数学 token 并挂载本组件）
+
+---
+
+# LatexContent LaTeX 公式渲染
+## 源码事实
+
+- **源码位置**：`src/components/markdown-token/latex-content/latex-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：使用 KaTeX 渲染 LaTeX 公式内容。
+
+> **能力域**：内容渲染
+
+Markdown Token 层的 LaTeX 公式渲染基础组件，基于 **KaTeX** 实现。被 `MarkdownContent` 在解析到数学公式 token 时自动调用，通常无需手动引入。
+
+核心能力：**流式防抖渲染**（throttle 100ms）、**语法自动补全**（`completeLatexContent`）、**渐进式降级重试**（最多 5 次）、**错误静默**（错误文本白色不可见）。
+
+## 组件结构与 Token 渲染路径
+
+```
+props.token（Token[]）
+│
+├─ token.type === 'math_block'（单块且 token.length ≤ 1）
+│    wrapperTag = 'div'，wrapperClass = 'block-latex-content'
+│    └─ <div class="block-latex-wrapper">
+│          └─ renderLatexToken(token) → <span class="block-katex">KaTeX HTML</span>
+│
+├─ token.type === 'math_inline'（或混合 token 数组）
+│    wrapperTag = 'span'，wrapperClass = 'inline-latex-content'
+│    └─ renderLatexToken(token) → <span class="inline-katex">KaTeX HTML</span>
+│
+├─ token.type === 'inline'（含 children）
+│    └─ renderInlineChildren(token.children)
+│         ├─ math_inline  → renderLatexToken（递归）
+│         ├─ text         → escapeHtml
+│         ├─ softbreak    → '\n'
+│         ├─ hardbreak    → '<br>'
+│         ├─ code_inline  → '<code>...</code>'
+│         ├─ strong_open/close → '<strong>' / '</strong>'
+│         ├─ em_open/close    → '<em>' / '</em>'
+│         ├─ s_open/close     → '<s>' / '</s>'
+│         ├─ link_open/close  → '<a href="...">...</a>'
+│         ├─ image            → '<img src="..." alt="...">'
+│         └─ 未知类型         → escapeHtml(token.content)
+│
+├─ token.type === 'paragraph_open/close' → '<p>' / '</p>'
+└─ token.type === 'text' / 其他         → escapeHtml(token.content)
+```
+
+### displayMode 判断规则
+
+```typescript
+// renderLatexToken 内部
+const displayMode = token.type === 'math_block' || token.meta?.displayMode === true;
+// math_inline 也可通过 meta.displayMode=true 强制块级渲染
+```
+
+## 基础用法：块级公式
+
+```vue
+<template>
+  <LatexContent :token="token" />
+</template>
+
+<script setup lang="ts">
+  import { LatexContent } from '@blueking/chat-x';
+  import type { Token } from 'markdown-it';
+
+  const token: Token[] = [{ type: 'math_block', content: 'E = mc^2' } as Token];
+</script>
+```
+
+## 行内公式
+
+`math_inline` 类型，包装为 `span.inline-latex-content`，嵌入文字流中渲染：
+
+```vue
+<template>
+  <!-- 行内公式 -->
+  <LatexContent :token="[{ type: 'math_inline', content: 'a^2 + b^2 = c^2' }]" />
+</template>
+```
+
+## 混合 inline token（文字 + 公式）
+
+传入 `inline` token 并带 `children` 时，`renderInlineChildren` 逐一处理文本、公式、标记：
+
+## 积分与根号
+
+## 矩阵
+
+## 对齐环境
+
+## 流式渲染防闪烁
+
+组件针对流式 Markdown 输入进行了优化：**100ms throttle**（leading + trailing）避免每字符重渲染，**`completeLatexContent`** 在每次渲染前自动补全不完整语法：
+
+```vue
+<template>
+  <LatexContent :token="streamingTokens" />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { LatexContent } from '@blueking/chat-x';
+
+  const streamingTokens = ref([{ type: 'math_block', content: '' }]);
+
+  const simulate = async () => {
+    const formula = '\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}';
+    let content = '';
+    for (const char of formula) {
+      await new Promise(r => setTimeout(r, 50));
+      content += char;
+      streamingTokens.value = [{ type: 'math_block', content }];
+    }
+  };
+</script>
+```
+
+## 语法自动补全（completeLatexContent）
+
+在每次调用 KaTeX 前，组件先通过 `completeLatexContent` 修复不完整语法，处理顺序为：
+
+| 步骤 | 处理内容                                                              | 示例                                          |
+| ---- | --------------------------------------------------------------------- | --------------------------------------------- |
+| 0    | 不完整 `\begin{env` → 猜测环境名补全 `\begin{env}\end{env}`           | `\begin{pma` → `\begin{pmatrix}\end{pmatrix}` |
+| 0.1  | 不完整 `\end{env` → 猜测环境名补全                                    | `\end{alig` → `\end{aligned}`                 |
+| 0.2  | 末尾不完整命令 `\begi` → 若匹配已知命令前缀则移除，完整命令则补全参数 | `\frac` → `\frac{}{}`                         |
+| 1    | 未闭合 `{}` → 补全缺失的 `}`                                          | `\frac{a}{b` → `\frac{a}{b}`                  |
+| 2    | 未闭合 `[]` → 补全缺失的 `]`                                          | `\sqrt[3` → `\sqrt[3]`                        |
+| 3    | 双参数命令缺第二个参数 → 追加 `{}`                                    | `\frac{a}` → `\frac{a}{}`                     |
+| 4    | `\begin{env}` 无对应 `\end{env}` → 追加 `\end{env}`                   | `\begin{matrix}...` → `...\end{matrix}`       |
+
+**可猜测的环境名**（`COMMON_ENVS`）：`aligned`、`align`、`equation`、`gather`、`matrix`、`pmatrix`、`bmatrix`、`vmatrix`、`cases`、`array`、`split`、`multline`
+
+**双参数命令**（`TWO_ARG_COMMANDS`）：`frac`、`dfrac`、`tfrac`、`binom`、`cfrac`、`overset`、`underset` 等
+
+**单参数命令**（`ONE_ARG_COMMANDS`）：`sqrt`、`text`、`mathbf`、`hat`、`vec`、`overline`、`boxed` 等
+
+## 渐进式降级重试（tryRenderKatex）
+
+补全后仍渲染失败时，最多重试 5 次，每次尝试两种裁剪策略：
+
+```
+尝试 completeLatexContent(content) → KaTeX 渲染
+  失败 →
+    策略 1：移除末尾不完整命令（正则 /\\[a-zA-Z]+(\{[^{}]*\})*\s*$/）
+    策略 2：移除未闭合 {（正则 /\{[^{}]*$/）
+  若仍失败 → 返回 null
+    → 渲染 <span class="katex-loading" style="color: #666; font-style: italic;">原始文本（HTML 转义）</span>
+```
+
+> **错误静默**：KaTeX 以 `errorColor: '#fff'`（白色）渲染错误文本，错误不可见。若检测到 HTML 中含 `katex-error` 类或 `color:#cc0000`，也视为渲染失败，降级为 `katex-loading` 显示原始文本。
+
+## API
+
+### Props
+
+| 属性名 | 类型      | 必填 | 说明                                                                                                                     |
+| ------ | --------- | ---- | ------------------------------------------------------------------------------------------------------------------------ |
+| token  | `Token[]` | ✓    | markdown-it Token 数组；支持 `math_block`、`math_inline`、`inline`（含 children）、`paragraph_open/close`、`text` 等类型 |
+
+### Token 结构
+
+```typescript
+// math_block / math_inline
+{
+  type: 'math_block' | 'math_inline';
+  content: string;              // LaTeX 公式字符串
+  meta?: { displayMode?: boolean }; // true → 块级渲染（math_inline 可用此强制块级）
+}
+
+// inline（含行内标记 + 公式混排）
+{
+  type: 'inline';
+  children: Token[];            // 子 token 列表
+}
+```
+
+## 样式说明
+
+| 类名                    | 标签   | 作用                                                                                        |
+| ----------------------- | ------ | ------------------------------------------------------------------------------------------- |
+| `.block-latex-content`  | `div`  | 单一 `math_block` 时的外层，`text-align: center`，`overflow: auto hidden`，`margin: 16px 0` |
+| `.inline-latex-content` | `span` | 混合/行内时的外层，`display: inline`，`vertical-align: baseline`                            |
+| `.block-latex-wrapper`  | `div`  | 每个 `math_block` token 的包装，`text-align: center`，`margin: 16px 0`                      |
+| `.block-katex`          | `span` | 块级 KaTeX 输出                                                                             |
+| `.inline-katex`         | `span` | 行内 KaTeX 输出                                                                             |
+| `.katex-loading`        | `span` | 渲染失败降级态，斜体灰色显示原始 LaTeX 文本                                                 |
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — 数学公式 token 的来源与挂载

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/loading-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/loading-message.md
@@ -1,0 +1,173 @@
+# LoadingMessage 加载消息
+
+> 能力域：消息系统 ｜ 导入：`import { LoadingMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+消息列表中的加载占位，默认使用 AiLoading，也支持默认插槽覆盖。 源码位置：src/components/chat-message/loading-message/loading-message.vue。
+
+**关联**：message-container（在消息列表末尾自动追加 Loading 消息组）、message-render（role 为 loading 时由 MessageRender 渲染）、ai-loading（内部使用 AiLoading 基础组件）
+
+---
+
+# LoadingMessage 加载中消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/loading-message/loading-message.vue`
+- **能力域**：消息系统
+- **能力说明**：消息列表中的加载占位，默认使用 AiLoading，也支持默认插槽覆盖。
+
+> **能力域**：消息系统
+
+加载等待状态组件，展示 AI 正在处理请求时的过渡动画。由旋转渐变环 + 脉冲星形图标（蓝→紫→粉渐变）和"请求中..."文案组成。支持通过默认插槽自定义加载文案。
+
+> **提示**：此组件通常**不需要手动使用**，`MessageContainer` 会在满足条件时自动注入。
+
+## 渲染效果
+
+## 基础用法
+
+组件无 Props，直接引入渲染即可：
+
+```vue
+<template>
+  <LoadingMessage />
+</template>
+
+<script setup lang="ts">
+  import { LoadingMessage } from '@blueking/chat-x';
+</script>
+```
+
+## 自定义加载文案
+
+通过默认插槽可覆盖默认的"请求中..."文案：
+
+```vue
+<template>
+  <LoadingMessage>正在思考中，请稍候...</LoadingMessage>
+</template>
+
+<script setup lang="ts">
+  import { LoadingMessage } from '@blueking/chat-x';
+</script>
+```
+
+## 动画说明
+
+`LoadingMessage` 内部使用 `AiLoading` 组件（18px），由两层动画叠加：
+
+| 图层       | 动画                                | 周期 |
+| ---------- | ----------------------------------- | ---- |
+| 旋转渐变环 | `rotate(0 → 360deg)`，线性          | 0.8s |
+| 脉冲星形   | `scale(0.5 → 1 → 0.5)`，ease-in-out | 0.8s |
+
+颜色均使用线性渐变：`#235DFA`（蓝）→ `#8A77EC`（紫）→ `#EB8CEC`（粉）。
+
+## 在 MessageContainer 中的自动注入
+
+`MessageContainer` 在构建消息分组列表时，检测到**消息列表最后一条为用户消息**（`role === 'user'`）时，自动在末尾追加一个 Loading 消息组：
+
+```typescript
+// MessageContainer 内部逻辑（简化）
+if (messages.at(-1)?.role === MessageRole.User) {
+  list.push({
+    messages: [
+      {
+        role: MessageRole.Loading, // 'loading'
+        content: '',
+        status: MessageStatus.Pending,
+        id: 'loading',
+        messageId: '',
+      },
+    ],
+    type: MessageRole.Loading,
+  });
+}
+```
+
+当下一条 AI 消息（`role: 'assistant'`）到来后，最后一条不再是用户消息，Loading 组自动消失。
+
+**触发示例**：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageContainer, MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  const messageStatus = ref(MessageStatus.Pending);
+
+  // 最后一条是 user 消息 → MessageContainer 自动追加 LoadingMessage
+  const messages = ref([
+    {
+      id: '1',
+      messageId: '1',
+      role: MessageRole.User,
+      content: '请帮我写一段 Vue 3 组合式 API 的示例代码',
+      status: MessageStatus.Complete,
+    },
+  ]);
+
+  const handleAgentAction = async () => {};
+</script>
+```
+
+## 注意事项
+
+- **无 Props**：`LoadingMessage` 组件内部没有 `defineProps`，`MessageRender` 向其传入 message 对象的字段均被忽略
+- **默认插槽**：可通过默认插槽自定义加载文案，未传入时显示内置的 "请求中..."
+- **i18n 支持**：默认文案 "请求中..." 通过内置 `t()` 函数处理，英文环境自动显示 "Requesting..."
+- **选择模式**：`MessageContainer` 开启 `enableSelection` 时，Loading 消息组不显示复选框
+- **自动生命周期**：Loading 组随消息列表变化自动插入/移除，无需手动控制
+
+## API
+
+### Props
+
+组件无 Props。
+
+> `MessageRender` 渲染 `role: 'loading'` 消息时会传入 message 对象字段，但 `LoadingMessage` 内部无 `defineProps`，所有传入字段均被忽略。
+
+### Slots
+
+| 插槽名  | 说明                                            |
+| ------- | ----------------------------------------------- |
+| default | 自定义加载文案，默认内容为 i18n 文案"请求中..." |
+
+## 类型定义
+
+```typescript
+import { MessageRole, MessageStatus } from '@blueking/chat-x';
+
+// MessageContainer 自动注入的 Loading 消息结构
+type LoadingMessageData = {
+  id: 'loading';
+  messageId: '';
+  role: MessageRole.Loading; // 'loading'
+  content: '';
+  status: MessageStatus.Pending;
+};
+
+enum MessageRole {
+  Loading = 'loading',
+  // ...
+}
+```
+
+## 使用场景
+
+- **等待 AI 响应**：用户消息发出后、AI 首个 token 到达前的过渡状态，由 `MessageContainer` 自动管理
+- **手动控制场景**：在自定义聊天布局中手动展示加载态（直接引入即可，无需任何配置）
+- **自定义文案**：通过默认插槽传入自定义加载提示文案，满足不同业务场景的文案需求
+
+## 关联组件
+
+- [MessageContainer](/components/setup/message-container) — 自动注入加载组
+- [MessageRender](/components/message/message-render) — loading 角色派发
+- [AiLoading](/components/helper/ai-loading) — 内部动画组件

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/markdown-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/markdown-content.md
@@ -1,0 +1,232 @@
+# MarkdownContent Markdown 内容渲染
+
+> 能力域：内容渲染 ｜ 导入：`import { MarkdownContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+Markdown 主渲染器，集成代码块、公式、错误降级和 codeHeader 插槽。 源码位置：src/components/chat-content/markdown-content/markdown-content.vue。
+
+**关联**：code-content（fence 代码块语法高亮与复制）、latex-content（数学公式 token 的 KaTeX 渲染）、mermaid-content（mermaid 代码块的图表渲染）、content-render（上层按类型分发到本组件渲染 Markdown 字符串）
+
+---
+
+# MarkdownContent Markdown 内容渲染
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/markdown-content/markdown-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：Markdown 主渲染器，集成代码块、公式、错误降级和 codeHeader 插槽。
+
+> **能力域**：内容渲染
+
+AI 消息内容渲染的核心基础组件，集成代码高亮、LaTeX 公式、Mermaid 图表等能力，内置流式渲染优化（5ms throttle + 语法补全 + 防闪烁）。
+
+由 `AssistantMessage`、`ReasoningMessage` 等组合组件内部自动使用，通常不需要手动引入。
+
+## 组件结构与渲染流程
+
+```
+props.content → completeMarkdownSyntax → md.parse → groupTokens → groupedTokens
+                                                                          │
+                          div.ai-markdown-content（contain: layout style）
+                                        │
+                        status === 'error' → CommonErrorContent（:content）
+                                        │
+                        else → div.ai-markdown-body[data-theme]（contain: content）
+                                  │
+                            v-for groupedToken
+                                  │
+                    ┌─────────────┼────────────────────┬───────────────┐
+                    │             │                    │               │
+              hasMermaid?   hasLatex?           hasCode?         else
+                    ↓             ↓                    ↓               ↓
+           MermaidContent  LatexContent        CodeContent    VNodeRenderer
+           @mounted         @mounted           @mounted       @vue:mounted
+                    │
+                    └──── handleTokenMounted（throttle 100ms）→ containerScroll.toScrollBottom()
+```
+
+`VNodeRenderer` 的 `options` 中包含与当前 `MarkdownIt` 实例一致的 `mditOptions`（即 `md.options`），以便 `tokensToVNodes` 调用 `renderer.rules` 时第三参与 markdown-it 原生规则签名一致。
+
+### Token 分组（groupTokens）
+
+`groupTokens` 使用栈将扁平 Token 数组转为分组数组，每组对应一个顶层 DOM 节点（段落、标题、列表、代码块等）：
+
+- `nesting === 1`（open）→ 入栈，建立新 group；顶层 group 立刻加入结果
+- `nesting === -1`（close）→ 出栈，完成该 group；嵌套 group 合并到父 group
+- `nesting === 0`（自闭合/inline）→ 无栈时独立成组，有栈时追加到当前 group
+
+每组第一个 token 的 `attrs` 追加 `class="ai-blueking-markdown-fade-in"`，触发渐显动画。
+
+### 子组件优先级
+
+对每个 token 组按以下顺序判断：
+
+| 优先级 | 检测逻辑                                                             | 使用组件                                  |
+| ------ | -------------------------------------------------------------------- | ----------------------------------------- |
+| 1      | `fence` token 且 `info === 'mermaid'`                                | `MermaidContent`                          |
+| 2      | `math_inline` / `math_block`，或 children 中递归含有（inline token） | `LatexContent`                            |
+| 3      | `fence`（非 mermaid）或 `code_block`                                 | `CodeContent`                             |
+| 4      | 其余                                                                 | `VNodeRenderer`（HTML 由 DOMPurify 过滤） |
+
+## 基础用法
+
+```vue
+<template>
+  <MarkdownContent
+    :content="markdownText"
+    :status="MessageStatus.Complete"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MarkdownContent, MessageStatus } from '@blueking/chat-x';
+
+  const markdownText = `# 标题\n\n这是一段 **Markdown** 内容。`;
+</script>
+```
+
+## 扩展文本格式
+
+支持标准 Markdown + 扩展插件：`++下划线++`（markdown-it-ins）、`==高亮==`（markdown-it-mark）、`~下标~`（markdown-it-sub）、`^上标^`（markdown-it-sup）：
+
+## 列表与任务清单
+
+## 代码块
+
+代码块由 `CodeContent` 渲染，支持 highlight.js 语法高亮、语言标签、一键复制。语法高亮主题样式由 `CodeContent` 侧引入（`github-dark`），`MarkdownContent` **不再**全局引入 `highlight.js` 主题 CSS，避免与代码块组件重复加载、并保持与消息区样式一致。
+
+## 表格
+
+## 对齐容器（markdown-it-container）
+
+支持 `::: hljs-left` / `::: hljs-center` / `::: hljs-right` 自定义容器，内容渲染在带对应 class 的块级容器中，由内置样式控制 `text-align`：
+
+## LaTeX 公式
+
+公式由 `LatexContent`（KaTeX）渲染，支持行内 `$...$` 和块级 `$$...$$`：
+
+## Mermaid 图表
+
+## 错误状态
+
+`status === MessageStatus.Error` 时渲染 `CommonErrorContent`，将 `content` 作为错误文本显示：
+
+## 流式渲染
+
+````vue
+<template>
+  <MarkdownContent
+    :content="streamingContent"
+    :status="isStreaming ? MessageStatus.Streaming : MessageStatus.Complete"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MarkdownContent, MessageStatus } from '@blueking/chat-x';
+
+  const streamingContent = ref('');
+  const isStreaming = ref(false);
+
+  const simulate = async () => {
+    const fullText = '## Hello\n\n**流式输出**演示。\n\n```js\nconsole.log(1);\n```';
+    isStreaming.value = true;
+    for (const char of fullText) {
+      await new Promise(r => setTimeout(r, 30));
+      streamingContent.value += char;
+    }
+    isStreaming.value = false;
+  };
+</script>
+````
+
+### 流式优化机制
+
+| 机制              | 实现                                                                                         | 作用                                                       |
+| ----------------- | -------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| 极速节流          | `parseMarkdownContent` throttle **5ms**，leading + trailing                                  | 每 5ms 最多解析一次，兼顾实时性与性能                      |
+| Markdown 语法补全 | `completeMarkdownSyntax(content)`                                                            | 自动闭合代码块、行内代码、粗斜体、删除线、链接等未完成语法 |
+| LaTeX 防闪烁      | `isIncomplete=true` 且已有渲染结果 → **跳过本次更新**                                        | 正在输入 LaTeX 命令时保持上一帧，避免闪白                  |
+| 子组件 throttle   | `handleTokenMounted` throttle 100ms                                                          | 限制子组件挂载后触发的滚动到底部频率                       |
+| CSS contain       | `.ai-markdown-content { contain: layout style }`<br>`.ai-markdown-body { contain: content }` | 限制重排/重绘范围，减少流式渲染的布局开销                  |
+| 渐显动画          | 每组首 token 追加 `.ai-blueking-markdown-fade-in`                                            | 新内容块淡入，减少视觉跳跃感                               |
+
+## 主题支持
+
+组件通过 `data-theme` 属性和本地 `markdown-content.css`（由 GitHub Markdown 样式 vendoring 而来，类前缀为 `ai-markdown-body`）控制主题，默认为 `light`，避免受宿主页面 `@media (prefers-color-scheme)` 影响。
+
+- **Light 模式**（默认）：`.ai-markdown-body[data-theme="light"]`，light 变量 + `color-scheme: light`
+- **Dark 模式**：`.ai-markdown-body[data-theme="dark"]`，dark 变量 + `color-scheme: dark`
+
+> 外层包裹类名为 `.ai-markdown-content`，内层正文区为 `.ai-markdown-body`，避免与宿主或其他库的 `.markdown-body` 全局样式冲突。
+
+## API
+
+### Props
+
+| 属性名  | 类型            | 必填 | 说明                                                      |
+| ------- | --------------- | ---- | --------------------------------------------------------- |
+| content | `string`        | —    | Markdown 文本；为空时清空渲染结果                         |
+| status  | `MessageStatus` | —    | `'error'` 时显示 `CommonErrorContent`，其余状态均正常渲染 |
+
+### Slots
+
+| 插槽名     | 参数                                   | 说明                                                                                    |
+| ---------- | -------------------------------------- | --------------------------------------------------------------------------------------- |
+| codeHeader | `{ language: string; token: Token[] }` | 代码块头部自定义操作区域，透传给 CodeContent 的 header 插槽，可添加"插入"、"应用"等按钮 |
+
+### 内置插件
+
+| 插件                        | 语法                | 功能                 |
+| --------------------------- | ------------------- | -------------------- |
+| `markdownItBkInlineStyle`   | 见下文「蓝鲸行内样式」 | 安全行内颜色/字号/粗斜体（非 HTML） |
+| `markdown-it-footnote`      | `[^1]`              | 脚注                 |
+| `markdown-it-ins`           | `++text++`          | 下划线               |
+| `markdown-it-mark`          | `==text==`          | 高亮                 |
+| `markdown-it-sub`           | `~text~`            | 下标                 |
+| `markdown-it-sup`           | `^text^`            | 上标                 |
+| `markdown-it-task-checkbox` | `- [x]`             | 任务列表             |
+| `markdownItMermaid`         | ` ```mermaid `      | Mermaid 图表 token   |
+| `markdownItLatex`           | `$...$` / `$$...$$` | KaTeX 数学公式 token |
+| `markdownItContainer`       | `::: hljs-left` 等  | 自定义对齐容器（class 与 highlight.js 命名对齐） |
+
+### 蓝鲸行内样式（`markdownItBkInlineStyle`）
+
+不开启 `html: true`，由专用语法生成带白名单 `style` 的 `<span class="bk-md-inline-style">`。
+
+**语法**：`::bk{` *属性* `}` *正文* `:/bk::`
+
+- 属性写在 `{}` 内，使用 `;` 分隔；每项为 `键=值` 或 `键:值`。
+- 正文支持行内 Markdown（如 `**粗体**`）。
+- 结束标记必须为字面量 `:/bk::`，请勿在正文中出现该序列。
+
+**支持的键**：`color` / `c`、`background-color`、`font-size`、`bold`、`italic`（详见 `plugins/markdown-bk-inline-style.ts` 内注释）。
+
+**示例**：
+
+```markdown
+::bk{color:#c00;font-size:18px}**重要**:/bk::
+::bk{background-color:yellow}高亮:/bk::
+::bk{bold;italic}强调:/bk::
+```
+
+### 安全性
+
+`MarkdownIt` **不**开启 `html: true`，用户无法插入任意 HTML 标签；行内彩色/字号等请使用上文「蓝鲸行内样式」扩展。
+
+`VNodeRenderer` 渲染的 HTML 统一经过 DOMPurify 过滤，并额外允许 KaTeX 所需标签：
+
+```typescript
+const domPurifyConfig = {
+  ADD_TAGS: ['semantics', 'mrow', 'mi', 'mo', 'mn', 'msup', 'msub', 'mfrac', 'mtext', 'annotation'],
+  ADD_ATTR: ['xmlns', 'mathvariant', 'encoding', 'style'],
+};
+```
+
+> `CodeContent`、`MermaidContent`、`LatexContent` 各自内部处理安全性（KaTeX `errorColor`、highlight.js 转义等），不经过 DOMPurify。
+
+## 关联组件
+
+- [CodeContent](/components/rendering/code-content) — 代码 fence 高亮
+- [LatexContent](/components/rendering/latex-content) — 公式渲染
+- [MermaidContent](/components/rendering/mermaid-content) — Mermaid 图表
+- [ContentRender](/components/rendering/content-render) — 内容类型分发入口

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/mermaid-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/mermaid-content.md
@@ -1,0 +1,189 @@
+# MermaidContent Mermaid 图表
+
+> 能力域：内容渲染 ｜ 导入：`import { MermaidContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 Mermaid 图表并处理渲染事件。 源码位置：src/components/markdown-token/mermaid-content/mermaid-content.vue。
+
+**关联**：markdown-content（解析 mermaid 类型 fence 代码块后传入 token）
+
+---
+
+# MermaidContent Mermaid 图表渲染
+## 源码事实
+
+- **源码位置**：`src/components/markdown-token/mermaid-content/mermaid-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：渲染 Mermaid 图表并处理渲染事件。
+
+> **能力域**：内容渲染
+
+Markdown Token 层的 Mermaid 图表渲染基础组件，被 `MarkdownContent` 在检测到 mermaid fence token 时自动调用，通常无需手动引入。
+
+核心能力：**按需懒加载 Mermaid**（动态 import 单例）、**三级去重跳过**（代码比对 → 语法校验 → SVG 比对）、**100ms throttle** 流式防抖、**错误静默**（parse 失败时保持上一次 SVG）。
+
+## 组件结构与渲染流程
+
+```
+props.token（Token[]）
+│
+├─ extractMermaidCode(tokens)
+│    → 遍历找第一个 type==='fence' && info.trim()==='mermaid' && content 非空的 token
+│    → 返回 content（无匹配返回空字符串）
+│
+└─ renderMermaid（throttle 100ms，leading + trailing）
+      │
+      ├─ 1. newCode === lastMermaidCode  → return（代码未变，跳过）
+      ├─ 2. lastMermaidCode = newCode
+      ├─ 3. getMermaidInstance()         → 动态 import('mermaid') 单例，初始化一次
+      ├─ 4. mermaid.parse(code, { suppressErrors: true })
+      │      → !isValid → return（语法无效，保持上次 SVG）
+      ├─ 5. mermaid.render('mermaid-content-' + randomId, code) → { svg }
+      ├─ 6. svgDomStr.value === svg      → return（SVG 无变化，跳过）
+      └─ 7. svgDomStr.value = svg
+             nextTick → emit('mounted', { get el() { return mermaidContentRef.value } })
+
+模板：
+div.mermaid-content（:key="svgDomStr"，v-html="svgDomStr"）
+  注：:key 绑定 svgDomStr，每次 SVG 变化会重建 div 而非就地 patch
+```
+
+## 基础用法
+
+```vue
+<template>
+  <MermaidContent
+    :token="tokens"
+    @mounted="handleMounted"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MermaidContent } from '@blueking/chat-x';
+  import type { Token } from 'markdown-it';
+
+  const tokens: Token[] = [
+    {
+      type: 'fence',
+      tag: 'code',
+      info: 'mermaid',
+      content: `graph TD
+    A[开始] --> B{判断}
+    B -->|是| C[执行]
+    B -->|否| D[结束]`,
+    } as Token,
+  ];
+
+  const handleMounted = ({ el }: { el: HTMLElement | null }) => {
+    // el 是 lazy getter，值为渲染后的 .mermaid-content 元素
+    console.log('渲染完成:', el);
+  };
+</script>
+```
+
+## 支持的图表类型
+
+### 时序图（Sequence Diagram）
+
+### 甘特图（Gantt）
+
+### 类图（Class Diagram）
+
+### 状态图（State Diagram）
+
+### 饼图（Pie Chart）
+
+## 流式渲染
+
+流式输入时 Mermaid 语法逐步完整，组件通过 throttle + `parse` 语法校验避免无效渲染：
+
+```vue
+<template>
+  <MermaidContent :token="streamingTokens" />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MermaidContent } from '@blueking/chat-x';
+
+  const streamingTokens = ref([{ type: 'fence', tag: 'code', info: 'mermaid', content: '' }]);
+
+  const simulate = async () => {
+    const code = `graph TD\n    A[开始] --> B[处理]\n    B --> C[结束]`;
+    let content = '';
+    for (const char of code) {
+      await new Promise(r => setTimeout(r, 50));
+      content += char;
+      streamingTokens.value = [{ type: 'fence', tag: 'code', info: 'mermaid', content }];
+    }
+  };
+</script>
+```
+
+**流式过程中的行为**：
+
+| 阶段                       | `parse` 结果 | 行为                                      |
+| -------------------------- | ------------ | ----------------------------------------- |
+| 代码未变化                 | —            | 三级去重第 1 关：直接跳过，不调用 Mermaid |
+| 语法不完整（如 `graph T`） | `false`      | 三级去重第 2 关：跳过渲染，保持上次 SVG   |
+| 语法完整，SVG 相同         | `true`       | 三级去重第 3 关：跳过 DOM 更新            |
+| 语法完整，SVG 变化         | `true`       | 更新 SVG，触发 `mounted` 事件             |
+
+## API
+
+### Props
+
+| 属性名 | 类型      | 必填 | 说明                                                                                         |
+| ------ | --------- | ---- | -------------------------------------------------------------------------------------------- |
+| token  | `Token[]` | ✓    | markdown-it Token 数组；组件自动从中提取第一个 `type==='fence' && info==='mermaid'` 的 token |
+
+### Events
+
+| 事件名  | 参数                          | 触发时机                                                                           |
+| ------- | ----------------------------- | ---------------------------------------------------------------------------------- |
+| mounted | `{ el: HTMLElement \| null }` | SVG 更新后的 `nextTick`；`el` 为 lazy getter，返回当前 `.mermaid-content` 元素引用 |
+
+### Token 结构
+
+```typescript
+// 组件只识别 type === 'fence' 且 info.trim() === 'mermaid' 的 token
+{
+  type: 'fence';
+  tag?: 'code';         // 可选
+  info: 'mermaid';      // 必须严格等于 'mermaid'（trim 后）
+  content: string;      // Mermaid 图表定义语法
+}
+```
+
+## 性能与错误处理细节
+
+### 单例 Mermaid 实例
+
+```typescript
+// 模块级变量，所有 MermaidContent 实例共享同一个 mermaid 模块
+let mermaidInstance: MermaidModule | null = null;
+
+// 初始化时调用一次（suppressErrorRendering: true 抑制 Mermaid 内部错误 UI）
+mermaidInstance.default.initialize({ suppressErrorRendering: true });
+```
+
+首次渲染因动态 import 会有约 200~500ms 的网络加载延迟，之后复用实例无额外开销。
+
+### SVG ID 随机化
+
+每次调用 `mermaid.render` 时生成随机 ID：
+
+```typescript
+mermaid.default.render('mermaid-content-' + Math.random().toString(36).substring(2, 15), code);
+```
+
+避免多个 MermaidContent 实例或同一实例多次渲染时 DOM ID 冲突。
+
+### 错误静默
+
+- `mermaid.parse` 失败（语法无效）→ `return`，不修改 `svgDomStr`，保持上次成功的 SVG
+- `mermaid.render` 抛出异常 → `console.warn`，不修改 `svgDomStr`，保持上次成功的 SVG
+- 两种情况下组件界面均无错误提示（静默降级）
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — mermaid fence token 的来源与挂载

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-container.md
@@ -1,0 +1,593 @@
+# MessageContainer 消息列表容器
+
+> 能力域：对话搭建 ｜ 导入：`import { MessageContainer } from '@blueking/chat-x'` ｜ since 1.0.0
+
+负责消息分组渲染、滚动控制、工具栏和消息插槽透传。 源码位置：src/components/chat-message/message-container/message-container.vue。
+
+**关联**：message-render（按组渲染每条消息时委托 MessageRender）、chat-input（常与 ChatInput 组合构成完整对话界面）、loading-message（末尾为用户消息时自动追加 Loading 消息组）、interrupt-message（透传 onInterruptResume；末条 interrupt 消息不触发组 hover）
+
+---
+
+# MessageContainer 消息容器
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/message-container/message-container.vue`
+- **能力域**：对话搭建
+- **能力说明**：负责消息分组渲染、滚动控制、工具栏和消息插槽透传。
+
+> **能力域**：对话搭建
+
+消息列表容器组件，负责将原始的 `Message[]` 数组渲染为结构化的对话界面。核心能力：
+
+- **消息分组**：将连续的非用户消息合并为一组，每组共享一个工具栏
+- **Tool 消息关联**：自动将 `role: 'tool'` 消息注入到对应 Assistant 消息的 toolCall 中
+- **Loading 自动注入**：末尾为用户消息时，自动追加 Loading 动画组
+- **滚动管理**：`messageStatus` 为流式、等待响应或请求中（`streaming` / `pending` / `fetching`）时显示「停止生成」，离开底部时显示「返回底部」
+- **多选模式**：支持按消息组勾选，用户消息与 AI 回复联动选中
+
+## 基础用法
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    message-status="complete"
+    :on-agent-action="handleAgentAction"
+    :on-agent-feedback="handleAgentFeedback"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageContainer, MessageRole, MessageStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+
+  const messages = ref<Message[]>([
+    {
+      id: '1',
+      messageId: '1',
+      role: MessageRole.User,
+      content: '你好，请介绍一下 Vue 3',
+      status: MessageStatus.Complete,
+    },
+    {
+      id: '2',
+      messageId: '2',
+      role: MessageRole.Assistant,
+      content: 'Vue 3 是一个渐进式 JavaScript 框架...',
+      status: MessageStatus.Complete,
+    },
+  ]);
+
+  const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
+    // copy 操作由 MessageContainer 内部处理，此处无需额外实现
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面', '表达清晰']; // 返回反馈原因列表
+    }
+  };
+  const handleAgentFeedback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList, otherReason);
+  };
+  const handleUserAction = async (tool: IToolBtn, message: Message) => {
+    console.log('用户消息操作:', tool.id, message);
+  };
+  const handleStopStreaming = () => {
+    console.log('停止流式输出');
+  };
+</script>
+```
+
+**渲染效果**
+
+## 消息分组机制
+
+`MessageContainer` 在内部通过 `watchEffect` 将 `messages` 数组转换为消息组列表（`MessageGroup[]`）。分组规则如下：
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  messages 原始数组（按顺序处理）                              │
+└──────────────────────────────┬──────────────────────────────┘
+                               │
+              ┌────────────────┴────────────────┐
+              │                                 │
+        role === 'user'               role === 'tool'
+              │                                 │
+  ① 先把已累积的 assistantMessages    ② 通过 toolCallId 找到对应的
+     推入 list 作为一组                  AssistantMessage，将 tool
+  ② 当前 user 消息单独成一组           消息注入 toolCall.toolMessage，
+                                        然后 continue（不单独渲染）
+                               │
+                   其他 role（assistant / reasoning /
+                     activity / info / loading 等）
+                               │
+                    ③ 累积到 assistantMessages
+                       等待 user 消息触发分组
+
+    ④ 遍历结束后，将剩余 assistantMessages 推入 list
+       每个 assistant 组计算 pause 字段：
+       pause = assistantMessages.some(m => m.property?.extra?.pause)
+    ⑤ 如果最后一条消息 role === 'user' → 追加 Loading 消息组
+```
+
+**关键细节**：
+
+- 每个消息组外层 DOM 的 `id` 为 **`MessageGroup.uid`**（由 `useMessageGroup` 生成），供执行摘要「在对话中定位」、侧栏自定义 Tab 等场景滚动锚定
+- `role: 'tool'` 消息**不会独立渲染**，而是被注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段
+- 若 `toolMessage.error` 存在，AssistantMessage 的 `status` 会被强制设为 `MessageStatus.Error`
+- 当消息组**最后一条**消息的 `role === 'interrupt'` 时，`mouseenter` **不会**设置 `isHover`，避免 AI 工具栏在审批卡片上误显
+- `MessageTools` 工具栏只在 `type === 'assistant'` 的消息组底部渲染（不依赖鼠标悬停，始终可见），且满足以下条件时**不渲染**：
+  - `renderMode === RenderMode.Share`（分享预览模式）
+  - 消息组的 `pause` 为 `true`（来源于 `message.property?.extra?.pause`）
+  - 多选模式（`enableSelection`）开启且消息组不是 Loading 类型
+- `renderMode === RenderMode.Test` 时，工具栏会过滤掉「分享」按钮，其余正常
+- `renderMode === RenderMode.Share` 时，`message-group-messages` 自动添加 `message-group-enabled-selection` 类名（与 `enableSelection: true` 一致的多选视觉效果）
+- Loading 消息组的 `type` 是 `MessageRole.Loading`，不显示工具栏和多选 Checkbox
+
+## 等待响应（Loading 自动注入）
+
+当 `messages` 末尾为 `role: 'user'` 时，自动追加 Loading 消息组，展示 AI 正在处理的加载动画：
+
+## 流式输出与停止生成
+
+当 `messageStatus` 为 `streaming`、`pending`（等待首包）或 `fetching`（请求中、与末尾 Loading 占位一致）时，底部固定区域显示「停止生成」按钮（`stop-loading` 时按钮展示为正在停止），点击后触发 `@stop-streaming` 事件。
+
+点击下方按钮体验完整的流式输出过程：
+
+**流式输出完整示例**：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+    :on-agent-feedback="handleAgentFeedback"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageContainer, MessageRole, MessageStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+
+  const messageStatus = ref<MessageStatus>(MessageStatus.Complete);
+  const messages = ref<Message[]>([]);
+
+  const sendMessage = async (userInput: string) => {
+    // 1. 推入用户消息
+    messages.value.push({
+      id: Date.now().toString(),
+      messageId: Date.now().toString(),
+      role: MessageRole.User,
+      content: userInput,
+      status: MessageStatus.Complete,
+    });
+
+    // 2. 推入空 assistant 消息（触发 Loading 消失）
+    const assistantMsg: Message = {
+      id: (Date.now() + 1).toString(),
+      messageId: (Date.now() + 1).toString(),
+      role: MessageRole.Assistant,
+      content: '',
+      status: MessageStatus.Pending,
+    };
+    messages.value.push(assistantMsg);
+    messageStatus.value = MessageStatus.Streaming;
+
+    // 3. 逐步追加流式内容
+    for await (const chunk of fetchStream(userInput)) {
+      assistantMsg.content += chunk;
+      assistantMsg.status = MessageStatus.Streaming;
+    }
+
+    // 4. 标记完成
+    assistantMsg.status = MessageStatus.Complete;
+    messageStatus.value = MessageStatus.Complete;
+  };
+
+  const handleStopStreaming = () => {
+    messageStatus.value = MessageStatus.Stop;
+    const last = messages.value.at(-1);
+    if (last) last.status = MessageStatus.Stop;
+  };
+
+  const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面'];
+    }
+  };
+  const handleAgentFeedback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList);
+  };
+  const handleUserAction = async (tool: IToolBtn, message: Message) => {};
+</script>
+```
+
+## 错误状态
+
+AI 回复状态为 `error` 时，消息以错误样式展示：
+
+## 推理过程消息
+
+`role: 'reasoning'` 消息会被归入当前 AI 消息组，带有折叠/展开效果和思考耗时展示：
+
+```vue
+<script setup lang="ts">
+  const messages = ref<Message[]>([
+    {
+      id: '1',
+      messageId: '1',
+      role: MessageRole.User,
+      content: '分析一下这段代码的问题',
+      status: MessageStatus.Complete,
+    },
+    {
+      id: '2',
+      messageId: '2',
+      role: MessageRole.Reasoning,
+      content: ['首先，我需要理解代码意图...', '看起来是数据处理函数...', '发现几个潜在问题...'],
+      status: MessageStatus.Complete,
+      duration: 3500,
+    },
+    {
+      id: '3',
+      messageId: '3',
+      role: MessageRole.Assistant,
+      content: '根据分析，存在以下问题：\n\n1. 变量命名不规范...',
+      status: MessageStatus.Complete,
+    },
+  ]);
+</script>
+```
+
+**渲染效果**
+
+## 工具调用消息
+
+`role: 'tool'` 消息通过 `toolCallId` 与对应 AssistantMessage 关联，被注入到 `toolCall.toolMessage` 后不再独立渲染：
+
+```vue
+<script setup lang="ts">
+  const messages = ref<Message[]>([
+    { id: '1', messageId: '1', role: MessageRole.User, content: '查询北京天气', status: MessageStatus.Complete },
+    {
+      id: '2',
+      messageId: '2',
+      role: MessageRole.Assistant,
+      content: '好的，我来帮你查询。',
+      status: MessageStatus.Complete,
+      toolCalls: [
+        {
+          id: 'call_weather',
+          type: 'function',
+          function: { name: 'get_weather', arguments: '{"city": "北京"}', description: '查询天气信息' },
+        },
+      ],
+    },
+    // role: 'tool' 消息通过 toolCallId 关联到上方 assistant 消息
+    {
+      id: '3',
+      messageId: '3',
+      role: MessageRole.Tool,
+      content: '{"temperature":25,"weather":"晴天"}',
+      status: MessageStatus.Complete,
+      toolCallId: 'call_weather',
+      duration: 1200,
+    },
+    {
+      id: '4',
+      messageId: '4',
+      role: MessageRole.Assistant,
+      content: '北京今天 **晴朗**，温度 **25°C**。',
+      status: MessageStatus.Complete,
+    },
+  ]);
+</script>
+```
+
+**渲染效果**
+
+## Activity 知识检索消息
+
+`role: 'activity'` 消息同样被归入 AI 消息组，与 assistant 消息一起渲染：
+
+## 多轮对话
+
+连续多轮问答，组件按角色自动分组，每个 AI 组独立显示工具栏：
+
+## 工具栏状态控制
+
+通过 `messageToolsStatus` 控制消息工具栏的显示状态。常见用法：流式输出期间禁用工具栏：
+
+```vue
+<script setup lang="ts">
+  import { computed, ref } from 'vue';
+  import { MessageContainer, MessageStatus, MessageToolsStatus } from '@blueking/chat-x';
+
+  const messageStatus = ref(MessageStatus.Complete);
+
+  // 流式输出期间禁用工具栏，完成后恢复
+  const messageToolsStatus = computed(() =>
+    messageStatus.value === MessageStatus.Streaming ? MessageToolsStatus.Disabled : undefined,
+  );
+</script>
+```
+
+**三种状态对比**
+
+| 状态值      | 说明                           |
+| ----------- | ------------------------------ |
+| `undefined` | 默认，工具栏正常可用           |
+| `disabled`  | 工具栏显示但所有按钮不可点击   |
+| `hidden`    | 工具栏（`MessageTools`）不渲染 |
+
+> **注意**：`messageToolsStatus` 同时透传给 `MessageRender`，控制用户消息中编辑、删除等按钮的状态。
+
+## 消息多选
+
+启用 `enableSelection` 后，每个消息组前显示 Checkbox，选中状态联动关联：
+
+```vue
+<template>
+  <MessageContainer
+    v-model:selected-user-messages="selectedUserMessages"
+    :messages="messages"
+    :message-status="messageStatus"
+    :enable-selection="true"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  />
+  <div v-if="selectedUserMessages.length > 0">
+    已选择 {{ selectedUserMessages.length }} 条消息
+    <button @click="selectedUserMessages = []">清空选择</button>
+  </div>
+</template>
+```
+
+**多选特性**：
+
+- `v-model:selected-user-messages` 仅包含选中的用户消息
+- 选中用户消息组 → 其后紧邻的 AI 回复组视觉联动选中
+- 选中 AI 回复组 → 其前紧邻的用户消息组联动选中
+- 取消任一关联组 → 另一组同时取消
+- 选中时消息组背景色变为 `#f5f7fa`
+- 多选模式下用户消息工具栏自动隐藏
+- Loading 消息组不显示 Checkbox
+
+**渲染效果**（点击 Checkbox 体验多选）
+
+## 自定义消息组渲染
+
+使用 `#group` 插槽可替换单个消息组的默认内容（Checkbox、消息列表、`MessageTools`）。外层 `.message-group` 容器（含 `id`、hover 状态、选中背景色）仍由 `MessageContainer` 管理。
+
+> **注意**：提供 `#group` 后需自行编排组内全部 UI；若只需替换单条消息，请使用 `#default` 插槽。
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-groups="messageGroups"
+    message-status="complete"
+    :on-agent-action="handleAgentAction"
+    @stop-streaming="handleStopStreaming"
+  >
+    <template #group="{ group }">
+      <div class="custom-group">
+        <span class="custom-group-label">{{ group.type }}</span>
+        <div
+          v-for="message in group.messages"
+          :key="message.id"
+          class="custom-group-message"
+        >
+          {{ typeof message.content === 'string' ? message.content : JSON.stringify(message.content) }}
+        </div>
+      </div>
+    </template>
+  </MessageContainer>
+</template>
+```
+
+**渲染效果**（简化自定义组布局，不含默认 Checkbox 与工具栏）
+
+## 自定义消息渲染
+
+使用默认插槽替换单条消息的渲染，插槽参数包含 `message`、`messageToolsStatus` 和 `onInterruptResume`：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  >
+    <template #default="{ message, messageToolsStatus, onInterruptResume }">
+      <MyCustomMessage
+        :message="message"
+        :message-tools-status="messageToolsStatus"
+        :on-interrupt-resume="onInterruptResume"
+      />
+    </template>
+  </MessageContainer>
+</template>
+```
+
+> 使用默认插槽后，每条消息由自定义组件完全接管渲染，但**消息分组逻辑和工具栏（`MessageTools`）仍由 `MessageContainer` 管理**。
+
+## 自定义工具栏 Tooltip 配置
+
+通过 `messageToolsTippyOptions` 可以自定义消息工具栏中按钮 tooltip 的 Tippy 配置，透传给所有 `ToolBtn`。典型用法是修改 `appendTo` 避免 tooltip 被父容器 `overflow: hidden` 遮挡：
+
+```vue
+<template>
+  <!-- tooltip 挂载到触发元素的父节点，避免被滚动容器裁剪 -->
+  <MessageContainer
+    :messages="messages"
+    :message-tools-tippy-options="{ appendTo: 'parent' }"
+    :on-agent-action="handleAgentAction"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+```
+
+> **注意**：`content`、`getReferenceClientRect`、`triggerTarget` 三个字段被排除，不可通过此 prop 覆盖。
+
+## 用户消息编辑与快捷指令
+
+通过 `onUserInputConfirm` 和 `onUserShortcutConfirm` 处理用户消息的编辑确认和快捷指令表单提交：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+    :on-user-input-confirm="handleUserInputConfirm"
+    :on-user-shortcut-confirm="handleUserShortcutConfirm"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer, type Message, type TagSchema } from '@blueking/chat-x';
+
+  // 用户点击编辑并确认时触发
+  const handleUserInputConfirm = async (message: Message, content: UserMessage['content'], docSchema: TagSchema) => {
+    // message: 原始消息对象
+    // content: 编辑后的内容（字符串或富文本结构）
+    // docSchema: 引用文档结构
+    console.log('用户编辑确认:', message.id, content);
+  };
+
+  // 用户提交快捷指令表单时触发
+  const handleUserShortcutConfirm = async (message: Message, formModel: Record<string, unknown>) => {
+    console.log('快捷指令提交:', message.id, formModel);
+  };
+</script>
+```
+
+## copy 操作内置处理
+
+`MessageContainer` 内部对 `copy` 工具操作进行了特殊处理：当 `tool.id === 'copy'` 时，自动将当前消息组中所有**非 reasoning 消息**的内容拼接后复制到剪贴板，**无需在 `onAgentAction` 中自行实现**。
+
+其他工具操作（`like`、`unlike`、`cite` 等）仍正常转发给 `onAgentAction` 回调。
+
+## 滚动控制
+
+底部固定区域（`position: sticky; bottom: 12px`）根据条件显示两个按钮：
+
+| 按钮         | 显示条件                                                                                       | 点击行为               |
+| ------------ | ---------------------------------------------------------------------------------------------- | ---------------------- |
+| 「停止生成」 | `messageStatus` 为 `streaming`、`pending`、`fetching` 或 `stop-loading`（停止中 loading 态） | 触发 `@stop-streaming` |
+| 「返回底部」 | `debouncedShowScrollBottomBtn`（距底部 > 100px，且防抖 300ms 后才显示/隐藏）                     | 滚动到消息列表底部     |
+
+> **防抖说明**：「返回底部」按钮的显隐使用 300ms 防抖，避免快速滚动时按钮频繁闪烁。隐藏时立即生效（无防抖），显示时延迟 300ms。
+
+## API
+
+### Props
+
+| 属性名                   | 类型                                                                                         | 默认值  | 说明                                                                                                                                     |
+| ------------------------ | -------------------------------------------------------------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| messages                 | `Message[]`                                                                                  | —       | **必填**，消息列表                                                                                                                       |
+| messageGroups            | `MessageGroup[]`                                                                             | —       | 预计算的消息分组；传入时跳过内部分组逻辑，由 `ChatContainer` 通过 `useMessageGroup` 提供                                                 |
+| messageStatus            | `MessageStatus`                                                                              | —       | 当前整体消息状态，控制底部「停止生成」按钮显示；`ChatContainer` 会结合末尾 Loading 占位推导 `fetching` 等再传入                                                                                                   |
+| messageToolsStatus       | `MessageToolsStatus`                                                                         | —       | 工具栏状态，透传给 `MessageTools` 和 `MessageRender`                                                                                     |
+| messageToolsTippyOptions | `AITippyProps`                                                                               | —       | 透传给 `MessageTools` 和 `MessageRender`（进而透传给 `UserMessage` 的工具栏）的 Tippy 配置，用于自定义 tooltip 挂载点、位置等（如 `appendTo`、`placement`、`zIndex`） |
+| enableSelection          | `boolean`                                                                                    | `false` | 是否启用多选模式                                                                                                                         |
+| onAgentAction            | `(tool: IToolBtn, messages: Message[]) => Promise<string[] \| void>`                         | —       | AI 消息工具操作回调；`copy` 操作由内部处理，`like/unlike` 应返回反馈原因字符串数组                                                       |
+| onAgentFeedback          | `(tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => void`   | —       | AI 消息反馈提交回调（点赞/踩选完原因后触发）                                                                                             |
+| onUserAction             | `(tool: IToolBtn, message: Message) => Promise<string[] \| void>`                            | —       | 用户消息工具操作回调                                                                                                                     |
+| onUserInputConfirm       | `(message: Message, content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | —       | 用户编辑消息确认回调                                                                                                                     |
+| onUserShortcutConfirm    | `(message: Message, formModel: Record<string, unknown>) => Promise<void>`                    | —       | 用户快捷指令表单提交回调                                                                                                                 |
+| onInterruptResume        | `OnInterruptResume`                                                                          | —       | AG-UI human-in-the-loop 中断响应回调，透传给 `MessageRender` → `InterruptMessageRender`                                                  |
+| renderMode               | `RenderMode`                                                                                 | —       | 渲染模式。`Share` 模式下启用多选样式并隐藏工具栏；`Test` 模式下过滤掉「分享」按钮；不传或 `Chat` 为默认行为                              |
+
+### v-model
+
+| 属性名               | 类型        | 说明                                               |
+| -------------------- | ----------- | -------------------------------------------------- |
+| selectedUserMessages | `Message[]` | 当前选中的用户消息列表（双向绑定，仅包含用户消息） |
+
+### Events
+
+| 事件名        | 参数 | 说明                       |
+| ------------- | ---- | -------------------------- |
+| stopStreaming | —    | 点击「停止生成」按钮时触发 |
+
+### Slots
+
+| 插槽名           | 参数                                                                                                        | 说明                                                                                     |
+| ---------------- | ----------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| answeredQuestion | `{ item, index, status }`                                                                                   | 自定义 UserQuestion 已回答回显，透传给 MessageRender → InterruptMessageRender            |
+| default          | `{ message: Message, messageToolsStatus?: MessageToolsStatus, onInterruptResume?: OnInterruptResume }`     | 自定义单条消息渲染；消息分组外层容器与 `#group` 未覆盖时的工具栏仍由容器管理             |
+| group            | `{ group: MessageGroup }`                                                                                   | 自定义单个消息组内容，替换默认 Checkbox、消息列表与 `MessageTools`；外层组容器仍由组件管理 |
+
+## 类型定义
+
+```typescript
+import { MessageRole, MessageStatus, MessageToolsStatus, type Message, type MessageGroup, type IToolBtn } from '@blueking/chat-x';
+
+// 消息组（由 useMessageGroup 生成，也可手动传入 messageGroups）
+interface MessageGroup {
+  checked: boolean;
+  isHover: boolean;
+  messages: Message[];
+  pause?: boolean;
+  startTime?: number;
+  type: MessageRole;
+  uid: string;
+  userMessageTitle?: number | string;
+}
+
+// onAgentAction 回调类型
+// messages 为当前消息组全部消息（可含 reasoning / activity 等）
+// 返回 string[] 时用作 like/unlike 的反馈原因列表
+type AgentActionCallback = (tool: IToolBtn, messages: Message[]) => Promise<string[] | void>;
+
+// onAgentFeedback 回调类型
+type AgentFeedbackCallback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => void;
+
+// onUserAction 回调类型
+type UserActionCallback = (tool: IToolBtn, message: Message) => Promise<string[] | void>;
+
+// 工具栏状态
+enum MessageToolsStatus {
+  Disabled = 'disabled',
+  Hidden = 'hidden',
+}
+
+// 消息角色
+enum MessageRole {
+  User = 'user',
+  Assistant = 'assistant',
+  Tool = 'tool',
+  Reasoning = 'reasoning',
+  Activity = 'activity',
+  Info = 'info',
+  Interrupt = 'interrupt',
+  Loading = 'loading',
+}
+
+// 消息状态
+enum MessageStatus {
+  Pending = 'pending',
+  Streaming = 'streaming',
+  Complete = 'complete',
+  Error = 'error',
+  Stop = 'stop',
+  Disabled = 'disabled',
+}
+```
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — 按组渲染每条消息时委托使用
+- [InterruptMessage 中断消息](/components/agent/interrupt-message) — `role: 'interrupt'` 的渲染与 `onInterruptResume` 透传
+- [ChatInput](/components/input/chat-input) — 常与输入区组合构成完整对话界面
+- [LoadingMessage](/components/message/loading-message) — 末尾为用户消息时自动追加加载组

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-loading.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-loading.md
@@ -1,0 +1,118 @@
+# MessageLoading 品牌加载
+
+> 能力域：辅助能力 ｜ 导入：`import { MessageLoading } from '@blueking/chat-x'` ｜ since 1.0.0
+
+带品牌图标和逐字渐变动画的加载组件。 源码位置：src/components/message-loading/message-loading.vue。
+
+**关联**：loading-message（消息列表加载占位可选择使用品牌加载动效）、ai-loading（更轻量的三点加载动画）
+
+---
+
+# MessageLoading 品牌加载
+
+> **能力域**：辅助能力
+
+`MessageLoading` 是带蓝鲸品牌图标和逐字渐变动画的加载组件，用于展示 AI 正在思考、生成或执行任务的等待状态。组件默认显示品牌图标和“加载中...”文案，也支持通过插槽替换图标或文本。
+
+与 [AiLoading](./ai-loading.md) 相比，它更偏品牌化、文案化；适合较明显的等待区域，不适合嵌入很紧凑的按钮或状态点。
+
+## 源码事实
+
+- **源码位置**：`src/components/message-loading/message-loading.vue`
+- **能力说明**：带品牌图标和逐字渐变动画的加载组件。
+
+## 核心能力
+
+- **品牌图标动画**：默认使用 `AIBluekingIcon`，图标随 `duration` 做透明度和滤镜动画
+- **逐字渐变文本**：未传 `#text` 插槽时，将 `text` 拆成字符逐个渲染，并按 `stagger` 延迟播放
+- **可调尺寸和节奏**：通过 `iconSize`、`gap`、`duration`、`stagger` 控制图标尺寸、间距和动画速度
+- **插槽覆盖**：`#icon` 可替换图标，`#text` 可替换整段文本渲染
+- **无障碍降级**：遵循 `prefers-reduced-motion: reduce`，减少动画效果
+
+## 基础用法
+
+```vue
+<template>
+  <MessageLoading />
+</template>
+
+<script setup lang="ts">
+  import { MessageLoading } from '@blueking/chat-x';
+</script>
+```
+
+**渲染效果**
+
+## 自定义文案和尺寸
+
+```vue
+<template>
+  <MessageLoading
+    text="正在思考中..."
+    :icon-size="28"
+    :gap="10"
+    :duration="2"
+    :stagger="0.12"
+  />
+</template>
+```
+
+## 自定义插槽
+
+传入 `#text` 后，组件不再按字符拆分 `text` prop，而是直接渲染插槽内容；传入 `#icon` 可替换默认品牌图标。
+
+```vue
+<template>
+  <MessageLoading>
+    <template #icon>
+      <span class="custom-icon">AI</span>
+    </template>
+    <template #text>
+      正在生成巡检结论
+    </template>
+  </MessageLoading>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名   | 类型     | 必填 | 默认值      | 说明                               |
+| -------- | -------- | ---- | ----------- | ---------------------------------- |
+| text     | `string` | 否   | `'加载中...'` | 逐字动画文案；使用 `#text` 时可不传 |
+| iconSize | `number` | 否   | `32`        | 默认图标边长，单位 px              |
+| gap      | `number` | 否   | `8`         | 图标与文字间距，单位 px            |
+| duration | `number` | 否   | `1.8`       | 单次动画循环时长，单位秒           |
+| stagger  | `number` | 否   | `0.135`     | 相邻字符动画延迟，单位秒           |
+
+### Emits
+
+- 无。
+
+### Slots
+
+| 插槽名 | 说明                     |
+| ------ | ------------------------ |
+| icon   | 自定义图标区域           |
+| text   | 自定义文本区域，覆盖逐字渲染 |
+
+### Expose
+
+- 无。
+
+## 样式与 attrs
+
+- 组件设置 `inheritAttrs: false`，会将外部 `class` 合并到根节点，并将除 `class` / `style` 外的 attrs 透传到根节点。
+- 外部对象形式的 `style` 会与 CSS 变量合并；字符串形式 `style` 不会参与合并。
+- 根节点使用 CSS 变量控制动画：`--ai-message-loading-duration`、`--ai-message-loading-stagger`、`--ai-message-loading-gap`。
+
+## 使用建议
+
+- 页面级或消息级等待态优先使用 `MessageLoading`；紧凑状态点优先使用 [AiLoading](./ai-loading.md)。
+- 需要自定义文本样式时优先使用 `#text` 插槽，避免只依赖全局覆盖内部 class。
+
+## 关联组件
+
+- [LoadingMessage](../message/loading-message.md) — 消息列表中的加载占位。
+- [AiLoading](./ai-loading.md) — 三点加载动画。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-render.md
@@ -1,0 +1,338 @@
+# MessageRender 消息渲染器
+
+> 能力域：消息系统 ｜ 导入：`import { MessageRender } from '@blueking/chat-x'` ｜ since 1.0.0
+
+按 message.role 分发到用户、助手、工具、推理、活动、中断等消息组件。 源码位置：src/components/chat-message/message-render/message-render.vue。
+
+**关联**：message-container（在 MessageContainer 中按组调用以渲染每条消息）、assistant-message（role 为 assistant 时渲染 AI 回复与工具调用）、user-message（role 为 user 时渲染用户消息）、interrupt-message（role 为 interrupt 时渲染 InterruptMessageRender）
+
+---
+
+# MessageRender 消息渲染器
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/message-render/message-render.vue`
+- **能力域**：消息系统
+- **能力说明**：按 message.role 分发到用户、助手、工具、推理、活动、中断等消息组件。
+
+> **能力域**：消息系统
+
+统一的消息渲染入口，通过 `message.role` 字段自动派发到对应的子组件。整个渲染过程由一个 `computed` 属性完成，无额外状态。
+
+## 渲染架构
+
+```
+MessageRender
+│
+├── props.message.role
+│     │
+│     ├── 'user'       → UserMessage（转发 message + onAction / onInputConfirm /
+│     │                               onShortcutConfirm / messageToolsStatus / tippyOptions）
+│     │
+│     ├── 'assistant'  → AssistantMessage（转发 message + default slot）
+│     │                    └── default slot 默认回退到 ContentRender
+│     │
+│     ├── 'info'       → InfoMessage（转发 message）
+│     ├── 'reasoning'  → ReasoningMessage（转发 message）
+│     ├── 'tool'       → ToolMessage（转发 message）
+│     ├── 'activity'   → ActivityMessage（转发 message + onInterruptResume）
+│     ├── 'loading'    → LoadingMessage（转发 message）
+│     ├── 'interrupt'  → InterruptMessageRender（转发 message + onInterruptResume）
+│     │
+│     └── 其他 / 未知   → null（不渲染任何内容）
+```
+
+> **重要**：`onAction`、`onInputConfirm`、`onShortcutConfirm`、`messageToolsStatus`、`tippyOptions` 这五个 prop **只转发给 `UserMessage`**。`AssistantMessage` 的工具栏由 `MessageContainer` 的 `MessageTools` 组件管理，`MessageRender` 不负责传递。
+
+## 基础用法
+
+```vue
+<template>
+  <MessageRender
+    :message="message"
+    :on-action="handleAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageRender, MessageRole, MessageStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    content: '你好！我是 AI 助手，有什么可以帮你的吗？',
+    status: MessageStatus.Complete,
+  };
+
+  const handleAction = async (tool: IToolBtn) => {
+    console.log('消息操作:', tool.id);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 各角色消息
+
+### 用户消息（user）
+
+`onAction`、`onInputConfirm`、`onShortcutConfirm`、`messageToolsStatus` 在此角色下生效。
+
+```vue
+<script setup lang="ts">
+  import { MessageRole, MessageStatus, type Message, type IToolBtn, type TagSchema } from '@blueking/chat-x';
+
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.User,
+    content: '你好，请帮我解释一下什么是 Vue 3 的组合式 API',
+    status: MessageStatus.Complete,
+  };
+
+  const handleAction = async (tool: IToolBtn) => {
+    console.log('用户消息操作:', tool.id); // delete / copy 等
+  };
+  const handleInputConfirm = async (content: Message['content'], docSchema: TagSchema) => {
+    console.log('编辑确认:', content);
+  };
+  const handleShortcutConfirm = async (formModel: Record<string, unknown>) => {
+    console.log('快捷指令提交:', formModel);
+  };
+</script>
+```
+
+**渲染效果**
+
+### AI 助手消息（assistant）
+
+`message` 中的全部字段（含 `toolCalls`）直接透传给 `AssistantMessage`。
+
+```vue
+<script setup lang="ts">
+  import { MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  const message = {
+    id: '2',
+    messageId: '2',
+    role: MessageRole.Assistant,
+    content: `## Vue 3 组合式 API\n\n**组合式 API** 是 Vue 3 引入的一种新方式...`,
+    status: MessageStatus.Complete,
+  };
+</script>
+```
+
+**渲染效果**
+
+### 信息消息（info）
+
+`content` 为字符串或字符串数组，渲染居中虚线分隔条。
+
+### 推理消息（reasoning）
+
+`content` 为字符串数组，`duration` 为推理耗时（毫秒）。
+
+### 工具调用结果（tool）
+
+在 `MessageContainer` 中通常不独立渲染（被注入到 AssistantMessage），单独使用时如下：
+
+### 活动消息（activity）
+
+### 加载消息（loading）
+
+由 `MessageContainer` 自动注入，无需手动使用。
+
+## 消息状态
+
+### 流式输出（streaming）
+
+`status: 'streaming'` 时，`AssistantMessage` 内部展示打字光标，内容可实时追加：
+
+```vue
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageRole, MessageStatus, type Message } from '@blueking/chat-x';
+
+  const message = ref<Message>({
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    content: '',
+    status: MessageStatus.Streaming,
+  });
+
+  // 模拟流式输出：逐步追加内容
+  const chunks = ['正在', '为你', '生成', '答案...'];
+  let i = 0;
+  const timer = setInterval(() => {
+    if (i < chunks.length) {
+      message.value.content += chunks[i++];
+    } else {
+      message.value.status = MessageStatus.Complete;
+      clearInterval(timer);
+    }
+  }, 300);
+</script>
+```
+
+**渲染效果**
+
+### 错误状态（error）
+
+```vue
+<script setup lang="ts">
+  import { MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    content: '抱歉，生成回答时发生了错误，请重试。',
+    status: MessageStatus.Error,
+  };
+</script>
+```
+
+**渲染效果**
+
+## 自定义内容渲染（default slot）
+
+`default` slot **仅对 `role: 'assistant'` 生效**，用于替换默认的 `ContentRender`。未提供 slot 时回退渲染 `<ContentRender :content="message.content" :status="message.status" />`。
+
+```vue
+<template>
+  <MessageRender
+    :message="message"
+    :on-action="handleAction"
+  >
+    <template #default="{ content, status }">
+      <!-- 完全接管内容区域渲染 -->
+      <MyMarkdownRenderer
+        :content="content"
+        :streaming="status === 'streaming'"
+      />
+    </template>
+  </MessageRender>
+</template>
+```
+
+slot 参数类型与 `AssistantMessage` 的 slot 保持一致（`Partial<AssistantMessage>`），主要使用：
+
+| 参数      | 类型            | 说明         |
+| --------- | --------------- | ------------ |
+| `content` | `string`        | 消息内容     |
+| `status`  | `MessageStatus` | 当前消息状态 |
+
+## 与 MessageContainer 配合
+
+在 `MessageContainer` 的 `default` slot 中使用，可替换默认的 `MessageRender` 渲染逻辑：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+    @stop-streaming="handleStopStreaming"
+  >
+    <template #default="{ message, messageToolsStatus }">
+      <!-- 自定义 MessageRender 的行为 -->
+      <MessageRender
+        :message="message"
+        :message-tools-status="messageToolsStatus"
+        :on-action="handleUserAction"
+        :on-input-confirm="handleInputConfirm"
+      >
+        <template
+          v-if="message.role === 'assistant'"
+          #default="{ content, status }"
+        >
+          <MyCustomContent
+            :content="content"
+            :status="status"
+          />
+        </template>
+      </MessageRender>
+    </template>
+  </MessageContainer>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名             | 类型                                                                       | 默认值 | 说明                                              |
+| ------------------ | -------------------------------------------------------------------------- | ------ | ------------------------------------------------- |
+| message            | `Partial<Message>`                                                         | —      | **必填**，消息对象，`role` 字段决定渲染哪个子组件 |
+| messageToolsStatus | `MessageToolsStatus`                                                       | —      | 工具按钮状态；**仅转发给 `UserMessage`**          |
+| onAction           | `(tool: IToolBtn) => Promise<string[] \| void>`                            | —      | 工具操作回调；**仅转发给 `UserMessage`**          |
+| onInputConfirm     | `(content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | —      | 用户编辑确认回调；**仅转发给 `UserMessage`**      |
+| onInterruptResume  | `(payload: InterruptResume, interrupt?: Interrupt) => Promise<void>`         | —      | 中断 / FlowAgent 节点操作回调；转发给 `InterruptMessageRender` 与 `ActivityMessage`（后者仅 `flow_agent` 子组件消费） |
+| onShortcutConfirm  | `(formModel: Record<string, unknown>) => Promise<void>`                    | —      | 用户快捷指令提交回调；**仅转发给 `UserMessage`**  |
+| tippyOptions       | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>` | —      | 自定义 Tippy 配置；**仅转发给 `UserMessage`**     |
+
+### Slots
+
+| 插槽名           | 参数                                         | 说明                                                                                                    |
+| ---------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| answeredQuestion | `{ item, index, status }`                    | 自定义 UserQuestion 已回答回显，透传给 InterruptMessageRender → UserQuestionAnsweredCard 的 `#answer`   |
+| codeHeader       | `{ language: string; token: Token[] }`       | 代码块头部自定义操作区域，透传给 ContentRender → MarkdownContent → CodeContent；**仅对 assistant 生效** |
+| default          | `{ content: string, status: MessageStatus }` | 替换 AssistantMessage 的内容区域渲染；**仅对 `role: 'assistant'` 生效**                                 |
+
+## 消息类型映射
+
+| `MessageRole` | 渲染组件           | prop 路由                                                                                               | 说明                  |
+| ------------- | ------------------ | ------------------------------------------------------------------------------------------------------- | --------------------- |
+| `user`        | `UserMessage`      | `message` + `onAction` + `onInputConfirm` + `onShortcutConfirm` + `messageToolsStatus` + `tippyOptions` | 用户发送的消息        |
+| `assistant`   | `AssistantMessage` | `message` + `default slot`                                                                              | AI 助手回复消息       |
+| `info`        | `InfoMessage`      | `message`                                                                                               | 系统信息 / 会话分隔符 |
+| `reasoning`   | `ReasoningMessage` | `message`                                                                                               | AI 思考过程（可折叠） |
+| `tool`        | `ToolMessage`      | `message`                                                                                               | 工具调用返回结果      |
+| `activity`    | `ActivityMessage`  | `message` + `onInterruptResume`                                                                         | 知识检索 / 引用文档 / FlowAgent 执行（节点重试 / 跳过） |
+| `loading`     | `LoadingMessage`   | `message`（字段被忽略，组件无 Props）                                                                   | 等待响应的加载占位    |
+| `interrupt`   | `InterruptMessageRender` | `message` + `onInterruptResume`                                                                         | human-in-the-loop 中断 |
+| 其他 / 未知   | —                  | —                                                                                                       | 返回 `null`，不渲染   |
+
+## 类型定义
+
+```typescript
+import { MessageRole, MessageStatus, MessageToolsStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+
+// 消息角色
+enum MessageRole {
+  User = 'user',
+  Assistant = 'assistant',
+  Info = 'info',
+  Reasoning = 'reasoning',
+  Tool = 'tool',
+  Activity = 'activity',
+  Loading = 'loading',
+}
+
+// 消息状态
+enum MessageStatus {
+  Pending = 'pending',
+  Streaming = 'streaming',
+  Complete = 'complete',
+  Error = 'error',
+  Stop = 'stop',
+  Disabled = 'disabled',
+}
+
+// 工具按钮状态（仅转发给 UserMessage）
+enum MessageToolsStatus {
+  Disabled = 'disabled',
+  Hidden = 'hidden',
+}
+```
+
+## 关联组件
+
+- [MessageContainer](/components/setup/message-container) — 内部按组调用以渲染每条消息
+- [AssistantMessage](/components/message/assistant-message) — assistant 角色派发目标
+- [UserMessage](/components/message/user-message) — user 角色派发目标
+- [InterruptMessage 中断消息](/components/agent/interrupt-message) — interrupt 角色派发目标
+- [ToolApprovalCard 审批卡片](/components/agent/tool-approval-card) — AI Dev 审批中断子卡片

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-tools.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/message-tools.md
@@ -1,0 +1,378 @@
+# MessageTools 消息工具栏
+
+> 能力域：工具与反馈 ｜ 导入：`import { MessageTools } from '@blueking/chat-x'` ｜ since 1.0.0
+
+消息悬浮工具栏，组合复制、删除、反馈等工具按钮。 源码位置：src/components/message-tools/message-tools.vue。
+
+**关联**：tool-btn（普通工具项由 ToolBtn 渲染）、user-feedback（like/unlike 时弹出反馈表单）、delete-tool（id 为 delete 时替换为带确认的删除按钮）
+
+---
+
+# MessageTools 消息工具栏
+## 源码事实
+
+- **源码位置**：`src/components/message-tools/message-tools.vue`
+- **能力域**：工具与反馈
+- **能力说明**：消息悬浮工具栏，组合复制、删除、反馈等工具按钮。
+
+> **能力域**：工具与反馈
+
+AI 消息的操作工具栏组件，由**左侧消息工具区**和**右侧更新工具区**两部分组成，中间以分隔线分隔。仅 `like` / `unlike` 按钮会弹出反馈表单（`UserFeedback`），其余按钮直接触发 `onAction`。
+
+## 组件结构
+
+```
+┌─────────────────────────────────────────────────────┐
+│  .message-tools-container                           │
+│  ┌─────────────────────┐  │  ┌───────────────────┐ │
+│  │  messageTools        │  │  │  updateTools      │ │
+│  │  copy cite rebuild…  │  │  │  like unlike del  │ │
+│  └─────────────────────┘  │  └───────────────────┘ │
+│             左侧区域      分隔线   右侧区域          │
+└─────────────────────────────────────────────────────┘
+```
+
+- 分隔线（`.ai-divider`）仅在 `updateTools` 非空时显示
+- `updateTools` 中 `id` 为 `like` / `unlike` 的按钮被 `Tippy` 弹窗包裹，点击后展示 `UserFeedback` 反馈表单
+- `updateTools` 中 `id` 为 `delete` 的按钮使用 `DeleteTool` 组件，点击后展示**确认删除弹窗**（含"删除"/"取消"按钮），确认后触发 `onAction`
+- `updateTools` 中其他按钮直接触发 `onAction`，不弹表单
+- `messageTools` 中 `id` 为 `delete` 的按钮同样使用 `DeleteTool` 组件弹确认框
+
+## 基础用法
+
+```vue
+<template>
+  <MessageTools
+    :on-action="handleAction"
+    @feedback="handleFeedback"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageTools, type IToolBtn } from '@blueking/chat-x';
+
+  // like / unlike 必须返回 Promise<string[]>，作为反馈表单的选项
+  const handleAction = async (tool: IToolBtn) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面', '表达清晰', '解决了问题'];
+    }
+  };
+
+  // 用户在反馈表单点击"提交"后触发
+  const handleFeedback = (tool: IToolBtn, reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList, otherReason);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 反馈交互流程
+
+点赞（`like`）和不满意（`unlike`）按钮的完整交互流程：
+
+```
+用户点击 like/unlike
+        │
+        ▼
+调用 onAction(tool)（显示 loading 状态）
+        │
+        ▼
+onAction 返回 string[]（反馈选项列表）
+        │
+        ▼
+弹出 UserFeedback 表单（显示选项）
+        │
+   ┌────┴────┐
+取消         提交
+  │           │
+关闭弹窗     emit('feedback', tool, reasonList, otherReason)
+             │
+             ▼
+          按钮切换为激活图标（activeLike / activeUnLike）
+          ↑ 再次点击同一按钮 → 取消激活并关闭弹窗（不触发 feedback）
+```
+
+**图标切换说明**：
+
+| 状态         | `like` 按钮图标          | `like` Tooltip   | `unlike` 按钮图标          | `unlike` Tooltip |
+| ------------ | ------------------------ | ---------------- | -------------------------- | ---------------- |
+| 未提交       | `like`（空心）           | 原始 description | `unlike`（空心）           | 原始 description |
+| 已提交点赞   | `activeLike`（实心填充） | 取消满意         | `unlike`（空心）           | 原始 description |
+| 已提交不满意 | `like`（空心）           | 原始 description | `activeUnLike`（实心填充） | 取消不满意       |
+
+> 激活态下 tooltip 内容自动切换为"取消满意"/"取消不满意"，用于提示用户再次点击可取消评价。
+
+## 默认工具列表
+
+### messageTools（左侧）
+
+```typescript
+const CONST_MESSAGE_TOOLS = [
+  { id: 'copy', name: '复制', description: '复制' },
+  { id: 'cite', name: '引用', description: '引用' },
+  { id: 'rebuild', name: '重新生成', description: '重新生成' },
+  { id: 'share', name: '分享', description: '分享' },
+];
+```
+
+### updateTools（右侧）
+
+```typescript
+const CONST_UPDATE_TOOLS = [
+  { id: 'like', name: '点赞', description: '点赞' },
+  { id: 'unlike', name: '不满意', description: '不满意' },
+  { id: 'delete', name: '删除', description: '删除' },
+];
+```
+
+> **注意**：`delete` 在 `updateTools` 中**不弹反馈表单**，而是弹出确认删除弹窗（`DeleteTool`）。用户确认后才触发 `onAction`，取消则不触发。
+
+## 内置图标 ID
+
+`ToolBtn` 会根据 `tool.id` 自动匹配图标，支持以下 ID：
+
+| ID             | 图标说明                             |
+| -------------- | ------------------------------------ |
+| `copy`         | 复制                                 |
+| `cite`         | 引用                                 |
+| `rebuild`      | 重新生成                             |
+| `share`        | 分享                                 |
+| `like`         | 点赞（空心）                         |
+| `unlike`       | 不满意（空心）                       |
+| `delete`       | 删除                                 |
+| `edit`         | 编辑                                 |
+| `activeLike`   | 点赞已激活（实心，由组件内部使用）   |
+| `activeUnLike` | 不满意已激活（实心，由组件内部使用） |
+
+> ID 不在列表中时，按钮显示 `tool.name` 文本。
+
+## 仅显示消息工具（不含反馈）
+
+将 `updateTools` 设为空数组可去掉右侧反馈按钮和分隔线：
+
+```vue
+<template>
+  <MessageTools
+    :message-tools="messageTools"
+    :update-tools="[]"
+    :on-action="handleAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageTools, type IToolBtn } from '@blueking/chat-x';
+
+  const messageTools: IToolBtn[] = [
+    { id: 'copy', name: '复制', description: '复制' },
+    { id: 'cite', name: '引用', description: '引用' },
+  ];
+
+  const handleAction = async (tool: IToolBtn) => {
+    console.log('操作:', tool.id);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 自定义工具列表
+
+`messageTools` 和 `updateTools` 均可完全替换：
+
+```vue
+<template>
+  <MessageTools
+    :message-tools="customMessageTools"
+    :update-tools="customUpdateTools"
+    :on-action="handleAction"
+    @feedback="handleFeedback"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageTools, type IToolBtn } from '@blueking/chat-x';
+
+  const customMessageTools: IToolBtn[] = [
+    { id: 'copy', name: '复制', description: '复制消息内容' },
+    { id: 'rebuild', name: '重新生成', description: '重新生成回答' },
+    { id: 'custom-action', name: '自定义', description: '自定义操作' }, // 无图标，显示文本
+  ];
+
+  // like / unlike 仍会触发反馈弹窗；delete 弹确认框，确认后触发 onAction
+  const customUpdateTools: IToolBtn[] = [
+    { id: 'like', name: '有帮助', description: '这个回答对我有帮助' },
+    { id: 'unlike', name: '没帮助', description: '这个回答没有帮助' },
+    { id: 'delete', name: '删除', description: '删除消息' },
+  ];
+
+  const handleAction = async (tool: IToolBtn) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面', '表达清晰', '解决了问题'];
+    }
+    console.log('操作:', tool.id);
+  };
+
+  const handleFeedback = (tool: IToolBtn, reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList, otherReason);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 工具栏状态控制
+
+`messageToolsStatus` 控制工具栏整体状态：
+
+| 值          | 效果                                                                   |
+| ----------- | ---------------------------------------------------------------------- |
+| `undefined` | 默认，按钮正常可点击，hover 有 tooltip                                 |
+| `disabled`  | 按钮显示但不可点击，tooltip 不显示，反馈弹窗无法打开                   |
+| `hidden`    | `MessageContainer` 检测到此值时不渲染 `MessageTools`（组件自身不处理） |
+
+> `hidden` 由 `MessageContainer` 在外部用 `v-if` 判断，`MessageTools` 本身不感知该值。
+
+**禁用状态**
+
+```vue
+<template>
+  <MessageTools
+    :message-tools-status="MessageToolsStatus.Disabled"
+    :on-action="handleAction"
+    @feedback="handleFeedback"
+  />
+</template>
+```
+
+## 自定义 Tippy 配置
+
+反馈弹窗的 `Tippy` 默认配置如下，可通过 `tippyOptions` 覆盖：
+
+```typescript
+// 内部默认值
+{
+  arrow: false,
+  interactive: true,
+  offset: [0, 6],
+  theme: 'ai-chat-box-light light',
+  trigger: 'click',
+  appendTo: () => document.body,
+}
+```
+
+```vue
+<template>
+  <MessageTools
+    :on-action="handleAction"
+    :tippy-options="tippyOptions"
+    @feedback="handleFeedback"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageTools, type IToolBtn } from '@blueking/chat-x';
+
+  const tippyOptions = {
+    placement: 'top', // 弹窗方向
+    offset: [0, 12], // 偏移量
+    appendTo: () => document.querySelector('#my-container') || document.body,
+  };
+
+  const handleAction = async (tool: IToolBtn) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面'];
+    }
+  };
+  const handleFeedback = (tool: IToolBtn, reasonList: string[], otherReason: string) => {
+    console.log('反馈:', tool.id, reasonList);
+  };
+</script>
+```
+
+> **注意**：`content`、`theme`、`getReferenceClientRect`、`triggerTarget` 四个选项由组件内部管理，不可通过 `tippyOptions` 覆盖。
+
+## 在 MessageContainer 中的使用
+
+`MessageContainer` 在每个 Assistant 消息组底部自动渲染 `MessageTools`，无需手动引入：
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :message-tools-status="messageToolsStatus"
+    :on-agent-action="handleAgentAction"
+    :on-agent-feedback="handleAgentFeedback"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { computed, ref } from 'vue';
+  import { MessageContainer, MessageStatus, MessageToolsStatus, type Message, type IToolBtn } from '@blueking/chat-x';
+
+  const messageStatus = ref(MessageStatus.Complete);
+
+  // 流式输出时禁用工具栏，避免误操作
+  const messageToolsStatus = computed(() =>
+    messageStatus.value === MessageStatus.Streaming ? MessageToolsStatus.Disabled : undefined,
+  );
+
+  // copy 操作由 MessageContainer 内部自动处理（无需在此实现）
+  const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
+    if (tool.id === 'like' || tool.id === 'unlike') {
+      return ['回答准确', '信息全面', '表达清晰'];
+    }
+  };
+
+  const handleAgentFeedback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => {
+    console.log('反馈提交:', tool.id, reasonList, otherReason);
+  };
+
+  const handleStopStreaming = () => {
+    messageStatus.value = MessageStatus.Stop;
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名             | 类型                                                                                                     | 默认值                | 说明                                                                                                                                 |
+| ------------------ | -------------------------------------------------------------------------------------------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| messageTools       | `IToolBtn[]`                                                                                             | `CONST_MESSAGE_TOOLS` | 左侧工具列表                                                                                                                         |
+| updateTools        | `IToolBtn[]`                                                                                             | `CONST_UPDATE_TOOLS`  | 右侧工具列表（`like`/`unlike` 弹反馈表单，`delete` 弹确认框，其他直接触发 `onAction`）                                               |
+| messageToolsStatus | `MessageToolsStatus`                                                                                     | —                     | 工具栏状态：`disabled` 禁用按钮和弹窗                                                                                                |
+| onAction           | `(tool: IToolBtn, content?: UserMessage['content'], docSchema?: TagSchema) => Promise<string[] \| void>` | —                     | 工具操作回调；`like`/`unlike` 需返回 `string[]` 作为反馈选项；`delete` 确认后触发；`content`、`docSchema` 为可选参数，供上层扩展使用 |
+| tippyOptions       | `AITippyProps`                                                                                           | —                     | 覆盖反馈弹窗和删除确认弹窗的默认配置；可覆盖 `placement` 等                                                                          |
+
+### Events
+
+| 事件名   | 参数                                                          | 触发时机                                   |
+| -------- | ------------------------------------------------------------- | ------------------------------------------ |
+| feedback | `(tool: IToolBtn, reasonList: string[], otherReason: string)` | 用户在反馈表单点击"提交"后触发（not 取消） |
+
+## 类型定义
+
+```typescript
+import { MessageToolsStatus, type IToolBtn } from '@blueking/chat-x';
+
+interface IToolBtn {
+  id?: keyof typeof ToolIconsMap; // 工具唯一标识；与 ToolIconsMap 匹配时显示内置图标，否则显示 name 文本
+  name?: string; // 工具名称，无对应图标时显示；也用作 tooltip fallback
+  description?: string; // tooltip 文本
+}
+
+enum MessageToolsStatus {
+  Disabled = 'disabled', // 禁用：按钮显示但不可点击，弹窗不打开
+  Hidden = 'hidden', // 隐藏：由 MessageContainer 外部 v-if 控制，组件本身不处理
+}
+```
+
+## 关联组件
+
+- [ToolBtn](/components/feedback/tool-btn) — 单项工具按钮
+- [UserFeedback](/components/feedback/user-feedback) — 点赞/踩反馈面板
+- [DeleteTool](/components/feedback/delete-tool) — 删除二次确认

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/preview-toolbar.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/preview-toolbar.md
@@ -1,0 +1,42 @@
+# PreviewToolbar 图片预览工具栏
+
+> 能力域：媒体文件 ｜ 导入：`import { PreviewToolbar } from '@blueking/chat-x'` ｜ since 1.0.0
+
+图片预览的缩放、旋转、下载等工具按钮。 源码位置：src/components/image-preview/preview-toolbar.vue。
+
+---
+
+# PreviewToolbar 图片预览工具栏
+
+> **能力域**：媒体文件
+
+## 源码事实
+
+- **源码位置**：`src/components/image-preview/preview-toolbar.vue`
+- **能力说明**：图片预览的缩放、旋转、下载等工具按钮。
+
+## API 摘要
+
+### Props
+
+- `{ activeIndex: number; currentImageInfo?: null | { resolution?: string; width?: number }; isMultiple: boolean; showInfo: boolean; total: number; }`
+
+### Emits
+
+- `{ (e: 'zoomIn'): void; (e: 'zoomOut'): void; (e: 'rotate'): void; (e: 'reset'): void; (e: 'download'): void; }`
+
+### Slots
+
+- `extra`
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过上层组合组件使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/questions-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/questions-container.md
@@ -1,0 +1,85 @@
+# QuestionsContainer 问题容器占位
+
+> 能力域：辅助能力 ｜ 导入：`import { QuestionsContainer } from '@blueking/chat-x'` ｜ since 1.0.0
+
+源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。 源码位置：src/components/ai-questions/questions-container.vue。
+
+**关联**：user-question-card（用户问题中断交互请使用实际可渲染的问题卡片组件）、user-question-option（用户问题选项行由实际中断组件承载）、interrupt-message（HITL 中断消息由 InterruptMessage 分发到具体问题组件）
+
+---
+
+# QuestionsContainer 问题容器占位
+
+> **能力域**：辅助能力
+
+`QuestionsContainer` 当前只是保留在源码目录中的空文件，占位路径为 `src/components/ai-questions/questions-container.vue`。它没有模板、脚本、样式、props、emits、slots 或任何渲染行为。
+
+本文档保留该条目，是为了在组件总览和 MCP 文档检索中明确说明：它不是当前可用能力。
+
+## 源码事实
+
+- **源码位置**：`src/components/ai-questions/questions-container.vue`
+- **文件大小**：`0` 字节
+- **能力说明**：源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。
+
+## 当前状态
+
+| 项目     | 状态 |
+| -------- | ---- |
+| 模板     | 无   |
+| 脚本逻辑 | 无   |
+| 样式     | 无   |
+| Props    | 无   |
+| Emits    | 无   |
+| Slots    | 无   |
+| Expose   | 无   |
+
+## 不可用示例
+
+下面的写法不会产生任何可见 UI，也不会承载问题列表逻辑：
+
+```vue
+<template>
+  <!-- 不建议使用：当前组件为空文件 -->
+  <QuestionsContainer />
+</template>
+```
+
+## 推荐替代
+
+如果要展示用户问题中断或选项交互，请使用已经实现的中断消息组件链路：
+
+```vue
+<template>
+  <InterruptMessage :message="message" />
+</template>
+```
+
+或在具体场景中使用：
+
+- [InterruptMessage](../agent/interrupt-message.md) — 中断消息分发入口。
+- [UserQuestionCard](../agent/user-question-card.md) — 用户问题中断交互面板。
+- [UserQuestionOption](../agent/user-question-option.md) — 用户问题选项行。
+
+## API
+
+### Props
+
+- 无。
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 使用建议
+
+- 不建议在业务中使用该组件。
+- 如果后续补齐实现，需要同步更新本文档的能力说明、示例、API 与关联组件。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reasoning-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reasoning-message.md
@@ -1,0 +1,235 @@
+# ReasoningMessage 推理消息
+
+> 能力域：消息系统 ｜ 导入：`import { ReasoningMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染推理过程，覆盖加载、错误与 Markdown 内容展示。 源码位置：src/components/chat-message/reasoning-message/reasoning-message.vue。
+
+**关联**：message-render（由 MessageRender 在 role 为 reasoning 时创建）、assistant-message（推理结束后通常紧跟 Assistant 的正式回复）、markdown-content（内容区通过 Markdown 渲染推理文本）
+
+---
+
+# ReasoningMessage 推理消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/reasoning-message/reasoning-message.vue`
+- **能力域**：消息系统
+- **能力说明**：渲染推理过程，覆盖加载、错误与 Markdown 内容展示。
+
+> **能力域**：消息系统
+
+AI 思维链（Chain-of-Thought）推理过程展示组件。由**可点击标题栏**和**内容区域**组成，内容区支持 Markdown 渲染。`duration` 传入后自动折叠一次，用户可随时点击标题展开/收起。
+
+## 组件结构
+
+```
+┌─────────────────────────────────────────────────┐
+│  .ai-reasoning-message-title（可点击，toggle 折叠）│
+│  ┌──────┐  标题文案（思考中/已思考完成/思考失败）  ▶ │
+│  │ 加载图标│                               折叠图标 │
+│  └──────┘                                        │
+└─────────────────────────────────────────────────┘
+▼ 展开时显示（v-show）
+┌─────────────────────────────────────────────────┐
+│  .ai-reasoning-message-content                  │
+│  <MarkdownContent> × content.length              │
+│  （Error 时改为 CommonErrorContent）              │
+│  .ai-markdown-body { color: #979ba5 }（灰色文字）   │
+└─────────────────────────────────────────────────┘
+```
+
+## 基础用法
+
+```vue
+<template>
+  <ReasoningMessage
+    :content="content"
+    :status="status"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ReasoningMessage, MessageStatus } from '@blueking/chat-x';
+
+  const status = MessageStatus.Complete;
+  const content = ['让我分析一下这个问题...', '首先需要考虑以下几个方面...'];
+</script>
+```
+
+**渲染效果**
+
+## 状态与视觉效果
+
+| `status`                       | 标题文案           | 加载图标      | 标题 CSS 类   |
+| ------------------------------ | ------------------ | ------------- | ------------- |
+| `pending` / `streaming` / 其他 | 思考中             | `AiLoading` ✓ | `is-thinking` |
+| `complete` / `success`         | 已思考完成（耗时） | 无            | `is-complete` |
+| `error`                        | 思考失败           | 无            | `is-error`    |
+
+> **说明**：`streaming` 通过 `switch` 的 `default` 分支显示"思考中"，与 `pending` 效果相同。
+
+### 思考中（pending / streaming）
+
+### 完成状态（带耗时）
+
+`duration` 传入后：
+
+1. 标题显示"已思考完成 (耗时：x.xs)"
+2. **自动折叠一次**（watch 触发后 `stop()`，后续不再自动折叠）
+3. 用户点击标题可重新展开
+
+### 错误状态（error）
+
+`status: 'error'` 时，标题显示"思考失败"，内容区改为 `CommonErrorContent` 渲染（将 `content` 数组 join `\n` 后传入）：
+
+## 折叠控制
+
+### 自动折叠机制
+
+组件内部 watch `duration` prop（`{ immediate: true }`）：
+
+- 当 `duration` **首次变为真值**时，将 `collapsed` 设为 `true` 并停止 watcher
+- **一次性行为**：watcher 停止后，后续 `duration` 变化不再触发自动折叠
+
+```typescript
+// 组件内部逻辑（简化）
+const { stop } = watch(
+  () => props.duration,
+  async duration => {
+    if (duration) {
+      collapsed.value = true;
+      await nextTick();
+      stop?.(); // 停止 watcher，后续 duration 变化不再自动折叠
+    }
+  },
+  { immediate: true },
+);
+```
+
+### 手动控制折叠状态
+
+通过 `v-model:collapsed` 从外部读取或设置折叠状态：
+
+```vue
+<template>
+  <button @click="collapsed = !collapsed">
+    {{ collapsed ? '展开推理' : '收起推理' }}
+  </button>
+  <ReasoningMessage
+    v-model:collapsed="collapsed"
+    :content="content"
+    :status="status"
+    :duration="duration"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ReasoningMessage, MessageStatus } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+  const status = MessageStatus.Complete;
+  const duration = 2800;
+  const content = ['经过分析，结论如下...', '具体原因是...'];
+</script>
+```
+
+## 在 MessageContainer 中使用
+
+`MessageContainer` 会自动将 `role: 'reasoning'` 的消息渲染为 `ReasoningMessage`，无需手动引入：
+
+```vue
+<script setup lang="ts">
+  import { MessageRole, MessageStatus, type Message } from '@blueking/chat-x';
+
+  const messages = [
+    {
+      id: '1',
+      messageId: '1',
+      role: MessageRole.User,
+      content: '如何实现 TypeScript 中的深拷贝？',
+      status: MessageStatus.Complete,
+    },
+    {
+      id: '2',
+      messageId: '2',
+      role: MessageRole.Reasoning,
+      content: [
+        '用户问的是 TypeScript 深拷贝，需要考虑几种常见方案...',
+        'JSON.parse/stringify 有局限性（函数、循环引用等）...',
+        'structuredClone 是更现代的选择，但需要注意兼容性...',
+      ],
+      status: MessageStatus.Complete,
+      duration: 2800, // 毫秒，传入后自动折叠
+    },
+    {
+      id: '3',
+      messageId: '3',
+      role: MessageRole.Assistant,
+      content: 'TypeScript 中实现深拷贝有以下几种方式...',
+      status: MessageStatus.Complete,
+    },
+  ];
+</script>
+```
+
+## API
+
+### Props
+
+组件 Props 继承自 `Partial<ReasoningMessage>`：
+
+| 属性名    | 类型                 | 说明                                                                           |
+| --------- | -------------------- | ------------------------------------------------------------------------------ |
+| content   | `string \| string[]` | 推理内容；字符串数组时每项独立渲染为 `MarkdownContent`；字符串时自动包装为数组 |
+| status    | `MessageStatus`      | 消息状态，决定标题文案、加载图标和 CSS 类                                      |
+| duration  | `number`             | 推理耗时（毫秒）；传入后标题追加耗时信息，并**触发一次自动折叠**               |
+| id        | `number \| string`   | 消息 ID（接收但不使用）                                                        |
+| messageId | `number \| string`   | 消息唯一标识（接收但不使用）                                                   |
+
+### v-model
+
+| 属性名    | 类型      | 默认值  | 说明                                                       |
+| --------- | --------- | ------- | ---------------------------------------------------------- |
+| collapsed | `boolean` | `false` | 内容折叠状态；`duration` 首次传入时组件内部自动设为 `true` |
+
+### 状态说明
+
+| `status`           | 标题文案                             | 加载图标 | 标题背景        |
+| ------------------ | ------------------------------------ | -------- | --------------- |
+| `pending`          | 思考中                               | ✓        | `#f0f1f5`       |
+| `streaming` / 其他 | 思考中（default 分支）               | ✓        | `#f0f1f5`       |
+| `complete`         | 已思考完成（含 duration 则追加耗时） | ✗        | `#f0f1f5`       |
+| `success`          | 已思考完成（同 complete）            | ✗        | `#f0f1f5`       |
+| `error`            | 思考失败                             | ✗        | `#fff0f0`（红） |
+
+## 类型定义
+
+```typescript
+import { MessageRole, MessageStatus, type ReasoningMessage } from '@blueking/chat-x';
+
+// ReasoningMessage 继承自 BaseMessage<MessageRole.Reasoning, string[]>
+interface ReasoningMessage {
+  id: string | number;
+  messageId: string | number;
+  role: MessageRole.Reasoning; // 'reasoning'
+  status: MessageStatus;
+  content: string[]; // TS 类型为 string[]，组件内部实际兼容 string
+  duration?: number; // 推理耗时（毫秒）
+  name?: string;
+}
+
+enum MessageStatus {
+  Pending = 'pending',
+  Streaming = 'streaming',
+  Complete = 'complete',
+  Success = 'success',
+  Error = 'error',
+  Stop = 'stop',
+}
+```
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — reasoning 角色由其实例化
+- [AssistantMessage](/components/message/assistant-message) — 推理后常接正式回答
+- [MarkdownContent](/components/rendering/markdown-content) — 推理正文 Markdown 渲染

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reference-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reference-content.md
@@ -1,0 +1,135 @@
+# ReferenceContent 引用来源
+
+> 能力域：内容渲染 ｜ 导入：`import { ReferenceContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染引用文档/来源列表。 源码位置：src/components/chat-content/reference-content/reference-content.vue。
+
+**关联**：content-render（ReferenceDocument 类型内容路由到本组件）、activity-message（知识库等活动场景内嵌引用列表）
+
+---
+
+# ReferenceContent 引用文档内容
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/reference-content/reference-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：渲染引用文档/来源列表。
+
+> **能力域**：内容渲染
+
+引用文档列表渲染基础组件，用于展示 AI 回复中引用的参考文档，每项包含文档图标、标题、预览与跳转操作。
+
+主要由 `ActivityMessage`（知识库问答场景）和 `ContentRender`（`reference_document` 类型内容）内部使用。
+
+## 组件结构
+
+```
+<template>（无根元素，Fragment 模式）
+  v-for item in links（过滤 name 为空 → 映射为 { title, url, originFileUrl }）
+    │
+    div.ai-reference-item（flex，height: 28px，padding: 0 12px，color: #3a84ff）
+      ├── DocLinkIcon（color="#D66F6B"，.ai-doc-link-icon，始终可见）
+      ├── span.ai-reference-item-title（flex: 1，ellipsis，font-size: 12px）
+      │     @click → url && gotoLink(url, event)
+      │     （XSS 安全：{{ item.title }} 文本插值）
+      ├── [v-if url && originFileUrl] PreviewIcon（.ai-common-icon）
+      │     v-tippy: "预览内容"
+      │     @click → gotoLink(url, event)
+      │     默认 display: none，hover 父容器后 display: flex
+      └── [v-if url && originFileUrl] TargetIcon（.ai-common-icon）
+            v-tippy: "跳转详情"
+            @click → gotoLink(originFileUrl, event)
+            默认 display: none，hover 父容器后 display: flex
+
+gotoLink(url, event):
+  event.stopPropagation() + event.preventDefault()
+  window.open(url, '_blank', 'noopener,noreferrer')
+```
+
+> **`v-for` key**：使用 `item.title`（即 `name`）作为 `:key`，同一组 `content` 中 `name` 须唯一，否则触发 Vue 重复 key 警告。
+
+## 图标可见性规则
+
+| 图标                      | 始终显示 | 显示条件（数据层）                | 显示条件（交互层） |
+| ------------------------- | -------- | --------------------------------- | ------------------ |
+| `DocLinkIcon`（红色书签） | ✓        | 无条件                            | 无条件             |
+| `PreviewIcon`（预览）     | —        | `url` 与 `originFileUrl` 均为真值 | 仅在 hover 时出现  |
+| `TargetIcon`（跳转）      | —        | `url` 与 `originFileUrl` 均为真值 | 仅在 hover 时出现  |
+
+即：只有 `url` 没有 `originFileUrl`（或反之），两个操作图标均不渲染。
+
+## 基础用法
+
+```vue
+<template>
+  <ReferenceContent :content="references" />
+</template>
+
+<script setup lang="ts">
+  import { ReferenceContent } from '@blueking/chat-x';
+  import type { ReferenceDocumentContent } from '@blueking/chat-x';
+
+  const references: ReferenceDocumentContent[] = [
+    { name: '蓝鲸 PaaS 平台文档', url: 'https://bk.tencent.com', originFile: '' },
+    { name: '组件库使用指南', url: 'https://bk.tencent.com/docs', originFile: '' },
+  ];
+</script>
+```
+
+## 含预览与跳转（url + originFile）
+
+同时提供 `url` 和 `originFile` 时，hover 后出现预览图标和跳转图标：
+
+## 混合场景：过滤与图标差异
+
+`name` 为空的项被过滤不渲染；`originFile` 为空时不显示 `PreviewIcon` / `TargetIcon`：
+
+```typescript
+const refs = [
+  { name: '有预览和跳转', url: 'https://…/preview', originFile: 'https://…/origin' }, // 两图标
+  { name: '仅有 url', url: 'https://…/only', originFile: '' }, // 无图标
+  { name: '', url: 'https://…/filtered', originFile: '' }, // 被过滤
+];
+// 实际渲染 2 条，第 3 条因 name='' 被过滤
+```
+
+## API
+
+### Props
+
+| 属性名  | 类型                         | 必填 | 说明                                          |
+| ------- | ---------------------------- | ---- | --------------------------------------------- |
+| content | `ReferenceDocumentContent[]` | ✓    | 引用文档列表；`name` 为空的项会被过滤，不渲染 |
+
+### 类型定义
+
+```typescript
+export type ReferenceDocumentContent = {
+  name: string; // 文档标题（用作列表展示文本，也作为 v-for :key）
+  url: string; // 预览链接：标题点击、PreviewIcon 点击时打开
+  originFile: string; // 原始文件链接：TargetIcon 点击时打开；为空则不渲染两个操作图标
+};
+```
+
+## 使用场景
+
+`ReferenceContent` 在两处被内部使用：
+
+**1. `ActivityMessage`（知识库问答）**
+
+```typescript
+// content 为 ReferenceDocumentContent[] 数组时直接传入
+<ReferenceContent :content="Array.isArray(content) ? content : content?.referenceDocument || []" />
+```
+
+**2. `ContentRender`（content 类型路由）**
+
+```typescript
+// type === MessageContentType.ReferenceDocument 且 content 为数组时
+h(ReferenceContent, { content: props.content as ReferenceDocumentContent[] });
+```
+
+## 关联组件
+
+- [ContentRender](/components/rendering/content-render) — 内容类型分发
+- [ActivityMessage](/components/message/activity-message) — 活动消息内引用

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reference-doc-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/reference-doc-content.md
@@ -1,0 +1,109 @@
+# ReferenceDocContent 引用文档活动
+
+> 能力域：Agent 能力 ｜ 导入：`import { ReferenceDocContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染引用文档类活动内容，复用 ActivityLayout 与 ReferenceContent。 源码位置：src/components/chat-content/reference-doc-content/reference-doc-content.vue。
+
+**关联**：activity-message（非 knowledge_rag / flow_agent 活动默认可分发为引用文档活动）、activity-layout（提供可折叠的活动容器外壳）、reference-content（渲染引用文档列表）
+
+---
+
+# ReferenceDocContent 引用文档活动
+
+> **能力域**：Agent 能力
+
+`ReferenceDocContent` 用于渲染“引用 N 篇资料作为参考”这类活动消息。组件基于 `ActivityLayout` 提供折叠外壳，并将文档数组交给 `ReferenceContent` 展示。
+
+通常不需要直接使用，`ActivityMessage` 会在引用文档活动场景中分发到本组件。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/reference-doc-content/reference-doc-content.vue`
+- **能力说明**：渲染引用文档类活动内容，复用 ActivityLayout 与 ReferenceContent。
+
+## 核心能力
+
+- **数量标题**：根据 `content.length` 生成标题，中文为“引用 N 篇资料作为参考”
+- **文档图标**：标题区域固定展示文档图标，不随消息状态变化
+- **可折叠内容**：通过 `v-model:collapsed` 控制引用列表展开/收起，默认展开
+- **引用列表复用**：文档展示、hover 操作图标、链接打开规则均由 `ReferenceContent` 负责
+
+## 基础用法
+
+```vue
+<template>
+  <ReferenceDocContent
+    v-model:collapsed="collapsed"
+    :content="docs"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import ReferenceDocContent from '@blueking/chat-x/src/components/chat-content/reference-doc-content/reference-doc-content.vue';
+  import type { ReferenceDocumentContent } from '@blueking/chat-x';
+
+  const collapsed = ref(false);
+
+  const docs: ReferenceDocumentContent[] = [
+    { name: '蓝鲸 Agent 接入指南', url: 'https://example.com/agent', originFile: 'https://example.com/docs/agent' },
+    { name: '主机巡检操作手册', url: 'https://example.com/host-check', originFile: 'https://example.com/docs/host-check' },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 空引用
+
+当 `content` 为空或未传入时，标题数量显示为 `0`，引用列表为空。
+
+## 折叠状态
+
+## API
+
+### Props
+
+| 属性名     | 类型                         | 必填 | 默认值 | 说明                                   |
+| ---------- | ---------------------------- | ---- | ------ | -------------------------------------- |
+| content    | `ReferenceDocumentContent[]` | 否   | —      | 引用文档列表                           |
+| messageUid | `string`                     | 否   | —      | 所属消息唯一标识，当前组件暂未直接使用 |
+
+### Models
+
+| 名称      | 类型      | 默认值  | 说明             |
+| --------- | --------- | ------- | ---------------- |
+| collapsed | `boolean` | `false` | 活动内容是否折叠 |
+
+### Emits
+
+- 无显式 emits；`v-model:collapsed` 会产生 `update:collapsed`。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+export type ReferenceDocumentContent = {
+  name: string;       // 文档标题
+  originFile: string; // 原始文件链接，存在时 ReferenceContent 显示跳转操作
+  url: string;        // 预览链接或标题点击链接
+};
+```
+
+## 使用建议
+
+- 只负责引用文档活动外壳；如果只需要纯引用列表，请直接使用 [ReferenceContent](../rendering/reference-content.md)。
+- 文档条目的过滤与操作图标规则以 `ReferenceContent` 为准，`ReferenceDocContent` 不重复处理。
+
+## 关联组件
+
+- [ActivityMessage](../message/activity-message.md) — 活动消息分发入口。
+- [ActivityLayout](../helper/activity-layout.md) — 折叠活动外壳。
+- [ReferenceContent](../rendering/reference-content.md) — 引用来源列表。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/scroll-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/scroll-btn.md
@@ -1,0 +1,159 @@
+# ScrollBtn 滚动按钮
+
+> 能力域：工具与反馈 ｜ 导入：`import { ScrollBtn } from '@blueking/chat-x'` ｜ since 1.0.0
+
+停止生成或返回底部等滚动/状态按钮。 源码位置：src/components/ai-buttons/scroll-btn/scroll-btn.vue。
+
+**关联**：message-container（消息列表底部固定区挂载滚动与停止按钮）
+
+---
+
+# ScrollBtn 滚动按钮
+## 源码事实
+
+- **源码位置**：`src/components/ai-buttons/scroll-btn/scroll-btn.vue`
+- **能力域**：工具与反馈
+- **能力说明**：停止生成或返回底部等滚动/状态按钮。
+
+> **能力域**：工具与反馈
+
+聊天容器底部浮动操作按钮的外壳组件，提供统一的胶囊样式（圆角 26px、高 24px、阴影），内容完全由插槽定制。
+
+由 `MessageContainer` 内部管理"停止生成"和"返回底部"两个按钮的显示逻辑，通常不需要手动引入。
+
+## 组件结构
+
+```
+div.ai-scroll-btn（flex，gap: 4px，width: fit-content，min-width: 84px，height: 24px）
+  .is-loading / .is-disabled → cursor: not-allowed，opacity: 0.65
+  border: 1px solid #dcdee5，border-radius: 26px
+  box-shadow: 0 -2px 6px 0 #0000001a
+  hover → border: #c4c6cc，box-shadow 加深，cursor: pointer
+  │
+  ├── Loading（loading=true 时显示旋转加载图标）
+  ├── <slot name="icon">（loading=false 时显示，无默认内容）
+  │     子图标自动继承 .ai-common-icon 样式：14×14px，font-size: 14px
+  │
+  └── <slot name="title">（默认内容：{{ title }}，XSS 安全）
+        传入 title slot 时完全替换 title prop 的文本
+```
+
+> **`loading` / `disabled` prop**：`loading` 为 `true` 时显示旋转加载图标替代 icon slot，且点击无效；`disabled` 为 `true` 时点击同样无效。两者均添加 `not-allowed` 光标和 `0.65` 透明度。
+>
+> **`@click` 事件**：通过内部 `handleClick` 处理，`loading` 或 `disabled` 时不触发。
+
+## 基础用法：返回底部
+
+```vue
+<template>
+  <ScrollBtn
+    title="返回底部"
+    @click="toScrollBottom"
+  >
+    <template #icon>
+      <ArrowDownIcon />
+    </template>
+  </ScrollBtn>
+</template>
+
+<script setup lang="ts">
+  import { ScrollBtn } from '@blueking/chat-x';
+  import { ArrowDownIcon } from '@blueking/chat-x';
+
+  const toScrollBottom = () => {
+    /* 滚动逻辑 */
+  };
+</script>
+```
+
+## 停止生成
+
+```vue
+<template>
+  <ScrollBtn
+    title="停止生成"
+    @click="stopStreaming"
+  >
+    <template #icon>
+      <CloseCircleIcon />
+    </template>
+  </ScrollBtn>
+</template>
+```
+
+## 仅图标（不传 title）
+
+不传 `title` prop 时，`title` slot 渲染空文本，按钮收缩至 `min-width: 84px`：
+
+## 自定义 title slot
+
+传入 `#title` 插槽时，完全覆盖 `title` prop 的文本渲染：
+
+```vue
+<template>
+  <ScrollBtn
+    title="此文本被覆盖"
+    @click="handleClick"
+  >
+    <template #icon>
+      <ArrowDownIcon />
+    </template>
+    <template #title>
+      <span style="color: #3a84ff; font-weight: 600;">新消息 ↓</span>
+    </template>
+  </ScrollBtn>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名   | 类型      | 必填 | 说明                                                                      |
+| -------- | --------- | ---- | ------------------------------------------------------------------------- |
+| title    | `string`  | —    | 按钮文本；被 `#title` 插槽覆盖时无效；XSS 安全（文本插值）                |
+| loading  | `boolean` | —    | 加载状态；为 `true` 时显示旋转 Loading 图标替代 icon slot，点击不触发事件 |
+| disabled | `boolean` | —    | 禁用状态；为 `true` 时点击不触发事件                                      |
+
+### Events
+
+| 事件名 | 参数                  | 说明                                             |
+| ------ | --------------------- | ------------------------------------------------ |
+| click  | `(event: MouseEvent)` | 点击按钮时触发；`loading` 或 `disabled` 时不触发 |
+
+### Slots
+
+| 插槽名 | 说明                                                                      |
+| ------ | ------------------------------------------------------------------------- |
+| icon   | 图标区域，无默认内容；放置 `@blueking/chat-x` 图标时自动应用 14×14px 样式 |
+| title  | 文本区域，默认渲染 `title` prop；传入后**完全替换** prop 文本             |
+
+## 在 MessageContainer 中的使用
+
+`ScrollBtn` 由 `MessageContainer` 内置，根据状态自动控制显隐，无需手动管理：
+
+```html
+<!-- 停止生成：仅在流式输出时显示 -->
+<ScrollBtn
+  v-show="messageStatus === MessageStatus.Streaming"
+  :title="t('停止生成')"
+  @click="$emit('stopStreaming')"
+>
+  <template #icon><CloseCircleIcon /></template>
+</ScrollBtn>
+
+<!-- 返回底部：距底部超过 100px 且不在底部时显示 -->
+<ScrollBtn
+  v-show="!isScrollBottom && scrollBottomHeight > 100"
+  :title="t('返回底部')"
+  @click="toScrollBottom"
+>
+  <template #icon><ArrowDownIcon /></template>
+</ScrollBtn>
+```
+
+两个按钮都渲染在 `div.ai-message-fixed-bottom` 容器内，由父布局定位到消息列表底部中央。
+
+## 关联组件
+
+- [MessageContainer](/components/setup/message-container) — 底部固定区集成

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/selection-footer.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/selection-footer.md
@@ -1,0 +1,78 @@
+# SelectionFooter 多选操作栏
+
+> 能力域：输入交互 ｜ 导入：`import { SelectionFooter } from '@blueking/chat-x'` ｜ since 1.0.0
+
+消息多选/分享模式下的底部操作栏。 源码位置：src/components/selection-footer/selection-footer.vue。
+
+**关联**：chat-container（多选/分享模式由容器渲染底部栏）、message-container（与消息列表勾选状态联动）
+
+---
+
+# SelectionFooter 选择操作栏
+## 源码事实
+
+- **源码位置**：`src/components/selection-footer/selection-footer.vue`
+- **能力域**：输入交互
+- **能力说明**：消息多选/分享模式下的底部操作栏。
+
+> **能力域**：输入交互
+
+消息多选模式下的底部操作栏，提供全选、取消和确认操作。由 `ChatContainer` 在分享模式下自动渲染，通常不需要单独使用。
+
+## 基础用法
+
+```vue
+<template>
+  <SelectionFooter
+    :is-all-selected="isAllSelected"
+    :selected-count="selectedCount"
+    :loading="false"
+    @toggle-all="handleToggleAll"
+    @cancel="handleCancel"
+    @confirm="handleConfirm"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { SelectionFooter } from '@blueking/chat-x';
+
+  const isAllSelected = ref(false);
+  const selectedCount = ref(0);
+
+  const handleToggleAll = (checked: boolean) => {
+    isAllSelected.value = checked;
+  };
+  const handleCancel = () => {
+    console.log('取消');
+  };
+  const handleConfirm = () => {
+    console.log('确认');
+  };
+</script>
+```
+
+**渲染效果**
+
+## API
+
+### Props
+
+| 属性名        | 类型      | 必填 | 默认值  | 说明                          |
+| ------------- | --------- | ---- | ------- | ----------------------------- |
+| isAllSelected | `boolean` | ✓    | —       | 是否全选                      |
+| selectedCount | `number`  | ✓    | —       | 已选数量，为 0 时确认按钮禁用 |
+| loading       | `boolean` | —    | `false` | 确认按钮加载状态              |
+
+### Events
+
+| 事件名     | 参数                 | 说明         |
+| ---------- | -------------------- | ------------ |
+| toggle-all | `(checked: boolean)` | 切换全选状态 |
+| cancel     | —                    | 点击取消按钮 |
+| confirm    | —                    | 点击确认按钮 |
+
+## 关联组件
+
+- [ChatContainer](/components/setup/chat-container) — 分享模式挂载
+- [MessageContainer](/components/setup/message-container) — 多选与消息列表

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/selection-question.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/selection-question.md
@@ -1,0 +1,88 @@
+# SelectionQuestion 选择问题占位
+
+> 能力域：辅助能力 ｜ 导入：`import { SelectionQuestion } from '@blueking/chat-x'` ｜ since 1.0.0
+
+源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。 源码位置：src/components/ai-questions/selection-question.vue。
+
+**关联**：user-question-card（选择类问题交互请使用实际可渲染的问题卡片组件）、user-question-option（单个选项行由实际问题组件渲染）、interrupt-message（HITL 中断消息由 InterruptMessage 分发到具体问题组件）
+
+---
+
+# SelectionQuestion 选择问题占位
+
+> **能力域**：辅助能力
+
+`SelectionQuestion` 当前只是保留在源码目录中的空文件，占位路径为 `src/components/ai-questions/selection-question.vue`。它没有模板、脚本、样式、props、emits、slots 或任何选择交互能力。
+
+本文档保留该条目，是为了明确它不是当前可用的问题选择组件，避免业务误接入。
+
+## 源码事实
+
+- **源码位置**：`src/components/ai-questions/selection-question.vue`
+- **文件大小**：`0` 字节
+- **能力说明**：源码为空文件，没有 props、emits、slots 或渲染能力；不建议作为功能组件使用。
+
+## 当前状态
+
+| 项目     | 状态 |
+| -------- | ---- |
+| 模板     | 无   |
+| 脚本逻辑 | 无   |
+| 样式     | 无   |
+| Props    | 无   |
+| Emits    | 无   |
+| Slots    | 无   |
+| Expose   | 无   |
+
+## 不可用示例
+
+下面的写法不会产生选择题 UI，也不会发出确认事件：
+
+```vue
+<template>
+  <!-- 不建议使用：当前组件为空文件 -->
+  <SelectionQuestion />
+</template>
+```
+
+## 推荐替代
+
+选择类用户问题请走中断消息链路，由已实现的组件负责展示选项和处理确认：
+
+```vue
+<template>
+  <UserQuestionCard
+    :content="content"
+    @confirm="handleConfirm"
+  />
+</template>
+```
+
+相关文档：
+
+- [UserQuestionCard](../agent/user-question-card.md) — 用户问题中断交互面板。
+- [UserQuestionOption](../agent/user-question-option.md) — 用户问题选项行。
+- [InterruptMessage](../agent/interrupt-message.md) — 中断消息分发入口。
+
+## API
+
+### Props
+
+- 无。
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 使用建议
+
+- 不建议在业务中使用该组件。
+- 如果后续补齐实现，需要同步更新本文档的示例、选择交互事件、API 与关联组件。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-btn.md
@@ -1,0 +1,204 @@
+# ShortcutBtn 快捷指令按钮
+
+> 能力域：输入交互 ｜ 导入：`import { ShortcutBtn } from '@blueking/chat-x'` ｜ since 1.0.0
+
+单个快捷指令按钮，支持默认/append 插槽和 expose focus。 源码位置：src/components/ai-shortcut/shortcut-btn/shortcut-btn.vue。
+
+**关联**：shortcut-btns（快捷指令横向列表中作为单项渲染）、ai-selection（划词浮窗内展示快捷操作按钮或溢出菜单项）、chat-input（已选快捷指令在输入框底部以单按钮展示）
+
+---
+
+# ShortcutBtn 快捷指令按钮
+## 源码事实
+
+- **源码位置**：`src/components/ai-shortcut/shortcut-btn/shortcut-btn.vue`
+- **能力域**：输入交互
+- **能力说明**：单个快捷指令按钮，支持默认/append 插槽和 expose focus。
+
+> **能力域**：输入交互
+
+单个快捷指令的渲染单元，封装图标选择逻辑和两种布局模式（按钮 / 菜单项）。
+
+被 `ShortcutBtns`（快捷指令栏）、`AiSelection`（划词浮窗）和 `ChatInput`（已选指令展示）内部使用，通常不需要手动引入。
+
+## 组件结构
+
+```
+button.ai-shortcut-btn（flex，gap: 4px，height: 28px，padding: 0 4px，white-space: nowrap）
+  border: none，border-radius: 4px，background: transparent
+  transition: background-color 0.2s
+  mode="menu" → 追加 .is-menu-mode（height: 32px，padding: 0 12px，width: 100%，justify-content: flex-start）
+  │
+  ├── <slot name="default">（覆盖后图标+名称全部替换）
+  │     ├── [shortcut.icon 为字符串 && 以 'http' 开头]
+  │     │     加载成功：<img … />；加载失败：回退 AgentIcon.ai-shortcut-btn-icon
+  │     ├── [shortcut.icon 为字符串 && 不以 'http' 开头]
+  │     │     <span :class="icon" />（CSS 图标类名，无其他 class）
+  │     ├── [shortcut.icon 为函数或组件]
+  │     │     <component :is="typeof icon==='function' ? icon(h) : icon" class="ai-shortcut-btn-icon" />
+  │     ├── [shortcut 存在，无 icon，components 为空/未设置] → AgentIcon.ai-shortcut-btn-icon
+  │     ├── [shortcut 存在，无 icon，components 有内容]      → 无图标
+  │     └── {{ shortcut?.name }}（XSS 安全，文本插值）
+  │
+  └── <slot name="append" />（渲染在名称之后，常用于关闭按钮）
+
+defineExpose: { get $el() { return el.value } }（懒 getter，返回 button 元素引用）
+```
+
+> **`hover` cursor 说明**：CSS 中 `:hover` 先写 `cursor: pointer` 再写 `cursor: default`，后者覆盖前者，实际 hover 时显示默认指针。仅 `append` 槽内的 `.ai-close-icon` 恢复 `cursor: pointer`。
+
+## 图标渲染规则
+
+| `shortcut.icon` 类型                  | 渲染结果                    | 额外说明                                                         |
+| ------------------------------------- | --------------------------- | ---------------------------------------------------------------- |
+| 未设置（且 `components` 为空/未设置） | `AgentIcon`（默认图标）     | `components: []` 与不传效果相同                                  |
+| 未设置（且 `components` 有内容）      | 无图标                      | 表单类快捷指令                                                   |
+| `string`，以 `'http'` 开头            | `<img>`，失败时 `AgentIcon` | `.ai-common-icon .ai-shortcut-btn-icon`；`@error` 后回退默认图标 |
+| `string`，不以 `'http'` 开头          | `<span :class="icon">`      | 视为 CSS 图标类名，无其他 class                                  |
+| 函数 `(h) => Component/VNode`         | `<component :is="icon(h)">` | 有 `.ai-shortcut-btn-icon`                                       |
+| 组件对象                              | `<component :is="icon">`    | 有 `.ai-shortcut-btn-icon`                                       |
+
+## 基础用法
+
+```vue
+<template>
+  <ShortcutBtn
+    :shortcut="shortcut"
+    @click="handleClick"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ShortcutBtn } from '@blueking/chat-x';
+  import type { Shortcut } from '@blueking/chat-x';
+
+  const shortcut: Shortcut = { id: 'ask-whale', name: '问问小鲸' };
+
+  const handleClick = (shortcut?: Shortcut) => {
+    console.log('选择了:', shortcut?.name);
+  };
+</script>
+```
+
+> 从左到右：无 `icon`（默认 AgentIcon）、`components: []`（同样显示 AgentIcon）、有 `components`（无图标）。
+
+## 图标类型对比
+
+```vue
+<template>
+  <!-- URL 图片图标 -->
+  <ShortcutBtn :shortcut="{ id: '1', name: '图片图标', icon: 'https://…/icon.png' }" />
+
+  <!-- CSS 类名图标（字体图标） -->
+  <ShortcutBtn :shortcut="{ id: '2', name: 'CSS 类图标', icon: 'bk-icon icon-star-shape' }" />
+
+  <!-- 函数/渲染函数图标 -->
+  <ShortcutBtn :shortcut="{ id: '3', name: '函数图标', icon: h => h('span', {}, '🚀') }" />
+</template>
+```
+
+## 菜单模式（mode="menu"）
+
+`mode="menu"` 时切换为 `is-menu-mode` 布局：左对齐、`width: 100%`、高 32px、padding `0 12px`：
+
+```vue
+<template>
+  <div class="shortcut-menu">
+    <ShortcutBtn
+      v-for="item in shortcuts"
+      :key="item.id"
+      mode="menu"
+      :shortcut="item"
+      @click="handleClick"
+    />
+  </div>
+</template>
+```
+
+## append 插槽：添加关闭按钮
+
+`#append` 渲染在名称之后，`@click.stop` 可阻止冒泡到 `@click`（父 ChatInput 使用场景）：
+
+```vue
+<template>
+  <ShortcutBtn
+    :shortcut="shortcut"
+    @click="handleSelect"
+  >
+    <template #append>
+      <CloseIcon @click.stop="handleRemove" />
+    </template>
+  </ShortcutBtn>
+</template>
+```
+
+## default 插槽：完全自定义内容
+
+`default` 插槽覆盖**全部**默认内容（图标 + 名称），`shortcut` prop 仅传递给 `@click` 事件：
+
+```vue
+<template>
+  <ShortcutBtn
+    :shortcut="shortcut"
+    @click="handleClick"
+  >
+    <MoreAgentIcon />
+    <span>更多</span>
+  </ShortcutBtn>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名   | 类型              | 必填 | 说明                                                         |
+| -------- | ----------------- | ---- | ------------------------------------------------------------ |
+| shortcut | `Shortcut`        | —    | 快捷指令配置；缺省时按钮无内容，`click` 事件传递 `undefined` |
+| mode     | `'btn' \| 'menu'` | —    | 布局模式；缺省为 `btn`（水平居中），`menu` 切换为列表项布局  |
+
+### Events
+
+| 事件名 | 参数                    | 说明                                                                 |
+| ------ | ----------------------- | -------------------------------------------------------------------- |
+| click  | `(shortcut?: Shortcut)` | 点击按钮时触发，传递当前 `shortcut` prop（无 prop 则为 `undefined`） |
+
+### Slots
+
+| 插槽名  | 说明                                                                 |
+| ------- | -------------------------------------------------------------------- |
+| default | 覆盖全部默认渲染（图标 + 名称）；`shortcut` prop 仍用于 `click` 事件 |
+| append  | 追加在名称之后；常用于关闭/删除图标，建议配合 `@click.stop` 阻止冒泡 |
+
+### Expose
+
+| 属性名 | 类型                  | 说明                                                                      |
+| ------ | --------------------- | ------------------------------------------------------------------------- |
+| `$el`  | `HTMLElement \| null` | 懒 getter，返回根 `<button>` 元素引用；供 `ShortcutBtns` 计算可见性时使用 |
+
+## 类型定义
+
+```typescript
+interface Shortcut {
+  id: string;
+  name: string;
+  description?: string;
+  icon?: string | Component | ((h: typeof h) => Component | VNode);
+  components?: ShortcutComponent[]; // 有内容时不显示默认 AgentIcon
+  formModel?: Record<string, unknown>;
+}
+```
+
+## 在各组件中的使用场景
+
+| 使用方         | 模式          | 特殊用法                                                                                     |
+| -------------- | ------------- | -------------------------------------------------------------------------------------------- |
+| `ShortcutBtns` | btn           | 可见项正常渲染；溢出项隐藏（CSS `visibility: hidden`），放入下拉菜单以 `mode="menu"` 展示    |
+| `AiSelection`  | btn / menu    | 最多显示 `maxShortcutCount` 个按钮，超出时以 `#default` 插槽显示"更多"，下拉用 `mode="menu"` |
+| `ChatInput`    | btn（已选态） | 使用 `#append` 插槽放置 `CloseIcon`，点击关闭删除已选快捷指令                                |
+
+## 关联组件
+
+- [ShortcutBtns](/components/input/shortcut-btns) — 快捷指令列表容器
+- [AiSelection](/components/input/ai-selection) — 划词浮窗内使用
+- [ChatInput](/components/input/chat-input) — 已选快捷指令展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-btns.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-btns.md
@@ -1,0 +1,266 @@
+# ShortcutBtns 快捷指令按钮组
+
+> 能力域：输入交互 ｜ 导入：`import { ShortcutBtns } from '@blueking/chat-x'` ｜ since 1.0.0
+
+快捷指令列表入口，内部组合多个 ShortcutBtn。 源码位置：src/components/ai-shortcut/shortcut-btns/shortcut-btns.vue。
+
+**关联**：shortcut-btn（列表中每一项由 ShortcutBtn 渲染）、chat-input（默认嵌入输入框底部附件区）、shortcut-render（表单类快捷指令选中后的表单渲染）
+
+---
+
+# ShortcutBtns 快捷指令按钮组
+## 源码事实
+
+- **源码位置**：`src/components/ai-shortcut/shortcut-btns/shortcut-btns.vue`
+- **能力域**：输入交互
+- **能力说明**：快捷指令列表入口，内部组合多个 ShortcutBtn。
+
+> **能力域**：输入交互
+
+快捷指令按钮列表，内置**响应式溢出收起**：根据容器实际宽度动态计算可见数量，超出部分自动收入"更多"下拉菜单。
+
+通常由 `ChatInput` 内部使用，一般不需要手动引入。
+
+## 组件结构
+
+```
+div.shortcut-btns（flex，gap: 4px，width: 100%，min-width: 168px，max-width: 1000px，overflow: hidden）
+  │
+  ├── ShortcutBtn.shortcut-btns-item × N（每个快捷指令）
+  │     height: 24px，padding: 0 6px，white-space: nowrap，background: #fff，border-radius: 4px
+  │     溢出时追加 .shortcut-btns-item-hidden（position: absolute; visibility: hidden; pointer-events: none; opacity: 0）
+  │       注意：隐藏项仍在 DOM 中，仅通过 CSS 不可见，offsetWidth 仍可读
+  │
+  └── [hiddenShortcuts.length > 0] Tippy（trigger="manual"，append-to="body"，interactive）
+        │  offset=[0,6]，z-index=SHORTCUT_MENU_Z_INDEX，theme="ai-chat-box-light light"
+        ├── ShortcutBtn.shortcut-btns-more（触发按钮）
+        │     MoreAgentIcon（rotate(90deg)） + "更多"
+        └── #content: div.shortcut-menu
+              ShortcutBtn（mode="menu"） × 隐藏数量
+```
+
+## 响应式溢出机制（useObserverVisibleList）
+
+组件使用 `ResizeObserver` 监听容器宽度变化，自动计算可见按钮列表：
+
+```
+calculateVisibleMenuItems 执行逻辑：
+  1. 遍历 shortcuts（按顺序）
+  2. 每项计算：neededWidth = totalWidth + itemWidth + gap（非首项才加 gap）
+  3. 判断：neededWidth + gap + moreButtonWidth ≤ containerWidth
+       → true：加入 visibleItems，更新 totalWidth
+       → false：break（后续项全部进入"更多"菜单）
+  4. 触发时机：ResizeObserver 回调 / itemRefs 变化 / moreItemRef 变化
+```
+
+- `shortcuts` prop 通过 `computed(() => props.shortcuts)` 包装为 `ComputedRef` 传入 `useObserverVisibleList`，确保 items 变化时计算逻辑能访问到最新数据
+- `shortcuts` prop 更新时（深度 watch），`itemRefs` 重置为同等长度的 null 数组，再等待下一帧重新计算
+- 隐藏项 = `shortcuts.filter(s => !visibleItems.includes(s))`，保持原始顺序
+- `ResizeObserver` 在 `onScopeDispose` 时断开，无内存泄漏
+
+## 基础用法
+
+```vue
+<template>
+  <ShortcutBtns
+    :shortcuts="shortcuts"
+    @select-shortcut="handleSelectShortcut"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ShortcutBtns } from '@blueking/chat-x';
+  import type { Shortcut } from '@blueking/chat-x';
+
+  const shortcuts: Shortcut[] = [
+    { id: 'ask', name: '问问小鲸' },
+    { id: 'translate', name: '翻译' },
+    { id: 'summarize', name: '总结' },
+    { id: 'explain', name: '解释代码' },
+    { id: 'code-review', name: '代码审查' },
+  ];
+
+  const handleSelectShortcut = (shortcut: Shortcut) => {
+    console.log('选择了:', shortcut.name);
+  };
+</script>
+```
+
+## 带描述的快捷指令
+
+`description` 字段由 `ShortcutRender` 表单弹窗使用（悬浮提示或说明文字），本组件不直接渲染：
+
+```vue
+<template>
+  <ShortcutBtns
+    :shortcuts="shortcuts"
+    @select-shortcut="handleSelectShortcut"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ShortcutBtns } from '@blueking/chat-x';
+  import type { Shortcut } from '@blueking/chat-x';
+
+  const shortcuts: Shortcut[] = [
+    { id: 'translate', name: '翻译', description: '将文本翻译成指定语言' },
+    { id: 'summarize', name: '总结', description: '自动总结长文本的核心要点' },
+    { id: 'explain', name: '解释', description: '解释代码或概念' },
+  ];
+</script>
+```
+
+## 带表单的快捷指令
+
+配置 `components` 后，`@select-shortcut` 事件仍正常触发，**表单弹窗逻辑需由父组件配合 `ShortcutRender` 实现**：
+
+```vue
+<template>
+  <ShortcutBtns
+    :shortcuts="shortcuts"
+    @select-shortcut="handleSelectShortcut"
+  />
+  <ShortcutRender
+    v-if="activeShortcut"
+    :shortcut="activeShortcut"
+    @submit="handleFormSubmit"
+    @cancel="activeShortcut = null"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ShortcutBtns, ShortcutRender } from '@blueking/chat-x';
+  import type { Shortcut } from '@blueking/chat-x';
+
+  const activeShortcut = ref<Shortcut | null>(null);
+
+  const shortcuts: Shortcut[] = [
+    {
+      id: 'translate',
+      name: '翻译',
+      description: '将文本翻译成指定语言',
+      components: [
+        {
+          type: 'select',
+          key: 'targetLang',
+          name: '目标语言',
+          props: {
+            options: [
+              { label: '英文', value: 'en' },
+              { label: '中文', value: 'zh' },
+            ],
+          },
+        },
+        { type: 'textarea', key: 'content', name: '翻译内容', fillBack: true },
+      ],
+    },
+    {
+      id: 'code-gen',
+      name: '代码生成',
+      components: [
+        { type: 'input', key: 'language', name: '编程语言' },
+        { type: 'textarea', key: 'description', name: '功能描述', fillBack: true },
+      ],
+    },
+  ];
+
+  const handleSelectShortcut = (shortcut: Shortcut) => {
+    if (shortcut.components?.length) {
+      activeShortcut.value = shortcut; // 打开表单弹窗
+    } else {
+      sendMessage(shortcut); // 直接发送
+    }
+  };
+</script>
+```
+
+## 响应式溢出（"更多"菜单）
+
+当按钮数量超出容器可用宽度时，自动显示"更多"按钮，点击展开下拉菜单：
+
+> 该 Demo 容器较窄时会自动触发溢出收起效果。`manyShortcuts` 共 12 项，超出容器宽度的按钮进入"更多"下拉菜单。
+
+## API
+
+### Props
+
+| 属性名    | 类型         | 必填 | 说明                                                                |
+| --------- | ------------ | ---- | ------------------------------------------------------------------- |
+| shortcuts | `Shortcut[]` | 是   | 快捷指令列表；`v-for` 使用 `shortcut.key \|\| shortcut.id` 作为 key |
+
+### Events
+
+| 事件名          | 参数                   | 说明                                                                         |
+| --------------- | ---------------------- | ---------------------------------------------------------------------------- |
+| select-shortcut | `(shortcut: Shortcut)` | 点击任意快捷指令（含"更多"菜单中的项）时触发；从"更多"菜单选择后菜单自动关闭 |
+
+## 类型定义
+
+```typescript
+interface Shortcut {
+  id: string;
+  name: string;
+  key?: string; // 自定义 v-for key，优先于 id
+  description?: string;
+  icon?: string | VNode | ((h: typeof h) => Component | VNode);
+  components?: ShortcutComponent[];
+  formModel?: Record<string, unknown>;
+}
+
+type ShortcutComponent =
+  | InputShortcutComponent // type: 'input'
+  | TextareaShortcutComponent // type: 'textarea'
+  | NumberShortcutComponent // type: 'number'
+  | SelectShortcutComponent // type: 'select'
+  | CheckboxGroupShortcutComponent // type: 'checkboxGroup'
+  | RadioGroupShortcutComponent // type: 'radioGroup'
+  | SwitcherShortcutComponent // type: 'switcher'
+  | TextShortcutComponent; // type: 'text'（纯文本展示）
+
+interface BaseShortcutComponent<T> {
+  type: T;
+  key: string; // 表单字段 key，对应 formModel 中的属性名
+  name?: string; // 表单项 label
+  fillBack?: boolean; // true 时，该字段值在提交后回填至聊天输入框
+  props?: Record<string, any>; // 传给底层 bkui-vue 组件的 props
+  formItemProps?: Record<string, any>; // 传给 bkui-vue Form.Item 的 props
+}
+```
+
+### 表单组件类型
+
+| type 值         | 底层组件                  | 说明                                    |
+| --------------- | ------------------------- | --------------------------------------- |
+| `input`         | bkui-vue Input            | 单行文本输入                            |
+| `textarea`      | bkui-vue Input (textarea) | 多行文本输入                            |
+| `number`        | bkui-vue Input (number)   | 数字输入                                |
+| `select`        | bkui-vue Select           | 下拉选择，通过 `props.options` 配置选项 |
+| `checkboxGroup` | bkui-vue Checkbox.Group   | 多选框组                                |
+| `radioGroup`    | bkui-vue Radio.Group      | 单选框组                                |
+| `switcher`      | bkui-vue Switcher         | 开关                                    |
+| `text`          | 纯文本                    | 仅展示说明文字，不收集值                |
+
+## 样式说明
+
+| 类名                         | 样式                                                                       | 说明                                               |
+| ---------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------- |
+| `.shortcut-btns`             | `width: 100%; min-width: 168px; max-width: 1000px; overflow: hidden`       | 容器，宽度撑满父元素，超出 1000px 截断             |
+| `.shortcut-btns-item`        | `height: 24px; padding: 0 6px; background: #fff; border-radius: 4px`       | 每个快捷指令按钮的外层包装 class                   |
+| `.shortcut-btns-item-hidden` | `position: absolute; visibility: hidden; pointer-events: none; opacity: 0` | 溢出按钮的隐藏态；仍在 DOM 中以便 offsetWidth 计算 |
+| `.shortcut-btns-more`        | `flex-shrink: 0; padding: 0 6px`                                           | "更多"按钮，`MoreAgentIcon` 旋转 90°               |
+| `.shortcut-menu`             | `@include menu.ai-common-menu-style`                                       | 下拉菜单容器样式                                   |
+
+## 注意事项
+
+1. **`key` 字段优先于 `id`**：`v-for` 使用 `shortcut.key || shortcut.id`，当多个指令 `id` 相同但代表不同实例时，可通过 `key` 字段区分
+2. **溢出项不可交互**：`.shortcut-btns-item-hidden` 通过 `pointer-events: none` 屏蔽点击，不会误触发事件
+3. **"更多"菜单 Teleport 至 body**：Tippy 使用 `append-to="body"`，避免被父容器的 `overflow: hidden` 裁剪
+4. **容器宽度限制**：`min-width: 168px` 和 `max-width: 1000px` 来自 `$chat-input-min-width` / `$chat-input-max-width` 变量，与输入框宽度保持一致
+5. **表单流程在外部**：`ShortcutBtns` 只负责显示和触发事件，`components` 的表单弹窗逻辑需配合 `ShortcutRender` 实现（`ChatInput` 已内置此流程）
+
+## 关联组件
+
+- [ShortcutBtn](/components/input/shortcut-btn) — 列表项基础组件
+- [ChatInput](/components/input/chat-input) — 默认嵌入输入框底部
+- [ShortcutRender](/components/input/shortcut-render) — 表单类快捷指令的表单渲染

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/shortcut-render.md
@@ -1,0 +1,424 @@
+# ShortcutRender 快捷指令表单
+
+> 能力域：输入交互 ｜ 导入：`import { ShortcutRender } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染快捷指令 components 表单并回传确认数据。 源码位置：src/components/ai-shortcut/shortcut-render/shortcut-render.vue。
+
+**关联**：shortcut-btn（与快捷指令 Shortcut 元数据一致，表单提交前在列表中选中入口）、chat-input（提交或取消后与输入框内容与状态联动）、chat-container（顶层聊天布局中承载快捷表单区域）
+
+---
+
+# ShortcutRender 快捷指令渲染器
+## 源码事实
+
+- **源码位置**：`src/components/ai-shortcut/shortcut-render/shortcut-render.vue`
+- **能力域**：输入交互
+- **能力说明**：渲染快捷指令 components 表单并回传确认数据。
+
+> **能力域**：输入交互
+
+快捷指令表单渲染组件，将 `Shortcut.components` 配置自动渲染为可交互表单（基于 bkui-vue 的 `Form`），支持 8 种控件类型、两列网格布局、必填校验和内置提交/取消操作。
+
+## 组件结构
+
+```
+┌─────────────────────────────────────────────────┐
+│  .shortcut-render-header（渐变左边框）            │
+│  ✧ ThinkingIcon  快捷指令名称           ✕ Close  │
+├─────────────────────────────────────────────────┤
+│  .shortcut-render-content（max-height: 424px，   │
+│   overflow-y: auto）                             │
+│  ┌─────────────┬─────────────┐                   │
+│  │ FormItem    │ FormItem    │  ← 两列网格        │
+│  ├─────────────┴─────────────┤                   │
+│  │    textarea（span 2）     │  ← 独占一行        │
+│  ├─────────────────────────── ┤                   │
+│  │  提交    取消（sticky）    │  ← 底部始终可见    │
+│  └─────────────────────────── ┘                   │
+└─────────────────────────────────────────────────┘
+```
+
+> 底部操作栏使用 `position: sticky; bottom: 1px`，滚动长表单时始终固定在底部可见区域。
+
+## 基础用法
+
+传入 `name` 和 `components` 即可渲染一个快捷指令表单：
+
+```vue
+<template>
+  <ShortcutRender
+    :name="shortcut.name"
+    :components="shortcut.components"
+    @close="handleClose"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ShortcutRender, type Shortcut } from '@blueking/chat-x';
+
+  const shortcut: Shortcut = {
+    id: 'translate',
+    name: '翻译',
+    components: [
+      {
+        type: 'select',
+        key: 'targetLang',
+        name: '目标语言',
+        default: 'en',
+        options: [
+          { label: '英文', value: 'en' },
+          { label: '中文', value: 'zh' },
+          { label: '日文', value: 'ja' },
+        ],
+      },
+      {
+        type: 'textarea',
+        key: 'content',
+        name: '翻译内容',
+        fillBack: true,
+        placeholder: '请输入要翻译的内容',
+        rows: 4,
+      },
+    ],
+  };
+
+  const handleClose = () => console.log('关闭');
+  const handleSubmit = (formModel: Record<string, unknown>) => {
+    // { targetLang: 'en', content: '...' }
+    console.log('提交:', formModel);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 全部表单类型
+
+`ShortcutRender` 支持 8 种控件类型，通过 `type` 字段指定：
+
+```vue
+<script setup lang="ts">
+  import { type ShortcutComponent } from '@blueking/chat-x';
+
+  const components: ShortcutComponent[] = [
+    // 单行文本输入
+    { type: 'input', key: 'language', name: '编程语言', placeholder: '如：TypeScript、Python' },
+    // 数字输入（支持 min/max）
+    { type: 'number', key: 'maxLines', name: '最大行数', default: '50', min: 1, max: 500 },
+    // 下拉选择
+    {
+      type: 'select',
+      key: 'style',
+      name: '代码风格',
+      default: 'concise',
+      options: [
+        { label: '简洁', value: 'concise' },
+        { label: '详细注释', value: 'detailed' },
+      ],
+    },
+    // 单选组
+    {
+      type: 'radioGroup',
+      key: 'outputFormat',
+      name: '输出格式',
+      default: 'code',
+      options: [
+        { label: '代码块', value: 'code' },
+        { label: '文件', value: 'file' },
+      ],
+    },
+    // 多选组
+    {
+      type: 'checkboxGroup',
+      key: 'features',
+      name: '包含功能',
+      options: [
+        { label: '注释', value: 'comments' },
+        { label: '错误处理', value: 'error-handling' },
+      ],
+    },
+    // 开关
+    { type: 'switcher', key: 'async', name: '异步函数' },
+    // 多行文本（独占一行）
+    {
+      type: 'textarea',
+      key: 'description',
+      name: '功能描述',
+      fillBack: true,
+      rows: 3,
+      placeholder: '请详细描述需要生成的代码功能',
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 表单初始值
+
+### 通过 `component.default`（推荐）
+
+直接在 `ShortcutComponent` 上设置 `default`，该字段在表单初始化时被优先使用：
+
+```typescript
+const components: ShortcutComponent[] = [
+  {
+    type: 'select',
+    key: 'lang',
+    name: '语言',
+    default: 'zh', // ← 初始选中"中文"
+    options: [
+      { label: '中文', value: 'zh' },
+      { label: '英文', value: 'en' },
+    ],
+  },
+];
+```
+
+### 通过 `formModel` prop
+
+`formModel` 适合传入**不在 `components` 中的额外字段**，或特殊场景下的外部初始值。
+
+```vue
+<template>
+  <ShortcutRender
+    name="搜索"
+    :components="components"
+    :form-model="initialValues"
+    @submit="handleSubmit"
+  />
+</template>
+
+<script setup lang="ts">
+  const components = [
+    { type: 'input', key: 'keyword', name: '关键词' },
+    {
+      type: 'select',
+      key: 'scope',
+      name: '范围',
+      options: [
+        { label: '全部', value: 'all' },
+        { label: '标题', value: 'title' },
+      ],
+    },
+  ];
+
+  // formModel 中与 components 同名的 key 会被 component.default 覆盖
+  // 若 component 没有设置 default，对应 formModel 的值也会被 undefined 覆盖
+  const initialValues = { keyword: 'Vue 3', scope: 'title' };
+</script>
+```
+
+**初始化优先级（`watchEffect` 执行顺序）**：
+
+```
+① 先写入 formModel 中的所有 key-value
+② 再遍历 components，对每个 component.key 写入：
+   component.default ?? component.props?.default ?? component.props?.modelValue
+```
+
+> **注意**：步骤 ② 会覆盖步骤 ① 的值。若某个 component 没有设置 `default`，该 key 会被写入 `undefined`，**formModel 中对应的值会丢失**。因此，当 component 和 formModel 存在同名 key 时，应在 component 上设置 `default`，而非依赖 `formModel`。
+
+## 必填校验（fillBack）
+
+`fillBack: true` 将表单项映射为 bkui-vue `Form.FormItem` 的 `required: true`，提交时若为空则阻止提交并展示错误提示：
+
+```typescript
+const components: ShortcutComponent[] = [
+  {
+    type: 'input',
+    key: 'title',
+    name: '标题',
+    fillBack: true, // 必填
+    placeholder: '请输入标题',
+  },
+  {
+    type: 'textarea',
+    key: 'content',
+    name: '内容',
+    fillBack: true, // 必填
+    rows: 5,
+  },
+  {
+    type: 'select',
+    key: 'category',
+    name: '分类', // 选填（无 fillBack）
+    options: [
+      { label: '技术', value: 'tech' },
+      { label: '业务', value: 'biz' },
+    ],
+  },
+];
+```
+
+> `fillBack` 同时具有语义作用：在 `ChatInput`/`UserMessage` 场景下，标记了 `fillBack: true` 的字段内容会被回填到对话输入框中。
+
+## 布局规则
+
+表单使用 **两列网格**（`grid-template-columns: repeat(2, 1fr)`）排列：
+
+| 情况                                                      | 占列数                    |
+| --------------------------------------------------------- | ------------------------- |
+| `type === 'textarea'`                                     | 始终 `span 2`（独占一行） |
+| 最后一个 item，且前面所有 item 累计列数为偶数（独占新行） | `span 2`                  |
+| 其他                                                      | `auto`（占 1 列）         |
+
+```
+┌─────────────┬─────────────┐
+│   input     │   number    │  ← 各占半行
+├─────────────┴─────────────┤
+│         textarea          │  ← 独占一行
+├─────────────┬─────────────┤
+│   select    │  switcher   │  ← 各占半行
+├─────────────┴─────────────┤
+│    最后一个（奇数起新行）  │  ← 自动独占
+└───────────────────────────┘
+```
+
+## 透传底层组件 props
+
+通过 `component.props` 可直接透传给 bkui-vue 底层控件，`component.props.options` 优先于 `component.options`：
+
+```typescript
+const components: ShortcutComponent[] = [
+  {
+    type: 'select',
+    key: 'lang',
+    name: '语言',
+    // 方式一：通过 component.options（常规）
+    options: [{ label: '中文', value: 'zh' }],
+    // 方式二：通过 component.props（优先级更高，覆盖 options）
+    props: {
+      options: [{ label: '英文', value: 'en' }], // 此处会覆盖上面的 options
+      clearable: true, // 透传给 bkui-vue Select 的其他 prop
+    },
+  },
+  {
+    type: 'input',
+    key: 'text',
+    name: '文本',
+    props: {
+      clearable: true, // 透传给 bkui-vue Input
+      maxlength: 100,
+    },
+  },
+];
+```
+
+通过 `component.formItemProps` 透传给 `Form.FormItem`：
+
+```typescript
+{
+  type: 'input',
+  key: 'email',
+  name: '邮箱',
+  formItemProps: {
+    description: '请输入有效的邮箱地址',  // bkui-vue FormItem 的 description prop
+  },
+}
+```
+
+## API
+
+### Props
+
+| 属性名      | 类型                      | 默认值 | 说明                                                                 |
+| ----------- | ------------------------- | ------ | -------------------------------------------------------------------- |
+| id          | `string`                  | —      | 快捷指令唯一标识（透传，不影响表单渲染）                             |
+| name        | `string`                  | —      | 表单标题，显示在头部栏                                               |
+| description | `string`                  | —      | 快捷指令描述（透传，组件内部不渲染）                                 |
+| components  | `ShortcutComponent[]`     | —      | 表单控件配置列表                                                     |
+| formModel   | `Record<string, unknown>` | —      | 外部初始值；与 `components` 同名 key 时，以 `component.default` 为准 |
+
+### Events
+
+| 事件名 | 参数                                   | 触发时机                                   |
+| ------ | -------------------------------------- | ------------------------------------------ |
+| close  | —                                      | 点击头部关闭图标 **或** 底部取消按钮时触发 |
+| submit | `(formModel: Record<string, unknown>)` | 表单校验通过后点击提交按钮触发             |
+
+## ShortcutComponent 配置项
+
+### 通用字段
+
+| 字段          | 类型                                 | 必填 | 说明                                                                                       |
+| ------------- | ------------------------------------ | ---- | ------------------------------------------------------------------------------------------ |
+| type          | 见[表单类型](#表单组件类型)          | ✓    | 控件类型；未知类型返回 `null`，不渲染                                                      |
+| key           | `string`                             | ✓    | 表单字段名；`submit` 事件返回对象以此为 key；同时作为校验 property                         |
+| name          | `string`                             | —    | 表单项标签；优先于 `formItemProps.label`，通过 `#label` 插槽渲染为 `.shortcut-render-form-label` |
+| default       | `string`                             | —    | 字段初始值；优先于 `formModel`，在 `watchEffect` 中覆盖写入                                |
+| fillBack      | `boolean`                            | —    | `true` 时映射为 `required: true`（必填校验），同时标记回填语义                             |
+| placeholder   | `string`                             | —    | 占位文本（`input` / `textarea` / `number` 可用）                                           |
+| rows          | `number`                             | —    | 文本行数（`textarea` 可用）                                                                |
+| min           | `number`                             | —    | 最小值（`number` 可用）                                                                    |
+| max           | `number`                             | —    | 最大值（`number` 可用）                                                                    |
+| options       | `{ label: string; value: string }[]` | —    | 选项列表（`select` / `radioGroup` / `checkboxGroup` 需要）；`component.props.options` 优先 |
+| props         | `object`                             | —    | 直接透传给底层 bkui-vue 控件的 props；`options` 优先于 `component.options`                 |
+| formItemProps | `object`                             | —    | 直接透传给 `Form.FormItem` 的 props                                                        |
+
+### 表单组件类型
+
+| `type`          | 底层控件               | 说明                         |
+| --------------- | ---------------------- | ---------------------------- |
+| `input`         | `Input`                | 单行文本输入框               |
+| `text`          | `Input`                | 同 `input`，兼容旧版写法     |
+| `textarea`      | `Input[type=textarea]` | 多行文本，**始终独占一行**   |
+| `number`        | `Input[type=number]`   | 数字输入，支持 `min` / `max` |
+| `select`        | `Select`               | 下拉选择，需配置 `options`   |
+| `radioGroup`    | `Radio.Group`          | 单选组，需配置 `options`     |
+| `checkboxGroup` | `Checkbox.Group`       | 多选组，需配置 `options`     |
+| `switcher`      | `Switcher`             | 开关，值为 `boolean`         |
+| 其他            | —                      | 返回 `null`，不渲染任何控件  |
+
+## 类型定义
+
+```typescript
+import type { Shortcut, ShortcutComponent } from '@blueking/chat-x';
+
+interface Shortcut {
+  id?: string;
+  name?: string;
+  description?: string;
+  icon?: string | VNode | ((h: typeof h) => Component | VNode);
+  components?: ShortcutComponent[];
+  formModel?: Record<string, unknown>;
+}
+
+// ShortcutComponent 是各具体类型的联合类型
+type ShortcutComponent =
+  | InputShortcutComponent
+  | TextShortcutComponent
+  | TextareaShortcutComponent
+  | NumberShortcutComponent
+  | SelectShortcutComponent
+  | RadioGroupShortcutComponent
+  | CheckboxGroupShortcutComponent
+  | SwitcherShortcutComponent;
+
+// 所有类型共有字段（BaseShortcutComponent）
+interface BaseShortcutComponent {
+  type: string;
+  key: string;
+  name?: string;
+  default?: string;
+  fillBack?: boolean;
+  placeholder?: string;
+  rows?: number;
+  min?: number;
+  max?: number;
+  options?: { label: string; value: string }[];
+  props?: Record<string, unknown>; // 透传给底层控件
+  formItemProps?: Record<string, unknown>; // 透传给 Form.FormItem
+}
+```
+
+## 样式说明
+
+表单项与控件会附加类型化 class，便于样式覆盖：`shortcut-render-form-item_{type}`（如 `_radio`、`_checkbox`），单选/多选项子项为 `shortcut-render-form-item_radio` / `shortcut-render-form-item_checkbox`。表单项标签使用 BEM 风格类名 `shortcut-render-form-label`。
+
+## 关联组件
+
+- [ShortcutBtn](/components/input/shortcut-btn) — 与 Shortcut 数据模型一致的入口按钮
+- [ChatInput](/components/input/chat-input) — 输入区与快捷指令流程联动
+- [ChatContainer](/components/setup/chat-container) — 顶层布局中挂载快捷表单

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/simple-table.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/simple-table.md
@@ -1,0 +1,101 @@
+# SimpleTable 简易表格
+
+> 能力域：Agent 能力 ｜ 导入：`import { SimpleTable } from '@blueking/chat-x'` ｜ since 1.0.0
+
+FlowAgent 节点详情中的轻量表格展示组件。 源码位置：src/components/chat-content/flow-agent-content/simple-table.vue。
+
+**关联**：flow-agent-node-detail（节点详情中用于展示输入参数、插件输出定义和结构化输出）、detail-section（通常放在详情分段容器内使用）
+
+---
+
+# SimpleTable 简易表格
+
+> **能力域**：Agent 能力
+
+`SimpleTable` 是 FlowAgent 节点详情中的轻量只读表格，用于展示参数名、参数值、插件输出定义等结构化信息。组件只根据 `columns` 和 `data` 渲染表格，不提供排序、筛选、分页或编辑能力。
+
+通常不需要单独使用，主要由 `FlowAgentNodeDetail` 内部组合。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/flow-agent-content/simple-table.vue`
+- **能力说明**：FlowAgent 节点详情中的轻量表格展示组件。
+
+## 核心能力
+
+- **列驱动渲染**：通过 `columns` 决定表头、字段读取 key 和单元格换行策略
+- **空值兜底**：单元格值为 `null` 或 `undefined` 时显示 `--`，`0` 会正常显示为 `0`
+- **空数据占位**：`data` 为空数组时渲染一行 `--`，`colspan` 等于列数
+- **长文本换行**：列配置 `breakAll: true` 后，该列单元格添加 `is-break-all` 样式，适合展示 JSON 或长字符串
+
+## 基础用法
+
+```vue
+<template>
+  <SimpleTable
+    :columns="columns"
+    :data="data"
+  />
+</template>
+
+<script setup lang="ts">
+  import SimpleTable from '@blueking/chat-x/src/components/chat-content/flow-agent-content/simple-table.vue';
+
+  const columns = [
+    { key: 'key', label: '参数名' },
+    { breakAll: true, key: 'value', label: '参数值' },
+  ];
+
+  const data = [
+    { key: 'bk_host_id', value: '10001' },
+    { key: 'metadata', value: '{"source":"cmdb","scope":"production"}' },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 空数据
+
+当 `data.length === 0` 时，组件渲染一行居中的 `--`，用于表示当前分段没有可展示数据。
+
+## API
+
+### Props
+
+| 属性名  | 类型                     | 必填 | 默认值 | 说明                         |
+| ------- | ------------------------ | ---- | ------ | ---------------------------- |
+| columns | `SimpleTableColumn[]`    | 是   | —      | 表格列配置                   |
+| data    | `Record<string, unknown>[]` | 是 | —      | 表格行数据，按列 `key` 取值 |
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+export interface SimpleTableColumn {
+  breakAll?: boolean; // 是否对该列单元格启用 word-break: break-all
+  key: string;        // 从 data 行对象中读取的字段名
+  label: string;      // 表头文案
+}
+```
+
+## 使用建议
+
+- 适合详情面板中的短表格，不适合承载复杂数据表能力。
+- 需要展示对象值时，建议在传入前先序列化为字符串；`FlowAgentNodeDetail` 内部会对对象值执行 `JSON.stringify`。
+
+## 关联组件
+
+- [FlowAgentNodeDetail](./flow-agent-node-detail.md) — 节点详情主体。
+- [DetailSection](./detail-section.md) — 表格常放置在详情分段内。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/text-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/text-content.md
@@ -1,0 +1,77 @@
+# TextContent 文本内容
+
+> 能力域：内容渲染 ｜ 导入：`import { TextContent } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染纯文本内容。 源码位置：src/components/chat-content/text-content/text-content.vue。
+
+**关联**：markdown-content（需要富文本时的替代方案）、user-message（用户消息中纯文本内容展示）
+
+---
+
+# TextContent 文本内容
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/text-content/text-content.vue`
+- **能力域**：内容渲染
+- **能力说明**：渲染纯文本内容。
+
+> **能力域**：内容渲染
+
+纯文本气泡组件，使用 Vue 文本插值渲染 `content`，天然防 XSS。
+
+## 组件结构
+
+```
+div.text-content
+  display: flex; width: fit-content
+  padding: 8px 12px; border-radius: 4px
+  background-color: #e1ecff（浅蓝色气泡）
+  word-break: break-all（无空格长文本按字符换行）
+  │
+  └── {{ content }}（文本插值，HTML 标签不被解析）
+```
+
+> **换行说明**：组件无 `white-space: pre-wrap`，`\n` 不会渲染为视觉换行。如需保留换行，需在外层添加 `white-space: pre-wrap` 样式。
+
+## 基础用法
+
+```vue
+<template>
+  <TextContent content="这是一条纯文本消息" />
+</template>
+
+<script setup lang="ts">
+  import { TextContent } from '@blueking/chat-x';
+</script>
+```
+
+## 长文本自动换行
+
+`word-break: break-all` 确保无空格的长字符串（如 URL、哈希值）也能在容器内正常换行：
+
+## XSS 安全
+
+`content` 使用 `{{ }}` 文本插值渲染，HTML 标签会被转义，不会执行脚本：
+
+## API
+
+### Props
+
+| 属性名  | 类型     | 必填 | 说明                                           |
+| ------- | -------- | ---- | ---------------------------------------------- |
+| content | `string` | 是   | 要显示的文本内容；空字符串时气泡仍渲染，无内容 |
+
+## 使用场景
+
+`TextContent` 为极简的文本气泡，适用于**不需要 Markdown 渲染**的纯文本展示场景。如需富文本，使用 `MarkdownContent` 组件。
+
+| 场景                              | 推荐组件          |
+| --------------------------------- | ----------------- |
+| 纯文本气泡（用户消息、简单提示）  | `TextContent`     |
+| 含 Markdown / 代码块 / 公式的内容 | `MarkdownContent` |
+| 工具调用结果描述                  | `DescPanel`       |
+
+## 关联组件
+
+- [MarkdownContent](/components/rendering/markdown-content) — 富文本替代
+- [UserMessage](/components/message/user-message) — 用户消息气泡

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-approval-card.md
@@ -1,0 +1,163 @@
+# ToolApprovalCard 工具审批卡片
+
+> 能力域：Agent 能力 ｜ 导入：`import { ToolApprovalCard } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 AIDevToolApproval 中断的审批信息与取消操作；outcome.success 回显时以 readonly 只读展示。 源码位置：src/components/chat-message/interrupt-message/tool-approval-card.vue。
+
+**关联**：interrupt-message（InterruptMessageRender 按 reason 派发渲染）
+
+---
+
+# ToolApprovalCard 审批卡片
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/tool-approval-card.vue`
+- **能力域**：Agent 能力
+- **能力说明**：渲染 AIDevToolApproval 中断的审批信息与取消操作；`readonly` 时用于 outcome.success 只读回显。
+
+> **能力域**：Agent 能力
+
+AI Dev 第三方工具审批（`InterruptReason.AIDevToolApproval`）专用卡片，由 [InterruptMessageRender](/components/agent/interrupt-message) 按 `reason` 动态挂载。
+
+> **通常不需要单独引入**；仅在需要独立预览卡片样式时使用。
+
+## 渲染结构
+
+```
+ToolApprovalCard
+├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
+├── 字段区：单据编号、提交时间
+├── 处理人：当前处理人（overflow-tips 省略）
+└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly）
+```
+
+`readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏「取消审批」按钮，不接受审批取消交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+
+状态徽章样式：
+
+| `ticket.status`                         | 视觉     |
+| --------------------------------------- | -------- |
+| `pending`、`draft`                      | 蓝色评审中 |
+| `approved`                              | 绿色通过 |
+| `rejected`、`cancelled`、`expired`、`abandoned` | 红色终态 |
+| `revoked`                               | 橙色已撤销 |
+
+## 基础用法（待审批）
+
+> `ToolApprovalCard` 为 `InterruptMessageRender` 内部子组件，**未从 `@blueking/chat-x` 包入口导出**。业务侧通过构造 `InterruptMessage` 触发渲染即可；下方为类型与数据结构参考。
+
+```vue
+<template>
+  <!-- 业务侧推荐：由 MessageRender / MessageContainer 自动渲染 -->
+  <InterruptMessageRender
+    :content="interruptMessage.content"
+    role="interrupt"
+    :status="interruptMessage.status"
+    :on-interrupt-resume="handleInterruptResume"
+  />
+</template>
+
+<script setup lang="ts">
+  import {
+    InterruptMessageRender,
+    APPROVAL_STATUS,
+    InterruptReason,
+    MessageRole,
+    MessageStatus,
+    type InterruptMessage,
+    type AIDevToolApprovalInterrupt,
+  } from '@blueking/chat-x';
+
+  const interrupt: AIDevToolApprovalInterrupt = {
+    id: 'interrupt_1',
+    reason: InterruptReason.AIDevToolApproval,
+    toolCallId: 'tool_call_1',
+    metadata: {
+      ticket: {
+        approvers: ['张三', '李四'],
+        sn: 'REV-2026-04-24-001',
+        status: APPROVAL_STATUS.PENDING,
+        submit_time: '2026-04-24 14:30:15',
+        title: '算法方案评审单',
+        url: 'https://example.com/tickets/001',
+      },
+    },
+  };
+
+  const interruptMessage: InterruptMessage = {
+    id: 'msg_1',
+    messageId: 'msg_1',
+    role: MessageRole.Interrupt,
+    status: MessageStatus.Pending,
+    content: {
+      outcome: { type: 'interrupt', interrupts: [interrupt] },
+    },
+  };
+
+  const handleInterruptResume = async (payload, interrupt) => {
+    console.log(payload, interrupt.id);
+  };
+</script>
+```
+
+**渲染效果**（文档站直接挂载 `ToolApprovalCard` 预览卡片 UI）
+
+## 已通过 / 已拒绝 / 已撤销
+
+```vue
+<div>
+  <InterruptMessageRender
+    :content="{ outcome: { type: 'interrupt', interrupts: [approvedInterrupt] } }"
+    role="interrupt"
+  />
+  <InterruptMessageRender
+    :content="{ outcome: { type: 'interrupt', interrupts: [rejectedInterrupt] } }"
+    role="interrupt"
+  />
+  <InterruptMessageRender
+    :content="{ outcome: { type: 'interrupt', interrupts: [revokedInterrupt] } }"
+    role="interrupt"
+  />
+</div>
+```
+
+**渲染效果**
+
+## 只读回显（readonly）
+
+`outcome.success` 时 [InterruptMessageRender](/components/agent/interrupt-message) 会将 `AIDevToolApprovalResume.payload.metadata` 还原为 `interrupt` 形态，并以 `readonly` 挂载本组件：
+
+```vue
+<ToolApprovalCard
+  :interrupt="approvedInterrupt"
+  readonly
+/>
+```
+
+**渲染效果**（待审批态下 readonly 不展示「取消审批」）
+
+## API
+
+### Props
+
+| 属性名            | 类型                         | 默认值 | 说明                                         |
+| ----------------- | ---------------------------- | ------ | -------------------------------------------- |
+| interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`               |
+| onInterruptResume | `OnInterruptResume`          | —      | 取消审批时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id } }` |
+| readonly          | `boolean`                    | —      | 只读回显态（`outcome.success` 结果回显）：隐藏取消审批按钮，不接受交互 |
+
+### Events / Slots / Expose
+
+无。打开链接、复制剪贴板在组件内部完成；取消审批通过 `onInterruptResume({ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: interrupt.id } }, interrupt)` 通知业务侧处理。
+
+## 依赖
+
+- `bkui-vue`：`Button`、`Loading`
+- `useClipboard` — 复制单据
+- `v-overflow-tips` — 处理人超长省略
+
+## 关联组件
+
+- [InterruptMessage 中断消息](/components/agent/interrupt-message)
+- [中断类型 Interrupt](../../types/interrupt.md)
+- [常量枚举 Constants](../../types/constants.md) — `APPROVAL_STATUS`、`APPROVAL_STATUS_MAP`

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-btn.md
@@ -1,0 +1,288 @@
+# ToolBtn 工具按钮
+
+> 能力域：工具与反馈 ｜ 导入：`import { ToolBtn } from '@blueking/chat-x'` ｜ since 1.0.0
+
+工具栏图标按钮。 源码位置：src/components/ai-buttons/tool-btn/tool-btn.vue。
+
+**关联**：message-tools（父级组装多个工具按钮与交互）、delete-tool（删除确认场景内嵌为触发控件）
+
+---
+
+# ToolBtn 工具按钮
+## 源码事实
+
+- **源码位置**：`src/components/ai-buttons/tool-btn/tool-btn.vue`
+- **能力域**：工具与反馈
+- **能力说明**：工具栏图标按钮。
+
+> **能力域**：工具与反馈
+
+消息工具栏中的单个操作按钮，内置 SVG 图标映射、Tippy 悬浮提示、激活态与禁用态，通常由 `MessageTools` 管理，一般不需要手动使用。
+
+## 组件结构
+
+```
+div.ai-tool-btn（v-tippy，flex，min-width: 20px，height: 20px，border-radius: 4px）
+  color: #a8aab2; background: transparent
+  active=true  → .is-active（color: var(--ai-tool-btn-active-color)）
+  disabled=true → .is-disabled（color: #979ba5; cursor: not-allowed）
+  :not(.is-disabled):hover → color: #4d4f56; background: #eaebf0
+  │
+  └── <slot>（默认内容，可完全自定义）
+        ├── [id && id in ToolIconsMap] → <component :is="ToolIconsMap[id]" />（SVG 图标）
+        └── [其他] → <div>{{ name }}</div>（文本回退，XSS 安全）
+
+Tippy：content=description, theme='ai-chat-box', disabled=true 时 onShow 返回 false 不显示
+click 事件：disabled=true 时被 JS 拦截，不触发 emit
+
+激活色（CSS 变量 --ai-tool-btn-active-color）：
+  id === 'like' 或 'activeLike' → #3a84ff（蓝色）
+  其他 id（如 'unlike'、'delete'） → #E71818（红色）
+```
+
+## 预置图标（ToolIconsMap）
+
+| id             | 说明           | 备注                     |
+| -------------- | -------------- | ------------------------ |
+| `copy`         | 复制           |                          |
+| `cite`         | 引用           |                          |
+| `rebuild`      | 重新生成       |                          |
+| `share`        | 分享           |                          |
+| `like`         | 点赞（空心）   | 配合 `activeLike` 使用   |
+| `unlike`       | 不满意（空心） | 配合 `activeUnLike` 使用 |
+| `delete`       | 删除           |                          |
+| `edit`         | 编辑           |                          |
+| `activeLike`   | 点赞（实心）   | 激活态填充图标           |
+| `activeUnLike` | 不满意（实心） | 激活态填充图标           |
+
+> 未传入 `id`、或 `id` 不在上表时，组件渲染 `<div>{{ name }}</div>` 作为文本回退。也可通过默认插槽完全自定义按钮内容（如全屏图标），此时可不传 `id`。
+
+## 基础用法
+
+```vue
+<template>
+  <div style="display: flex; gap: 6px;">
+    <ToolBtn
+      id="copy"
+      name="复制"
+      description="复制消息内容"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="cite"
+      name="引用"
+      description="引用此消息"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="rebuild"
+      name="重新生成"
+      description="重新生成回答"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="share"
+      name="分享"
+      description="分享消息"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="like"
+      name="点赞"
+      description="对此回答满意"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="unlike"
+      name="不满意"
+      description="对此回答不满意"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="edit"
+      name="编辑"
+      description="编辑消息"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="delete"
+      name="删除"
+      description="删除消息"
+      @click="handleClick"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ToolBtn } from '@blueking/chat-x';
+  import type { IToolBtn } from '@blueking/chat-x';
+
+  const handleClick = (data: IToolBtn & { active?: boolean; disabled?: boolean }, event: MouseEvent) => {
+    console.log('点击了:', data.id, data.name);
+  };
+</script>
+```
+
+## 激活态与图标切换（点赞/踩）
+
+`active` 只控制 `.is-active` 背景高亮，不自动切换图标。若需要填充图标，需在 `:id` 绑定中主动切换 `activeLike` / `activeUnLike`：
+
+```vue
+<template>
+  <div style="display: flex; gap: 6px;">
+    <!-- 切换 id 实现图标填充 -->
+    <ToolBtn
+      :id="activeId === 'like' ? 'activeLike' : 'like'"
+      name="点赞"
+      description="点赞"
+      :active="activeId === 'like'"
+      @click="toggleActive"
+    />
+    <ToolBtn
+      :id="activeId === 'unlike' ? 'activeUnLike' : 'unlike'"
+      name="不满意"
+      description="不满意"
+      :active="activeId === 'unlike'"
+      @click="toggleActive"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ToolBtn } from '@blueking/chat-x';
+  import type { IToolBtn } from '@blueking/chat-x';
+
+  const activeId = ref<string | null>(null);
+
+  const toggleActive = (data: IToolBtn) => {
+    // 规范化 id（activeLike → like）后再比较
+    const baseId = data.id.replace(/^active/, '').replace(/^./, c => c.toLowerCase());
+    activeId.value = activeId.value === baseId ? null : baseId;
+  };
+</script>
+```
+
+## 禁用状态
+
+`disabled=true` 时：JS 拦截 click 不触发事件 + Tippy 的 `onShow` 返回 `false` 不显示 tooltip：
+
+```vue
+<template>
+  <div style="display: flex; gap: 6px; align-items: center;">
+    <ToolBtn
+      id="copy"
+      name="复制"
+      description="复制"
+      :disabled="isDisabled"
+      @click="handleClick"
+    />
+    <ToolBtn
+      id="edit"
+      name="编辑"
+      description="编辑"
+      :disabled="isDisabled"
+      @click="handleClick"
+    />
+    <button @click="isDisabled = !isDisabled">{{ isDisabled ? '启用' : '禁用' }}</button>
+  </div>
+</template>
+```
+
+## 未知 ID 的文本回退
+
+`id` 不在 `ToolIconsMap` 时渲染 `name` 文本，适用于自定义扩展场景：
+
+## 自定义插槽内容
+
+通过默认插槽可完全替换内置图标/文本，适用于预置 `ToolIconsMap` 未覆盖的图标场景（如侧栏全屏按钮）：
+
+```vue
+<template>
+  <ToolBtn
+    description="全屏"
+    :tippy-options="{ content: '全屏' }"
+    @click="handleFullScreen"
+  >
+    <FullScreenIcon />
+  </ToolBtn>
+</template>
+
+<script setup lang="ts">
+  import { ToolBtn, FullScreenIcon } from '@blueking/chat-x';
+
+  const handleFullScreen = () => {
+    // 进入全屏逻辑
+  };
+</script>
+```
+
+## API
+
+### Props
+
+| 属性名       | 类型                                                                       | 必填 | 默认值 | 说明                                                                                                               |
+| ------------ | -------------------------------------------------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------------------------------------ |
+| id           | `keyof typeof ToolIconsMap`                                                | 否   | —      | 按钮标识；在 `ToolIconsMap` 中时渲染对应 SVG 图标，否则渲染 `name` 文本；使用插槽自定义内容时可省略                  |
+| name         | `string`                                                                   | 否   | —      | 按钮名称；`id` 无对应图标时作为文本内容渲染                                                                        |
+| description  | `string`                                                                   | 否   | —      | Tippy tooltip 内容；`disabled=true` 时不显示 tooltip                                                               |
+| active       | `boolean`                                                                  | 否   | —      | 激活态；`true` 时追加 `.is-active`（字色由 `id` 决定：`like`/`activeLike` 为蓝色 `#3a84ff`，其他为红色 `#E71818`） |
+| disabled     | `boolean`                                                                  | 否   | —      | 禁用态；`true` 时追加 `.is-disabled`，阻止 click 事件，隐藏 tooltip                                                |
+| tippyOptions | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>` | 否   | —      | 自定义 Tippy 配置，与内部默认配置合并；可用于控制 `content`、`appendTo`、`placement` 等                            |
+
+### Events
+
+| 事件名 | 参数                                                                             | 说明                                                                                        |
+| ------ | -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| click  | `(data: IToolBtn & { active?: boolean; disabled?: boolean }, event: MouseEvent)` | 点击时触发；`data` 为组件当前全量 props（含 `active`/`disabled`）；`disabled=true` 时不触发 |
+
+### Slots
+
+| 插槽名  | 说明                                                                                       |
+| ------- | ------------------------------------------------------------------------------------------ |
+| default | 按钮内容；传入时替换默认的图标/文本渲染逻辑，常用于自定义 SVG 图标（如全屏、退出全屏按钮） |
+
+## 类型定义
+
+```typescript
+// 来自 @blueking/chat-x 导出
+interface IToolBtn {
+  id?: keyof typeof ToolIconsMap; // 预置 ID；省略时走 name 文本或插槽
+  name?: string;
+  description?: string;
+}
+
+// ToolBtn 完整 Props
+type ToolBtnProps = IToolBtn & {
+  active?: boolean;
+  disabled?: boolean;
+  tippyOptions?: Partial<Omit<TippyOptions, 'getReferenceClientRect' | 'triggerTarget'>>;
+};
+
+// 预置 ID 枚举
+type ToolIcons =
+  | 'copy'
+  | 'cite'
+  | 'rebuild'
+  | 'share'
+  | 'like'
+  | 'unlike'
+  | 'delete'
+  | 'edit'
+  | 'activeLike'
+  | 'activeUnLike';
+```
+
+## 注意事项
+
+1. **`click` 事件的 `data` 参数**是组件的完整 props 对象（含 `active`、`disabled`），并非单纯的 `IToolBtn`
+2. **`activeLike` / `activeUnLike`**：是单独的填充版图标 ID，并非 `active=true` 时自动切换，需要手动在 `:id` 绑定中控制
+3. **根元素是 `<div>` 而非 `<button>`**：没有原生按钮语义，键盘无障碍访问需外部额外处理
+4. **`description` 可选**：不传时 tooltip 内容为 `undefined`，Tippy 不显示提示
+5. **`disabled` 的 CSS**：`pointer-events: hover` 为无效 CSS 值（应为 `none`），鼠标事件实际由 JS 层拦截，CSS 层仍可触发 hover 样式
+6. **`tippyOptions` 优先级**：`tippyOptions` 中的配置会覆盖内部默认值（包括 `content`、`theme`），但 `onShow` 始终保留内部逻辑（禁用时不显示）。`getReferenceClientRect`、`triggerTarget` 两个字段被 Omit 排除，不可通过此 prop 覆盖；`content` 已可通过 `tippyOptions.content` 覆盖
+
+## 关联组件
+
+- [MessageTools](/components/feedback/message-tools) — 工具栏容器
+- [DeleteTool](/components/feedback/delete-tool) — 删除确认内嵌触发

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/tool-message.md
@@ -1,0 +1,219 @@
+# ToolMessage 工具消息
+
+> 能力域：消息系统 ｜ 导入：`import { ToolMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染工具返回内容，JSON 场景交给 DescPanel 展示。 源码位置：src/components/chat-message/tool-message/tool-message.vue。
+
+**关联**：assistant-message（结果常作为 assistant 消息中 toolCall.toolMessage 内联展示）、message-render（独立 tool 角色消息由 MessageRender 渲染为 ToolMessage）、desc-panel（内部使用 DescPanel 展示「返回内容」）
+
+---
+
+# ToolMessage 工具消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/tool-message/tool-message.vue`
+- **能力域**：消息系统
+- **能力说明**：渲染工具返回内容，JSON 场景交给 DescPanel 展示。
+
+> **能力域**：消息系统
+
+工具（Function Call）执行结果展示组件。内部通过 `DescPanel` 渲染，标题固定为"返回内容"，支持将 JSON 自动解析为 key-value 列表。
+
+> **通常不需要直接使用此组件**。`ToolcallRender` 在 `toolCall.toolMessage` 有值时会自动内联渲染；`MessageContainer` 处理 `role: 'tool'` 消息时也会通过 `MessageRender` 自动渲染。
+
+## 渲染架构
+
+```
+ToolMessage
+└── DescPanel（desc="content || (typeof error === 'string' ? error : undefined)"，title="返回内容"）
+      ├── JSON.parse(desc) 成功且结果为 object/array
+      │     └── key-value 列表（v-for 遍历）
+      │           值超长时截断 + overflow-tips tooltip
+      └── 其他（parse 失败 / 结果为基本类型）
+            └── 纯文本展示
+```
+
+## 基础用法
+
+```vue
+<template>
+  <ToolMessage
+    :content="content"
+    tool-call-id="call_1"
+    :duration="850"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ToolMessage } from '@blueking/chat-x';
+
+  const content = JSON.stringify({
+    city: '北京',
+    temperature: 22,
+    weather: '晴',
+    humidity: '45%',
+    wind: '东北风 3 级',
+  });
+</script>
+```
+
+**JSON 对象内容（key-value 列表）**
+
+**纯文本内容**
+
+## 错误状态
+
+`content` 为空时展示 `error`，由 `content || (typeof error === 'string' ? error : undefined)` 决定。仅当 `error` 为字符串类型时才会展示，非字符串类型的 `error`（如对象）会被忽略：
+
+```vue
+<template>
+  <ToolMessage
+    content=""
+    :error="error"
+    tool-call-id="call_3"
+    :duration="5000"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ToolMessage } from '@blueking/chat-x';
+
+  const error = 'Connection timeout: database server is unreachable (timeout: 5000ms)';
+</script>
+```
+
+## DescPanel 内容渲染规则
+
+`DescPanel` 内部对 `desc`（即 `content || (typeof error === 'string' ? error : undefined)`）进行 `JSON.parse`，然后根据解析结果类型决定渲染方式：
+
+| `desc` 内容                 | `JSON.parse` 结果               | 渲染方式                            |
+| --------------------------- | ------------------------------- | ----------------------------------- |
+| 合法 JSON 对象 `{}`         | `object`（非 null）             | **key-value 列表**，键为字段名      |
+| 合法 JSON 数组 `[]`         | `array`（也是 `object`）        | **index-keyed 列表**，键为 0、1、2… |
+| 合法 JSON 基本类型          | `number` / `string` / `boolean` | 纯文本                              |
+| `"null"` 字符串             | `null`（`typeof 'object'`）     | 空内容区（v-for 遍历 null 无输出）  |
+| 解析失败（非法 JSON）       | 捕获异常，返回原字符串          | 纯文本                              |
+| `content` 和 `error` 均为空 | `''` → 解析失败                 | 空内容区                            |
+
+> **注意**：JSON 数组在 JavaScript 中 `typeof [] === 'object'` 为 `true`，因此数组会以 `0:`、`1:`、`2:` 为键渲染为 key-value 列表，而**非**纯文本。
+
+**嵌套对象值的处理**：当 value 本身是对象时，`{{ value }}` 会渲染为 `[object Object]`，但 hover 展示的 overflow-tips 会显示 `JSON.stringify(value)` 的完整字符串。
+
+```typescript
+// ✅ 渲染为 key-value 列表
+const jsonObject = '{"city":"北京","temperature":22}';
+
+// ✅ 渲染为 index-keyed 列表（0: item1, 1: item2）
+const jsonArray = '["item1","item2","item3"]';
+
+// ✅ 渲染为纯文本（基本类型）
+const jsonNumber = '42';
+const jsonBool = 'true';
+
+// ✅ 渲染为纯文本（解析失败）
+const plainText = '查询成功，共返回 10 条记录。';
+```
+
+## 与 ToolcallRender 的关系
+
+`ToolcallRender` 在详情面板展开时，若 `toolCall.toolMessage` 有值，会在底部内联渲染 `ToolMessage`：
+
+```typescript
+// toolcall-render.vue 内部逻辑（简化）
+// <ToolMessage v-if="toolCall?.toolMessage" v-bind="toolCall.toolMessage" />
+
+const toolCall = {
+  id: 'call_weather',
+  type: 'function',
+  function: {
+    name: 'get_weather',
+    arguments: '{"city":"北京"}',
+    description: '获取天气信息',
+  },
+  // 提供此字段后 ToolcallRender 会自动渲染 ToolMessage
+  toolMessage: {
+    id: '3',
+    messageId: '3',
+    role: 'tool',
+    content: '{"temperature":22,"weather":"晴"}',
+    status: 'complete',
+    duration: 850,
+    toolCallId: 'call_weather',
+  },
+};
+```
+
+## 与 MessageContainer 的关系
+
+`MessageContainer` 通过 `toolCallId` 将 `role: 'tool'` 消息注入对应 AssistantMessage 的 `toolCall.toolMessage`，整个过程自动完成，无需手动引入 `ToolMessage`：
+
+```typescript
+const messages = [
+  {
+    id: '1',
+    messageId: '1',
+    role: 'assistant',
+    content: '好的，我来查询天气。',
+    status: 'complete',
+    toolCalls: [
+      {
+        id: 'call_weather',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"city":"北京"}' },
+      },
+    ],
+  },
+  {
+    id: '2',
+    messageId: '2',
+    role: 'tool', // MessageContainer 自动处理
+    content: '{"temperature":22,"weather":"晴"}',
+    status: 'complete',
+    toolCallId: 'call_weather', // ← 通过此字段自动关联并注入上方 toolCall
+    duration: 850,
+  },
+];
+```
+
+## API
+
+### Props
+
+组件 Props 继承自 `Partial<ToolMessage>`，所有字段均可选：
+
+| 属性名     | 类型               | 说明                                                                            |
+| ---------- | ------------------ | ------------------------------------------------------------------------------- |
+| content    | `string`           | 工具执行返回内容；与 `error` 通过 `\|\|` 决定优先级，**truthy 时 error 被忽略** |
+| error      | `string`           | 工具执行错误信息；仅当 `content` 为 falsy 且 `error` 为 `string` 类型时展示     |
+| toolCallId | `string`           | 关联的工具调用 ID（透传，组件内不使用）                                         |
+| duration   | `number`           | 工具执行耗时（毫秒，透传，组件内不使用）                                        |
+| status     | `MessageStatus`    | 消息状态（透传，组件内不使用）                                                  |
+| id         | `string \| number` | 消息 ID（透传，组件内不使用）                                                   |
+| messageId  | `string \| number` | 消息唯一标识（透传，组件内不使用）                                              |
+
+> **说明**：`ToolMessage` 组件内部只使用 `content` 和 `error` 两个字段（传给 `DescPanel`），其他字段均被透传接收但不使用，由父组件（`ToolcallRender` / `MessageContainer`）在外部管理。
+
+## 类型定义
+
+```typescript
+import { MessageRole, MessageStatus, type ToolMessage } from '@blueking/chat-x';
+
+// ToolMessage 继承自 BaseMessage<MessageRole.Tool, string>
+interface ToolMessage {
+  id: string | number;
+  messageId: string | number;
+  role: MessageRole.Tool; // 'tool'
+  status: MessageStatus;
+  content: string;
+  toolCallId: string; // 关联的 ToolCall.id
+  duration: number; // 工具执行耗时（毫秒）
+  error?: string; // 执行错误信息
+  name?: string;
+}
+```
+
+## 关联组件
+
+- [AssistantMessage](/components/message/assistant-message) — toolCall.toolMessage 内联场景
+- [MessageRender](/components/message/message-render) — 独立 tool 消息派发
+- [DescPanel](/components/rendering/desc-panel) — 返回内容面板

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
@@ -1,0 +1,301 @@
+# ToolcallRender 工具调用渲染器
+
+> 能力域：Agent 能力 ｜ 导入：`import { ToolcallRender } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 assistant toolCalls，展示工具调用状态、参数和结果。 源码位置：src/components/tool-call/toolcall-render/toolcall-render.vue。
+
+**关联**：desc-panel（详情区展示参数与描述文本）、highlight-keyword（标题与状态文案关键词高亮）、tool-message（详情底部可内联工具返回消息）
+
+---
+
+# ToolcallRender 工具调用渲染器
+## 源码事实
+
+- **源码位置**：`src/components/tool-call/toolcall-render/toolcall-render.vue`
+- **能力域**：Agent 能力
+- **能力说明**：渲染 assistant toolCalls，展示工具调用状态、参数和结果。
+
+> **能力域**：Agent 能力
+
+展示 AI 调用外部工具/函数过程与结果的渲染组件。由**可折叠头部**和**详情面板**组成，根据 `status` 自动切换颜色和状态文案，支持 MCP 调用识别和内联结果展示。
+
+## 组件结构
+
+```
+.ai-toolcall-render
+├── .ai-toolcall-render-header（高 40px，class="toolcall-status-{status}"）
+│   ├── ArrowRightIcon（14×14px，点击切换折叠；默认 rotate(0deg)，展开后 rotate(90deg)）
+│   ├── "调用工具：" / "调用 MCP："（有 mcpName 时）
+│   ├── .toolcall-header-title（工具名，overflow-tips 溢出截断）
+│   └── .toolcall-status-title
+│         ├── Loading（仅 pending / streaming 时显示）
+│         ├── 状态文案（调用中 / 调用成功 / 调用失败）
+│         └── .toolcall-duration（耗时，如 "(1.2s)"）
+│
+└── .ai-toolcall-render-content（v-show，默认折叠）
+      ├── DescPanel（title="描述"，desc=function.description）← 始终渲染
+      ├── DescPanel（title="参数"，desc=function.arguments）← 始终渲染
+      └── ToolMessage（v-if="toolCall?.toolMessage"）← 有结果时渲染
+```
+
+## 基础用法
+
+```vue
+<template>
+  <ToolcallRender
+    :tool-call="toolCall"
+    :status="MessageStatus.Complete"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ToolcallRender, MessageStatus, MessageContentType, type ToolCall } from '@blueking/chat-x';
+
+  const toolCall: ToolCall = {
+    id: 'call_1',
+    type: MessageContentType.Function,
+    function: {
+      name: 'get_weather',
+      arguments: JSON.stringify({ city: '北京', unit: 'celsius' }),
+      description: '获取指定城市的实时天气信息',
+    },
+    toolMessage: {
+      content: JSON.stringify({ city: '北京', temperature: 22, weather: '晴' }),
+      status: 'complete',
+      duration: 1200,
+      toolCallId: 'call_1',
+    },
+  };
+</script>
+```
+
+**渲染效果**
+
+## 调用状态
+
+`status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和 Loading 动画：
+
+| `status`                | 状态文案 | 背景色            | 边框色    | Loading |
+| ----------------------- | -------- | ----------------- | --------- | ------- |
+| `pending` / `streaming` | 调用中   | `#fafbfd`         | `#dcdee5` | ✓       |
+| `complete` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | -       |
+| `error`                 | 调用失败 | `#fff0f0`         | `#f8b4b4` | -       |
+| 其他 / `undefined`      | 调用中   | —（无匹配 class） | —         | -       |
+
+> **说明**：`statusTitle` 的 `switch` 语句中 `default` 与 `case Pending` 共享同一返回值，`streaming` 和未知 status 均命中 `default` 分支，显示"调用中"。Loading 动画由 `v-if="status === 'pending' || status === 'streaming'"` 单独控制。
+
+**三种状态对比**
+
+## 工具标题（toolTitle）
+
+头部标题的计算规则：
+
+```
+有 mcpName → "{mcpName} / {function.name}"
+无 mcpName → function.name || toolCall.id
+```
+
+`function.name` 为空字符串时，自动回退到 `toolCall.id` 作为标题。标题超出容器宽度时截断并配备 overflow-tips。
+
+## 折叠/展开详情面板
+
+详情面板**默认折叠**，点击头部左侧的 **箭头图标**（14×14px 可点区域，非整行）切换折叠状态。折叠状态由 `collapsed`（默认 `true`）和 `superCollapsed` 两个 `shallowRef` 共同管理，不暴露为 prop/v-model。
+
+| 折叠状态     | 箭头旋转角度            | 详情面板      |
+| ------------ | ----------------------- | ------------- |
+| 折叠（默认） | `rotate(0deg)`（朝右）  | `v-show` 隐藏 |
+| 展开         | `rotate(90deg)`（朝下） | 可见          |
+
+详情面板由三块区域构成：
+
+| 区块     | 数据来源               | 渲染方式                                             | 渲染条件                     |
+| -------- | ---------------------- | ---------------------------------------------------- | ---------------------------- |
+| 描述     | `function.description` | `DescPanel`（纯文本 / key-value 列表）               | **始终渲染**，无值则显示空白 |
+| 参数     | `function.arguments`   | `DescPanel`（JSON 对象 → key-value；其他 → 纯文本）  | **始终渲染**，无值则显示空白 |
+| 工具结果 | `toolCall.toolMessage` | `ToolMessage` 组件（`v-if="toolCall?.toolMessage"`） | 仅当 `toolMessage` 存在时    |
+
+## 调用耗时
+
+耗时来源优先级（`||` 运算符）：
+
+```typescript
+durationDisplay = formatDuration(props.duration || toolCall?.toolMessage?.duration);
+```
+
+| 场景                                       | 耗时来源                    |
+| ------------------------------------------ | --------------------------- |
+| 传入 `duration` prop                       | 使用 prop 值                |
+| 未传 `duration`，toolMessage 有 `duration` | 使用 `toolMessage.duration` |
+| 两者均无                                   | 不显示耗时                  |
+
+```vue
+<!-- 方式一：直接传 duration prop（优先） -->
+<ToolcallRender :tool-call="toolCall" status="complete" :duration="1200" />
+
+<!-- 方式二（推荐）：duration 放在 toolMessage 中，无需额外 prop -->
+<ToolcallRender :tool-call="toolCallWithDuration" status="complete" />
+```
+
+```typescript
+// 推荐：duration 统一由 toolMessage 管理
+const toolCallWithDuration: ToolCall = {
+  id: 'call_1',
+  type: 'function',
+  function: { name: 'get_weather', arguments: '{"city":"北京"}' },
+  toolMessage: {
+    content: '{"temperature":22}',
+    status: 'complete',
+    duration: 1200, // ← 组件自动读取，无需额外传 duration prop
+    toolCallId: 'call_1',
+  },
+};
+```
+
+## MCP 工具调用
+
+`function.mcpName` 有值时：
+
+- 头部文案从 **"调用工具："** 自动切换为 **"调用 MCP："**
+- 标题格式变为 `{mcpName} / {functionName}`
+
+```typescript
+const mcpToolCall: ToolCall = {
+  id: 'call_mcp_1',
+  type: 'function',
+  function: {
+    name: 'query_table',
+    arguments: JSON.stringify({ table: 'events', limit: 50 }),
+    description: '通过 MCP 协议查询蓝鲸数据平台中的事件数据',
+    mcpName: 'bk-data-server', // ← 有值时头部显示"调用 MCP："
+  },
+};
+// 头部显示：调用 MCP：  bk-data-server / query_table
+```
+
+**渲染效果**
+
+## 调用失败
+
+`toolMessage.error` 有值且 `content` 为空时，`ToolMessage` 内部展示错误信息（由 `content || error` 决定）。`status` 设为 `error` 控制头部红色样式：
+
+```typescript
+const failedToolCall: ToolCall = {
+  id: 'call_1',
+  type: 'function',
+  function: {
+    name: 'execute_sql',
+    arguments: JSON.stringify({ sql: 'SELECT * FROM users' }),
+    description: '执行数据库查询',
+  },
+  toolMessage: {
+    content: '', // 空 content → ToolMessage 显示 error
+    error: 'Connection timeout: database is unreachable (5000ms)',
+    status: 'error',
+    duration: 5000,
+    toolCallId: 'call_1',
+  },
+};
+```
+
+**渲染效果**
+
+## 无 description 场景
+
+`function.description` 为可选字段，缺失时"描述"区块仍会渲染（`DescPanel` 始终存在），但内容为空白占位：
+
+## 与 AssistantMessage 配合
+
+`ToolcallRender` 通常不需要单独使用，将 `toolCalls` 传给 `AssistantMessage`，会自动为每个工具调用渲染 `ToolcallRender`：
+
+```typescript
+const assistantMessage = {
+  id: '1',
+  role: 'assistant',
+  content: '好的，我来帮你查询天气。',
+  status: 'complete',
+  toolCalls: [
+    {
+      id: 'call_1',
+      type: 'function',
+      function: {
+        name: 'get_weather',
+        arguments: '{"city":"北京"}',
+        description: '获取天气信息',
+      },
+      toolMessage: {
+        content: '{"temperature":22,"weather":"晴"}',
+        status: 'complete',
+        duration: 850,
+        toolCallId: 'call_1',
+      },
+    },
+  ],
+};
+```
+
+需要自定义遍历渲染时：
+
+```vue
+<template>
+  <ToolcallRender
+    v-for="toolCall in assistantMessage.toolCalls"
+    :key="toolCall.id"
+    :tool-call="toolCall"
+    :status="toolCall.toolMessage?.status ?? MessageStatus.Pending"
+  />
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名   | 类型            | 默认值 | 说明                                                                        |
+| -------- | --------------- | ------ | --------------------------------------------------------------------------- |
+| toolCall | `ToolCall`      | —      | 工具调用信息对象                                                            |
+| status   | `MessageStatus` | —      | 调用状态，控制头部颜色和状态文案；未传时 `default` 分支显示"调用中"         |
+| duration | `number`        | —      | 调用耗时（毫秒），优先于 `toolCall.toolMessage?.duration`；均无时不显示耗时 |
+
+## 类型定义
+
+```typescript
+import {
+  MessageStatus,
+  MessageContentType,
+  type ToolCall,
+  type FunctionCall,
+  type ToolMessage,
+} from '@blueking/chat-x';
+
+// ToolCall —— 工具调用对象
+type ToolCall = {
+  id: string;
+  type: 'function'; // MessageContentType.Function
+  function: FunctionCall;
+  toolMessage?: Partial<ToolMessage>; // 有值时在详情面板底部内联渲染 ToolMessage
+};
+
+// FunctionCall —— 函数调用描述
+type FunctionCall = {
+  name: string; // 函数名；为空时标题 fallback 为 toolCall.id
+  arguments: string; // 调用参数（通常为 JSON 字符串）
+  description?: string; // 工具描述；为空时"描述"区块保留但内容为空白
+  mcpName?: string; // MCP 服务名；有值时头部改为"调用 MCP："，标题格式变为 "{mcpName} / {name}"
+};
+
+// ToolMessage —— 工具返回消息
+interface ToolMessage {
+  role: 'tool';
+  content: string; // 返回内容（通常为 JSON 字符串）
+  status: MessageStatus;
+  duration: number; // 调用耗时（毫秒），被 ToolcallRender 自动读取
+  error?: string; // 错误信息（仅当 content 为空时由 ToolMessage 展示）
+  toolCallId: string; // 对应 ToolCall.id
+}
+```
+
+## 关联组件
+
+- [DescPanel](/components/rendering/desc-panel) — 描述与参数面板
+- [HighlightKeyword](/components/helper/highlight-keyword) — 标题高亮
+- [ToolMessage](/components/message/tool-message) — 内联工具返回

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-feedback.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-feedback.md
@@ -1,0 +1,233 @@
+# UserFeedback 用户反馈
+
+> 能力域：工具与反馈 ｜ 导入：`import { UserFeedback } from '@blueking/chat-x'` ｜ since 1.0.0
+
+用户反馈弹层，提交踩/反馈原因。 源码位置：src/components/message-tools/user-feedback/user-feedback.vue。
+
+**关联**：message-tools（点赞/踩操作触发并收集反馈）
+
+---
+
+# MessageUserFeedback 用户反馈
+## 源码事实
+
+- **源码位置**：`src/components/message-tools/user-feedback/user-feedback.vue`
+- **能力域**：工具与反馈
+- **能力说明**：用户反馈弹层，提交踩/反馈原因。
+
+> **能力域**：工具与反馈
+
+AI 消息点赞/踩后收集用户具体反馈原因的弹出面板。支持多选预设原因标签、补充文字说明（textarea）、异步加载原因列表（骨架屏）。
+
+> **通常不需要直接使用。** `MessageTools` 在用户点击 `like`/`unlike` 工具按钮时，会通过内置 Tippy 弹出层自动呈现本组件，并驱动 `loading` 和 `reasonList`。
+
+## 组件结构
+
+```
+.ai-user-feedback（width: 400px，padding: 16px，gap: 16px）
+├── .ai-feedback-title（font-size: 16px，color: #313238）
+│     props.title
+│
+├── .ai-feedback-reason-list（flex-wrap，gap: 4px）
+│     loading=true  → 8 × .reason-item.ai-skeleton-element（每项 width: 70px）
+│     loading=false → v-for reasonList → .reason-item
+│                       is-active（已选）：color #1768ef，bg #e1ecff
+│                       :hover        ：同上（与 is-active 共享样式）
+│
+├── .ai-feedback-other
+│     bkui-vue Input（type=textarea，rows=3，placeholder="说出您的想法"）
+│     → v-model 绑定内部 shallowRef otherReason
+│
+└── .ai-feedback-footer（justify-content: flex-end，gap: 8px）
+      Button primary "提交"（width: 64px，disabled：selectedReasons 空且 otherReason 空）
+      Button default "取消"（width: 64px）
+```
+
+## 基础用法
+
+```vue
+<template>
+  <MessageUserFeedback
+    title="什么原因让你满意？"
+    :reason-list="reasonList"
+    @submit="handleSubmit"
+    @cancel="handleCancel"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageUserFeedback } from '@blueking/chat-x';
+
+  const reasonList = ['回答准确', '信息全面', '表达清晰', '解决了问题', '示例恰当'];
+
+  const handleSubmit = (selectedReasons: string[], otherReason: string) => {
+    // selectedReasons: 当前已勾选的原因（提交后组件不自动清空）
+    // otherReason: textarea 中的补充说明（可为空字符串）
+    console.log('已选原因:', selectedReasons, '补充说明:', otherReason);
+  };
+
+  const handleCancel = () => {
+    // cancel 触发前组件已清空 selectedReasons 和 otherReason
+    console.log('用户取消了反馈');
+  };
+</script>
+```
+
+**满意反馈**
+
+**不满意反馈**
+
+## 加载状态
+
+原因列表通常需要异步获取，将 `loading` 设为 `true` 时渲染 **8 个**骨架屏占位块（固定数量，与 `reasonList` 无关），数据就绪后切换为 `false`：
+
+```vue
+<template>
+  <MessageUserFeedback
+    title="什么原因让你满意？"
+    :reason-list="reasonList"
+    :loading="isLoading"
+    @submit="handleSubmit"
+    @cancel="handleCancel"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageUserFeedback } from '@blueking/chat-x';
+
+  const isLoading = ref(true);
+  const reasonList = ref<string[]>([]);
+
+  async function fetchReasons() {
+    isLoading.value = true;
+    try {
+      reasonList.value = await fetchFeedbackReasons();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+</script>
+```
+
+**骨架屏效果**
+
+## 交互说明
+
+| 操作         | 行为说明                                                                                                      |
+| ------------ | ------------------------------------------------------------------------------------------------------------- |
+| 点击原因标签 | **多选**，高亮（`is-active`）；再次点击取消选中；hover 效果与选中态相同                                       |
+| 填写补充说明 | 可选；不选任何标签时，仅有补充说明文本也可解锁提交按钮                                                        |
+| 点击提交     | `selectedReasons.length === 0 && otherReason === ''` 时禁用；点击后触发 `submit` 事件，**组件不自动清空状态** |
+| 点击取消     | 先将 `selectedReasons` 和 `otherReason` 清空（两者均重置），再触发 `cancel` 事件                              |
+
+> **提交与取消的状态差异**：点击"提交"后内部 `selectedReasons` / `otherReason` **不重置**，由父组件决定后续行为（如关闭弹层）；点击"取消"则**立即重置**两者，再触发事件。
+
+## 与 MessageTools 配合使用
+
+`MessageUserFeedback` 在实际场景中由 `MessageTools` 驱动，整体流程：
+
+```
+用户点击 like / unlike
+    ↓
+MessageTools 内部：loading=true，弹出反馈面板（骨架屏）
+    ↓
+调用 onAction(tool) → 返回 string[]（支持 async）
+    ↓
+loading=false，展示原因标签列表
+    ↓
+用户选择原因 → 点击提交
+    ↓
+触发 onAgentFeedback(tool, messages, reasonList, otherReason)
+```
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :on-agent-action="handleAgentAction"
+    :on-agent-feedback="handleFeedback"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer, type IToolBtn, type Message } from '@blueking/chat-x';
+
+  const messages: Message[] = [
+    /* ... */
+  ];
+
+  // 点击 like/unlike 时调用，返回原因列表（支持异步）
+  const handleAgentAction = async (tool: IToolBtn): Promise<string[]> => {
+    if (tool.id === 'like') {
+      return ['回答准确', '信息全面', '表达清晰', '解决了问题'];
+    }
+    if (tool.id === 'unlike') {
+      return ['信息错误', '回答不相关', '解释不清楚', '没有解决问题'];
+    }
+    return [];
+  };
+
+  // 用户提交反馈后触发
+  const handleFeedback = (tool: IToolBtn, messages: Message[], reasonList: string[], otherReason: string) => {
+    console.log(`${tool.id} 反馈:`, { reasonList, otherReason });
+    // 上报到后端
+  };
+</script>
+```
+
+若需在自定义位置独立使用，可配合 `vue-tippy`：
+
+```vue
+<template>
+  <Tippy
+    :arrow="false"
+    interactive
+    trigger="click"
+    theme="ai-chat-box-light light"
+    :offset="[0, 6]"
+    :append-to="() => document.body"
+  >
+    <button>👍 点赞</button>
+    <template #content>
+      <MessageUserFeedback
+        title="什么原因让你满意？"
+        :reason-list="reasonList"
+        :loading="isLoading"
+        @submit="handleSubmit"
+        @cancel="handleCancel"
+      />
+    </template>
+  </Tippy>
+</template>
+```
+
+## API
+
+### Props
+
+| 属性名     | 类型       | 必填 | 默认值  | 说明                                                   |
+| ---------- | ---------- | ---- | ------- | ------------------------------------------------------ |
+| title      | `string`   | ✓    | —       | 面板标题文本                                           |
+| reasonList | `string[]` | ✓    | —       | 预设原因标签列表；`loading=true` 时列表不渲染          |
+| loading    | `boolean`  | —    | `false` | `true` 时显示 8 个骨架屏占位块，隐藏 `reasonList` 内容 |
+
+### Events
+
+| 事件名 | 参数签名                                      | 触发时机                                                    |
+| ------ | --------------------------------------------- | ----------------------------------------------------------- |
+| submit | `(reasonList: string[], otherReason: string)` | 点击提交按钮时（至少一项原因或补充说明不为空）              |
+| cancel | —                                             | 点击取消按钮时（内部已重置 selectedReasons 和 otherReason） |
+
+### 内部状态
+
+以下为组件内部 `shallowRef` 状态，不暴露为 props/emits：
+
+| 状态名          | 类型       | 说明                                        |
+| --------------- | ---------- | ------------------------------------------- |
+| selectedReasons | `string[]` | 当前已选原因列表；取消时重置，提交时不重置  |
+| otherReason     | `string`   | textarea 补充说明；取消时重置，提交时不重置 |
+
+## 关联组件
+
+- [MessageTools](/components/feedback/message-tools) — 点赞/踩入口与反馈联动

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-message.md
@@ -1,0 +1,353 @@
+# UserMessage 用户消息
+
+> 能力域：消息系统 ｜ 导入：`import { UserMessage } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。 源码位置：src/components/chat-message/user-message/user-message.vue。
+
+**关联**：message-render（由 MessageRender 在 role 为 user 时创建）、message-tools（消息工具栏交互与状态由 MessageTools 体系承载）、message-container（嵌入列表时由 MessageContainer 管理分组与多选）
+
+---
+
+# UserMessage 用户消息
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/user-message/user-message.vue`
+- **能力域**：消息系统
+- **能力说明**：渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。
+
+> **能力域**：消息系统
+
+用户消息展示组件，右对齐显示用户发送的消息内容。支持纯文本、多媒体（图片/文件）、文本引用、结构化引用、快捷指令等多种内容形式，以及消息的内联编辑功能。
+
+## 组件结构
+
+**正常模式**
+
+```
+.ai-user-message（align-items: flex-end，gap: 6px，font-size: 12px）
+├── CiteContent（v-if：cite 为字符串）
+│     紧凑条带（高 28px，灰色 #f5f7fa），引用图标 + 单行截断文本
+│
+├── [Binary 图片区] v-if binaryImageFiles.length
+│     .ai-user-message-binary-files → FileContent（readonly=true，图片统一渲染，支持点击预览）
+│
+├── [Binary 非图片文件区] v-for binaryNonImageFiles
+│     .ai-user-message-binary-files → FileContent（readonly=true，每个文件独立渲染）
+│
+├── .ai-user-message-content（气泡：bg #e1ecff，padding 8×12，border-radius 4px）
+│     v-if: cite 为数组 → KeyValueContent（title + key/value 列表）
+│     v-else-if: content  → MarkdownContent × N（每个 text 项一个实例）
+│
+└── MessageTools（.ai-user-message-tools）
+      v-if: messageToolsStatus !== 'hidden'
+      visibility: hidden（默认）→ visible（:hover 时）
+      tools: [copy, cite, edit]，updateTools: []
+```
+
+**编辑模式**（点击 `edit` 按钮后 `isEdit=true`）
+
+```
+.ai-user-message
+├── CiteContent（同上，不受编辑模式影响）
+│
+├── ShortcutRender（v-if: shortcut 有值）
+│     @close → isEdit=false
+│     @submit(formModel) → onShortcutConfirm(formModel) + isEdit=false
+│
+└── ChatInput（v-else，带自定义 #send-icon slot）
+      v-model: editContent（仅含文本内容，数组时取第一个 text 项）
+      defaultUploadFiles: binaryFiles
+      #send-icon slot → .user-edit-footer
+            Button "取消" → isEdit=false
+            Button primary "发送" → chatInputRef.triggerSendMessage() + isEdit=false
+```
+
+## 基础用法
+
+`content` 为字符串时，通过 `MarkdownContent` 渲染（支持 Markdown 语法）。
+
+```vue
+<template>
+  <UserMessage
+    :content="content"
+    :on-action="handleAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { UserMessage, type IToolBtn } from '@blueking/chat-x';
+
+  const content = '你好，请帮我分析以下这段 Python 代码的性能瓶颈。';
+
+  const handleAction = async (tool: IToolBtn) => {
+    console.log('工具操作:', tool.id);
+  };
+</script>
+```
+
+> **工具栏**：鼠标悬停时，消息下方出现「复制」「引用」「编辑」三个操作按钮（CSS `visibility` 切换，始终占位）。
+
+## 多媒体消息
+
+`content` 为数组时，同时支持文本（`type: 'text'`）和二进制文件（`type: 'binary'`）。组件将 `binary` 项按图片和非图片分为两组：
+
+- **图片文件**（`binaryImageFiles`）：判断 `url` 存在或 `mimeType` / `file.type` 以 `image/` 开头的文件，统一放入一个 `FileContent`（`readonly=true`）中渲染，支持点击缩略图全屏预览
+- **非图片文件**（`binaryNonImageFiles`）：每个文件单独渲染在 `FileContent`（`readonly=true`）中
+
+`text` 项按顺序各渲染一个 `MarkdownContent`。
+
+```vue
+<script setup lang="ts">
+  import { UserMessage, MessageContentType } from '@blueking/chat-x';
+
+  const content = [
+    {
+      type: MessageContentType.Binary, // 'binary'
+      url: 'https://example.com/screenshot.png',
+      mimeType: 'image/png',
+      filename: 'screenshot.png',
+    },
+    {
+      type: MessageContentType.Text, // 'text'
+      text: '请帮我分析这张架构图，指出其中的问题。',
+    },
+  ];
+</script>
+```
+
+## 带引用的消息
+
+通过 `property.extra.cite` 传入引用内容，支持两种格式，渲染位置不同：
+
+| `cite` 类型               | 渲染组件                                         | 渲染位置         |
+| ------------------------- | ------------------------------------------------ | ---------------- |
+| `string`                  | `CiteContent`（紧凑条带，高 28px，文本单行截断） | 气泡**外部上方** |
+| `{ title?, data[] }` 对象 | `KeyValueContent`（键值对列表）                  | 气泡**内部**     |
+
+### 文本引用
+
+`cite` 为字符串时，在气泡上方显示一个带引用图标的灰色条带（`#f5f7fa`），文本过长时截断。
+
+```vue
+<script setup lang="ts">
+  import { UserMessage } from '@blueking/chat-x';
+
+  const content = '这段代码每次循环都发起请求，应该如何优化？';
+  const property = {
+    extra: {
+      cite: '// 原始代码\nfor (let i = 0; i < arr.length; i++) {\n  fetch(`/api/${arr[i]}`)\n}',
+    },
+  };
+</script>
+```
+
+### 结构化引用（键值对）
+
+`cite` 为对象 `{ title?, data: { key, value }[] }` 时，引用内容渲染在气泡**内部**（`KeyValueContent` 组件）：
+
+```vue
+<script setup lang="ts">
+  import { UserMessage } from '@blueking/chat-x';
+
+  const content = '请帮我分析这份报表的数据趋势。';
+  const property = {
+    extra: {
+      cite: {
+        title: '销售数据分析',
+        data: [
+          { key: '报表名称', value: '2024 年 Q4 销售报表' },
+          { key: '时间范围', value: '2024年10月 - 12月' },
+          { key: '数据量', value: '12,580 条' },
+        ],
+      },
+    },
+  };
+</script>
+```
+
+## 快捷指令消息
+
+当消息来自快捷指令时，`property.extra.shortcut` 中携带快捷指令对象。在**编辑模式**下，组件渲染 `ShortcutRender` 代替普通 `ChatInput`。
+
+`shortcut` computed 支持两条来源路径：
+
+```
+1. property.extra.shortcut 有值 → 直接使用
+2. property.extra.cite 为对象 + property.extra.context 有值
+     → 从 cite.data 和 context 动态构建 ShortcutComponent[] 数组
+```
+
+```vue
+<script setup lang="ts">
+  import { UserMessage } from '@blueking/chat-x';
+
+  const content = '请帮我翻译这段文字';
+  const property = {
+    extra: {
+      shortcut: {
+        id: 'translate',
+        name: '翻译',
+        components: [
+          {
+            type: 'select',
+            key: 'targetLang',
+            name: '目标语言',
+            default: 'en',
+            options: [
+              { label: '英文', value: 'en' },
+              { label: '中文', value: 'zh' },
+            ],
+          },
+          {
+            type: 'textarea',
+            key: 'content',
+            name: '翻译内容',
+            fillBack: true,
+            default: '请帮我翻译这段文字',
+          },
+        ],
+        formModel: { targetLang: 'en', content: '请帮我翻译这段文字' },
+      },
+    },
+  };
+</script>
+```
+
+## 消息编辑
+
+点击「编辑」按钮后进入编辑模式，根据消息类型呈现不同界面：
+
+| 消息类型                                     | 编辑界面                                              | 确认回调            |
+| -------------------------------------------- | ----------------------------------------------------- | ------------------- |
+| 普通文本 / 含文件消息                        | `ChatInput`（自定义 `#send-icon`，含"取消/发送"按钮） | `onInputConfirm`    |
+| 含 `property.extra.shortcut` 或 cite+context | `ShortcutRender`                                      | `onShortcutConfirm` |
+
+**`editContent` 的初始化逻辑**（仅文本部分，二进制文件通过 `defaultUploadFiles` 恢复）：
+
+```
+content 为 string     → editContent = content
+textContent 为 string → editContent = textContent
+textContent 为 array  → editContent = textContent[0]?.text（取第一个文本项）
+binaryFiles 有值      → 进入编辑模式（editContent 可为空）
+```
+
+```vue
+<template>
+  <UserMessage
+    :content="content"
+    :on-action="handleAction"
+    :on-input-confirm="handleInputConfirm"
+    :on-shortcut-confirm="handleShortcutConfirm"
+  />
+</template>
+
+<script setup lang="ts">
+  import { UserMessage, type IToolBtn, type TagSchema } from '@blueking/chat-x';
+
+  const content = '请帮我优化这段代码';
+
+  const handleAction = async (tool: IToolBtn) => {
+    // tool.id === 'edit'  → 组件内部自动切换编辑模式
+    // tool.id === 'copy'  → 自动复制（字符串直接复制，数组 JSON.stringify 后复制）
+    // tool.id === 'cite'  → 由外部 onAction 处理（组件内无内置行为）
+    console.log('工具:', tool.id);
+  };
+
+  const handleInputConfirm = async (content: string | InputContent[], docSchema: TagSchema) => {
+    console.log('编辑后内容:', content);
+    // 重新发送消息
+  };
+
+  const handleShortcutConfirm = async (formModel: Record<string, unknown>) => {
+    console.log('快捷指令表单:', formModel);
+    // 重新发送快捷指令
+  };
+</script>
+```
+
+## 工具按钮
+
+工具栏使用 CSS `visibility` 控制可见性（非 `display`），始终占位，hover 时显示：
+
+**内置工具列表（`CONST_USER_MESSAGE_TOOLS`）**
+
+| 工具 ID | 名称 | 内置行为                                     |
+| ------- | ---- | -------------------------------------------- |
+| `copy`  | 复制 | 字符串直接复制；数组 `JSON.stringify` 后复制 |
+| `cite`  | 引用 | 无内置行为，需通过 `onAction` 外部处理       |
+| `edit`  | 编辑 | 切换 `isEdit=true`，进入编辑模式             |
+
+```vue
+<!-- 隐藏工具按钮（从 DOM 移除，不占位） -->
+<UserMessage :content="content" message-tools-status="hidden" />
+
+<!-- 禁用工具按钮（保留占位，不可点击，无 hover 效果） -->
+<UserMessage :content="content" message-tools-status="disabled" />
+```
+
+## API
+
+### Props
+
+| 属性名             | 类型                                                                         | 说明                                                      |
+| ------------------ | ---------------------------------------------------------------------------- | --------------------------------------------------------- |
+| content            | `string \| InputContent[]`                                                   | 消息内容，字符串或含 text/binary 的数组                   |
+| property           | `{ extra?: MessageExtra }`                                                   | 消息附加属性，包含引用、快捷指令、context 等信息          |
+| messageToolsStatus | `MessageToolsStatus`                                                         | 工具按钮状态，`disabled` 禁用、`hidden` 从 DOM 移除       |
+| onAction           | `(tool: IToolBtn) => Promise<void>`                                          | 工具按钮回调；`copy`/`edit` 有内置行为，`cite` 需外部处理 |
+| onInputConfirm     | `(content: string \| InputContent[], docSchema: TagSchema) => Promise<void>` | 普通消息编辑确认回调                                      |
+| onShortcutConfirm  | `(formModel: Record<string, unknown>) => Promise<void>`                      | 快捷指令消息编辑确认回调                                  |
+| tippyOptions       | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>`   | 自定义工具栏 Tippy 配置，透传给内部 `MessageTools` 组件   |
+
+### 全局配置依赖
+
+编辑模式下的 `ChatInput` 会通过 `injectGlobalConfig()` 获取全局配置中的 `supportUpload` 值。需要确保祖先组件（通常是 `ChatContainer`）已调用 `useGlobalConfig()` 注册配置。
+
+## 类型定义
+
+```typescript
+// 文本内容项
+interface TextInputContent {
+  type: 'text'; // MessageContentType.Text
+  text: string;
+}
+
+// 二进制内容项（图片、文件）
+interface BinaryContent {
+  type: 'binary'; // MessageContentType.Binary
+  url?: string;
+  mimeType?: string;
+  filename?: string;
+}
+
+type InputContent = TextInputContent | BinaryContent;
+
+// 消息附加属性
+interface MessageExtra {
+  // 文本引用（字符串）：渲染在气泡外 CiteContent
+  cite?: string;
+
+  // 结构化引用（对象）：渲染在气泡内 KeyValueContent；与 context 配合可重建 ShortcutRender
+  cite?: {
+    title?: string;
+    data: Array<{ key: string; value: string }>;
+  };
+
+  // 快捷指令：编辑时渲染 ShortcutRender（优先于 cite+context 路径）
+  shortcut?: Shortcut;
+
+  // 上下文变量：与结构化 cite 配合，在编辑模式下动态构建 ShortcutComponent[]
+  context?: Array<{
+    __key: string;
+    __label: string;
+    __value: string;
+    fillBack?: boolean;
+  }>;
+}
+```
+
+## 关联组件
+
+- [MessageRender](/components/message/message-render) — user 角色由其实例化
+- [MessageTools](/components/feedback/message-tools) — 工具栏交互
+- [MessageContainer](/components/setup/message-container) — 列表与多选容器

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-answered-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-answered-card.md
@@ -1,0 +1,104 @@
+# UserQuestionAnsweredCard 用户问题回答回显
+
+> 能力域：Agent 能力 ｜ 导入：`import { UserQuestionAnsweredCard } from '@blueking/chat-x'` ｜ since 1.0.0
+
+在 UserQuestion resume 成功后回显用户回答或取消状态。 源码位置：src/components/chat-message/interrupt-message/user-question/user-question-answered-card.vue。
+
+**关联**：interrupt-message（outcome.success 且 reason 为 UserQuestion 时挂载本组件）、user-question-card（待回答面板，与本组件成对出现）
+
+---
+
+# UserQuestionAnsweredCard 用户问题回答回显
+
+> **能力域**：Agent 能力
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-answered-card.vue`
+- **能力说明**：在 UserQuestion resume 成功后回显用户回答或取消状态。
+
+由 [InterruptMessageRender](/components/agent/interrupt-message) 在 `content.outcome.type === 'success'` 且 `result.reason === InterruptReason.UserQuestion` 时渲染。默认逐条展示选择题答案；业务可通过 `#answer` slot 自定义回显形态（如自定义表单字段）。
+
+## 基础用法
+
+```vue
+<template>
+  <UserQuestionAnsweredCard
+    :answers="answers"
+    status="resolved"
+  />
+</template>
+
+<script setup lang="ts">
+  import { UserQuestionAnsweredCard, type UserQuestionAnswerItem } from '@blueking/chat-x';
+
+  const answers: UserQuestionAnswerItem[] = [
+    {
+      question: '你希望采用哪种实现？',
+      multiSelect: false,
+      answer: [{ label: 'optimized', description: '优化版' }],
+    },
+  ];
+</script>
+```
+
+**渲染效果**
+
+## 已取消（跳过）
+
+```vue
+<UserQuestionAnsweredCard
+  :answers="[]"
+  status="cancelled"
+/>
+```
+
+**渲染效果**
+
+## 自定义回显（#answer slot）
+
+当待回答阶段使用了自定义 `#question` 表单时，可通过 `#answer` slot 自定义回显：
+
+```vue
+<UserQuestionAnsweredCard
+  :answers="answers"
+  status="resolved"
+>
+  <template #answer="{ item, index, status }">
+    <MyCustomAnswerView :data="item" :index="index" :status="status" />
+  </template>
+</UserQuestionAnsweredCard>
+```
+
+`InterruptMessageRender`、`MessageRender`、`MessageContainer` 提供 `#answeredQuestion` slot，参数与 `#answer` 一致，逐层透传至本组件。使用 `ChatContainer` 时若覆盖了 `#message` 插槽，需在自定义 `MessageRender` 中继续透传 `#answeredQuestion`。
+
+## API
+
+### Props
+
+| 属性名  | 类型                         | 默认值       | 说明                                   |
+| ------- | ---------------------------- | ------------ | -------------------------------------- |
+| answers | `UserQuestionAnswerItem[]`   | —            | **必填**，已回答内容列表               |
+| status  | `'resolved' \| 'cancelled'` | `'resolved'` | resume 状态：`resolved` 已回复，`cancelled` 已取消（跳过） |
+
+### Slots
+
+| 插槽名 | 参数                                              | 说明                                                         |
+| ------ | ------------------------------------------------- | ------------------------------------------------------------ |
+| answer | `{ item, index, status }`                         | 自定义单题回答回显；未覆盖时默认渲染 `answer[].description \|\| label` |
+
+| 参数   | 类型                              | 说明                     |
+| ------ | --------------------------------- | ------------------------ |
+| item   | `UserQuestionAnswerItem`          | 当前题的回答数据         |
+| index  | `number`                          | 题目序号（从 0 开始）    |
+| status | `'resolved' \| 'cancelled'`      | 与 Props.status 一致     |
+
+### Events / Expose
+
+无。
+
+## 关联文档
+
+- [InterruptMessage 中断消息](/components/agent/interrupt-message)
+- [UserQuestionCard 用户问题中断](/components/agent/user-question-card)
+- [中断类型 Interrupt](../../types/interrupt.md)

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-card.md
@@ -1,0 +1,225 @@
+# UserQuestionCard 用户问题中断
+
+> 能力域：Agent 能力 ｜ 导入：`import { UserQuestionCard } from '@blueking/chat-x'` ｜ since 1.0.0
+
+渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。 源码位置：src/components/chat-message/interrupt-message/user-question/user-question-card.vue。
+
+**关联**：interrupt-message（outcome.success 时挂载 UserQuestionAnsweredCard 回显回答）、chat-container（检测最近待回答 UserQuestion 并把 UserQuestionCard 放在输入区上方）、interrupt（定义 UserQuestionInterrupt 与 UserQuestionResume 协议）
+
+---
+
+# UserQuestionCard 用户问题中断
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-card.vue`
+- **能力域**：Agent 能力
+- **能力说明**：渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。
+
+> **能力域**：Agent 能力
+
+`UserQuestionCard` 用于渲染 `InterruptReason.UserQuestion`（`'aidev:user_question'`）中断。它通常由 `ChatContainer` 自动挂载到 `ChatInput` 上方，用户回答后通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
+
+## 交互能力
+
+- **单选 / 多选**：每道题通过 `multiSelect` 控制选择行为；未传时不展示单选/多选标签，默认仍按单选处理。
+- **Others 自由输入**：默认 [UserQuestionChoice](/components/agent/user-question-choice) 为每道题追加 `label: 'others'` 输入项，输入文本写入 `answer[].description`。
+- **自定义作答形态**：通过 `#question` slot 可替换默认选择题，渲染任意表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
+- **完成校验**：所有题目均已作答（`setAnswer` 收到有效答案）后才允许点击「完成」。
+- **跳过**：点击「跳过」返回 `status: 'cancelled'` 与空 `answers`。
+- **输入框发送**：存在待回答 UserQuestion 时，用户也可在 `ChatInput` 直接发送；`ChatContainer` 会调用 `onSendMessage` 并在第三参数附带与「跳过」等价的 skip `payload` 及 `interrupt`，输入框内容不会自动清空。
+
+## 数据协议
+
+待回答中断：
+
+```typescript
+const interrupt = {
+  id: 'interrupt_user_question',
+  reason: InterruptReason.UserQuestion,
+  toolCallId: 'tool_call_user_question',
+  message: '请选择实现方案',
+  metadata: {
+    questions: [
+      {
+        header: '请选择实现方案',
+        multiSelect: false,
+        question: '你希望采用哪种冒泡排序实现？',
+        options: [
+          { label: 'basic', description: '基础冒泡排序' },
+          { label: 'optimized', description: '优化版冒泡排序' },
+        ],
+      },
+    ],
+  },
+};
+```
+
+完成回答后生成的 resume：
+
+```typescript
+const payload = {
+  interruptId: 'interrupt_user_question',
+  reason: InterruptReason.UserQuestion,
+  status: 'resolved',
+  payload: {
+    answers: [
+      {
+        question: '你希望采用哪种冒泡排序实现？',
+        multiSelect: false,
+        answer: [{ label: 'optimized', description: '优化版冒泡排序' }],
+      },
+    ],
+  },
+};
+```
+
+## 基础用法
+
+> 业务侧通常不直接使用本组件；推荐构造 `InterruptMessage` 后交给 `ChatContainer` / `MessageContainer` 渲染。下面示例用于说明组件 API 和 payload 形状。
+
+```vue
+<template>
+  <UserQuestionCard
+    :interrupt="pendingInterrupt"
+    :on-resume="handleResume"
+  />
+</template>
+
+<script setup lang="ts">
+  import { InterruptReason, UserQuestionCard, type OnInterruptResume } from '@blueking/chat-x';
+
+  const pendingInterrupt = {
+    id: 'interrupt_user_question',
+    reason: InterruptReason.UserQuestion,
+    toolCallId: 'tool_call_user_question',
+    metadata: {
+      questions: [
+        {
+          header: '请选择实现方案',
+          multiSelect: false,
+          question: '你希望采用哪种实现？',
+          options: [{ label: 'basic', description: '基础冒泡排序' }],
+        },
+      ],
+    },
+  };
+
+  const handleResume: OnInterruptResume = async (payload, interrupt) => {
+    console.log(interrupt.id, payload);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 已回答回显
+
+`InterruptMessageRender` 在 `content.outcome.type === 'success'` 且 `content.result.reason === InterruptReason.UserQuestion` 时，会在会话内渲染 `UserQuestionAnsweredCard`。
+
+```vue
+<UserQuestionAnsweredCard
+  :answers="answers"
+  status="resolved"
+/>
+```
+
+**渲染效果**
+
+## ChatContainer 自动挂载
+
+`ChatContainer` 内部通过 `useMessageGroup` 查找最近一条 `outcome.type === 'interrupt'` 的 `UserQuestion`，并在 `ChatInput` 的 `#interrupt` 插槽中渲染 `UserQuestionCard`：
+
+```vue
+<ChatContainer
+  v-model="inputValue"
+  :messages="messages"
+  :on-interrupt-resume="handleResume"
+  :on-send-message="handleSendMessage"
+/>
+```
+
+- 卡片内「完成 / 跳过」→ `onInterruptResume(payload, interrupt)`
+- 输入框直接发送 → `onSendMessage(content, docSchema, { interrupt, payload })`，其中 `payload` 由 `buildSkipResumePayload(interrupt)` 生成（`status: 'cancelled'`）
+
+## 工具函数 buildSkipResumePayload
+
+从 `@blueking/chat-x` 导出，用于构造 UserQuestion 的 skip resume（与卡片「跳过」及输入框发送时容器注入的 `options.payload` 一致）：
+
+```typescript
+import { buildSkipResumePayload, InterruptReason } from '@blueking/chat-x';
+
+const payload = buildSkipResumePayload(interrupt);
+// {
+//   interruptId: interrupt.id,
+//   reason: InterruptReason.UserQuestion,
+//   status: 'cancelled',
+//   payload: { answers: [] },
+// }
+```
+
+## 自定义题目渲染（#question slot）
+
+默认每道题由 [UserQuestionChoice](/components/agent/user-question-choice) 渲染；业务可覆盖 `#question` slot 接入自定义表单：
+
+```vue
+<template>
+  <UserQuestionCard
+    :interrupt="pendingInterrupt"
+    :on-resume="handleResume"
+  >
+    <template #question="{ question, qIndex, answer, setAnswer, confirm }">
+      <!-- 自定义表单：作答有效时 setAnswer(answerItem)，无效时 setAnswer(undefined) -->
+      <MyCustomForm
+        :model="question"
+        @change="setAnswer"
+        @submit="confirm"
+      />
+    </template>
+  </UserQuestionCard>
+</template>
+```
+
+`ChatContainer` 提供同名 `#interruptQuestion` slot，参数与 `#question` 一致，透传自输入区上方的 `UserQuestionCard`。
+
+## API
+
+### UserQuestionCard Props
+
+| 属性名    | 类型                    | 默认值 | 说明                                   |
+| --------- | ----------------------- | ------ | -------------------------------------- |
+| interrupt | `UserQuestionInterrupt` | —      | **必填**，含 `metadata.questions`      |
+| onResume  | `OnInterruptResume`     | —      | 完成 / 跳过时触发，签名为 `(payload, interrupt)` |
+
+### UserQuestionAnsweredCard Props
+
+| 属性名  | 类型                         | 默认值       | 说明                         |
+| ------- | ---------------------------- | ------------ | ---------------------------- |
+| answers | `UserQuestionAnswerItem[]`   | —            | 已回答内容列表               |
+| status  | `'resolved' \| 'cancelled'` | `'resolved'` | 回显状态，决定展示已回复/已取消 |
+
+### UserQuestionCard Slots
+
+| 插槽名   | 参数                                                                                                              | 说明                                                                 |
+| -------- | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| question | `{ question, qIndex, answer, setAnswer, confirm }`                                                                | 自定义单题渲染；未覆盖时回退 [UserQuestionChoice](/components/agent/user-question-choice) |
+
+slot 参数说明：
+
+| 参数       | 类型                                              | 说明                                           |
+| ---------- | ------------------------------------------------- | ---------------------------------------------- |
+| question   | `UserQuestionItem`                                | 原始题目数据                                   |
+| qIndex     | `number`                                          | 题目序号（从 0 开始）                          |
+| answer     | `UserQuestionAnswerItem \| undefined`             | 当前题已组装答案，`undefined` 表示未作答       |
+| setAnswer  | `(answer: UserQuestionAnswerItem \| undefined) => void` | 写入/清空当前题答案                            |
+| confirm    | `() => void`                                      | 触发「完成」，等价点击底部完成按钮（需全部已答） |
+
+### Events / Expose
+
+无。
+
+## 关联文档
+
+- [中断类型 Interrupt](../../types/interrupt.md)
+- [UserQuestionChoice 选择题](/components/agent/user-question-choice)
+- [InterruptMessage 中断消息](/components/agent/interrupt-message)
+- [ChatContainer 聊天容器](/components/setup/chat-container)

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-choice.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-choice.md
@@ -1,0 +1,105 @@
+# UserQuestionChoice 用户问题选择题
+
+> 能力域：Agent 能力 ｜ 导入：`import { UserQuestionChoice } from '@blueking/chat-x'` ｜ since 1.0.0
+
+UserQuestionCard 默认的选择题渲染组件，封装单选/多选、Others 输入与答案组装。 源码位置：src/components/chat-message/interrupt-message/user-question/user-question-choice.vue。
+
+**关联**：user-question-card（默认通过）、user-question-option（内部逐条渲染选项行）、interrupt（答案结构遵循 UserQuestionAnswerItem）
+
+---
+
+# UserQuestionChoice 用户问题选择题
+
+> **能力域**：Agent 能力
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-choice.vue`
+- **能力说明**：封装 UserQuestion 的选择题交互，负责选项归一化、单选/多选切换、Others 输入校验与 `UserQuestionAnswerItem` 组装。
+
+`UserQuestionChoice` 是 [UserQuestionCard](/components/agent/user-question-card) 在 `#question` slot 未覆盖时的**默认渲染**。业务侧也可单独使用，配合 `useUserQuestion` 的 `setAnswer` 接入自定义面板。
+
+## 交互能力
+
+- **单选 / 多选**：由 `question.multiSelect` 控制；未传时不展示单选/多选标签，但仍按单选行为处理。
+- **Others 自由输入**：前端自动在选项末尾追加 `label: 'others'` 输入项。
+- **实时同步答案**：选择或输入变化时 emit `answer`；作答有效时回传已组装的 `UserQuestionAnswerItem`，无效时回传 `undefined`。
+- **Enter 确认**：Others 输入框按 Enter 触发 `confirm`，等价于点击「完成」按钮（需上层已全部作答）。
+
+## 基础用法（单选）
+
+```vue
+<template>
+  <UserQuestionChoice
+    :question="singleQuestion"
+    @answer="handleAnswer"
+    @confirm="handleConfirm"
+  />
+</template>
+
+<script setup lang="ts">
+  import { UserQuestionChoice, type UserQuestionAnswerItem } from '@blueking/chat-x';
+
+  const singleQuestion = {
+    header: '请选择实现方案',
+    multiSelect: false,
+    question: '你希望采用哪种冒泡排序实现？',
+    options: [
+      { label: 'basic', description: '基础冒泡排序' },
+      { label: 'optimized', description: '优化版冒泡排序' },
+    ],
+  };
+
+  const handleAnswer = (answer: UserQuestionAnswerItem | undefined) => {
+    console.log(answer);
+  };
+</script>
+```
+
+**渲染效果**
+
+## 多选
+
+```vue
+<UserQuestionChoice
+  :question="multiQuestion"
+  @answer="handleAnswer"
+/>
+```
+
+**渲染效果**
+
+## 在 UserQuestionCard 中使用
+
+通常无需直接使用本组件；`UserQuestionCard` 默认已在 `#question` slot 回退中挂载：
+
+```vue
+<UserQuestionCard :interrupt="interrupt" :on-resume="handleResume" />
+```
+
+如需替换某一题的渲染，覆盖 `#question` slot 即可；未覆盖时仍回退到 `UserQuestionChoice`。
+
+## API
+
+### Props
+
+| 属性名   | 类型               | 默认值 | 说明                         |
+| -------- | ------------------ | ------ | ---------------------------- |
+| question | `UserQuestionItem` | —      | **必填**，含 `options` 等字段 |
+
+### Events
+
+| 事件名  | 参数                                      | 说明                                                         |
+| ------- | ----------------------------------------- | ------------------------------------------------------------ |
+| answer  | `(answer: UserQuestionAnswerItem \| undefined)` | 作答变化；有效时回传已组装答案，无效（未选/ Others 空）时 `undefined` |
+| confirm | —                                         | 用户在 Others 输入框按 Enter 时触发，上层可绑定「完成」逻辑   |
+
+### Slots / Expose
+
+无。
+
+## 关联文档
+
+- [UserQuestionCard 用户问题中断](/components/agent/user-question-card)
+- [UserQuestionOption 用户问题选项](/components/agent/user-question-option)
+- [中断类型 Interrupt](../../types/interrupt.md)

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-option.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-option.md
@@ -1,0 +1,42 @@
+# UserQuestionOption 用户问题选项
+
+> 能力域：Agent 能力 ｜ 导入：`import { UserQuestionOption } from '@blueking/chat-x'` ｜ since 1.0.0
+
+UserQuestionChoice 内部选项行，处理单选/多选状态和 Others 输入。 源码位置：src/components/chat-message/interrupt-message/user-question/user-question-option.vue。
+
+---
+
+# UserQuestionOption 用户问题选项
+
+> **能力域**：Agent 能力
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-option.vue`
+- **能力说明**：UserQuestionChoice 内部选项行，处理单选/多选状态和 Others 输入。
+
+## API 摘要
+
+### Props
+
+- `{ option: NormalizedUserQuestionOption; othersText?: string; selected: boolean; }`
+
+### Emits
+
+- `{ (e: 'confirm'): void; (e: 'select'): void; (e: 'update:othersText', value: string): void; }`
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 组件依赖
+
+- 无组件依赖或仅依赖基础库。
+
+## 使用建议
+
+- 优先通过 [UserQuestionChoice](/components/agent/user-question-choice) 或 [UserQuestionCard](/components/agent/user-question-card) 使用；直接使用前请确认 props 数据结构来自对应类型定义。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/vnode-renderer.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/vnode-renderer.md
@@ -1,0 +1,122 @@
+# VNodeRenderer VNode 渲染器
+
+> 能力域：辅助能力 ｜ 导入：`import { VNodeRenderer } from '@blueking/chat-x'` ｜ since 1.0.0
+
+将 Markdown token 转成 VNode 的内部渲染桥。 源码位置：src/components/chat-content/vnode-renderer.ts。
+
+**关联**：markdown-content（MarkdownContent 对普通 token 分组使用本组件渲染）、code-content（fence/code_block 代码块通常会被 MarkdownContent 提前分流到 CodeContent）、mermaid-content（mermaid 代码块通常会被 MarkdownContent 提前分流到 MermaidContent）、image-content（图片 token 由 tokensToVNodes 转为 ImageContent）
+
+---
+
+# VNodeRenderer VNode 渲染器
+
+> **能力域**：辅助能力
+
+`VNodeRenderer` 是 Markdown 渲染链路里的内部桥接组件。它接收 markdown-it 解析出的 `Token[]`，调用 `tokensToVNodes` 转成 Vue VNode，并返回渲染函数结果。
+
+通常不需要业务侧直接使用。完整 Markdown 内容请优先使用 [MarkdownContent](../rendering/markdown-content.md)，它会先识别 Mermaid、LaTeX、代码块等特殊 token，再把普通 token 分组交给 `VNodeRenderer`。
+
+## 源码事实
+
+- **源码位置**：`src/components/chat-content/vnode-renderer.ts`
+- **能力说明**：将 Markdown token 转成 VNode 的内部渲染桥。
+
+## 核心能力
+
+- **Token 到 VNode**：将 markdown-it 的 block、inline、text、link、image、html 等 token 转为 Vue VNode
+- **稳定 key**：`tokensToVNodes` 基于 token 类型、标签和内容 hash 生成 key，降低流式渲染时 DOM 误复用风险
+- **HTML 安全入口**：`options.html` 开启时可渲染 HTML token，实际安全过滤依赖 `options.sanitize`
+- **渲染规则复用**：支持传入 markdown-it `renderer` 与 `mditOptions`，复用自定义 renderer rule
+- **特殊 token 兜底**：图片 token 转成 `ImageContent`，链接自动补充 `target="_blank"` 与 `rel="noopener noreferrer"`
+
+## 基础用法
+
+```vue
+<template>
+  <VNodeRenderer :tokens="tokens" />
+</template>
+
+<script setup lang="ts">
+  import MarkdownIt from '@blueking/chat-x/src/markdown-it/index';
+  import VNodeRenderer from '@blueking/chat-x/src/components/chat-content/vnode-renderer';
+
+  const md = new MarkdownIt();
+  const tokens = md.parse('这是一段 **加粗文本**。', {});
+</script>
+```
+
+**渲染效果**
+
+## 空 Tokens
+
+`tokens` 为空数组时，`tokensToVNodes` 返回空数组，不渲染任何内容。
+
+## 与 MarkdownContent 的关系
+
+`MarkdownContent` 会先按 token 类型分流，再将普通 token 交给 `VNodeRenderer`：
+
+```vue
+<template v-else>
+  <VNodeRenderer
+    :options="vnodeOptions"
+    :tokens="groupedToken"
+  />
+</template>
+```
+
+其中 `vnodeOptions` 会携带 HTML 净化函数、markdown-it renderer 和 parser options：
+
+```typescript
+const vnodeOptions = {
+  html: true,
+  mditOptions: md.options,
+  renderer: md.renderer,
+  sanitize: (html: string) => dompurify.sanitize(html, domPurifyConfig),
+};
+```
+
+## API
+
+### Props
+
+| 属性名  | 类型                  | 必填 | 默认值 | 说明                         |
+| ------- | --------------------- | ---- | ------ | ---------------------------- |
+| tokens  | `Token[]`             | 是   | —      | markdown-it token 数组       |
+| options | `TokenToVNodeOptions` | 否   | `{}`   | token 转 VNode 的渲染选项    |
+
+### Emits
+
+- 无。
+
+### Slots
+
+- 无。
+
+### Expose
+
+- 无。
+
+## 类型定义
+
+```typescript
+export interface TokenToVNodeOptions {
+  highlight?: ((str: string, lang: string, attrs?: unknown) => string) | null;
+  html?: boolean;
+  mditOptions?: Options;
+  renderer?: Renderer;
+  sanitize?: (html: string) => string;
+}
+```
+
+## 使用建议
+
+- 业务侧不要绕过 `MarkdownContent` 直接渲染完整 Markdown 字符串；`VNodeRenderer` 只接收已经解析好的 token。
+- 如果启用 `options.html`，必须同步传入 `sanitize`，否则 HTML token 会直接进入 `innerHTML`。
+- 特殊内容如代码块、Mermaid、LaTeX 推荐继续走 `MarkdownContent` 的分流逻辑。
+
+## 关联组件
+
+- [MarkdownContent](../rendering/markdown-content.md) — Markdown 主渲染器。
+- [CodeContent](../rendering/code-content.md) — 代码块渲染。
+- [MermaidContent](../rendering/mermaid-content.md) — Mermaid 图表渲染。
+- [ImageContent](../medias/image-content.md) — 图片 token 渲染。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-animation-text.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-animation-text.md
@@ -1,0 +1,196 @@
+# useAnimationText
+
+> 导入：`import { useAnimationText } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useAnimationText 接收 MaybeRef<string> 与可选 AnimationConfig（fadeDuration、easing），返回 chunks 与 animationStyle。 监听文本变化：前缀追加则增量拆分为新 chunk 并触发动画，否则重置为单 chunk，适合流式输出逐段淡入。 全局样式已含 ai-markdown-fade-in。AnimationText 组件内部封装同一逻辑。
+
+**关联**：animation-text（封装 chunks 与样式渲染）、markdown-content（流式 Markdown 文本展示场景可组合使用）
+
+---
+
+# useAnimationText
+
+> **分类**：composable
+
+文本淡入动画的组合式函数。将响应式文本按**增量**拆分为独立 chunk，每个新增 chunk 对应一次淡入动画，适用于 AI 流式输出的逐段渐显效果。
+
+## 工作原理
+
+每当 `text` 发生变化时，composable 通过比较新旧文本决定如何更新 chunks：
+
+| 变化情况                            | 处理方式                  |
+| ----------------------------------- | ------------------------- |
+| 新文本以旧文本为前缀（追加）        | 将增量部分追加为新 chunk  |
+| 新文本与旧文本完全不同（替换/重置） | chunks 重置为 `[newText]` |
+| 文本未变化                          | 无操作                    |
+
+每个 chunk 对应一个独立的 DOM 节点，节点加入 DOM 时自动触发 `ai-markdown-fade-in` 淡入动画。
+
+> `@keyframes ai-markdown-fade-in` 已内置于 `@blueking/chat-x` 全局样式，**无需手动定义**。
+
+## 基础用法
+
+将 `Ref<string>` 传入 composable，配合 `v-for` + `:style` 渲染各 chunk。
+
+```vue
+<template>
+  <div>
+    <span
+      v-for="(chunk, index) in chunks"
+      :key="index"
+      :style="animationStyle"
+      >{{ chunk }}</span
+    >
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { useAnimationText } from '@blueking/chat-x';
+
+  const text = ref('');
+  const { chunks, animationStyle } = useAnimationText(text);
+
+  // 模拟流式追加
+  async function startStreaming() {
+    const fullText = '这是一段模拟 AI 流式输出的文本内容...';
+    for (const char of fullText) {
+      text.value += char;
+      await new Promise(resolve => setTimeout(resolve, 50));
+    }
+  }
+
+  startStreaming();
+</script>
+```
+
+**渲染效果**
+
+## 自定义动画配置
+
+通过 `options` 调整淡入动画的持续时间和缓动函数。
+
+```vue
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { useAnimationText } from '@blueking/chat-x';
+
+  const text = ref('');
+  const { chunks, animationStyle } = useAnimationText(text, {
+    fadeDuration: 600, // 淡入持续时间，默认 200ms
+    easing: 'ease-out', // CSS 缓动函数，默认 'ease-in-out'
+  });
+</script>
+```
+
+**渲染效果**（fadeDuration=600ms）
+
+## 文本重置行为
+
+当 `text` 被完全替换（新值不以旧值为前缀）时，chunks 会重置为单一片段，之前积累的 chunks 清空。这适用于多轮对话中切换消息的场景。
+
+```vue
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { useAnimationText } from '@blueking/chat-x';
+
+  const text = ref('');
+  const { chunks, animationStyle } = useAnimationText(text);
+
+  async function nextMessage(newContent: string) {
+    // 直接替换整个 text，chunks 自动重置
+    text.value = '';
+    for (const char of newContent) {
+      text.value += char;
+      await new Promise(r => setTimeout(r, 50));
+    }
+  }
+</script>
+```
+
+**渲染效果**（两条消息依次播放，第二条时 chunks 重置）
+
+## 使用 AnimationText 组件
+
+如无需定制渲染逻辑，可直接使用封装好的 `AnimationText` 组件，内部已集成 `useAnimationText`：
+
+```vue
+<template>
+  <AnimationText :text="text" />
+</template>
+
+<script setup lang="ts">
+  import { AnimationText } from '@blueking/chat-x';
+</script>
+```
+
+> 详见 [AnimationText 组件文档](/components/rendering/animation-text)。
+
+## API
+
+### 函数签名
+
+```typescript
+function useAnimationText(
+  text: MaybeRef<string>,
+  options?: AnimationConfig,
+): {
+  chunks: Ref<string[]>;
+  animationStyle: ComputedRef<CSSProperties>;
+};
+```
+
+### 参数
+
+| 参数      | 类型               | 必填 | 说明                                      |
+| --------- | ------------------ | ---- | ----------------------------------------- |
+| `text`    | `MaybeRef<string>` | 是   | 响应式文本，传入 `Ref<string>` 可追踪变化 |
+| `options` | `AnimationConfig`  | 否   | 动画配置                                  |
+
+### AnimationConfig
+
+| 属性           | 类型     | 默认值          | 说明                   |
+| -------------- | -------- | --------------- | ---------------------- |
+| `fadeDuration` | `number` | `200`           | 淡入动画持续时间（ms） |
+| `easing`       | `string` | `'ease-in-out'` | CSS 缓动函数           |
+
+### 返回值
+
+| 属性             | 类型                         | 说明                                       |
+| ---------------- | ---------------------------- | ------------------------------------------ |
+| `chunks`         | `Ref<string[]>`              | 拆分后的文本片段数组，每个片段对应一次动画 |
+| `animationStyle` | `ComputedRef<CSSProperties>` | 所有 chunk 共用的动画样式对象              |
+
+## 类型定义
+
+```typescript
+import type { MaybeRef, Ref, ComputedRef, CSSProperties } from 'vue';
+
+interface AnimationConfig {
+  fadeDuration?: number;
+  easing?: string;
+}
+
+function useAnimationText(
+  text: MaybeRef<string>,
+  options?: AnimationConfig,
+): {
+  chunks: Ref<string[]>;
+  animationStyle: ComputedRef<CSSProperties>;
+};
+```
+
+## 注意事项
+
+1. **在组件 `setup` 中通过 `watch(text, ...)` 直接监听 Ref**：composable 内部使用 `watch(() => text, ...)` 的 getter 形式，当 `text` 是 `Ref` 时，getter 每次返回同一个 Ref 对象，Vue 判断为"值未变化"，**watch 不会触发**。在自定义 setup 中如需直接响应文本变化，请用 `watch(text, handler)` 而非 `watch(() => text, handler)`。
+
+2. **`animationStyle` 为所有 chunk 共享的同一个对象**：动画效果来自每个 chunk 对应的 DOM 节点被创建时触发，而非样式本身的差异。
+
+3. **内置 CSS 关键帧**：引入 `@blueking/chat-x` 的全局样式后，`@keyframes ai-markdown-fade-in` 自动可用，无需手动定义。
+
+4. **性能**：长时间流式输出会积累大量 chunk 节点，动画完成后（`forwards`）这些节点保持 `opacity: 1`，对性能影响可接受；如有需要可在流式结束后将 `text` 合并为单次赋值以归并 chunk
+
+## 关联组件
+
+- [AnimationText](../components/rendering/animation-text) — 默认封装组件
+- [MarkdownContent](../components/rendering/markdown-content) — 富文本流式展示场景。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-clipboard.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-clipboard.md
@@ -1,0 +1,203 @@
+# useClipboard
+
+> 导入：`import { useClipboard } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useClipboard 返回 { copy }，copy(text) 将字符串写入剪贴板，返回 Promise<void>。 优先使用 navigator.clipboard.writeText，失败或不支持时降级为隐藏 textarea + execCommand('copy')。 成功/失败均通过 bkui-vue Message 提示，调用方无需处理结果。CodeContent、MessageContainer、UserMessage 的复制能力内部使用。
+
+**关联**：code-content（复制代码块时取 innerText 后调用 copy）、message-container（AI 消息复制工具回调）、user-message（用户消息复制工具回调）
+
+---
+
+# useClipboard 剪贴板
+
+> **分类**：composable
+
+复制文本到剪贴板的组合式函数。内置两级降级策略，并自动通过 bkui-vue `Message` 提示复制结果，调用方无需关心成功/失败处理。
+
+## 执行流程
+
+```
+copy(text)
+  │
+  ├── isClipboardApiSupported（模块加载时判断一次）
+  │     = typeof navigator !== 'undefined' && 'clipboard' in navigator
+  │
+  ├── true → navigator.clipboard.writeText(text)
+  │           ├── 成功 → success = true
+  │           └── 失败（权限拒绝等）→ legacyCopy(text)
+  │
+  └── false → legacyCopy(text)
+              （创建隐藏 textarea，document.execCommand('copy')，finally 清理 DOM）
+  │
+  └── Message({ message: t('复制成功/失败'), theme: 'success/error' })
+```
+
+> **注意**：`copy` 返回 `Promise<void>`，调用方无法获取成功/失败结果；通知由内部自动弹出，不可关闭或自定义。
+
+## 基础用法
+
+```vue
+<template>
+  <button @click="handleCopy">复制文本</button>
+</template>
+
+<script setup lang="ts">
+  import { useClipboard } from '@blueking/chat-x';
+
+  const { copy } = useClipboard();
+
+  const handleCopy = () => {
+    copy('Hello, World!');
+    // 自动弹出"复制成功/失败"提示，无需额外处理
+  };
+</script>
+```
+
+## 复制代码块内容
+
+`CodeContent` 组件内部的实际用法，取 DOM 元素的 `innerText` 避免 HTML 实体：
+
+```vue
+<template>
+  <div class="code-block">
+    <pre ref="codeRef"><code>{{ code }}</code></pre>
+    <button @click="handleCopyCode">复制代码</button>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { useTemplateRef } from 'vue';
+  import { useClipboard } from '@blueking/chat-x';
+
+  const codeRef = useTemplateRef<HTMLElement>('codeRef');
+  const { copy } = useClipboard();
+
+  // 使用 innerText 获取渲染后的纯文本，而非原始 token.content
+  const handleCopyCode = () => {
+    copy(codeRef.value?.innerText ?? '');
+  };
+</script>
+```
+
+## 复制消息内容
+
+`MessageContainer` 和 `UserMessage` 内部的实际用法：
+
+```vue
+<script setup lang="ts">
+  import { useClipboard } from '@blueking/chat-x';
+
+  const { copy } = useClipboard();
+
+  // 在 onAction 工具回调中调用
+  const onAction = tool => {
+    if (tool.id === 'copy') {
+      copy(props.content ?? '');
+    }
+  };
+</script>
+```
+
+## API
+
+### 返回值
+
+| 属性名 | 类型                              | 说明                                                 |
+| ------ | --------------------------------- | ---------------------------------------------------- |
+| copy   | `(text: string) => Promise<void>` | 复制文本；内部自动弹出结果提示，调用方无需处理返回值 |
+
+### copy(text)
+
+```typescript
+const copy: (text: string) => Promise<void>;
+```
+
+**参数：**
+
+- `text: string`：要复制的文本内容
+
+**内部行为：**
+
+| 步骤         | 说明                                                                                                           |
+| ------------ | -------------------------------------------------------------------------------------------------------------- |
+| 1. 能力检测  | 模块导入时执行一次：`typeof navigator !== 'undefined' && 'clipboard' in navigator`                             |
+| 2a. 现代路径 | `navigator.clipboard.writeText(text)`，捕获异常后降级到步骤 2b                                                 |
+| 2b. 降级路径 | 创建隐藏 `textarea`（`position: fixed; left: -9999px; opacity: 0`），`execCommand('copy')`，`finally` 清理 DOM |
+| 3. 通知      | 始终调用 `Message({ message: t('复制成功/失败'), theme: 'success/error' })`                                    |
+
+## 实现源码
+
+```typescript
+import { Message } from 'bkui-vue';
+import { t } from '../lang/lang';
+
+// 模块加载时检测一次，SSR 安全
+const isClipboardApiSupported = typeof navigator !== 'undefined' && 'clipboard' in navigator;
+
+const legacyCopy = (text: string): boolean => {
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.style.cssText = 'position:fixed;left:-9999px;top:-9999px;opacity:0';
+  document.body.appendChild(textarea);
+  textarea.focus();
+  textarea.select();
+  try {
+    return document.execCommand('copy');
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea); // 无论成败都清理 DOM
+  }
+};
+
+export const useClipboard = () => {
+  const copy = async (text: string) => {
+    let success = false;
+    if (isClipboardApiSupported) {
+      try {
+        await navigator.clipboard.writeText(text);
+        success = true;
+      } catch {
+        success = legacyCopy(text); // Clipboard API 失败时降级
+      }
+    } else {
+      success = legacyCopy(text);
+    }
+    Message({
+      message: success ? t('复制成功') : t('复制失败'),
+      theme: success ? 'success' : 'error',
+    });
+  };
+
+  return { copy };
+};
+```
+
+## 兼容性
+
+| 策略                            | 触发条件                                      | 要求                                           |
+| ------------------------------- | --------------------------------------------- | ---------------------------------------------- |
+| `navigator.clipboard.writeText` | 浏览器支持 Clipboard API                      | HTTPS 或 localhost；用户需授权剪贴板权限       |
+| `document.execCommand('copy')`  | 不支持 Clipboard API，或 `writeText` 抛出异常 | 需由用户事件（如 click）直接触发，否则可能失败 |
+
+## 内部使用场景
+
+| 组件               | 用途                                      |
+| ------------------ | ----------------------------------------- |
+| `CodeContent`      | 复制代码块，取 `codeRef.value?.innerText` |
+| `MessageContainer` | 复制 AI 消息内容                          |
+| `UserMessage`      | 复制用户消息内容                          |
+
+## 注意事项
+
+1. **结果不对外暴露**：`copy` 返回 `Promise<void>`，调用方无法获知成功/失败；如需自定义通知，不应使用此 composable
+2. **通知使用 i18n**：消息文本通过 `t()` 函数处理，在多语言环境下自动切换，无法在外部覆盖
+3. **`isClipboardApiSupported` 模块级检测**：在文件 import 时执行一次（非响应式），SSR 环境下 `navigator` 为 `undefined` 时安全降级
+4. **`execCommand` 已废弃**：降级路径依赖 `document.execCommand('copy')`，该 API 在部分浏览器已标记废弃，但目前仍广泛可用
+5. **用户手势要求**：在没有用户交互上下文时（如定时器回调），两种方式都可能失败
+
+## 关联组件
+
+- [CodeContent](../components/rendering/code-content) — 代码块复制
+- [MessageContainer](../components/setup/message-container) — 助手消息复制
+- [UserMessage](../components/message/user-message) — 用户消息复制

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-command-selection.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-command-selection.md
@@ -1,0 +1,150 @@
+# useCommandSelection
+
+> 导入：`import { useCommandSelection } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useCommandSelection 无参数，返回 commandSelection、docSnapshot、GetCursorPosition、GetDocSnapshot。 GetCursorPosition 写入光标行列；GetDocSnapshot 将当前文档快照写入 docSnapshot，供外部 modelValue 与编辑器比对同步。 仅在 AiSlashInput（@ 菜单插入与 modelValue 同步）内部使用。
+
+**关联**：chat-input（AiSlashInput 内部使用）
+
+---
+
+# useCommandSelection 光标位置追踪
+
+> **分类**：composable
+
+为 `edix` 富文本编辑器提供光标位置追踪能力的组合式函数。内部封装一个 `EditorCommand`，由编辑器调用后将光标的行列信息存入响应式变量，供后续编辑命令（如插入 tag、删除关键词）精确定位。
+
+> 该 composable 仅在 `AiSlashInput` 内部使用，属于编辑器底层基础设施，**通常无需直接调用**。
+
+## 实现原理
+
+```
+editor.command(GetCursorPosition)
+  │  edix 编辑器将 (doc, selection) 注入 EditorCommand
+  │
+  └── GetCursorPosition(doc, selection)
+        const [, focus] = selection   // selection = [anchor, focus]
+        const [line, column] = focus  // focus = [lineIndex, columnIndex]
+        commandSelection.value = { column, line }
+                                 ↓
+               commandSelection（shallowRef，初始值 { column: 0, line: 0 }）
+
+editor.command(GetDocSnapshot)
+  └── GetDocSnapshot(doc)
+        docSnapshot.value = doc   // 当前文档快照，用于与 props.modelValue 比对
+```
+
+**使用时机**：
+
+- 在 `@` 资源插入流程中，先执行 `GetCursorPosition` 快照当前光标，再据此计算删除范围和插入位置。
+- 在外部 `modelValue` 变化时，先执行 `GetDocSnapshot` 取得编辑器当前文档，与 `docToString(modelValue)` 比对，决定是否 `ReplaceAll` 同步。
+
+## 概念演示
+
+`commandSelection` 追踪编辑器光标的 `{ line, column }` 位置（行从 0 开始，column 为字符偏移量）。以下用原生 textarea 模拟等价的位置信息：
+
+> 实际使用时，由 `editor.command(GetCursorPosition)` 触发写入，而非手动计算。
+
+## 在 AiSlashInput 中的实际用法
+
+```typescript
+import { watch } from 'vue';
+
+const { commandSelection, GetCursorPosition, GetDocSnapshot, docSnapshot } = useCommandSelection();
+
+// 用户从 @xxx 菜单中选择资源时：
+const insertTagAtCursor = (tag: IAiSlashMenuItem) => {
+  editor.command(GetCursorPosition);
+  const { column, line } = commandSelection.value;
+  editor.command(DeleteTag, [line, column - keyword.value.length - 1], [line, column]);
+  editor.command(InsertTag, [line, column], tag);
+};
+
+// 外部 modelValue 变化时，与编辑器文档对齐（简化示意；需已存在 editor、props、text、docToString）
+watch(
+  () => props.modelValue,
+  () => {
+    editor.command(GetDocSnapshot);
+    if (docToString(docSnapshot.value || []) !== docToString(text.value || [])) {
+      editor.command(ReplaceAll, docToString(text.value || []) as unknown as string);
+    }
+  },
+  { deep: false },
+);
+```
+
+## API
+
+### 参数
+
+无。`useCommandSelection()` 不接受任何参数。
+
+### 返回值
+
+| 属性名              | 类型                                           | 初始值                   | 说明                                                                                       |
+| ------------------- | ---------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------ |
+| `commandSelection`  | `ShallowRef<{ column: number; line: number }>` | `{ column: 0, line: 0 }` | 存储最近一次执行 `GetCursorPosition` 时的光标行列位置                                      |
+| `docSnapshot`       | `ShallowRef<DocFragment>`                      | `[]`                     | 存储最近一次执行 `GetDocSnapshot` 时的文档快照                                             |
+| `GetCursorPosition` | `EditorCommand<[]>`                            | —                        | 编辑器命令，由 `editor.command(GetCursorPosition)` 触发，将当前光标写入 `commandSelection` |
+| `GetDocSnapshot`    | `EditorCommand<[]>`                            | —                        | 编辑器命令，由 `editor.command(GetDocSnapshot)` 触发，将当前文档写入 `docSnapshot`       |
+
+## 类型说明
+
+```typescript
+// EditorCommand：edix 编辑器的命令签名
+type EditorCommand<A extends unknown[]> = (
+  doc: DocFragment,
+  selection: SelectionSnapshot, // [[anchorLine, anchorColumn], [focusLine, focusColumn]]
+  ...args: A
+) => Transaction | void;
+
+// useCommandSelection 返回值
+interface UseCommandSelectionReturn {
+  commandSelection: ShallowRef<{ column: number; line: number }>;
+  docSnapshot: ShallowRef<DocFragment>;
+  GetCursorPosition: EditorCommand<[]>;
+  GetDocSnapshot: EditorCommand<[]>;
+}
+```
+
+## 实现源码
+
+```typescript
+import { shallowRef } from 'vue';
+
+import type { EditorCommand } from '../edix';
+import type { DocFragment } from '../edix/doc/types';
+
+export const useCommandSelection = () => {
+  const commandSelection = shallowRef<{ column: number; line: number }>({ column: 0, line: 0 });
+  const docSnapshot = shallowRef<DocFragment>([]);
+
+  const GetCursorPosition: EditorCommand<[]> = (_doc, selection) => {
+    const [, focus] = selection;
+    const [line, column] = focus;
+    commandSelection.value = { column, line };
+  };
+
+  const GetDocSnapshot: EditorCommand<[]> = doc => {
+    docSnapshot.value = doc;
+  };
+
+  return {
+    commandSelection,
+    docSnapshot,
+    GetCursorPosition,
+    GetDocSnapshot,
+  };
+};
+```
+
+## 注意事项
+
+1. **只读命令**：`GetCursorPosition` 不返回 `Transaction`，不修改编辑器文档内容，仅记录位置
+2. **异步快照**：`commandSelection` 在 `editor.command(GetCursorPosition)` 执行后**同步**更新，下一行代码即可安全读取
+3. **`shallowRef` 而非 `ref`**：对象引用替换触发响应式，内部字段修改不触发（此处每次整体替换，无影响）
+4. **仅适用于 edix 编辑器**：`GetCursorPosition` / `GetDocSnapshot` 依赖 edix 的文档与选区格式，不适用于原生 contenteditable 或其他富文本库
+
+## 关联组件
+
+- [ChatInput](../components/input/chat-input) — AiSlashInput 子模块使用

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-container-scroll.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-container-scroll.md
@@ -1,0 +1,53 @@
+# useContainerScroll
+
+> 导入：`import { useContainerScroll } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useContainerScrollProvider 在滚动容器与底部锚点上绑定 IntersectionObserver、scroll、wheel，提供 isScrollBottom、scrollBottomHeight、autoScrollEnabled、toScrollBottom/toScrollTop 及防抖「返回底部」按钮状态。 useContainerScrollConsumer 通过 inject 在子组件中获取同一套控制，无需 props 透传。 典型用于流式输出时仅在用户位于底部时自动滚底。MessageContainer 与 ScrollBtn 配合使用。
+
+**关联**：message-container（Provider 挂载于消息列表滚动区域）、scroll-btn（使用 debouncedShowScrollBottomBtn 与 toScrollBottom）、chat-container（组合消息区与输入区时的整体布局上下文）
+
+---
+
+# useContainerScroll 容器滚动
+
+> **分类**：composable
+
+为消息容器提供滚动控制的组合式函数对，通过 **Provider/Consumer** 模式在父子组件间共享滚动状态。
+
+- `useContainerScrollProvider`：在容器组件中调用，创建滚动控制并通过 `provide` 向下共享
+- `useContainerScrollConsumer`：在任意后代组件中调用，通过 `inject` 获取滚动控制
+
+## 工作原理
+
+```
+useContainerScrollProvider(containerRef, bottomRef)
+  │
+  ├── IntersectionObserver 监听 bottomRef
+  │     可见 → isScrollBottom=true, scrollBottomHeight=0, autoScrollEnabled=true
+  │     不可见 → isScrollBottom=false, calculateScrollBottom()
+  │
+  ├── scroll 事件（passive）→ calculateScrollBottom()
+  │     scrollBottomHeight = max(0, scrollHeight - scrollTop - clientHeight)
+  │
+  ├── wheel 事件（passive）→ deltaY < 0 时 autoScrollEnabled=false
+  │     （用户向上滚动时暂停自动滚动）
+  │
+  ├── toScrollBottom() → autoScrollEnabled=true + bottomRef.scrollIntoView('smooth')
+  ├── toScrollTop()    → containerRef.scrollTo({ top:0, behavior:'smooth' })
+  │
+  └── provide(CONTAINER_SCROLL_TOKEN, computed(() => ({
+            autoScrollEnabled: autoScrollEnabled.value,  // 解包为 boolean
+            isScrollBottom,             // ShallowRef<boolean>（保持响应式）
+            scrollBottomHeight,         // ShallowRef<number>（保持响应式）
+            debouncedShowScrollBottomBtn, // customRef，防抖显示返回底部按钮
+            toScrollBottom,
+            toScrollTop,
+        })))
+
+useContainerScrollConsumer()
+  └── inject(CONTAINER_SCROLL_TOKEN) → ComputedRef<ContainerScrollData> | undefined
+```
+
+> **注意**：Consumer 获得的 `ComputedRef` 中，`isScrollBottom` 和 `scrollBottomHeight` 是 `ShallowRef` 对象（非解包值），需要通过 `.value` 访问。
+
+## 渲染示例

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-custom-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-custom-tab.md
@@ -1,0 +1,126 @@
+# useCustomTab
+
+> 导入：`import { useCustomTab } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useCustomTabProvider 返回 tabs、selectedTab、isCollapse 及 add/remove/selectCustomTab，并通过 provide 共享；可选 onTabChange 在切换时拉取数据。 useCustomTabConsumer 在后代注入同一套 API，常用于侧栏动态节点详情等。EXECUTION_TAB_NAME 标识默认「执行情况」Tab。 ChatContainer 侧栏集成 Provider 与 Tab UI。
+
+**关联**：chat-container（Provider 与侧栏 Tab 主场景）
+
+---
+
+# useCustomTab 自定义 Tab 管理
+
+> **分类**：composable
+
+Provider/Consumer 模式的自定义 Tab 管理，用于 `ChatContainer` 侧边栏的 Tab 动态管理。Provider 在 `ChatContainer` 中创建，Consumer 在任意后代组件中注入使用。
+
+## 函数签名
+
+### useCustomTabProvider
+
+```typescript
+function useCustomTabProvider<T extends Record<string, unknown>>(options: {
+  onTabChange?: (tab: CustomTab<T>) => void;
+}): {
+  tabs: ShallowRef<CustomTab<T>[]>;
+  selectedTab: Ref<CustomTab<T>>;
+  isCollapse: ShallowRef<boolean>;
+  addCustomTab: (tab: CustomTab<T>) => void;
+  removeCustomTab: (tabName: string) => void;
+  selectCustomTab: (tab: CustomTab<T>) => void;
+  resetCustomTab: () => void;
+};
+```
+
+### useCustomTabConsumer
+
+```typescript
+function useCustomTabConsumer<T extends Record<string, unknown>>():
+  | undefined
+  | {
+      tabs: ShallowRef<CustomTab<T>[]>;
+      selectedTab: ShallowRef<CustomTab<T> | null>;
+      addCustomTab: (tab: CustomTab<T>) => void;
+      removeCustomTab: (tabName: string) => void;
+      selectCustomTab: (tab: CustomTab<T>) => void;
+      resetCustomTab: () => void;
+    };
+```
+
+## 使用示例
+
+### Provider（容器组件）
+
+```typescript
+import { useCustomTabProvider, EXECUTION_TAB_NAME } from '@blueking/chat-x';
+
+const { tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
+  useCustomTabProvider({
+  onTabChange: async tab => {
+    // Tab 切换时加载数据
+    const data = await fetchTabData(tab.name);
+    return data;
+  },
+});
+```
+
+### Consumer（后代组件）
+
+```typescript
+import { useCustomTabConsumer } from '@blueking/chat-x';
+
+const tabManager = useCustomTabConsumer();
+
+// 添加一个自定义 Tab
+tabManager?.addCustomTab({
+  name: 'node-detail-123',
+  label: '节点详情',
+  data: {
+    component: NodeDetailComponent,
+    props: { nodeId: '123' },
+  },
+});
+
+// 移除 Tab
+tabManager?.removeCustomTab('node-detail-123');
+```
+
+## 内置常量
+
+| 常量名               | 值            | 说明                      |
+| -------------------- | ------------- | ------------------------- |
+| `EXECUTION_TAB_NAME` | `'execution'` | 执行情况 Tab 的固定标识   |
+| `CUSTOM_TAB_TOKEN`   | `Symbol`      | provide/inject 注入 Token |
+
+## 返回值说明
+
+| 属性/方法名     | 类型                        | 说明                                              |
+| --------------- | --------------------------- | ------------------------------------------------- |
+| tabs            | `ShallowRef<CustomTab[]>`   | 所有 Tab 列表（含默认的执行情况 Tab）             |
+| selectedTab     | `Ref<CustomTab>`            | 当前选中的 Tab                                    |
+| isCollapse      | `ShallowRef<boolean>`       | 侧边栏折叠状态；`addCustomTab` 时自动设为 `false` |
+| addCustomTab    | `(tab: CustomTab) => void`  | 添加 Tab（同名 Tab 不重复添加）                   |
+| removeCustomTab | `(tabName: string) => void` | 移除指定 Tab                                      |
+| selectCustomTab | `(tab: CustomTab) => void`  | 切换到指定 Tab，触发 `onTabChange` 回调           |
+| resetCustomTab  | `() => void`                  | 重置为仅保留「执行情况」Tab、折叠侧栏并选中默认 Tab；`ChatContainer` 在卸载时调用，避免残留自定义 Tab |
+
+## 类型定义
+
+```typescript
+interface CustomTab<T = Record<string, unknown>> {
+  label: string;
+  name: string;
+  /** 可与 `component` / `props` 并列；用于侧栏「在对话中定位」与主消息 `message.uid` 对齐 */
+  data?: T & { messageUid?: string };
+}
+```
+
+## 设计特点
+
+- `tabs` 使用 `shallowRef`，`addCustomTab` 通过展开新数组触发更新，避免 `UnwrapRef<T>` 类型问题
+- 默认的「执行情况」Tab 始终存在且不可关闭
+- `addCustomTab` 同时展开侧边栏（`isCollapse = false`）并在 `nextTick` 后自动选中新 Tab
+
+## 关联组件
+
+- [ChatContainer](../components/setup/chat-container) — 侧栏 Tab 与自定义面板

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-flow-node-actions.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-flow-node-actions.md
@@ -1,0 +1,123 @@
+# useFlowNodeActions
+
+> 导入：`import { useFlowNodeActions } from '@blueking/chat-x'` ｜ since 2.0.0
+
+useFlowNodeActions 接收 onInterruptResume 与 openNodeDetail，返回 getNodeActions(task, node)。 失败节点按 retryable/skippable 展示重试/跳过，详情恒在末尾；点击 resume 时不传 interrupt。
+
+**关联**：flow-agent-content（FlowAgentContent 内部消费，驱动节点行尾按钮组渲染）
+
+---
+
+# useFlowNodeActions 节点行尾操作
+
+> **分类**：composable
+
+将 FlowAgent 节点行尾的「详情（打开侧栏）」与「重试 / 跳过（回传 Agent resume）」聚合为统一的声明式操作列表。`FlowAgentContent` 只需遍历 `getNodeActions` 返回值渲染按钮，显隐与点击行为均收敛于此 composable。
+
+源码：`src/components/chat-content/flow-agent-content/use-flow-node-actions.ts`
+
+## 函数签名
+
+```typescript
+function useFlowNodeActions(options: {
+  /** resume 回调（与第三方审批取消同一回调，按 payload.operation 分流） */
+  onInterruptResume: Ref<OnInterruptResume | undefined>;
+  /** 打开节点详情侧栏（复用 useFlowTab 的能力） */
+  openNodeDetail: (task: BkFlowTask, node: BkFlowNode) => void;
+}): {
+  getNodeActions: (task: FlowTaskVM, node: FlowNodeVM) => FlowNodeActionVM[];
+};
+```
+
+## 返回值：FlowNodeActionVM
+
+```typescript
+type FlowNodeActionId =
+  | 'detail'
+  | InterruptResumeOperation.FlowNodeRetry
+  | InterruptResumeOperation.FlowNodeSkip;
+
+interface FlowNodeActionVM {
+  icon: Component;
+  id: FlowNodeActionId;
+  label: string;
+  run: () => void;
+}
+```
+
+| 字段    | 说明                           |
+| ------- | ------------------------------ |
+| `icon`  | 按钮图标组件                   |
+| `id`    | 唯一标识，用于 `v-for` key     |
+| `label` | 国际化文案                     |
+| `run`   | 点击执行（详情或 resume）      |
+
+## 操作显隐规则
+
+| 操作 | `id`               | 显隐条件                                   | 点击行为                                      |
+| ---- | ------------------ | ------------------------------------------ | --------------------------------------------- |
+| 重试 | `flow_node_retry`  | `convergedState === 'failed'` 且 `retryable` | 调用 `onInterruptResume`，**不传** `interrupt` |
+| 跳过 | `flow_node_skip`   | `convergedState === 'failed'` 且 `skippable` | 同上                                          |
+| 详情 | `detail`           | 始终（Share 模式由上层组件隐藏整组）       | 调用 `openNodeDetail(task.raw, node.raw)`     |
+
+展示顺序：重试 → 跳过 → 详情。
+
+## resume 负载格式
+
+```typescript
+// 重试
+onInterruptResume?.({
+  operation: InterruptResumeOperation.FlowNodeRetry,
+  payload: { node_id: node.id, task_id: task.task_id },
+});
+
+// 跳过
+onInterruptResume?.({
+  operation: InterruptResumeOperation.FlowNodeSkip,
+  payload: { node_id: node.id, task_id: task.task_id },
+});
+```
+
+## 使用示例
+
+`FlowAgentContent` 内部用法（业务侧通常通过 `MessageRender` 传入 `onInterruptResume`，无需直接调用本 composable）：
+
+```typescript
+import { toRef } from 'vue';
+import { useFlowNodeActions } from '@blueking/chat-x';
+// 或相对路径：'./use-flow-node-actions'
+
+const { getNodeActions } = useFlowNodeActions({
+  onInterruptResume: toRef(props, 'onInterruptResume'),
+  openNodeDetail,
+});
+
+// 模板中
+// v-for="action in getNodeActions(task, node)" :key="action.id"
+// @click.stop="action.run()"
+```
+
+## 扩展新操作
+
+在 `RESUME_ACTION_DEFS` 注册表中追加一项即可，需声明 `visible` 与 `operation` 枚举：
+
+```typescript
+const RESUME_ACTION_DEFS: FlowNodeResumeActionDef[] = [
+  // 现有：重试、跳过
+  {
+    icon: MyIcon,
+    id: InterruptResumeOperation.MyNewOp, // 需先在 InterruptResumeOperation 扩展
+    label: () => t('新操作'),
+    visible: node => /* 自定义显隐 */,
+  },
+];
+```
+
+同时在 `interrupt.ts` 扩展 `InterruptResumeOperation` 与 `FlowNodeResume` 联合类型。
+
+## 关联文档
+
+- [FlowAgentContent 执行内容](/components/agent/flow-agent-content) — 消费方组件
+- [中断类型 Interrupt](/types/interrupt) — `InterruptResumeOperation`、`FlowNodeResume`、`OnInterruptResume`
+- [ActivityMessage 活动消息](/components/message/activity-message) — `onInterruptResume` 透传链路
+- [MessageRender 消息渲染器](/components/message/message-render) — 顶层透传入口

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-full-screen.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-full-screen.md
@@ -1,0 +1,112 @@
+# useFullScreen
+
+> 导入：`import { useFullScreen } from '@blueking/chat-x'` ｜ since 2.0.0
+
+useFullScreen 将目标元素（或 document.documentElement）以浏览器原生全屏展示。 模块加载时一次性嗅探 requestFullscreen / webkitRequestFullscreen，返回 isSupported、只读 isFullScreen 与 enter/exit/toggle。 监听 fullscreenchange 同步 ESC 等外部退出；ChatContainer 侧栏全屏按钮使用此 composable。
+
+**关联**：chat-container（侧栏 .ai-full-screen-wrapper 全屏切换）、tool-btn（全屏按钮通过插槽渲染 FullScreenIcon）
+
+---
+
+# useFullScreen 全屏控制
+
+> **分类**：composable
+
+基于浏览器原生 Fullscreen API 的全屏控制组合式函数。模块加载时一次性嗅探标准 API 与 `webkit` 前缀（兼容旧版 Safari），在组件作用域销毁时自动移除事件监听。
+
+## 工作原理
+
+```
+useFullScreen(target?)
+  │
+  ├── resolveFullscreenApi()（模块级，仅执行一次）
+  │     requestFullscreen / webkitRequestFullscreen
+  │
+  ├── isSupported = !!fullscreenApi
+  ├── isFullScreen（readonly shallowRef，与浏览器真实状态同步）
+  │
+  ├── enter()  → target.requestFullscreen()
+  ├── exit()   → document.exitFullscreen()
+  ├── toggle() → isFullScreen ? exit() : enter()
+  │
+  └── document.addEventListener(fullscreenchange, syncState)
+        syncState：指定 target 时，仅当 fullscreenElement === target 视为全屏
+        onScopeDispose 时移除监听
+```
+
+> **注意**：`enter()` 可能因缺少用户手势等原因被浏览器拒绝，内部会静默捕获异常，避免未处理的 Promise rejection。
+
+## 基础用法
+
+```vue
+<template>
+  <div>
+    <div ref="panelRef" class="demo-panel">
+      <p>可全屏展示的面板内容</p>
+    </div>
+    <button :disabled="!isSupported" @click="enter">进入全屏</button>
+    <button :disabled="!isFullScreen" @click="exit">退出全屏</button>
+    <span>当前状态：{{ isFullScreen ? '全屏' : '窗口' }}</span>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { useTemplateRef } from 'vue';
+  import { useFullScreen } from '@blueking/chat-x';
+
+  const panelRef = useTemplateRef<HTMLElement>('panelRef');
+  const { isSupported, isFullScreen, enter, exit } = useFullScreen(panelRef);
+</script>
+```
+
+## 在 ChatContainer 中的使用
+
+`ChatContainer` 将侧栏包裹在 `.ai-full-screen-wrapper` 中，通过 `useFullScreen(fullScreenRef)` 控制侧栏全屏；Tab 栏 `#setting` 插槽内的 `ToolBtn` 使用自定义插槽渲染 `FullScreenIcon` / `UnFullScreenIcon`。
+
+详见 [ChatContainer 侧栏全屏](../components/setup/chat-container.md#侧栏全屏)。
+
+## API
+
+### 参数
+
+| 参数名 | 类型 | 默认值 | 说明 |
+| ------ | ---- | ------ | ---- |
+| target | `MaybeRef<HTMLElement \| null>` | — | 需要全屏的目标元素；省略时回退到 `document.documentElement` |
+
+### 返回值
+
+| 属性名 | 类型 | 说明 |
+| ------ | ---- | ---- |
+| isSupported | `boolean` | 当前环境是否支持 Fullscreen API（SSR 或不支持时为 `false`） |
+| isFullScreen | `Readonly<ShallowRef<boolean>>` | 只读响应式全屏状态；与浏览器真实状态同步（含 ESC 退出） |
+| enter | `() => Promise<void>` | 进入全屏；已全屏或不受支持时无操作 |
+| exit | `() => Promise<void>` | 退出全屏；当前无全屏元素时无操作 |
+| toggle | `() => void` | 切换全屏状态 |
+
+## 类型定义
+
+```typescript
+import { useFullScreen } from '@blueking/chat-x';
+import type { MaybeRef, Readonly, ShallowRef } from 'vue';
+
+type UseFullScreenReturn = {
+  isSupported: boolean;
+  isFullScreen: Readonly<ShallowRef<boolean>>;
+  enter: () => Promise<void>;
+  exit: () => Promise<void>;
+  toggle: () => void;
+};
+
+// 调用签名
+declare function useFullScreen(target?: MaybeRef<HTMLElement | null>): UseFullScreenReturn;
+```
+
+## 使用场景
+
+- `ChatContainer` 侧栏执行情况 / 自定义 Tab 区域全屏查看
+- 任意需要将局部 DOM 区域以浏览器原生全屏展示的交互面板
+
+## 关联组件
+
+- [ChatContainer](../components/setup/chat-container.md) — 内置侧栏全屏按钮
+- [ToolBtn](../components/feedback/tool-btn.md) — 全屏按钮自定义插槽

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-global-config.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-global-config.md
@@ -1,0 +1,139 @@
+# useGlobalConfig
+
+> 导入：`import { useGlobalConfig } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useGlobalConfig 接收 GlobalConfig（含 size?: ComputedRef<AiSizeMode>、supportUpload: ComputedRef<boolean>），以 GLOBAL_CONFIG_TOKEN provide 给后代； injectGlobalConfig 在子组件中取出配置，无 Provider 时返回 undefined。ChatContainer 在 setup 中调用 useGlobalConfig 注入 size 与 supportUpload； 后代组件可通过 injectGlobalConfig 读取配置；字号主题主要通过根节点 data-ai-size 与 CSS 变量生效。
+
+**关联**：chat-container（根容器调用 useGlobalConfig 注入 supportUpload）
+
+---
+
+# useGlobalConfig 全局配置
+
+> **分类**：composable
+
+在聊天容器根组件与子组件之间通过 Vue `provide` / `inject` 共享**全局展示相关配置**（当前包括字号主题档位 `size`、是否支持上传 `supportUpload`）。与 Teleport 插槽 ID 无关。
+
+> 字号主题主要通过 `ChatContainer` 根节点的 `data-ai-size` 与 CSS 变量（`--ai-font-size` 等）生效；`GlobalConfig.size` 供后代在逻辑层读取当前档位，样式层无需逐组件传参。
+
+## 工作原理
+
+```
+ChatContainer（根）
+  ├── :data-ai-size="size"（CSS 变量作用域）
+  ├── useGlobalConfig({
+  │     size: computed(() => props.size ?? 'small'),
+  │     supportUpload: computed(() => props.supportUpload ?? false),
+  │   })
+  │     └── provide(GLOBAL_CONFIG_TOKEN, { size, supportUpload })
+  │
+  └── MessageContainer → … → UserMessage 等
+
+UserMessage（后代）
+  ├── injectGlobalConfig()
+  │     └── inject(GLOBAL_CONFIG_TOKEN) → GlobalConfig | undefined
+  └── 模板中：globalConfig?.supportUpload.value ?? false
+```
+
+- **Provider**：必须在组件树的祖先（如 `ChatContainer`）的 `setup` 中调用 `useGlobalConfig`，否则后代 `injectGlobalConfig()` 得到 `undefined`。
+- **Consumer**：任意后代在 `setup` 中调用 `injectGlobalConfig()`，拿到与 Provider 相同的 `GlobalConfig` 对象引用；`supportUpload` 为 `ComputedRef<boolean>`，可随根 props 响应式更新。
+
+## 渲染示例
+
+## 根容器用法（ChatContainer）
+
+```vue
+<script setup lang="ts">
+  import { computed } from 'vue';
+  import { useGlobalConfig } from '@blueking/chat-x';
+
+  const props = defineProps<{
+    size?: 'normal' | 'small';
+    supportUpload?: boolean;
+  }>();
+
+  useGlobalConfig({
+    size: computed(() => props.size ?? 'small'),
+    supportUpload: computed(() => props.supportUpload ?? false),
+  });
+</script>
+```
+
+## 子组件用法（UserMessage）
+
+```vue
+<script setup lang="ts">
+  import { injectGlobalConfig } from '@blueking/chat-x';
+
+  const globalConfig = injectGlobalConfig();
+</script>
+
+<template>
+  <ChatInput :support-upload="globalConfig?.supportUpload.value ?? false" />
+</template>
+```
+
+## API
+
+### 类型与函数签名（摘要）
+
+```typescript
+import type { ComputedRef } from 'vue';
+
+export const GLOBAL_CONFIG_TOKEN: unique symbol;
+
+export type AiSizeMode = 'normal' | 'small';
+
+export type GlobalConfig = {
+  size?: ComputedRef<AiSizeMode>;
+  supportUpload: ComputedRef<boolean>;
+};
+
+export function useGlobalConfig(options: GlobalConfig): {
+  size?: ComputedRef<AiSizeMode>;
+  supportUpload: ComputedRef<boolean>;
+};
+
+export function injectGlobalConfig(): GlobalConfig | undefined;
+```
+
+### `GLOBAL_CONFIG_TOKEN`
+
+| 名称                  | 说明                                   |
+| --------------------- | -------------------------------------- |
+| `GLOBAL_CONFIG_TOKEN` | `provide` / `inject` 使用的 Symbol key |
+
+### `GlobalConfig`
+
+| 字段            | 说明                                                                     |
+| --------------- | ------------------------------------------------------------------------ |
+| `size`          | 可选。字号主题档位 `normal`（14px）/ `small`（12px），与 `ChatContainer.size` 对齐 |
+| `supportUpload` | 是否支持上传，与根容器 `ChatContainer` 的 `supportUpload` 等展示策略对齐 |
+
+### `useGlobalConfig(options)`
+
+| 参数                    | 说明                                                                                  |
+| ----------------------- | ------------------------------------------------------------------------------------- |
+| `options.size`          | 可选。字号主题档位，建议使用 `computed(() => props.size ?? 'small')` 与根 props 同步 |
+| `options.supportUpload` | 是否支持上传，建议使用 `computed(() => props.supportUpload ?? false)` 与根 props 同步 |
+
+- 调用后立即 `provide(GLOBAL_CONFIG_TOKEN, options)`。
+- 必须在具有组件实例上下文的 `setup` 中调用（与 Vue `provide` 要求一致）。
+
+### `injectGlobalConfig()`
+
+| 返回值         | 说明                                                        |
+| -------------- | ----------------------------------------------------------- |
+| `GlobalConfig` | 祖先已调用 `useGlobalConfig` 时，与 Provider 传入的同一对象 |
+| `undefined`    | 组件树中无对应 `provide` 时                                 |
+
+## 注意事项
+
+1. **Provider 须在祖先调用**：子组件的 `injectGlobalConfig` 依赖同一组件树内的 `useGlobalConfig`。
+2. **可选链访问**：无 Provider 时返回 `undefined`，模板中建议使用 `globalConfig?.supportUpload.value ?? false`。
+3. **扩展配置**：后续若在 `GlobalConfig` 中增加字段，应在根容器统一传入并在文档中说明。
+
+## 关联组件
+
+- [ChatContainer](../components/setup/chat-container) — 调用 `useGlobalConfig` 注入 `size` 与 `supportUpload`
+- [主题配置](../theme/theme) — `data-ai-size` 与 CSS 变量说明

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-menu-keydown.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-menu-keydown.md
@@ -1,0 +1,163 @@
+# useMenuKeydown
+
+> 导入：`import { useMenuKeydown } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useMenuKeydown 接收 items、menuRef、onSelect，在 window 捕获阶段监听 keydown；菜单不可见（offsetParent 为空）或列表为空时不响应。 维护 activeIndex，处理 ArrowUp/ArrowDown 循环与 Enter 选中，并 scrollIntoView 当前 .is-active 项。 AiSlashMenu、AiPromptList（ChatInput 子模块）内部使用。
+
+**关联**：chat-input（AiSlashMenu / AiPromptList 键盘导航）
+
+---
+
+# useMenuKeydown 菜单键盘导航
+
+> **分类**：composable
+
+为弹出菜单提供键盘导航能力的组合式函数。在 `onMounted` 时于 **`window` 捕获阶段**注册 `keydown` 监听，在 `onScopeDispose` 时自动移除，通过 `menuRef.offsetParent` 检测菜单可见性来决定是否响应按键。
+
+内部维护 `activeIndex`（高亮项索引），由调用方将其绑定到列表的 `.is-active` 样式；`handleKeydown` 完全内部管理，**无需手动绑定到模板**。
+
+## 工作原理
+
+```
+onMounted：window.addEventListener('keydown', handleKeydown, true)  ← 捕获阶段
+onScopeDispose：window.removeEventListener('keydown', handleKeydown, true)
+
+handleKeydown(e):
+  ├── !menuRef.value?.offsetParent → return（菜单不可见，忽略）
+  ├── !items.value?.length        → return（列表为空，忽略）
+  │
+  ├── ArrowUp   → e.preventDefault/stopPropagation
+  │               activeIndex = (activeIndex - 1 + length) % length  ← 循环到末尾
+  │               scrollToActive()
+  ├── ArrowDown → e.preventDefault/stopPropagation
+  │               activeIndex = (activeIndex + 1) % length           ← 循环到开头
+  │               scrollToActive()
+  └── Enter / NumpadEnter → e.preventDefault/stopPropagation
+                            onSelect(items[activeIndex])
+
+scrollToActive()：nextTick → menuRef.querySelector('.is-active')?.scrollIntoView({ block: 'nearest' })
+```
+
+> **`.is-active` 依赖**：`scrollToActive` 通过 CSS 类名 `.is-active` 定位当前高亮项，调用方必须在模板中将 `activeIndex` 对应的项加上此类名。
+
+## 渲染示例
+
+使用 ↑ ↓ 键移动高亮，Enter 选中：
+
+## 基础用法
+
+```vue
+<template>
+  <!-- 菜单容器，ref 传给 useMenuKeydown 用于可见性检测 -->
+  <div
+    ref="menuRef"
+    class="prompt-menu"
+  >
+    <div
+      v-for="(item, i) in items"
+      :key="item.id"
+      :class="['menu-item', { 'is-active': activeIndex === i }]"
+      @click="onSelect(item)"
+      @mouseenter="activeIndex = i"
+    >
+      {{ item.name }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { shallowRef, useTemplateRef } from 'vue';
+  import { useMenuKeydown } from '@blueking/chat-x';
+
+  const menuRef = useTemplateRef<HTMLElement>('menuRef');
+  const items = shallowRef([
+    { id: 'ask', name: '问问小鲸' },
+    { id: 'translate', name: '翻译文本' },
+    { id: 'review', name: '代码审查' },
+  ]);
+
+  const onSelect = (item: (typeof items.value)[0]) => {
+    console.log('选中：', item.name);
+  };
+
+  // activeIndex 由 composable 内部管理，无需手动传入
+  // window keydown 监听自动注册，无需手动绑定 @keydown
+  const { activeIndex } = useMenuKeydown({ items, menuRef, onSelect });
+</script>
+
+<style scoped>
+  .menu-item.is-active {
+    background: #e1ecff;
+    color: #3a84ff;
+  }
+</style>
+```
+
+## 在 AiSlashInput 内部的实际用法
+
+`useMenuKeydown` 被 `AiSlashMenu`（`@` 资源菜单）和 `AiPromptList`（`/` 提示词列表）内部使用：
+
+```typescript
+// AiPromptList 中
+const promptListRef = useTemplateRef<HTMLElement>('promptListRef');
+const { activeIndex } = useMenuKeydown<string>({
+  items: computed(() => props.prompts), // ComputedRef 也可传入
+  onSelect: props.onSelect,
+  menuRef: promptListRef,
+});
+
+// AiSlashMenu 中
+const menuRef = useTemplateRef<HTMLElement>('menuRef');
+const { activeIndex } = useMenuKeydown<IAiSlashMenuItem>({
+  items: sortedResourceList,
+  onSelect: props.onSelect,
+  menuRef,
+});
+```
+
+## API
+
+### 参数
+
+```typescript
+useMenuKeydown<T>(props: {
+  items: ShallowRef<T[]>;                          // 菜单项列表
+  menuRef: Readonly<ShallowRef<HTMLElement | null>>; // 菜单容器 DOM 引用（用于可见性检测和滚动定位）
+  onSelect: (item: T) => void;                     // 选中回调
+}): { activeIndex: ShallowRef<number> }
+```
+
+### 参数说明
+
+| 参数       | 类型                              | 说明                                                        |
+| ---------- | --------------------------------- | ----------------------------------------------------------- |
+| `items`    | `ShallowRef<T[]>`                 | 菜单项数组；为空时所有按键均不响应                          |
+| `menuRef`  | `ShallowRef<HTMLElement \| null>` | 菜单容器引用；`offsetParent === null`（不可见）时按键不响应 |
+| `onSelect` | `(item: T) => void`               | Enter 确认时触发，传入当前 `activeIndex` 对应的项           |
+
+### 返回值
+
+| 属性名        | 类型                 | 初始值 | 说明                                                                           |
+| ------------- | -------------------- | ------ | ------------------------------------------------------------------------------ |
+| `activeIndex` | `ShallowRef<number>` | `0`    | 当前高亮项索引；需在模板中绑定 `.is-active` 类；鼠标 `mouseenter` 也可修改此值 |
+
+### 按键行为（硬编码，不可自定义）
+
+| 按键                    | 行为                                   |
+| ----------------------- | -------------------------------------- |
+| `ArrowUp`               | 高亮上一项（从第 0 项循环到末尾）      |
+| `ArrowDown`             | 高亮下一项（从末尾循环到第 0 项）      |
+| `Enter` / `NumpadEnter` | 选中当前高亮项，调用 `onSelect`        |
+| `Escape`                | 无处理（不在此 composable 负责范围内） |
+
+## 注意事项
+
+1. **`handleKeydown` 内部自动注册**：在 `window` 捕获阶段（第三参数 `true`）绑定，优先于页面其他元素；调用方**无需**手动绑定 `@keydown`
+2. **`.is-active` 类名约定**：`scrollToActive` 通过 `menuRef.querySelector('.is-active')` 定位元素，项目模板必须在 `activeIndex === i` 时添加此类
+3. **`activeIndex` 不自动重置**：列表内容（`items`）变化时，`activeIndex` 保持不变。如需重置（如过滤后），需在外部 `watch` items 并手动将 `activeIndex.value = 0`
+4. **可见性检测依赖 `offsetParent`**：元素通过 `display:none` 隐藏时 `offsetParent === null`，按键会被忽略；`visibility:hidden` 或 `opacity:0` 不会被忽略
+5. **捕获阶段拦截**：`ArrowUp`/`ArrowDown`/`Enter` 均调用 `e.preventDefault()` 和 `e.stopPropagation()`，防止方向键滚动页面或 Enter 提交表单
+
+## 关联组件
+
+- [ChatInput](../components/input/chat-input) — `@` 菜单与 `/` 提示词列表

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
@@ -1,0 +1,214 @@
+# useMessageGroup
+
+> 导入：`import { useMessageGroup } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useMessageGroup 接收 keyword、messages、selectedUserMessages，通过 watchEffect 产出 messageGroups（User/Assistant/Tool 合并、末尾 Loading 注入且占位 id 为 LOADING_MESSAGE_ID、pause 与分享勾选等）。 executionGroups 供侧边执行摘要过滤，并暴露 isShareMode、全选与 onConfirmShare。 ChatContainer 组装后传给 MessageContainer；ExecutionSummary 消费 executionGroups。
+
+**关联**：chat-container（调用并传入 MessageContainer）、message-container（必填 messageGroups 数据源）、execution-summary（使用 executionGroups 与定位）
+
+---
+
+# useMessageGroup 消息分组
+
+> **分类**：composable
+
+核心消息分组逻辑，将原始 `Message[]` 数组转换为结构化的 `MessageGroup[]`。处理 Tool 消息合并、Loading 自动注入、执行摘要过滤和消息多选/分享等逻辑。
+
+## 函数签名
+
+```typescript
+function useMessageGroup(options: {
+  keyword?: ShallowRef<string>;
+  messages: ComputedRef<Message[]>;
+  selectedUserMessages: Ref<Message[] | undefined>;
+}): {
+  messageGroups: Ref<MessageGroup[]>;
+  executionGroups: ComputedRef<MessageGroup[]>;
+  pendingApprovalCount: ComputedRef<number>;
+  pendingApprovalTipText: ComputedRef<string>;
+  isShareMode: ShallowRef<boolean>;
+  isAllSelected: ComputedRef<boolean>;
+  onToggleShareAll: (isAllSelected: boolean) => void;
+  onCancelShare: () => void;
+  onConfirmShare: () => Message[];
+};
+```
+
+## 分组规则
+
+`watchEffect` 遍历 `messages` 数组，按以下规则分组：
+
+**消息 `uid`：** 若某条消息缺少 `uid`，分组前会自动为其生成并写入 `uid`（与 `MessageGroup.uid` 及 DOM 定位约定配合）。
+
+```
+messages 原始数组（按顺序处理）
+         │
+    ┌────┴────┐────────────┐
+    │         │            │
+role=user  role=tool     其他 role
+    │         │            │
+ ① 将累积的    ② 通过          ③ 累积到
+ assistant     toolCallId     assistantMessages
+ 消息推入       找到对应的      等待 user 消息
+ list 作为      Assistant       触发分组
+ 一组，当前     消息，注入
+ user 单独      toolMessage
+ 成组           后 continue
+
+④ 遍历结束后将剩余 assistantMessages 推入 list
+⑤ 末尾为 user 消息 → 追加 Loading 消息组
+```
+
+注入的占位 Loading 消息使用固定 id：`LOADING_MESSAGE_ID`（`'__loading__'`，定义于 `common/constants`）。`ChatContainer` 据此判断是否在「请求中」阶段，并向 `ChatInput` / `MessageContainer` 下传 `MessageStatus.Fetching`，与流式中的停止、防重复发送行为对齐。
+
+### Tool 消息处理
+
+`role: 'tool'` 消息不会独立渲染，而是通过 `toolCallId` 注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段：
+
+```typescript
+const toolMessage = messages.find(
+  m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === message.toolCallId),
+);
+if (toolMessage) {
+  const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+  if (toolCall) {
+    toolCall.toolMessage = message;
+  }
+  // 同步 assistant 状态（错误等）
+}
+```
+
+若找不到对应 `toolCall`（例如数据不一致），**跳过注入**，避免非空断言导致的运行时异常。
+
+### pause 字段
+
+每个 Assistant 消息组计算 `pause` 属性：
+
+```typescript
+pause = assistantMessages.some(m => m.property?.extra?.pause) ?? false;
+```
+
+`pause` 为 `true` 时，`MessageContainer` 不渲染该组的 `MessageTools` 工具栏。
+
+## executionGroups
+
+`executionGroups` 从 `messageGroups` 中过滤出执行类消息，供 `ExecutionSummary` 使用。每个执行组会自动从前一组用户消息中提取 `userMessageTitle`，作为执行摘要的标题显示；若无前置用户消息则回退为当前时间戳：
+
+```typescript
+const isExecutionMessage = (m: Message): boolean => {
+  return (
+    // 带 toolCalls 的 assistant 消息
+    (m.role === 'assistant' && !!m.toolCalls?.length) ||
+    // FlowAgent 类型的 activity 消息
+    (m.role === 'activity' && m.activityType === 'flow_agent')
+  );
+};
+```
+
+支持关键词过滤，通过 `SEARCH_TEXT_EXTRACTORS` 注册表扩展可搜索文本：
+
+| 消息类型   | 搜索范围                                                     |
+| ---------- | ------------------------------------------------------------ |
+| toolCall   | `function.name`、`mcpName`、`description`、`arguments`、`id` |
+| flow_agent | 各任务 `task_name`、各节点 `name`                             |
+
+## 待审批统计
+
+`useMessageGroup` 会统计消息列表中处于待审批状态的 AI Dev 审批中断：
+
+```typescript
+const pendingApprovalStatusSet = new Set([APPROVAL_STATUS.PENDING, APPROVAL_STATUS.DRAFT]);
+```
+
+当 `MessageRole.Interrupt` 消息的 `content.outcome.type === 'interrupt'`，且其中断项满足 `reason === InterruptReason.AIDevToolApproval`、`metadata.ticket.status` 为 `pending` 或 `draft` 时，计入 `pendingApprovalCount`。
+
+`pendingApprovalTipText` 根据数量生成输入区提示文案：
+
+```typescript
+'当前会话有 {count} 个待审批单，如需继续，请先取消审批'
+```
+
+`ChatContainer` 会消费该返回值，向 `ChatInput` 传入 `sendDisabledTip` 并在输入区上方展示提示，从而阻止继续发送。
+
+## 分享模式
+
+`useMessageGroup` 提供完整的分享模式支持：
+
+```typescript
+const {
+  isShareMode, // 是否处于分享模式
+  isAllSelected, // 是否全选
+  onToggleShareAll, // 切换全选
+  onCancelShare, // 取消分享（清空选中 + 退出分享模式）
+  onConfirmShare, // 确认分享（返回选中的消息）
+} = useMessageGroup(options);
+```
+
+选中联动规则：
+
+- 选中用户消息组 → 其后紧邻的 AI 回复组视觉联动选中
+- 取消用户消息组 → 关联 AI 回复组同时取消
+
+## 使用示例
+
+```typescript
+import { computed, ref as deepRef, shallowRef } from 'vue';
+import { useMessageGroup, type Message } from '@blueking/chat-x';
+
+const keyword = shallowRef('');
+const messages = computed(() => props.messages);
+const selectedUserMessages = deepRef<Message[]>([]);
+
+const {
+  messageGroups,
+  executionGroups,
+  pendingApprovalCount,
+  pendingApprovalTipText,
+  isShareMode,
+  isAllSelected,
+  onToggleShareAll,
+  onCancelShare,
+  onConfirmShare,
+} = useMessageGroup({
+  keyword,
+  messages,
+  selectedUserMessages,
+});
+```
+
+## 返回值说明
+
+| 属性/方法名      | 类型                          | 说明                                                                        |
+| ---------------- | ----------------------------- | --------------------------------------------------------------------------- |
+| messageGroups    | `Ref<MessageGroup[]>`         | 完整消息分组列表                                                            |
+| executionGroups  | `ComputedRef<MessageGroup[]>` | 仅包含执行类消息的分组（工具调用 + FlowAgent），自动提取 `userMessageTitle` |
+| pendingApprovalCount | `ComputedRef<number>`      | 当前消息中待审批 AI Dev 审批中断的数量                                      |
+| pendingApprovalTipText | `ComputedRef<string>`    | 待审批阻塞发送提示文案；无待审批时为空字符串                                |
+| isShareMode      | `ShallowRef<boolean>`         | 是否处于分享模式                                                            |
+| isAllSelected    | `ComputedRef<boolean>`        | 所有用户消息组是否全部选中                                                  |
+| onToggleShareAll | `(checked: boolean) => void`  | 切换全选                                                                    |
+| onCancelShare    | `() => void`                  | 取消分享模式                                                                |
+| onConfirmShare   | `() => Message[]`             | 确认分享，返回选中的消息数组                                                |
+
+## 类型定义
+
+```typescript
+import { type MessageGroup } from '@blueking/chat-x';
+
+interface MessageGroup {
+  uid: string;
+  type: MessageRole;
+  messages: Message[];
+  checked: boolean;
+  isHover: boolean;
+  pause?: boolean;
+  startTime?: number;
+  userMessageTitle?: number | string;
+}
+```
+
+## 关联组件
+
+- [ChatContainer](../components/setup/chat-container) — 调用 useMessageGroup 并下传分组
+- [MessageContainer](../components/setup/message-container) — 渲染 messageGroups
+- [ExecutionSummary](../components/agent/execution-summary) — 消费 executionGroups

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-observer-visible-list.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-observer-visible-list.md
@@ -1,0 +1,188 @@
+# useObserverVisibleList
+
+> 导入：`import { useObserverVisibleList } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useObserverVisibleList 根据 containerRef、itemRefs、gap、ComputedRef items 与可选 moreItemRef，用 ResizeObserver + 贪心算法得到 visibleItems。 依赖每项真实 offsetWidth，隐藏项需仍挂载于 DOM。返回 calculateVisibleMenuItems 供必要时手动触发。 ShortcutBtns 内部用于快捷指令溢出收入「更多」菜单。
+
+**关联**：shortcut-btns（唯一内置使用方）
+
+---
+
+# useObserverVisibleList 可见列表计算
+
+> **分类**：composable
+
+基于 `ResizeObserver` 的容器宽度感知组合式函数：遍历列表项的实际 `offsetWidth`，使用贪心算法计算在容器中能完整显示的项目子集，并为"更多"按钮动态预留空间。
+
+> 该 composable 仅在 `ShortcutBtns` 内部使用，**通常直接使用 `ShortcutBtns` 组件即可**。
+
+## 工作原理
+
+```
+calculateVisibleMenuItems():
+  await nextTick()
+  containerWidth = containerRef.value.offsetWidth
+
+  Set<T> list = {}
+  totalWidth = 0
+
+  for i in params.items.value:   // items 是 ComputedRef<T[]>，通过 .value 访问
+    itemRef = itemRefs.value[i]
+    buttonWidth = itemRef.offsetWidth
+    gap = list.size > 0 ? params.gap : 0          // 首项不加 gap
+    neededWidth = totalWidth + buttonWidth + gap
+    moreItemWidth = moreItemRef?.value?.$el?.offsetWidth ?? 0  // 动态读取
+
+    if neededWidth + params.gap + moreItemWidth <= containerWidth:
+      list.add(item)
+      totalWidth = neededWidth
+    else:
+      break  ← 立即中止，不跳过尝试后续项
+
+  visibleItems.value = Array.from(list)
+
+触发时机：
+  ├── onMounted：ResizeObserver.observe(containerRef) + nextTick 初始计算
+  ├── watch([itemRefs, moreItemRef])：DOM 引用更新时（nextTick 后）重新计算
+  └── onScopeDispose：ResizeObserver.disconnect()
+```
+
+## 渲染示例
+
+`ShortcutBtns` 内部使用 `useObserverVisibleList`，缩放浏览器窗口观察溢出效果：
+
+## 直接使用示例
+
+```vue
+<template>
+  <div
+    ref="containerRef"
+    class="btn-bar"
+  >
+    <!-- 所有项始终渲染，溢出项用 CSS 隐藏（offsetWidth 仍可读） -->
+    <template
+      v-for="(item, i) in items"
+      :key="item.id"
+    >
+      <button
+        :ref="el => setItemRef(el as HTMLElement, i)"
+        :class="['btn-item', { 'btn-item--hidden': !visibleItems.includes(item) }]"
+        @click="handleClick(item)"
+      >
+        {{ item.name }}
+      </button>
+    </template>
+
+    <!-- 更多按钮：仅在有隐藏项时显示 -->
+    <MoreBtn
+      v-show="hiddenItems.length > 0"
+      ref="moreBtnRef"
+      @click="showMoreMenu"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed, shallowRef, useTemplateRef } from 'vue';
+  import { useObserverVisibleList } from '@blueking/chat-x';
+
+  interface Item {
+    id: string;
+    name: string;
+  }
+
+  const containerRef = useTemplateRef<HTMLElement>('containerRef');
+  const moreBtnRef = useTemplateRef('moreBtnRef');
+
+  // 必须是 ShallowRef，由调用方维护（DOM 更新后写入）
+  const itemRefs = shallowRef<(HTMLElement | null)[]>([]);
+
+  const items = shallowRef<Item[]>([
+    { id: '1', name: '按钮 1' },
+    { id: '2', name: '按钮 2' },
+    { id: '3', name: '按钮 3' },
+    { id: '4', name: '按钮 4' },
+    { id: '5', name: '按钮 5' },
+  ]);
+
+  const { visibleItems, calculateVisibleMenuItems } = useObserverVisibleList<Item>(containerRef, itemRefs, {
+    gap: 4, // 按钮间距（必填）
+    items: computed(() => items.value), // 需传入 ComputedRef<T[]>，内部通过 .value 访问
+    moreItemRef: moreBtnRef, // 可选，动态读取"更多"按钮宽度
+  });
+
+  const hiddenItems = computed(() => items.value.filter(i => !visibleItems.value.includes(i)));
+
+  const setItemRef = (el: HTMLElement | null, index: number) => {
+    itemRefs.value[index] = el;
+  };
+
+  // items 变化时：重置 itemRefs（触发 watch → 重新计算）
+  watch(items, () => {
+    itemRefs.value = new Array(items.value.length).fill(null);
+  });
+</script>
+
+<style scoped>
+  .btn-bar {
+    display: flex;
+    gap: 4px;
+    overflow: hidden;
+  }
+
+  /* 隐藏项必须保持在 DOM 中（offsetWidth 才可读），用定位脱离文档流 */
+  .btn-item--hidden {
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+    opacity: 0;
+  }
+</style>
+```
+
+## API
+
+```typescript
+function useObserverVisibleList<T>(
+  containerRef: TemplateRef<HTMLElement>,
+  itemRefs: ShallowRef<(HTMLElement | null)[]>,
+  params: {
+    gap: number; // 必填，按钮间距（px）
+    items: ComputedRef<T[]>; // 必填，响应式项目数组（ComputedRef）
+    moreItemRef?: TemplateRef<InstanceType<typeof ShortcutBtn>>; // 可选，"更多"按钮引用
+  },
+): {
+  visibleItems: ShallowRef<T[]>;
+  calculateVisibleMenuItems: () => Promise<void>;
+};
+```
+
+### 参数说明
+
+| 参数                 | 类型                                  | 必填 | 说明                                                                                                        |
+| -------------------- | ------------------------------------- | ---- | ----------------------------------------------------------------------------------------------------------- |
+| `containerRef`       | `TemplateRef<HTMLElement>`            | 是   | 容器 DOM 引用；`ResizeObserver` 监听此元素宽度变化                                                          |
+| `itemRefs`           | `ShallowRef<(HTMLElement \| null)[]>` | 是   | 各项 DOM 引用数组；`watch` 监听其变化触发重新计算                                                           |
+| `params.gap`         | `number`                              | 是   | 相邻按钮间距（px）；首项不加 gap                                                                            |
+| `params.items`       | `ComputedRef<T[]>`                    | 是   | **响应式**项目数组，需传入 `ComputedRef`（如 `computed(() => list.value)`）；内部通过 `.value` 访问最新数据 |
+| `params.moreItemRef` | `TemplateRef<ShortcutBtn>`            | 否   | "更多"按钮引用；每次计算从 `$el.offsetWidth` 动态读取宽度；缺省时按 0 计算                                  |
+
+### 返回值
+
+| 属性名                      | 类型                  | 说明                                                               |
+| --------------------------- | --------------------- | ------------------------------------------------------------------ |
+| `visibleItems`              | `ShallowRef<T[]>`     | 当前能完整放入容器的项目子集（引用与 `params.items` 中的对象一致） |
+| `calculateVisibleMenuItems` | `() => Promise<void>` | 手动触发计算（内部有 `await nextTick()`）；一般无需调用            |
+
+## 注意事项
+
+1. **`items` 必须为 `ComputedRef`**：`params.items` 现在接受 `ComputedRef<T[]>` 类型，内部通过 `.value` 读取最新数据。建议使用 `computed(() => props.shortcuts)` 包装后传入，确保 items 变化时计算逻辑能访问到最新数据。注意 `itemRefs` 的重置仍需在外部维护（`itemRefs.value = new Array(items.value.length).fill(null)`），以触发 `watch([itemRefs, moreItemRef])` 重新计算
+2. **隐藏项必须留在 DOM**：算法依赖 `itemRef.offsetWidth` 读取每项实际宽度；使用 `position: absolute; visibility: hidden` 隐藏而非 `display: none`
+3. **算法贪心且单调**：遇到第一个放不下的项就立即 `break`，不跳过继续尝试后续较短的项
+4. **`moreItemRef` 宽度动态读取**：每次计算循环中实时读取 `$el.offsetWidth`，宽度可以随内容变化（如显示隐藏数量文字时）
+5. **`ResizeObserver` 仅在 `onMounted` 时绑定一次**：若 `containerRef.value` 在挂载时为 `null`，则不会监听容器宽度变化
+6. **`moreItemRef` 类型限定为 `ShortcutBtn`**：强依赖内部 `$el` expose，若用于其他组件需确保 expose 了 `$el`
+
+## 关联组件
+
+- [ShortcutBtns](../components/input/shortcut-btns.md) — 快捷指令条与「更多」

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-parent-scrolling.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-parent-scrolling.md
@@ -1,0 +1,46 @@
+# useParentScrolling
+
+> 导入：`import { useParentScrolling } from '@blueking/chat-x'` ｜ since 1.0.0
+
+useParentScrolling(domRef) 在挂载后通过 getScrollParent 找到最近可滚动祖先，监听 scroll 与 scrollend，返回 isScrolling 与 scrollParent。 scroll 时将 isScrolling 置 true，300ms 无滚动或 scrollend 时置 false，适合滚动时隐藏浮层等交互。getScrollParent 可单独导出使用。 当前源码无组件内引用，供业务或后续浮层组件按需集成。
+
+---
+
+# useParentScrolling 父容器滚动监听
+
+> **分类**：composable
+
+向上递归查找**最近可滚动祖先**，监听其 `scroll` / `scrollend` 事件，提供 `isScrolling` 状态。常用于滚动时自动关闭浮层、禁用交互等场景。
+
+同时导出辅助函数 `getScrollParent`，可单独使用。
+
+## 工作原理
+
+```
+getScrollParent(node):
+  ├── !node → null
+  ├── !(node instanceof HTMLElement) → getScrollParent(parentElement) 或 document.body
+  ├── scrollHeight > clientHeight
+  │     && overflowY in ['scroll', 'auto', 'overlay'] → return node（找到）
+  └── else → getScrollParent(parentElement) 或 document.body（fallback）
+
+useParentScrolling(domRef):
+  onMounted:
+    scrollParent = getScrollParent(toValue(domRef))
+    removeEventListener（防御性清理）
+    addEventListener('scroll', handleScroll)    ← 非 passive
+    addEventListener('scrollend', handleScrollEnd)
+
+  handleScroll:
+    isScrolling = true
+    clearTimeout(timer)
+    timer = setTimeout(() => isScrolling = false, 300)  ← 300ms 无滚动后重置
+
+  handleScrollEnd:
+    isScrolling = false  ← 原生 scrollend 事件立即重置（浏览器兼容性见下）
+
+  onScopeDispose:
+    removeEventListener（自动清理）
+```
+
+## 渲染示例

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/theme/theme.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/theme/theme.md
@@ -1,0 +1,431 @@
+# 主题配置
+
+> since 1.0.0
+
+说明通过 SCSS 变量（尺寸、颜色、z-index）、字号主题 CSS 变量（data-ai-size 切换 small/normal）与 CSS 类覆盖自定义主题。 ChatContainer.size 控制根节点 data-ai-size；浮层同步 document.body.dataset.aiSize。含渐变边框 mixin、骨架屏类 ai-skeleton-element 等。
+
+**关联**：chat-container（整体布局与侧栏）、chat-input（输入区与渐变边框）、message-container（消息区样式上下文）
+
+---
+
+# 主题配置
+
+> **分类**：theme
+
+`@blueking/chat-x` 使用 SCSS 变量和 CSS 类来控制样式，支持通过覆盖变量或样式来自定义主题。
+
+## 样式引入
+
+组件库的样式会在引入组件时自动加载，无需单独引入：
+
+```typescript
+// 引入组件时会自动引入样式
+import { ChatInput, MessageContainer } from '@blueking/chat-x';
+```
+
+## 字号主题
+
+组件库通过根节点 `[data-ai-size]` 切换两档字号主题，内部组件统一引用 CSS 变量（均带兜底值，无 provider 时退回 `small`）。
+
+### 切换方式
+
+| 方式 | 说明 |
+| ---- | ---- |
+| `ChatContainer` 的 `size` prop | 推荐。根节点 `.ai-chat-container` 设置 `data-ai-size`；同时通过 `useGlobalConfig` 注入 `size` 供逻辑层读取 |
+| 手动设置 `data-ai-size` | 在任意祖先元素上设置 `data-ai-size="small"` 或 `data-ai-size="normal"`，后代继承 CSS 变量 |
+| `document.body.dataset.aiSize` | `ChatContainer` 会自动同步，供 Tippy / Teleport 等挂载到 `body` 的浮层继承字号变量；容器卸载时清理 |
+
+```vue
+<template>
+  <ChatContainer v-model="input" :messages="messages" size="normal" />
+</template>
+```
+
+### CSS 变量
+
+定义于 `src/styles/size-theme.scss`，随 `global.scss` 自动引入：
+
+| 变量名 | `small`（默认） | `normal` | 说明 |
+| ------ | --------------- | -------- | ---- |
+| `--ai-font-size` | `12px` | `14px` | 基准字号 |
+| `--ai-line-height` | `20px` | `24px` | 标准行高 |
+| `--ai-line-height-compact` | `20px` | `22px` | 紧凑行高 |
+| `--ai-spacing-comfortable` | `8px` | `12px` | 舒适间距（如消息气泡水平内边距） |
+| `--ai-icon-size` | `16px` | `20px` | 标准图标尺寸 |
+| `--ai-icon-size-sm` | `16px` | `18px` | 小号图标尺寸 |
+
+组件样式中统一使用 `var(--ai-font-size, 12px)` 等形式引用，保证无 `data-ai-size` 时仍退回 small 档位。
+
+```scss
+// 示例：在自定义样式中复用字号主题变量
+.my-custom-panel {
+  font-size: var(--ai-font-size, 12px);
+  line-height: var(--ai-line-height, 20px);
+}
+```
+
+### 骨架屏
+
+全局类 `.ai-skeleton-element` 用于加载占位（如 FlowAgent 节点详情、UserFeedback 原因列表）。可通过 `.skeleton-element-lg` 修饰尺寸。详见各业务组件文档中的加载态说明。
+
+## SCSS 变量
+
+组件库使用以下 SCSS 变量，可以在项目中覆盖：
+
+### 尺寸变量
+
+```scss
+// 输入框尺寸
+$chat-input-min-width: 350px;
+$chat-input-max-width: 700px;
+```
+
+### 颜色变量
+
+```scss
+// 主题色
+$primary-color: #3a84ff;
+
+// 文字颜色
+$text-color-primary: #313238;
+$text-color-secondary: #4d4f56;
+$text-color-placeholder: #979ba5;
+
+// 背景色
+$bg-color-white: #fff;
+$bg-color-light: #f5f7fa;
+$bg-color-hover: #f0f1f5;
+
+// 边框色
+$border-color: #dcdee5;
+$border-color-hover: #c4c6cc;
+```
+
+### Z-Index 变量
+
+组件库使用分层的 z-index 管理：
+
+```scss
+// 基础 z-index
+$chat-z-index: 9999;
+
+// 编辑器 z-index
+$editor-z-index: $chat-z-index + 1;
+
+// 编辑器菜单 z-index
+$editor-menu-z-index: $editor-z-index + 1;
+
+// 快捷指令菜单 z-index
+$shortcut-menu-z-index: $editor-menu-z-index + 1;
+
+// 划选弹窗 z-index
+$selection-z-index: $shortcut-menu-z-index + 1;
+```
+
+## CSS 类覆盖
+
+### 输入框样式
+
+```scss
+// 覆盖输入框容器样式
+.chat-input-container {
+  .chat-input {
+    min-height: 120px; // 自定义最小高度
+    max-height: 250px; // 自定义最大高度
+    background: #fafafa; // 自定义背景色
+
+    // 覆盖边框渐变
+    &::before {
+      background: linear-gradient(180deg, #ff6b6b, #ff8e53);
+    }
+  }
+}
+```
+
+### 消息样式
+
+```scss
+// 用户消息样式
+.ai-user-message {
+  &-content {
+    background-color: #d4edda; // 自定义背景色
+    border-radius: 8px;
+  }
+}
+
+// AI 消息样式
+.assistant-message {
+  &-content {
+    background-color: #f8f9fa;
+    border-left: 3px solid #3a84ff;
+    padding-left: 12px;
+  }
+}
+```
+
+### 快捷指令按钮样式
+
+```scss
+// 快捷指令按钮
+.shortcut-btns {
+  &-item {
+    background: linear-gradient(135deg, #667eea, #764ba2);
+    color: #fff;
+
+    &:hover {
+      transform: translateY(-2px);
+      box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    }
+
+    // 移除默认渐变边框
+    &::before {
+      display: none;
+    }
+  }
+}
+```
+
+### 消息工具栏样式
+
+```scss
+// 工具按钮
+.tool-btn {
+  width: 24px;
+  height: 24px;
+  font-size: 16px;
+
+  &:hover {
+    background-color: #e1ecff;
+    color: #3a84ff;
+  }
+}
+```
+
+### Markdown 内容样式
+
+```scss
+// Markdown 内容
+.ai-markdown-content {
+  .ai-markdown-body {
+    font-size: 14px;
+    line-height: 1.6;
+
+    // 代码块样式
+    pre code.hljs {
+      background-color: #1e1e1e;
+      border-radius: 8px;
+    }
+
+    // 表格样式
+    table {
+      border-collapse: collapse;
+
+      th,
+      td {
+        border: 1px solid #dcdee5;
+        padding: 8px 12px;
+      }
+
+      th {
+        background-color: #f5f7fa;
+      }
+    }
+  }
+}
+```
+
+## 主题切换示例
+
+### 暗色主题
+
+```scss
+// 暗色主题变量
+.dark-theme {
+  // 输入框
+  .chat-input-container .chat-input {
+    background: #2d2d2d;
+
+    &::before {
+      background: linear-gradient(180deg, #4a90d9, #357abd);
+    }
+  }
+
+  // 用户消息
+  .ai-user-message-content {
+    background-color: #3d5a80;
+    color: #fff;
+  }
+
+  // AI 消息
+  .assistant-message {
+    color: #e0e0e0;
+  }
+
+  // Markdown 内容
+  .ai-markdown-content .ai-markdown-body {
+    color: #e0e0e0;
+
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      color: #fff;
+    }
+
+    a {
+      color: #6cb2eb;
+    }
+
+    code {
+      background-color: #3d3d3d;
+      color: #e0e0e0;
+    }
+  }
+
+  // 快捷指令
+  .shortcut-btns-item {
+    background: #3d3d3d;
+    color: #e0e0e0;
+
+    &::before {
+      background: linear-gradient(105deg, #4a90d940, #9b59b640);
+    }
+  }
+
+  // 工具按钮
+  .tool-btn {
+    color: #9e9e9e;
+
+    &:hover {
+      background-color: #424242;
+      color: #fff;
+    }
+  }
+}
+```
+
+### 使用暗色主题
+
+```vue
+<template>
+  <div :class="{ 'dark-theme': isDark }">
+    <ChatInput v-model="input" />
+    <MessageContainer :messages="messages" />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { ChatInput, MessageContainer } from '@blueking/chat-x';
+
+  const isDark = ref(false);
+  const input = ref('');
+  const messages = ref([]);
+</script>
+```
+
+## 渐变边框
+
+组件库使用 CSS mask 实现渐变边框效果：
+
+```scss
+// 渐变边框 mixin
+@mixin linear-gradient-border($angle: 105deg, $start-color: #235dfa40, $end-color: #bc81ef40) {
+  content: '';
+  position: absolute;
+  inset: 0;
+  padding: 1px;
+  background: linear-gradient($angle, $start-color, $end-color);
+  mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  mask-composite: xor;
+  mask-composite: exclude;
+  border-radius: inherit;
+  pointer-events: none;
+}
+```
+
+使用示例：
+
+```scss
+.custom-card {
+  position: relative;
+  border-radius: 8px;
+
+  &::before {
+    @include linear-gradient-border(180deg, #6cbaff, #3a84ff);
+  }
+}
+```
+
+## 动画效果
+
+### 淡入动画
+
+```scss
+// 全局淡入动画
+@keyframes ai-markdown-fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.ai-blueking-markdown-fade-in {
+  animation: ai-markdown-fade-in 0.2s ease-out forwards;
+}
+```
+
+### 弹窗过渡
+
+```scss
+// 选择弹窗过渡
+.ai-fade-enter-active,
+.ai-fade-leave-active {
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
+}
+
+.ai-fade-enter-from,
+.ai-fade-leave-to {
+  opacity: 0;
+  transform: translateY(4px);
+}
+```
+
+## 响应式设计
+
+```scss
+// 移动端适配
+@media (max-width: 768px) {
+  .chat-input-container .chat-input {
+    min-width: 100%;
+    max-width: 100%;
+  }
+
+  .shortcut-btns {
+    min-width: 100%;
+    max-width: 100%;
+  }
+}
+```
+
+## 注意事项
+
+1. **样式优先级**：覆盖样式时可能需要使用更高优先级的选择器
+2. **变量位置**：SCSS 变量需要在组件样式之前定义
+3. **构建配置**：确保项目配置支持 SCSS 处理
+4. **组件隔离**：使用 scoped 样式时，深度选择器 `::v-deep` 或 `:deep()` 可能需要
+
+## 关联组件
+
+- [ChatContainer](../components/setup/chat-container) — 布局与字号主题根节点（`size` prop）
+- [useGlobalConfig](../composables/use-global-config) — 注入 `size` 供后代读取
+- [ChatInput](../components/input/chat-input) — 输入区变量与类名
+- [MessageContainer](../components/setup/message-container) — 消息列表区域

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/constants.md
@@ -1,0 +1,305 @@
+# 常量枚举
+
+> since 1.0.0
+
+汇总 MessageRole、MessageStatus（含 Fetching 请求中）、MessageContentType、MessageToolsStatus、MessageState、Z-Index 与 CONST_MESSAGE_TOOLS 等导出常量。 用于构造消息、配置 MessageContainer 工具栏与输入态，以及层级与默认快捷指令。与类型 messages 配套使用。
+
+**关联**：message-tools（默认工具 ID 与展示）、chat-input（MessageState 与快捷指令）、message-container（工具栏与消息态）
+
+---
+
+# 常量枚举
+
+> **分类**：type
+
+`@blueking/chat-x` 导出的常量和枚举类型。
+
+## 消息相关
+
+### MessageRole
+
+消息角色枚举：
+
+```typescript
+enum MessageRole {
+  User = 'user',
+  Assistant = 'assistant',
+  System = 'system',
+  Developer = 'developer',
+  Guide = 'guide',
+  Hidden = 'hidden',
+  HiddenAssistant = 'hidden-assistant',
+  HiddenGuide = 'hidden-guide',
+  HiddenSystem = 'hidden-system',
+  HiddenUser = 'hidden-user',
+  Info = 'info',
+  Interrupt = 'interrupt',
+  Loading = 'loading',
+  Pause = 'pause',
+  Placeholder = 'placeholder',
+  Reasoning = 'reasoning',
+  TemplateAssistant = 'template-assistant',
+  TemplateGuide = 'template-guide',
+  TemplateHidden = 'template-hidden',
+  TemplateSystem = 'template-system',
+  TemplateUser = 'template-user',
+  Tool = 'tool',
+  Activity = 'activity',
+}
+```
+
+### MessageStatus
+
+消息状态枚举：
+
+```typescript
+enum MessageStatus {
+  Complete = 'complete',
+  Disabled = 'disabled',
+  Error = 'error',
+  Fetching = 'fetching', // 请求中（例如已发用户消息、尚未开始流式，与末尾 Loading 占位一致）
+  Pending = 'pending',
+  Stop = 'stop',
+  StopLoading = 'stop-loading',
+  Streaming = 'streaming',
+  Success = 'success',
+}
+```
+
+| 枚举值          | 说明 |
+| --------------- | ---- |
+| `Fetching`      | 请求中：与 `useMessageGroup` 在末尾用户消息后注入的 Loading 占位（`LOADING_MESSAGE_ID`）配合时，`ChatContainer` 会将传入输入区与列表底部的状态推导为该值，便于展示「停止」与禁止重复发送。 |
+
+### InterruptReason
+
+human-in-the-loop 中断原因枚举，用于 `Interrupt.reason` 区分中断类型并选择对应的 UI 渲染器。
+
+```typescript
+enum InterruptReason {
+  AIDevToolApproval = 'aidev:tool_approval',
+  UserQuestion = 'aidev:user_question',
+}
+```
+
+### APPROVAL_STATUS
+
+AI Dev 工具审批单状态枚举，`AIDevToolApprovalInterrupt.metadata.ticket.status` 使用该类型。
+
+```typescript
+enum APPROVAL_STATUS {
+  ABANDONED = 'abandoned',
+  APPROVED = 'approved',
+  CANCELLED = 'cancelled',
+  DRAFT = 'draft',
+  EXPIRED = 'expired',
+  PENDING = 'pending',
+  REJECTED = 'rejected',
+  REVOKED = 'revoked',
+}
+```
+
+### APPROVAL_STATUS_MAP
+
+审批单状态到展示文案的映射，供 `ToolApprovalCard` 等组件使用：
+
+```typescript
+const APPROVAL_STATUS_MAP: Record<APPROVAL_STATUS, string> = {
+  [APPROVAL_STATUS.ABANDONED]: '已废弃',
+  [APPROVAL_STATUS.APPROVED]: '已通过',
+  [APPROVAL_STATUS.CANCELLED]: '已取消',
+  [APPROVAL_STATUS.DRAFT]: '待审批',
+  [APPROVAL_STATUS.EXPIRED]: '已过期',
+  [APPROVAL_STATUS.PENDING]: '待审批',
+  [APPROVAL_STATUS.REJECTED]: '已拒绝',
+  [APPROVAL_STATUS.REVOKED]: '已撤销',
+};
+```
+
+| 状态值      | 展示文案 |
+| ----------- | -------- |
+| `pending`   | 待审批   |
+| `draft`     | 待审批   |
+| `approved`  | 已通过   |
+| `rejected`  | 已拒绝   |
+| `cancelled` | 已取消   |
+| `expired`   | 已过期   |
+| `abandoned` | 已废弃   |
+| `revoked`   | 已撤销   |
+
+### RunFinishedOutcome
+
+AG-UI `RUN_FINISHED` 事件的结束结果类型。中断结果不再是字符串枚举，而是对象联合类型；`type: 'interrupt'` 时，中断列表放在 `interrupts` 字段中。
+
+```typescript
+type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
+```
+
+### MessageContentType
+
+消息内容类型枚举：
+
+```typescript
+enum MessageContentType {
+  Binary = 'binary',
+  FlowAgent = 'flow_agent',
+  Function = 'function',
+  KeyValue = 'key_value',
+  KnowledgeRag = 'knowledge_rag',
+  Other = 'other',
+  ReferenceDocument = 'reference_document',
+  Text = 'text',
+}
+```
+
+### MessageToolsStatus
+
+消息工具栏状态枚举：
+
+```typescript
+enum MessageToolsStatus {
+  Disabled = 'disabled', // 禁用状态，按钮显示但不可点击
+  Hidden = 'hidden', // 隐藏状态，工具栏完全隐藏
+}
+```
+
+### RenderMode
+
+渲染模式枚举，控制 `ChatContainer` / `MessageContainer` 的 UI 行为：
+
+```typescript
+enum RenderMode {
+  Chat = 'chat',   // 默认对话模式
+  Share = 'share', // 分享预览模式：隐藏侧边栏和工具栏，启用多选样式
+  Test = 'test',   // 测试/嵌入模式：过滤掉「分享」按钮
+}
+```
+
+| 枚举值  | 侧边栏 | MessageTools   | 说明                           |
+| ------- | ------ | -------------- | ------------------------------ |
+| `Chat`  | 正常   | 全部按钮       | 默认行为                       |
+| `Share` | 隐藏   | 隐藏           | 分享预览，仅展示消息内容       |
+| `Test`  | 正常   | 过滤掉「分享」 | 测试或嵌入场景，隐藏分享入口   |
+
+## 输入状态
+
+### MessageState
+
+输入框消息状态：
+
+```typescript
+const MessageState = {
+  ACTIVE: 'active',
+  DISABLED: 'disabled',
+  LOADING: 'loading',
+} as const;
+```
+
+## Z-Index 常量
+
+```typescript
+// 全局 chat-x 组件 Z-Index
+const CHAT_Z_INDEX = 9999;
+
+// 编辑器组件 Z-Index
+const EDITOR_Z_INDEX = 10000;
+
+// 编辑器菜单 Z-Index
+const EDITOR_MENU_Z_INDEX = 10001;
+
+// 快捷指令菜单 Z-Index
+const SHORTCUT_MENU_Z_INDEX = 10002;
+
+// 划选弹窗 Z-Index
+const SELECTION_Z_INDEX = 10003;
+```
+
+## 默认工具按钮
+
+### CONST_MESSAGE_TOOLS
+
+消息工具按钮列表：
+
+```typescript
+const CONST_MESSAGE_TOOLS: IToolBtn[] = [
+  { id: 'copy', name: '复制', description: '复制' },
+  { id: 'cite', name: '引用', description: '引用' },
+  { id: 'rebuild', name: '重新生成', description: '重新生成' },
+  { id: 'share', name: '分享', description: '分享' },
+];
+```
+
+### CONST_USER_MESSAGE_TOOLS
+
+用户消息工具按钮列表：
+
+```typescript
+const CONST_USER_MESSAGE_TOOLS: IToolBtn[] = [
+  { id: 'copy', name: '复制', description: '复制' },
+  { id: 'cite', name: '引用', description: '引用' },
+  { id: 'edit', name: '编辑', description: '编辑' },
+  { id: 'delete', name: '删除', description: '删除' },
+];
+```
+
+### CONST_UPDATE_TOOLS
+
+更新工具按钮列表（点赞/不满意）：
+
+```typescript
+const CONST_UPDATE_TOOLS: IToolBtn[] = [
+  { id: 'like', name: '点赞', description: '点赞' },
+  { id: 'unlike', name: '不满意', description: '不满意' },
+  { id: 'delete', name: '删除', description: '删除' },
+];
+```
+
+## 默认快捷指令
+
+### DEFAULT_SHORTCUTS
+
+默认快捷指令列表：
+
+```typescript
+const DEFAULT_SHORTCUTS: Shortcut[] = [{ id: 'ask-whale', name: '问问小鲸' }];
+```
+
+## 使用示例
+
+```typescript
+import {
+  MessageRole,
+  MessageStatus,
+  MessageContentType,
+  MessageToolsStatus,
+  RenderMode,
+  CHAT_Z_INDEX,
+  CONST_MESSAGE_TOOLS,
+  DEFAULT_SHORTCUTS,
+} from '@blueking/chat-x';
+
+// 创建消息
+const message = {
+  id: '1',
+  messageId: 1,
+  role: MessageRole.User,
+  content: '你好',
+  status: MessageStatus.Complete,
+};
+
+// 检查消息状态
+if (message.status === MessageStatus.Streaming) {
+  console.log('消息正在流式输出中...');
+}
+
+// 使用默认工具按钮
+console.log(
+  '可用工具:',
+  CONST_MESSAGE_TOOLS.map(t => t.name),
+);
+```
+
+## 关联组件
+
+- [MessageTools](../components/feedback/message-tools) — 消息工具栏
+- [ChatInput](../components/input/chat-input) — 输入与状态
+- [MessageContainer](../components/setup/message-container) — 工具与消息展示

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/interrupt.md
@@ -1,0 +1,373 @@
+# 中断类型 Interrupt
+
+> since 2.0.0
+
+定义 RunFinishedOutcome、BaseInterrupt、AIDevToolApprovalInterrupt、AIDevToolApprovalResume、UserQuestionInterrupt、InterruptResult、BaseResume、InterruptMessage 与 OnInterruptResume。 与 MessageRole.Interrupt、InterruptMessageRender、UserQuestionCard、ToolApprovalCard 配合，对应 RUN_FINISHED outcome。
+
+**关联**：interrupt-message（根据 outcome.interrupts 与 reason 渲染中断 UI，success 时按 result.reason 回显审批单或用户回答）、user-question-card（UserQuestion 交互面板，挂载在 ChatInput 上方）、tool-approval-card（AIDevToolApproval 专用卡片）、message-render（role 为 interrupt 时派发 InterruptMessageRender）
+
+---
+
+# 中断类型 Interrupt
+
+> **分类**：type
+
+AG-UI [Interrupts](https://docs.ag-ui.com/drafts/interrupts) 协议相关类型，定义在 `src/ag-ui/types/interrupt.ts`，由 `@blueking/chat-x` 导出。
+
+中断链路分为两段：
+
+1. Agent 返回 `RUN_FINISHED { outcome: { type: 'interrupt', interrupts } }`，前端渲染等待用户处理的 UI。
+2. 用户操作后调用 `onInterruptResume(payload, interrupt?)`，业务侧按 `payload.operation` 分支处理，并将 `payload` 作为 `RunAgentInput.resume` 回传给 Agent。
+
+## InterruptResumeOperation
+
+统一标识用户在「中断消息 / 活动消息」上触发的、需回传 Agent 处理的动作：
+
+```typescript
+enum InterruptResumeOperation {
+  /** 主动取消第三方工具审批 */
+  ApprovalCancel = 'approval_cancel',
+  /** 重试失败的流程节点（bkflow） */
+  FlowNodeRetry = 'flow_node_retry',
+  /** 跳过失败的流程节点（bkflow） */
+  FlowNodeSkip = 'flow_node_skip',
+}
+```
+
+业务侧通过 `onInterruptResume` 回调的 `payload.operation` 字段进行分支处理；新增操作类型只需扩展此枚举，回调契约与透传链路保持不变。
+
+## RunFinishedOutcome
+
+`RUN_FINISHED` 事件的 `outcome` 联合类型：
+
+```typescript
+type RunFinishedOutcome =
+  | { interrupts: Interrupt[]; type: 'interrupt' }
+  | { type: 'success' };
+```
+
+| `type`        | 说明                                                                 |
+| ------------- | -------------------------------------------------------------------- |
+| `'interrupt'` | 等待用户响应；`interrupts` 驱动 UI 渲染审批卡片、用户问题面板等       |
+| `'success'`   | 用户已通过 `resume` 处理；按 `result.reason` 在会话内回显审批单（`AIDevToolApproval`）或用户回答（`UserQuestion`） |
+
+## BaseInterrupt
+
+所有中断项的公共结构：
+
+```typescript
+type BaseInterrupt<T extends InterruptReason, M extends Record<string, any>> = {
+  expiresAt?: string;
+  id: string;
+  message?: string;
+  metadata?: M;
+  properties?: Record<string, any>;
+  reason: T;
+  toolCallId: string;
+};
+```
+
+## AIDevToolApprovalInterrupt
+
+AI Dev 第三方工具审批中断，`reason` 为 `InterruptReason.AIDevToolApproval`（`'aidev:tool_approval'`）：
+
+```typescript
+type AIDevToolApprovalInterruptPayloadMetaData = {
+  ticket: {
+    approvers: string[];
+    sn: string;
+    status: APPROVAL_STATUS;
+    submit_time: string;
+    title: string;
+    url: string;
+  };
+};
+
+type AIDevToolApprovalInterrupt = BaseInterrupt<
+  InterruptReason.AIDevToolApproval,
+  AIDevToolApprovalInterruptPayloadMetaData
+>;
+```
+
+## AIDevToolApprovalResume
+
+AI Dev 第三方工具审批中断响应（resume 后用于 `outcome.success` 时会话内回显审批单）。`payload.metadata` 透传中断时的 `metadata`（含 `ticket`），以便复用 `ToolApprovalCard` 只读渲染：
+
+```typescript
+type AIDevToolApprovalResume = BaseResume<
+  InterruptReason.AIDevToolApproval,
+  { metadata: AIDevToolApprovalInterruptPayloadMetaData }
+>;
+```
+
+## UserQuestionInterrupt
+
+用户回答问题中断，`reason` 为 `InterruptReason.UserQuestion`（`'aidev:user_question'`）。交互面板由 `ChatContainer` 挂载到 `ChatInput` 上方。
+
+```typescript
+type UserQuestionInterrupt = BaseInterrupt<
+  InterruptReason.UserQuestion,
+  {
+    questions: UserQuestionItem[];
+  }
+>;
+
+type UserQuestionItem = {
+  header: string;
+  /** 是否多选；仅选择题语义，自定义表单类问题可不传 */
+  multiSelect?: boolean;
+  options?: UserQuestionOptionItem[];
+  question: string;
+};
+
+type UserQuestionOptionItem = {
+  description: string;
+  label: string;
+};
+```
+
+约定：
+
+- `multiSelect: false` 表示单选题，`true` 表示多选题；**不传**时 UI 不展示单选/多选标签，默认选择题组件仍按单选行为处理。
+- 前端会为每道**选择题**追加 `label: 'others'` 的自由输入项；后端无需重复下发该选项。
+- 当用户选择 Others 时，`answer[].description` 为用户输入文本。
+- 业务可通过 `UserQuestionCard` 的 `#question` slot 渲染自定义表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
+
+## Interrupt
+
+当前支持的中断联合类型：
+
+```typescript
+type Interrupt =
+  | AIDevToolApprovalInterrupt
+  | UserQuestionInterrupt
+  | BaseInterrupt<InterruptReason, Record<string, any>>;
+```
+
+## InterruptResult
+
+中断处理结果（resume 后回传/持久化，用于 `outcome.success` 时会话内回显）。按 `reason` 区分不同结果形态，统一具备 `BaseResume` 的 `{ interruptId, reason, status }`；新增中断类型的回显结果只需在此联合扩展：
+
+```typescript
+type InterruptResult = AIDevToolApprovalResume | UserQuestionResume;
+```
+
+## InterruptResume 联合类型
+
+用户操作后通过 `onInterruptResume` 回传的负载（与 `InterruptResult` 用途不同：`InterruptResume` 侧重**动作回传**，`InterruptResult` 侧重**success 态会话内回显**）：
+
+```typescript
+type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestionResume;
+```
+
+| 类型                 | `operation` / `reason`              | 说明                                                         |
+| -------------------- | ----------------------------------- | ------------------------------------------------------------ |
+| `ToolApprovalResume` | `InterruptResumeOperation.ApprovalCancel` | 第三方工具审批取消                                           |
+| `FlowNodeResume`     | `flow_node_retry` / `flow_node_skip` | FlowAgent 失败节点重试 / 跳过；**无**对应 `Interrupt` 项     |
+| `UserQuestionResume` | `InterruptReason.UserQuestion`（`reason` 字段） | 用户回答问题                                                 |
+
+### ToolApprovalResume
+
+```typescript
+type ToolApprovalResume = {
+  operation: InterruptResumeOperation.ApprovalCancel;
+  payload: { interrupt_id: number | string };
+};
+```
+
+### FlowNodeResume
+
+流程节点不属于 interrupt，节点定位信息（`task_id` / `node_id`）随 `payload` 回传；此时 `onInterruptResume` 的第二个 `interrupt` 参数**不传**。
+
+```typescript
+type FlowNodeResume = {
+  operation: InterruptResumeOperation.FlowNodeRetry | InterruptResumeOperation.FlowNodeSkip;
+  payload: {
+    node_id: string;
+    task_id: number;
+  };
+};
+```
+
+## BaseResume / UserQuestionResume
+
+`UserQuestion` 的 resume payload 为单个对象，与 `chat-helper` 的 `IResume` 保持一致：
+
+```typescript
+type BaseResume<T extends InterruptReason, P extends Record<string, any>> = {
+  interruptId: string;
+  payload: P;
+  reason: T;
+  status: 'cancelled' | 'resolved';
+};
+
+type UserQuestionAnswerItem = {
+  answer: UserQuestionOptionItem[];
+  multiSelect?: boolean;
+  question: string;
+};
+
+type UserQuestionResume = BaseResume<
+  InterruptReason.UserQuestion,
+  {
+    answers: UserQuestionAnswerItem[];
+  }
+>;
+```
+
+示例：
+
+```typescript
+const resume: UserQuestionResume = {
+  interruptId: 'interrupt_user_question',
+  reason: InterruptReason.UserQuestion,
+  status: 'resolved',
+  payload: {
+    answers: [
+      {
+        question: '请选择语言',
+        multiSelect: true,
+        answer: [
+          { label: 'Java', description: 'Java' },
+          { label: 'others', description: 'Rust' },
+        ],
+      },
+    ],
+  },
+};
+```
+
+## InterruptMessage
+
+`MessageRole.Interrupt` 对应的消息类型，`content` 承载 outcome、可选说明文案与 resume 结果：
+
+```typescript
+type InterruptMessage = BaseMessage<
+  MessageRole.Interrupt,
+  {
+    message?: string;
+    outcome?: RunFinishedOutcome;
+    result?: InterruptResult;
+    runId?: string;
+    threadId?: string;
+  }
+>;
+```
+
+| 字段       | 说明                                                         |
+| ---------- | ------------------------------------------------------------ |
+| `message`  | 消息组顶部可选说明文案，由 `InterruptMessageRender` 展示     |
+| `outcome`  | `type: 'interrupt'` 时从 `interrupts` 渲染交互；`success` 时进入已处理态 |
+| `result`   | 用户 resume 后回传/持久化的 `InterruptResult`；按 `reason` 在会话内回显审批单或用户回答 |
+| `runId`    | 关联 AG-UI run 标识                                          |
+| `threadId` | 关联会话线程标识                                             |
+
+## OnInterruptResume
+
+用户完成中断操作或 FlowAgent 节点操作后的回调（由 `ChatContainer` / `MessageContainer` / `MessageRender` 透传）：
+
+```typescript
+type OnInterruptResume = (
+  payload: InterruptResume,
+  interrupt?: Interrupt,
+) => Promise<void> | void;
+```
+
+| 参数        | 说明                                                                                                       |
+| ----------- | ---------------------------------------------------------------------------------------------------------- |
+| `payload`   | 用户操作产生的 resume 负载；通过 `payload.operation`（或 `UserQuestionResume.reason`）区分动作类型         |
+| `interrupt` | 原始中断项；审批取消、用户问题等中断来源**必传**；FlowAgent 节点重试 / 跳过等非中断来源**不传**             |
+
+| `payload.operation`              | 触发场景                         | `interrupt` |
+| -------------------------------- | -------------------------------- | ----------- |
+| `approval_cancel`                | `ToolApprovalCard` 取消审批      | 必传        |
+| `flow_node_retry` / `flow_node_skip` | `FlowAgentContent` 失败节点操作 | 不传        |
+| —（`UserQuestionResume`）        | `UserQuestionCard` 提交回答      | 必传        |
+
+## 使用示例
+
+```typescript
+import {
+  APPROVAL_STATUS,
+  InterruptReason,
+  InterruptResumeOperation,
+  MessageRole,
+  MessageStatus,
+  type InterruptMessage,
+  type OnInterruptResume,
+} from '@blueking/chat-x';
+
+const message: InterruptMessage = {
+  id: 'msg_interrupt_1',
+  messageId: 'msg_interrupt_1',
+  role: MessageRole.Interrupt,
+  status: MessageStatus.Pending,
+  content: {
+    message: '需要您处理以下中断',
+    outcome: {
+      type: 'interrupt',
+      interrupts: [
+        {
+          id: 'interrupt_approval_1',
+          reason: InterruptReason.AIDevToolApproval,
+          toolCallId: 'tool_call_approval_1',
+          metadata: {
+            ticket: {
+              approvers: ['张三'],
+              sn: 'REV-2026-04-24-001',
+              status: APPROVAL_STATUS.PENDING,
+              submit_time: '2026-04-24 14:30:15',
+              title: '算法方案评审单',
+              url: 'https://example.com/tickets/REV-2026-04-24-001',
+            },
+          },
+        },
+        {
+          id: 'interrupt_question_1',
+          reason: InterruptReason.UserQuestion,
+          toolCallId: 'tool_call_question_1',
+          message: '请选择实现方案',
+          metadata: {
+            questions: [
+              {
+                header: '请选择实现方案',
+                multiSelect: false,
+                question: '你希望采用哪种排序实现？',
+                options: [
+                  { label: 'basic', description: '基础冒泡排序' },
+                  { label: 'optimized', description: '提前终止优化版' },
+                ],
+              },
+            ],
+          },
+        },
+      ],
+    },
+  },
+};
+
+const handleInterruptResume: OnInterruptResume = async (payload, interrupt) => {
+  if ('operation' in payload) {
+    switch (payload.operation) {
+      case InterruptResumeOperation.ApprovalCancel:
+        console.log('取消审批', payload.payload.interrupt_id, interrupt?.id);
+        break;
+      case InterruptResumeOperation.FlowNodeRetry:
+      case InterruptResumeOperation.FlowNodeSkip:
+        console.log('流程节点操作', payload.operation, payload.payload);
+        break;
+    }
+    return;
+  }
+  // UserQuestionResume
+  console.log('用户问题 resume', interrupt?.id, payload);
+};
+```
+
+## 关联文档
+
+- [常量枚举 Constants](./constants.md) — `InterruptReason`、`APPROVAL_STATUS`
+- [消息类型 Messages](./messages.md) — `InterruptMessage` 在消息联合类型中的位置
+- [InterruptMessage 中断消息](../components/agent/interrupt-message)
+- [UserQuestionCard 用户问题中断](../components/agent/user-question-card)
+- [ToolApprovalCard 审批卡片](../components/agent/tool-approval-card)

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/messages.md
@@ -1,0 +1,539 @@
+# 消息类型
+
+> since 1.0.0
+
+文档说明 Message 联合类型、BaseMessage、MessageRole、MessageStatus、User/Assistant/Tool/Activity/Reasoning 等具体形态及 MessageContentType。 业务构造 messages 数组供 ChatContainer/MessageContainer 渲染；Tool 消息经 useMessageGroup 注入 Assistant。可声明合并扩展 AIBluekingMessageMap。
+
+**关联**：message-container（列表渲染与工具栏）、message-render（按 role 分发渲染）、chat-container（数据源与交互入口）
+
+---
+
+# 消息类型
+
+> **分类**：type
+
+`@blueking/chat-x` 提供了完整的消息类型定义，用于构建 AI 对话消息。
+
+## 消息基础类型
+
+### Message
+
+所有消息类型的联合类型：
+
+```typescript
+type Message = MessageMap[MessageType];
+```
+
+### BaseMessage
+
+消息基础接口：
+
+```typescript
+interface BaseMessage<T extends MessageType, C = string> {
+  // 消息唯一 ID（客户端生成）
+  id: number | string;
+
+  // 消息 ID（服务端返回）
+  messageId: number | string;
+
+  // 消息角色
+  role: T;
+
+  // 消息内容
+  content: C;
+
+  // 消息状态
+  status: MessageStatus;
+
+  // 可选：单条消息实例唯一标识（`useMessageGroup` 在缺失时会自动生成并写回）
+  uid?: string;
+
+  // 消息名称（可选）
+  name?: string;
+
+  // 消息属性（可选）
+  property?: {
+    extra?: {
+      // 引用内容
+      cite:
+        | string
+        | {
+            title: string;
+            data: { key: string; value: string }[];
+            type: 'structured';
+          };
+      // 快捷指令名称
+      command: string;
+      // 上下文信息
+      context: Record<string, any>[];
+      // 快捷指令配置
+      shortcut?: Shortcut;
+      // 暂停标记：为 true 时该消息所在消息组不显示 MessageTools 工具栏
+      pause?: boolean;
+    };
+  };
+}
+```
+
+## 消息角色
+
+```typescript
+enum MessageRole {
+  // 用户消息
+  User = 'user',
+
+  // AI 助手消息
+  Assistant = 'assistant',
+
+  // 系统消息
+  System = 'system',
+
+  // 开发者消息
+  Developer = 'developer',
+
+  // 引导消息
+  Guide = 'guide',
+
+  // 隐藏消息（不显示）
+  Hidden = 'hidden',
+  HiddenAssistant = 'hidden-assistant',
+  HiddenGuide = 'hidden-guide',
+  HiddenSystem = 'hidden-system',
+  HiddenUser = 'hidden-user',
+
+  // 信息消息
+  Info = 'info',
+
+  // human-in-the-loop 中断消息
+  Interrupt = 'interrupt',
+
+  // 加载中消息
+  Loading = 'loading',
+
+  // 暂停消息
+  Pause = 'pause',
+
+  // 占位消息
+  Placeholder = 'placeholder',
+
+  // 推理过程消息
+  Reasoning = 'reasoning',
+
+  // 模板消息
+  TemplateAssistant = 'template-assistant',
+  TemplateGuide = 'template-guide',
+  TemplateHidden = 'template-hidden',
+  TemplateSystem = 'template-system',
+  TemplateUser = 'template-user',
+
+  // 工具调用消息
+  Tool = 'tool',
+
+  // 活动消息（如引用文档）
+  Activity = 'activity',
+}
+```
+
+## 消息状态
+
+```typescript
+enum MessageStatus {
+  // 已完成
+  Complete = 'complete',
+
+  // 已禁用
+  Disabled = 'disabled',
+
+  // 错误
+  Error = 'error',
+
+  // 请求中
+  Fetching = 'fetching',
+
+  // 等待中
+  Pending = 'pending',
+
+  // 已停止
+  Stop = 'stop',
+
+  // 停止请求中
+  StopLoading = 'stop-loading',
+
+  // 流式输出中
+  Streaming = 'streaming',
+
+  // 成功
+  Success = 'success',
+}
+```
+
+## 具体消息类型
+
+### UserMessage
+
+用户消息：
+
+```typescript
+type UserMessage = BaseMessage<MessageRole.User, InputContent[] | string>;
+
+// 示例
+const userMessage: UserMessage = {
+  id: '1',
+  messageId: 1,
+  role: MessageRole.User,
+  content: '你好',
+  status: MessageStatus.Complete,
+};
+```
+
+### AssistantMessage
+
+AI 助手消息：
+
+```typescript
+interface AssistantMessage extends BaseMessage<MessageRole.Assistant> {
+  // 工具调用列表
+  toolCalls?: ToolCall[];
+}
+
+// 工具调用
+type ToolCall = {
+  id: string;
+  type: MessageContentType.Function;
+  function: FunctionCall;
+};
+
+type FunctionCall = {
+  name: string;
+  arguments: string;
+  description?: string;
+  mcpName?: string;
+};
+
+// 示例
+const assistantMessage: AssistantMessage = {
+  id: '2',
+  messageId: 2,
+  role: MessageRole.Assistant,
+  content: '你好！有什么可以帮助你的？',
+  status: MessageStatus.Complete,
+  toolCalls: [
+    {
+      id: 'call_1',
+      type: MessageContentType.Function,
+      function: {
+        name: 'get_weather',
+        arguments: '{"city": "北京"}',
+      },
+    },
+  ],
+};
+```
+
+### ReasoningMessage
+
+推理过程消息：
+
+```typescript
+interface ReasoningMessage extends BaseMessage<MessageRole.Reasoning, string[]> {
+  // 推理耗时（毫秒）
+  duration?: number;
+}
+
+// 示例
+const reasoningMessage: ReasoningMessage = {
+  id: '3',
+  messageId: 3,
+  role: MessageRole.Reasoning,
+  content: ['让我分析一下这个问题...', '首先，需要考虑以下几点：', '1. 技术可行性'],
+  status: MessageStatus.Complete,
+  duration: 3500,
+};
+```
+
+### ToolMessage
+
+工具调用结果消息：
+
+```typescript
+interface ToolMessage extends BaseMessage<MessageRole.Tool, string> {
+  // 工具调用 ID（对应 AssistantMessage 中的 toolCalls[].id）
+  toolCallId: string;
+
+  // 执行耗时（毫秒）
+  duration: number;
+
+  // 错误信息
+  error?: string;
+}
+
+// 示例
+const toolMessage: ToolMessage = {
+  id: '4',
+  messageId: 4,
+  role: MessageRole.Tool,
+  content: '{"temperature": 25, "weather": "晴天"}',
+  status: MessageStatus.Complete,
+  toolCallId: 'call_1',
+  duration: 1200,
+};
+```
+
+### ActivityMessage
+
+活动消息（如引用文档、知识检索）：
+
+```typescript
+// 引用文档内容类型
+type ReferenceDocumentContent = {
+  name: string;
+  originFile: string;
+  url: string;
+};
+
+// 知识检索内容类型
+type KnowledgeRagContent = {
+  content: string;
+  referenceDocument: ReferenceDocumentContent[];
+};
+
+interface ActivityMessage extends BaseMessage<MessageRole.Activity, KnowledgeRagContent | ReferenceDocumentContent[]> {
+  activityType: MessageContentType.KnowledgeRag | MessageContentType.ReferenceDocument | string;
+}
+
+// 示例 1：引用文档
+const referenceMessage: ActivityMessage = {
+  id: '5',
+  messageId: 5,
+  role: MessageRole.Activity,
+  content: [
+    { name: '参考文档 1', url: 'https://example.com/1', originFile: 'https://example.com/origin/1' },
+    { name: '参考文档 2', url: 'https://example.com/2', originFile: 'https://example.com/origin/2' },
+  ],
+  status: MessageStatus.Complete,
+  activityType: 'reference',
+};
+
+// 示例 2：知识检索（knowledge_rag）
+const knowledgeRagMessage: ActivityMessage = {
+  id: '6',
+  messageId: 6,
+  role: MessageRole.Activity,
+  content: {
+    content: '开始召回知识\n重排召回结果中\n完成召回并分类\n',
+    referenceDocument: [
+      { name: '知识文档 1', url: 'https://example.com/doc1', originFile: 'https://example.com/origin/doc1' },
+      { name: '知识文档 2', url: 'https://example.com/doc2', originFile: 'https://example.com/origin/doc2' },
+    ],
+  },
+  status: MessageStatus.Complete,
+  activityType: 'knowledge_rag',
+};
+```
+
+**ActivityMessage 类型说明：**
+
+| activityType      | content 类型                 | 说明                                     |
+| ----------------- | ---------------------------- | ---------------------------------------- |
+| `'reference'`     | `ReferenceDocumentContent[]` | 引用文档列表                             |
+| `'knowledge_rag'` | `KnowledgeRagContent`        | 知识检索结果，包含检索过程内容和引用文档 |
+
+**ReferenceDocumentContent 字段说明：**
+
+| 字段         | 类型     | 说明             |
+| ------------ | -------- | ---------------- |
+| `name`       | `string` | 文档名称         |
+| `url`        | `string` | 文档预览链接     |
+| `originFile` | `string` | 文档原始文件链接 |
+
+### InterruptMessage
+
+human-in-the-loop 中断消息，对应 AG-UI `RUN_FINISHED` 事件的 `outcome` 对象结构。`content.outcome.type === 'interrupt'` 时，[InterruptMessageRender](../components/agent/interrupt-message) 从 `interrupts` 渲染审批卡片或把 `UserQuestion` 交给输入区；`type: 'success'` 表示 resume 后的成功结果，`UserQuestion` 会根据 `result` 回显回答内容。类型详见 [中断类型 Interrupt](./interrupt.md)。
+
+```typescript
+type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
+
+type InterruptMessage = BaseMessage<
+  MessageRole.Interrupt,
+  {
+    message?: string;
+    outcome?: RunFinishedOutcome;
+    result?: BaseResume<InterruptReason>;
+    runId?: string;
+    threadId?: string;
+  }
+>;
+
+const interruptMessage: InterruptMessage = {
+  id: 'interrupt-message-1',
+  messageId: 'interrupt-message-1',
+  role: MessageRole.Interrupt,
+  status: MessageStatus.Pending,
+  content: {
+    message: '算法方案评审单需要您关注',
+    runId: 'run_ai_dev_tool_approval',
+    threadId: 'thread_ai_dev_tool_approval',
+    outcome: {
+      type: 'interrupt',
+      interrupts: [
+        {
+          id: 'interrupt_ai_dev_tool_approval',
+          reason: InterruptReason.AIDevToolApproval,
+          toolCallId: 'tool_call_review_ticket',
+          message: '算法方案评审单需要您关注',
+          metadata: {
+            ticket: {
+              approvers: ['张三', '李四'],
+              sn: 'REV-2026-04-24-001',
+              status: APPROVAL_STATUS.PENDING,
+              submit_time: '2026-04-24 14:30:15',
+              title: '算法方案评审单',
+              url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+            },
+          },
+        },
+      ],
+    },
+  },
+};
+```
+
+### InfoMessage
+
+信息消息：
+
+```typescript
+type InfoMessage = BaseMessage<MessageRole.Info, string>;
+
+// 示例
+const infoMessage: InfoMessage = {
+  id: '6',
+  messageId: 6,
+  role: MessageRole.Info,
+  content: '会话已开始',
+  status: MessageStatus.Complete,
+};
+```
+
+### LoadingMessage
+
+加载中消息，用于在等待 AI 响应时显示加载状态：
+
+```typescript
+type LoadingMessage = BaseMessage<MessageRole.Loading, string>;
+
+// 示例
+const loadingMessage: LoadingMessage = {
+  id: 'loading',
+  messageId: '',
+  role: MessageRole.Loading,
+  content: '',
+  status: MessageStatus.Pending,
+};
+```
+
+## 消息内容类型
+
+```typescript
+enum MessageContentType {
+  // 二进制内容
+  Binary = 'binary',
+
+  // FlowAgent 流程执行
+  FlowAgent = 'flow_agent',
+
+  // 函数调用
+  Function = 'function',
+
+  // 键值对
+  KeyValue = 'key_value',
+
+  // 知识检索
+  KnowledgeRag = 'knowledge_rag',
+
+  // 其他
+  Other = 'other',
+
+  // 引用文档
+  ReferenceDocument = 'reference_document',
+
+  // 文本
+  Text = 'text',
+}
+```
+
+## 类型扩展
+
+支持通过声明合并扩展消息类型：
+
+```typescript
+// 在项目中扩展
+declare global {
+  interface AIBluekingMessageMap {
+    'custom-role': CustomMessage;
+  }
+}
+
+interface CustomMessage extends BaseMessage<'custom-role'> {
+  customField: string;
+}
+```
+
+## 使用示例
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-status="messageStatus"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref } from 'vue';
+  import { MessageContainer, MessageRole, MessageStatus, type Message } from '@blueking/chat-x';
+
+  const messageStatus = ref<MessageStatus>(MessageStatus.Complete);
+
+  const messages = ref<Message[]>([
+    {
+      id: '1',
+      messageId: 1,
+      role: MessageRole.User,
+      content: '你好',
+      status: MessageStatus.Complete,
+    },
+    {
+      id: '2',
+      messageId: 2,
+      role: MessageRole.Reasoning,
+      content: ['思考中...', '分析问题...'],
+      status: MessageStatus.Complete,
+      duration: 2000,
+    },
+    {
+      id: '3',
+      messageId: 3,
+      role: MessageRole.Assistant,
+      content: '你好！有什么可以帮助你的？',
+      status: MessageStatus.Complete,
+    },
+  ]);
+
+  const handleAgentAction = async tool => {
+    console.log('Agent action:', tool);
+  };
+
+  const handleUserAction = async tool => {
+    console.log('User action:', tool);
+  };
+</script>
+```
+
+## 关联组件
+
+- [MessageContainer](../components/setup/message-container) — 消息列表
+- [MessageRender](../components/message/message-render) — 单条消息渲染
+- [ChatContainer](../components/setup/chat-container) — 聊天容器

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/schema.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/schema.md
@@ -1,0 +1,91 @@
+# 用户问题 Schema
+
+> since 2.0.0
+
+schema.ts 仍导出 UserSingleChoiceQuestionSchema、UserMultiChoiceQuestionSchema、UserQuestionSchema 及 FromSchema 推导类型； 新的 aidev:user_question 中断不再通过 BaseInterrupt.responseSchema 区分单选/多选，而是在 metadata.questions[].multiSelect 中描述题型。
+
+**关联**：interrupt（新 UserQuestionInterrupt 与 UserQuestionResume 协议）、user-question-card（根据 metadata.questions 渲染单选、多选与 Others 输入）
+
+---
+
+# 用户问题 Schema
+
+> **分类**：type
+
+`src/ag-ui/types/schema.ts` 保留了历史 JSON Schema 工具导出：
+
+- `UserSingleChoiceQuestionSchema`
+- `UserMultiChoiceQuestionSchema`
+- `UserQuestionSchema`
+- `UserSingleChoiceQuestion`
+- `UserMultiChoiceQuestion`
+- `UserQuestion`
+
+新的 `InterruptReason.UserQuestion`（`'aidev:user_question'`）协议不再依赖 `BaseInterrupt.responseSchema`，而是在 `UserQuestionInterrupt.metadata.questions[]` 中用 `multiSelect` 描述单选 / 多选题，并通过 `UserQuestionResume.payload.answers` 回传回答。
+
+## 新协议入口
+
+```typescript
+type UserQuestionItem = {
+  header: string;
+  multiSelect: boolean;
+  options?: UserQuestionOptionItem[];
+  question: string;
+};
+
+type UserQuestionResume = {
+  interruptId: string;
+  reason: InterruptReason.UserQuestion;
+  status: 'cancelled' | 'resolved';
+  payload: {
+    answers: UserQuestionAnswerItem[];
+  };
+};
+```
+
+完整结构见 [中断类型 Interrupt](./interrupt.md#userquestioninterrupt)。
+
+## 历史导出
+
+### UserSingleChoiceQuestionSchema
+
+```typescript
+const UserSingleChoiceQuestionSchema = {
+  properties: {
+    question: {
+      enum: [],
+      type: 'string',
+    },
+  },
+  required: ['question'],
+  type: 'object',
+} as const;
+```
+
+### UserMultiChoiceQuestionSchema
+
+```typescript
+const UserMultiChoiceQuestionSchema = {
+  properties: {
+    question: {
+      items: {
+        enum: [],
+        type: 'string',
+      },
+      uniqueItems: true,
+      type: 'array',
+    },
+  },
+  required: ['question'],
+  type: 'object',
+} as const;
+```
+
+### UserQuestionSchema
+
+`UserQuestionSchema` 与 `UserQuestion` 仍为 `UserMultiChoiceQuestionSchema` / `UserMultiChoiceQuestion` 的别名。
+
+## 关联文档
+
+- [中断类型 Interrupt](./interrupt.md)
+- [UserQuestionCard 用户问题中断](../components/agent/user-question-card)

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/scripts/generate-references.mjs
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/scripts/generate-references.mjs
@@ -1,0 +1,314 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+/** biome-ignore-all lint/suspicious/noAssignInExpressions: <explanation> */
+
+/**
+ * 从 wikis 生成 blueking-chat-x skill 的 references。
+ *
+ * 设计目标：把面向人类阅读的 VitePress 文档（含大量 demo 脚本/演示 HTML）清洗成
+ * LLM 友好的「使用方视角」精简文档——剥离演示噪音、保留完整 API 表格与示例代码。
+ *
+ * 与 mcp/scripts/build-index.ts 共享清洗思路，但本脚本：
+ *   1. 强化代码围栏处理：正确识别 ````vue 内嵌套 ``` 的情况，避免误删示例里的 <script setup>；
+ *   2. 按「使用方」需要的范围生成（组件全量 + composables/types/theme），并产出能力地图索引。
+ *
+ * 运行（在 packages/chat-x 下，依赖 glob / gray-matter 已在 devDependencies）：
+ *   node skills/blueking-chat-x/scripts/generate-references.mjs
+ */
+
+import { glob } from 'glob';
+import matter from 'gray-matter';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { basename, dirname, join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// scripts/ -> blueking-chat-x -> skills -> chat-x
+const WIKIS_DIR = resolve(__dirname, '../../../wikis');
+const REFERENCES_DIR = resolve(__dirname, '../references');
+
+/** 组件能力域：以 wikis/components/<domain>/ 目录为准，避免依赖 frontmatter.domain 出现的拼写漂移。 */
+const DOMAIN_LABELS = {
+  setup: '对话搭建',
+  message: '消息系统',
+  rendering: '内容渲染',
+  medias: '媒体文件',
+  input: '输入交互',
+  agent: 'Agent 能力',
+  feedback: '工具与反馈',
+  helper: '辅助能力',
+};
+
+/** 生成范围：每条对应 references 下的一个子目录与一个 wikis glob。 */
+const GROUPS = [
+  { key: 'components', label: '组件', pattern: 'components/*/*.md', grouped: true },
+  { key: 'composables', label: 'Composables 组合式函数', pattern: 'composables/*.md', grouped: false },
+  { key: 'types', label: '类型定义', pattern: 'types/*.md', grouped: false },
+  { key: 'theme', label: '主题', pattern: 'theme/*.md', grouped: false },
+];
+
+const FENCE_RE = /^(\s*)(`{3,}|~{3,})(.*)$/;
+
+/** 生成能力地图索引：组件按能力域分组，其余按组列出。 */
+function buildIndexDoc(index) {
+  const lines = [];
+  lines.push('# @blueking/chat-x 能力地图（自动生成）');
+  lines.push('');
+  lines.push('> 由 `scripts/generate-references.mjs` 从 `wikis/` 生成，请勿手改。');
+  lines.push('> 查某个能力时：先在本索引定位 slug，再读对应 `path` 的 reference 文档。');
+  lines.push('');
+  lines.push(`> 生成时间：${index.generatedAt}`);
+  lines.push('');
+
+  lines.push('## 组件（按能力域）');
+  lines.push('');
+  for (const domainKey of Object.keys(DOMAIN_LABELS)) {
+    const list = index.components[domainKey];
+    if (!list?.length) continue;
+    lines.push(`### ${DOMAIN_LABELS[domainKey]}`);
+    lines.push('');
+    for (const entry of list.sort((a, b) => a.slug.localeCompare(b.slug))) {
+      lines.push(`- **${entry.name}** — ${entry.description} → \`${entry.path}\``);
+    }
+    lines.push('');
+  }
+
+  for (const group of GROUPS) {
+    if (group.grouped) continue;
+    const list = index[group.key];
+    if (!list?.length) continue;
+    lines.push(`## ${group.label}`);
+    lines.push('');
+    for (const entry of list.sort((a, b) => a.slug.localeCompare(b.slug))) {
+      lines.push(`- **${entry.name}** — ${entry.description} → \`${entry.path}\``);
+    }
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/** 组装单个 reference 文档：精简元信息头 + 关联组件 + 清洗后的完整正文。 */
+function buildReferenceDoc(meta, cleanedBody) {
+  const lines = [];
+  lines.push(`# ${meta.name}`);
+  lines.push('');
+
+  const tags = [];
+  if (meta.domainLabel) tags.push(`能力域：${meta.domainLabel}`);
+  if (meta.symbol) tags.push(`导入：\`import { ${meta.symbol} } from '@blueking/chat-x'\``);
+  if (meta.since) tags.push(`since ${meta.since}`);
+  if (tags.length) {
+    lines.push(`> ${tags.join(' ｜ ')}`);
+    lines.push('');
+  }
+
+  if (meta.aiSummary) {
+    lines.push(meta.aiSummary.trim());
+    lines.push('');
+  }
+
+  if (meta.related.length) {
+    lines.push(`**关联**：${meta.related.map(r => (r.relation ? `${r.slug}（${r.relation}）` : r.slug)).join('、')}`);
+    lines.push('');
+  }
+
+  lines.push('---');
+  lines.push('');
+  lines.push(cleanedBody);
+  lines.push('');
+
+  return lines.join('\n');
+}
+
+/**
+ * 清洗 wiki 正文：剥离 <script> demo 块、<div class="demo"> 演示块、内联 style，
+ * 并合并多余空行。代码围栏内的内容原样保留。
+ *
+ * 围栏处理采用 CommonMark 规则：记录开围栏的字符与长度，只有「同字符、长度 >= 开围栏、
+ * 且其后无信息串」的行才视为闭围栏。这样 ````vue 内的 ``` 会被当作内容，
+ * 不会误把示例里的 <script setup> 当成需剥离的 VitePress demo。
+ */
+function cleanMarkdownBody(rawBody) {
+  const lines = rawBody.split('\n');
+  const out = [];
+  let fence = null; // { char, len }
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    const fenceMatch = line.match(FENCE_RE);
+
+    if (fenceMatch) {
+      const marker = fenceMatch[2];
+      const char = marker[0];
+      const len = marker.length;
+      const rest = fenceMatch[3].trim();
+
+      if (!fence) {
+        fence = { char, len };
+      } else if (char === fence.char && len >= fence.len && rest === '') {
+        fence = null;
+      }
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    if (fence) {
+      out.push(line);
+      i++;
+      continue;
+    }
+
+    // 以下分支仅在围栏外生效——剥离 VitePress 演示噪音
+    if (/<script\b/i.test(line)) {
+      if (/<\/script>/i.test(line)) {
+        i++;
+        continue;
+      }
+      i++;
+      while (i < lines.length && !/<\/script>/i.test(lines[i])) {
+        i++;
+      }
+      if (i < lines.length) i++;
+      continue;
+    }
+
+    if (/<div[^>]*\bclass="demo"[^>]*>/i.test(line)) {
+      let depth = 0;
+      const start = i;
+      while (i < lines.length) {
+        depth += countDivDelta(lines[i]);
+        i++;
+        if (depth <= 0) break;
+      }
+      if (i === start) i++;
+      continue;
+    }
+
+    out.push(stripInlineStyles(line));
+    i++;
+  }
+
+  return mergeBlankLines(out.join('\n')).trim();
+}
+
+function countDivDelta(line) {
+  const opens = (line.match(/<div\b/gi) ?? []).length;
+  const closes = (line.match(/<\/div>/gi) ?? []).length;
+  return opens - closes;
+}
+
+/** frontmatter.name 形如 "ChatContainer 聊天容器"，首段若是合法标识符则视为导入符号。 */
+function extractSymbol(name) {
+  const first = String(name).trim().split(/\s+/)[0] ?? '';
+  return /^[A-Za-z][A-Za-z0-9]*$/.test(first) ? first : '';
+}
+
+function main() {
+  // 全量重建，避免删除/重命名后的残留
+  rmSync(REFERENCES_DIR, { recursive: true, force: true });
+  mkdirSync(REFERENCES_DIR, { recursive: true });
+
+  const index = {
+    generatedAt: new Date().toISOString(),
+    components: {}, // domainKey -> entries[]
+    composables: [],
+    types: [],
+    theme: [],
+  };
+
+  for (const group of GROUPS) {
+    const files = glob.sync(join(WIKIS_DIR, group.pattern)).sort();
+    const outDir = join(REFERENCES_DIR, group.key);
+    mkdirSync(outDir, { recursive: true });
+
+    for (const file of files) {
+      const fileName = basename(file, '.md');
+      if (fileName === 'index') continue;
+
+      const rel = relative(WIKIS_DIR, file).replace(/\\/g, '/');
+      const parsed = matter(readFileSync(file, 'utf-8'));
+      const data = parsed.data ?? {};
+
+      const slug = typeof data.slug === 'string' && data.slug.trim() ? data.slug.trim() : fileName;
+      const name = typeof data.name === 'string' && data.name.trim() ? data.name.trim() : slug;
+      const description = typeof data.description === 'string' ? data.description.trim() : '';
+      const aiSummary =
+        typeof data.aiSummary === 'string' && data.aiSummary.trim() ? data.aiSummary.trim() : description;
+      const since = typeof data.sinceVersion === 'string' ? data.sinceVersion.trim() : '';
+      const related = normalizeRelated(data.relatedComponents);
+      const symbol = extractSymbol(name);
+
+      // 组件能力域以目录为准：components/<domain>/<slug>.md
+      let domainKey = '';
+      let domainLabel = '';
+      if (group.grouped) {
+        domainKey = rel.split('/')[1] ?? 'helper';
+        domainLabel = DOMAIN_LABELS[domainKey] ?? domainKey;
+      }
+
+      const cleanedBody = cleanMarkdownBody(parsed.content);
+      const doc = buildReferenceDoc({ name, domainLabel, symbol, since, aiSummary, related }, cleanedBody);
+      writeFileSync(join(outDir, `${slug}.md`), doc);
+
+      const entry = { name, slug, description: description || aiSummary, path: `${group.key}/${slug}.md` };
+      if (group.grouped) {
+        (index.components[domainKey] ??= []).push({ ...entry, domainLabel });
+      } else {
+        index[group.key].push(entry);
+      }
+    }
+  }
+
+  writeFileSync(join(REFERENCES_DIR, '_index.md'), buildIndexDoc(index));
+
+  const componentCount = Object.values(index.components).reduce((acc, list) => acc + list.length, 0);
+  console.log(
+    `生成完成：components ${componentCount}、composables ${index.composables.length}、` +
+      `types ${index.types.length}、theme ${index.theme.length}`,
+  );
+}
+
+function mergeBlankLines(text) {
+  return text.replace(/\n{3,}/g, '\n\n');
+}
+
+function normalizeRelated(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter(item => item && typeof item === 'object' && 'slug' in item)
+    .map(item => ({ slug: String(item.slug), relation: 'relation' in item ? String(item.relation) : '' }));
+}
+
+function stripInlineStyles(line) {
+  return line.replace(/\sstyle="[^"]*"/gi, '');
+}
+
+main();

--- a/src/frontend/ai-blueking/scripts/pre-commit-test.mjs
+++ b/src/frontend/ai-blueking/scripts/pre-commit-test.mjs
@@ -157,7 +157,7 @@ const runTests = testFiles => {
     return true;
   } catch {
     console.error('\n❌ 测试失败！请修复测试后再提交。\n');
-    console.log('💡 提示：可以使用 @update-test 命令让 AI 帮助修复测试\n');
+    console.log('💡 提示：可让 AI 使用 chat-x-update-docs skill 帮助修复测试\n');
     return false;
   }
 };
@@ -168,9 +168,7 @@ const runTests = testFiles => {
  * @param {{ target: string, src: string }[]} items 未更新的文件列表
  */
 const showNotUpdatedWarning = (type, items) => {
-  const isTest = type === 'test';
-  const label = isTest ? '测试文件' : 'Wiki 文档';
-  const command = isTest ? 'update-test' : 'update-wiki';
+  const label = type === 'test' ? '测试文件' : 'Wiki 文档';
 
   console.log(`\n⚠️  检测到以下源文件改动，但对应的${label}未更新：\n`);
 
@@ -182,14 +180,12 @@ const showNotUpdatedWarning = (type, items) => {
 
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('');
-  console.log(`  💡 请使用 Cursor 的 ${command} 命令来更新${label}：`);
+  console.log(`  💡 测试与文档需在提交前同步更新。请在 Cursor 聊天中让 AI 使用`);
+  console.log('     chat-x-update-docs skill 自动分析改动并同步 test + wiki：');
   console.log('');
-  console.log('     1. 在 Cursor 中按 Cmd+Shift+P (Mac) 或 Ctrl+Shift+P (Windows)');
-  console.log(`     2. 输入 "${command}" 并选择该命令`);
-  console.log(`     3. AI 将自动分析改动并更新${label}`);
+  console.log('     例如输入：「提交前同步这次改动对应的 test 和 wiki」');
   console.log('');
-  console.log('  或者直接在 Cursor 聊天中输入：');
-  console.log(`     @${command}`);
+  console.log('  skill 位置：packages/chat-x/.agents/skills/chat-x-update-docs/');
   console.log('');
   console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('');
@@ -224,7 +220,7 @@ const main = () => {
 
   if (testFilesMap.length === 0) {
     console.log('\n⚠️  源文件改动但没有找到对应的测试文件');
-    console.log('💡 提示：可以使用 @update-test 命令让 AI 帮助创建测试\n');
+    console.log('💡 提示：可让 AI 使用 chat-x-update-docs skill 帮助创建测试\n');
   } else {
     const notUpdatedTests = findUnstaged(testFilesMap, stagedSet);
     if (notUpdatedTests.length > 0) {


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】沉淀 blueking-chat-x 消费方 skill

@blueking/chat-x 已有完善的 `wikis/` 与库内开发 skill（`chat-x-dev`），但消费方项目接入时缺少统一的 AI 导航 skill，Agent 容易凭记忆臆测 props/events/slots。

## 改动
- 新增 `skills/blueking-chat-x/` 消费方 skill（SKILL.md + references 能力地图与组件/composable/类型/主题文档）
- 新增 `generate-references.mjs`，从 `wikis/` 自动生成 references（清洗 VitePress demo 噪音，保留 API 表格与示例）
- 完善 `AGENTS.md`：编码约定、Skills 与文档体系、Git 提交校验、Figma 开发指引
- `packages/chat-x/.gitignore` 忽略 `skills-lock.json`
- `pre-commit-test.mjs` 提示文案引导使用 `chat-x-update-docs` skill

## 影响面
- 仅文档/skill/脚本提示，无运行时组件逻辑变更
- 消费方可将 `skills/blueking-chat-x` 作为 Cursor skill 引用
- 库内开发仍走 `.agents/skills/chat-x-dev`，职责边界清晰

## 测试
- [x] pre-commit 钩子通过（commit-msg + pre-commit-test）
- [ ] 消费方项目验证 skill 可被 Cursor 正确识别与触发
- [ ] `generate-references.mjs` 可重复执行且输出稳定

Made with [Cursor](https://cursor.com)