### PR TITLE
fix: 【chat-x】share 模式隐藏交互元素 --bug=159831775

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -492,6 +492,7 @@
   } = useMessageGroup({
     keyword,
     messages: computed(() => props.messages),
+    renderMode: computed(() => renderMode.value),
     selectedUserMessages,
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -861,6 +861,25 @@ describe('MessageContainer', () => {
       expect(loadingRender).toBeTruthy();
     });
 
+    it('renderMode 为 Share 时不应渲染 Loading 消息组', async () => {
+      const messages: Message[] = [createUserMessage('1', 'Hello', 1)];
+
+      wrapper = mount(MessageContainer, {
+        props: {
+          ...defaultProps,
+          messages,
+          messageGroups: buildGroups(messages),
+          renderMode: RenderMode.Share,
+        },
+      });
+
+      await nextTick();
+
+      const messageRenders = wrapper.findAll('.mock-message-render');
+      const loadingRender = messageRenders.find(r => r.attributes('data-role') === MessageRole.Loading);
+      expect(loadingRender).toBeUndefined();
+    });
+
     it('最后一条消息是助手消息时不应该追加 Loading 消息组', async () => {
       const messages: Message[] = [createUserMessage('1', 'Hello', 1), createAssistantMessage('2', 'Hi!', 2)];
 
@@ -1365,6 +1384,23 @@ describe('MessageContainer', () => {
 
       const messageGroupMessages = wrapper.find('.message-group-messages');
       expect(messageGroupMessages.classes()).toContain('message-group-enabled-selection');
+    });
+
+    it('renderMode 为 Share 时流式状态不应显示停止生成按钮', async () => {
+      wrapper = mount(MessageContainer, {
+        props: {
+          ...defaultProps,
+          messageStatus: MessageStatus.Streaming,
+          renderMode: RenderMode.Share,
+        },
+      });
+
+      await nextTick();
+
+      const scrollBtns = wrapper.findAll('.mock-scroll-btn');
+      const stopBtn = scrollBtns.find(btn => btn.text().includes('停止生成'));
+      expect(stopBtn).toBeTruthy();
+      expect((stopBtn?.element as HTMLElement).style.display).toBe('none');
     });
 
     it('renderMode 为 Test 时 MessageTools 应过滤掉 share 按钮', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -4,7 +4,7 @@
     class="ai-message-container"
   >
     <div
-      v-for="(group, groupIndex) in messageGroups"
+      v-for="(group, groupIndex) in visibleMessageGroups"
       :id="group.uid"
       :key="groupIndex"
       class="message-group"
@@ -98,10 +98,11 @@
     <div class="ai-message-fixed-bottom">
       <ScrollBtn
         v-show="
-          messageStatus === MessageStatus.Streaming ||
-          messageStatus === MessageStatus.StopLoading ||
-          messageStatus === MessageStatus.Fetching ||
-          messageStatus === MessageStatus.Pending
+          renderMode !== RenderMode.Share &&
+          (messageStatus === MessageStatus.Streaming ||
+            messageStatus === MessageStatus.StopLoading ||
+            messageStatus === MessageStatus.Fetching ||
+            messageStatus === MessageStatus.Pending)
         "
         :loading="messageStatus === MessageStatus.StopLoading"
         :title="messageStatus === MessageStatus.StopLoading ? t('正在停止') : t('停止生成')"
@@ -219,6 +220,12 @@
   const messageTools = computed(() => {
     return CONST_MESSAGE_TOOLS.filter(tool => props.renderMode !== RenderMode.Test || tool.id !== 'share');
   });
+  // Share 模式仅展示历史消息，过滤自动注入或外部传入的 Loading 占位组
+  const visibleMessageGroups = computed(() =>
+    props.renderMode === RenderMode.Share
+      ? props.messageGroups.filter(group => group.type !== MessageRole.Loading)
+      : props.messageGroups,
+  );
   const handleMouseEnter = (group: MessageGroup) => {
     const lastMessage = group.messages?.at(-1);
     if (lastMessage?.role === MessageRole.Interrupt) {

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -28,7 +28,7 @@ import { computed, ref as deepRef, nextTick, shallowRef } from 'vue';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { APPROVAL_STATUS, InterruptReason, MessageContentType, MessageRole, MessageStatus } from '../ag-ui/types';
-import { LOADING_MESSAGE_ID } from '../common/constants';
+import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
 import { useMessageGroup } from './use-message-group';
 
 import type { AssistantMessage, Message, ToolMessage, UserMessage } from '../ag-ui/types';
@@ -102,18 +102,20 @@ const createApprovalInterruptMessage = (id: string, status: APPROVAL_STATUS): Me
     },
   }) as Message;
 
-const setupMessageGroup = (messages: Message[], keyword = '') => {
+const setupMessageGroup = (messages: Message[], keyword = '', renderMode?: RenderMode) => {
   const messagesRef = computed(() => messages);
   const selectedUserMessages = deepRef<Message[] | undefined>([]);
   const keywordRef = shallowRef(keyword);
+  const renderModeRef = shallowRef(renderMode);
 
   const result = useMessageGroup({
     keyword: keywordRef,
     messages: messagesRef,
+    renderMode: renderModeRef,
     selectedUserMessages,
   });
 
-  return { ...result, selectedUserMessages, keywordRef, messagesRef };
+  return { ...result, selectedUserMessages, keywordRef, messagesRef, renderModeRef };
 };
 
 describe('useMessageGroup', () => {
@@ -207,6 +209,14 @@ describe('useMessageGroup', () => {
 
       const lastGroup = messageGroups.value.at(-1);
       expect(lastGroup?.type).toBe(MessageRole.Assistant);
+    });
+
+    it('renderMode 为 Share 时末尾为用户消息不应追加 Loading 组', async () => {
+      const { messageGroups } = setupMessageGroup([createUserMessage('1')], '', RenderMode.Share);
+      await nextTick();
+
+      expect(messageGroups.value.length).toBe(1);
+      expect(messageGroups.value[0]?.type).toBe(MessageRole.User);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -23,8 +23,8 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import type { ComputedRef, Ref, ShallowRef } from 'vue';
-import { computed, ref as deepRef, shallowRef, watch, watchEffect } from 'vue';
+import type { ComputedRef, MaybeRef, Ref, ShallowRef } from 'vue';
+import { computed, ref as deepRef, shallowRef, toValue, watch, watchEffect } from 'vue';
 
 import {
   type ActivityMessage,
@@ -36,7 +36,7 @@ import {
   MessageRole,
   MessageStatus,
 } from '../ag-ui/types';
-import { LOADING_MESSAGE_ID } from '../common/constants';
+import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
 import { t } from '../lang/lang';
 import { generateUUID } from '../utils';
 
@@ -139,6 +139,7 @@ const countPendingApprovalInterrupts = (messages: Message[]): number =>
 export const useMessageGroup = (options: {
   keyword?: ShallowRef<string>;
   messages: ComputedRef<Message[]>;
+  renderMode?: MaybeRef<RenderMode>;
   selectedUserMessages: Ref<Message[] | undefined>;
 }) => {
   const messageGroups = deepRef<MessageGroup[]>([]);
@@ -200,7 +201,9 @@ export const useMessageGroup = (options: {
         pause: assistantMessages?.some(m => m.property?.extra?.pause) ?? false,
       });
     }
-    if (options.messages.value.at(-1)?.role === MessageRole.User) {
+    const shouldAppendLoading =
+      options.messages.value.at(-1)?.role === MessageRole.User && toValue(options.renderMode) !== RenderMode.Share;
+    if (shouldAppendLoading) {
       list.push({
         messages: [
           {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
@@ -287,7 +287,7 @@ sinceVersion: 1.0.0
 - **消息分组**：将连续的非用户消息合并为一组，每组共享一个工具栏
 - **Tool 消息关联**：自动将 `role: 'tool'` 消息注入到对应 Assistant 消息的 toolCall 中
 - **Loading 自动注入**：末尾为用户消息时，自动追加 Loading 动画组
-- **滚动管理**：`messageStatus` 为流式、等待响应或请求中（`streaming` / `pending` / `fetching`）时显示「停止生成」，离开底部时显示「返回底部」
+- **滚动管理**：`messageStatus` 为流式、等待响应或请求中（`streaming` / `pending` / `fetching`）时显示「停止生成」，离开底部时显示「返回底部」；`renderMode` 为 `Share` 时不显示「停止生成」
 - **多选模式**：支持按消息组勾选，用户消息与 AI 回复联动选中
 
 ## 基础用法
@@ -405,7 +405,7 @@ sinceVersion: 1.0.0
 
 ## 等待响应（Loading 自动注入）
 
-当 `messages` 末尾为 `role: 'user'` 时，自动追加 Loading 消息组，展示 AI 正在处理的加载动画：
+当 `messages` 末尾为 `role: 'user'` 时，自动追加 Loading 消息组，展示 AI 正在处理的加载动画（`renderMode` 为 `Share` 时不追加，且 `MessageContainer` 会过滤 Loading 组）：
 
 <div class="demo">
   <p style="margin: 0 0 4px; font-size: 12px; color: #979ba5;">最后一条为 user 消息 → 自动显示 LoadingMessage</p>
@@ -424,7 +424,7 @@ sinceVersion: 1.0.0
 
 ## 流式输出与停止生成
 
-当 `messageStatus` 为 `streaming`、`pending`（等待首包）或 `fetching`（请求中、与末尾 Loading 占位一致）时，底部固定区域显示「停止生成」按钮（`stop-loading` 时按钮展示为正在停止），点击后触发 `@stop-streaming` 事件。
+当 `messageStatus` 为 `streaming`、`pending`（等待首包）或 `fetching`（请求中、与末尾 Loading 占位一致）时，底部固定区域显示「停止生成」按钮（`stop-loading` 时按钮展示为正在停止），点击后触发 `@stop-streaming` 事件。`renderMode` 为 `Share` 时不显示「停止生成」按钮。
 
 点击下方按钮体验完整的流式输出过程：
 
@@ -964,7 +964,7 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 
 | 按钮         | 显示条件                                                                                       | 点击行为               |
 | ------------ | ---------------------------------------------------------------------------------------------- | ---------------------- |
-| 「停止生成」 | `messageStatus` 为 `streaming`、`pending`、`fetching` 或 `stop-loading`（停止中 loading 态） | 触发 `@stop-streaming` |
+| 「停止生成」 | `messageStatus` 为 `streaming`、`pending`、`fetching` 或 `stop-loading`（停止中 loading 态），且 `renderMode` 不为 `Share` | 触发 `@stop-streaming` |
 | 「返回底部」 | `debouncedShowScrollBottomBtn`（距底部 > 100px，且防抖 300ms 后才显示/隐藏）                     | 滚动到消息列表底部     |
 
 > **防抖说明**：「返回底部」按钮的显隐使用 300ms 防抖，避免快速滚动时按钮频繁闪烁。隐藏时立即生效（无防抖），显示时延迟 300ms。
@@ -987,7 +987,7 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 | onUserInputConfirm       | `(message: Message, content: UserMessage['content'], docSchema: TagSchema) => Promise<void>` | —       | 用户编辑消息确认回调                                                                                                                     |
 | onUserShortcutConfirm    | `(message: Message, formModel: Record<string, unknown>) => Promise<void>`                    | —       | 用户快捷指令表单提交回调                                                                                                                 |
 | onInterruptResume        | `OnInterruptResume`                                                                          | —       | AG-UI human-in-the-loop 中断响应回调，透传给 `MessageRender` → `InterruptMessageRender`                                                  |
-| renderMode               | `RenderMode`                                                                                 | —       | 渲染模式。`Share` 模式下启用多选样式并隐藏工具栏；`Test` 模式下过滤掉「分享」按钮；不传或 `Chat` 为默认行为                              |
+| renderMode               | `RenderMode`                                                                                 | —       | 渲染模式。`Share` 模式下启用多选样式并隐藏工具栏与「停止生成」按钮；`Test` 模式下过滤掉「分享」按钮；不传或 `Chat` 为默认行为                              |
 
 ### v-model
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -31,6 +31,7 @@ sinceVersion: 1.0.0
 function useMessageGroup(options: {
   keyword?: ShallowRef<string>;
   messages: ComputedRef<Message[]>;
+  renderMode?: MaybeRef<RenderMode>;
   selectedUserMessages: Ref<Message[] | undefined>;
 }): {
   messageGroups: Ref<MessageGroup[]>;
@@ -67,7 +68,7 @@ role=user  role=tool     其他 role
  成组           后 continue
 
 ④ 遍历结束后将剩余 assistantMessages 推入 list
-⑤ 末尾为 user 消息 → 追加 Loading 消息组
+⑤ 末尾为 user 消息 → 追加 Loading 消息组（`renderMode` 为 `Share` 时不追加）
 ```
 
 注入的占位 Loading 消息使用固定 id：`LOADING_MESSAGE_ID`（`'__loading__'`，定义于 `common/constants`）。`ChatContainer` 据此判断是否在「请求中」阶段，并向 `ChatInput` / `MessageContainer` 下传 `MessageStatus.Fetching`，与流式中的停止、防重复发送行为对齐。


### PR DESCRIPTION
## 背景

TAPD: 【chat-x】share 模式下不应展示「停止生成」按钮（1070093903159831775）

占旭反馈：使用 `ChatContainer` 的 `render-mode="share"` 仅作消息展示时，底部仍错误出现「停止生成」按钮；后续确认 Share 模式下 Loading 占位消息同样不应展示。

根因：
1. `MessageContainer` 底部「停止生成」按钮未判断 `RenderMode.Share`
2. `useMessageGroup` 在末尾为用户消息时仍会注入 Loading 占位组

## 改动

- `MessageContainer`：Share 模式下隐藏「停止生成」按钮，并过滤 Loading 消息组
- `useMessageGroup`：新增 `renderMode` 入参，Share 模式下不追加 Loading 占位
- `ChatContainer`：将 `renderMode` 透传给 `useMessageGroup`
- 同步单测与 wiki 文档

## 影响面

- 仅影响 `render-mode="share"` 场景，默认 Chat/Test 模式行为不变

## 测试

- [x] `message-container.spec.ts`：Share 模式不展示停止按钮与 Loading 组
- [x] `use-message-group.spec.ts`：Share 模式不追加 Loading 组

Made with [Cursor](https://cursor.com)