### PR TITLE
fix: 【chat-x】中断 resume loading 防重复 --story=135573171

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -27,6 +27,8 @@
 import { type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Button } from 'bkui-vue';
+
 import { APPROVAL_STATUS, InterruptReason } from '../../../ag-ui/types/constants';
 import { InterruptResumeOperation } from '../../../ag-ui/types/interrupt';
 import InterruptMessage from './interrupt-message.vue';
@@ -191,6 +193,26 @@ describe('InterruptMessage', () => {
       },
       approvalInterrupt,
     );
+  });
+
+  it('点击取消审批后按钮进入 loading 并防重复提交', async () => {
+    const onInterruptResume = vi.fn();
+    wrapper = mount(InterruptMessage, {
+      props: {
+        ...buildInterruptProps({
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        }),
+        onInterruptResume,
+      },
+    });
+
+    const cancelBtn = wrapper.find('.ai-tool-approval-card__cancel');
+    await cancelBtn.trigger('click');
+    await cancelBtn.trigger('click');
+
+    expect(onInterruptResume).toHaveBeenCalledTimes(1);
+    expect(cancelBtn.findComponent(Button).props('loading')).toBe(true);
   });
 
   it('点击查看单据详情时只打开单据链接，不触发 resume', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -73,6 +73,7 @@
       <Button
         v-if="isPendingApproval && !readonly"
         class="ai-tool-approval-card__cancel"
+        :loading="cancelling"
         outline
         theme="primary"
         @click="handleCancelApproval"
@@ -84,7 +85,7 @@
 </template>
 
 <script setup lang="ts">
-  import { computed } from 'vue';
+  import { computed, shallowRef } from 'vue';
 
   import { Button, Loading } from 'bkui-vue';
   import { directive as vTippy } from 'vue-tippy';
@@ -147,7 +148,13 @@
     copy(copyText.value);
   };
 
+  // 取消审批为同步 resume，无法拿到请求结果；点击后立即进入 loading 并禁用按钮防重复提交，
+  // 待后台数据刷新使按钮 v-if 失效（卡片卸载/重建）后该状态随实例销毁自然消失
+  const cancelling = shallowRef(false);
+
   const handleCancelApproval = () => {
+    if (cancelling.value) return;
+    cancelling.value = true;
     props.onInterruptResume?.(
       { operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: props.interrupt.id } },
       props.interrupt,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
@@ -27,6 +27,8 @@
 import { type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { Button } from 'bkui-vue';
+
 import { InterruptReason } from '../../../../ag-ui/types/constants';
 import UserQuestionCard from './user-question-card.vue';
 
@@ -136,6 +138,40 @@ describe('UserQuestionCard', () => {
     expect(itrpt).toEqual(interrupt);
     expect(payload.status).toBe('cancelled');
     expect(payload.payload.answers).toHaveLength(0);
+  });
+
+  it('点击完成后完成按钮 loading、跳过按钮禁用，且防重复提交', async () => {
+    const onResume = vi.fn();
+    wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt(), onResume } });
+
+    const options = wrapper.findAll('.ai-user-question-option');
+    await options[0].trigger('click');
+    await options[3].trigger('click');
+
+    const completeBtn = wrapper.find('.ai-user-question-card__complete');
+    const skipBtn = wrapper.find('.ai-user-question-card__skip');
+    await completeBtn.trigger('click');
+    await completeBtn.trigger('click');
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(completeBtn.findComponent(Button).props('loading')).toBe(true);
+    expect(skipBtn.findComponent(Button).props('disabled')).toBe(true);
+    expect(wrapper.find('.ai-user-question-card__enter-icon').exists()).toBe(false);
+  });
+
+  it('点击跳过后跳过按钮 loading、完成按钮禁用，且防重复提交', async () => {
+    const onResume = vi.fn();
+    wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt(), onResume } });
+
+    const skipBtn = wrapper.find('.ai-user-question-card__skip');
+    const completeBtn = wrapper.find('.ai-user-question-card__complete');
+    await skipBtn.trigger('click');
+    await skipBtn.trigger('click');
+
+    expect(onResume).toHaveBeenCalledTimes(1);
+    expect(skipBtn.findComponent(Button).props('loading')).toBe(true);
+    expect(completeBtn.findComponent(Button).props('disabled')).toBe(true);
+    expect(wrapper.find('.ai-user-question-card__skip-icon').exists()).toBe(false);
   });
 
   it('点击箭头可折叠，body 与 footer 通过 v-show 隐藏而非卸载', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
@@ -78,21 +78,30 @@
     >
       <Button
         class="ai-user-question-card__complete"
-        :disabled="!completed"
+        :disabled="!completed || pendingAction === 'skip'"
+        :loading="pendingAction === 'complete'"
         size="small"
         theme="primary"
         @click="handleComplete"
       >
-        <EnterIcon class="ai-user-question-card__enter-icon" />
+        <EnterIcon
+          v-if="pendingAction !== 'complete'"
+          class="ai-user-question-card__enter-icon"
+        />
         {{ t('完成') }}
       </Button>
       <Button
         class="ai-user-question-card__skip"
+        :disabled="pendingAction === 'complete'"
+        :loading="pendingAction === 'skip'"
         size="small"
         text
         @click="handleSkip"
       >
-        <SkipIcon class="ai-user-question-card__skip-icon" />
+        <SkipIcon
+          v-if="pendingAction !== 'skip'"
+          class="ai-user-question-card__skip-icon"
+        />
         {{ t('跳过') }}
       </Button>
     </footer>
@@ -170,12 +179,19 @@
     }
   };
 
+  // 完成/跳过为同步 resume，无法拿到请求结果；点击后立即在被点按钮上显示 loading 并禁用两个按钮，
+  // 待后台数据刷新使 activeUserQuestionInterrupt 失效（整卡卸载）后该状态随实例销毁自然消失
+  const pendingAction = shallowRef<'complete' | 'skip' | null>(null);
+
   const handleComplete = () => {
-    if (!completed.value) return;
+    if (!completed.value || pendingAction.value !== null) return;
+    pendingAction.value = 'complete';
     props.onResume?.(buildResolvePayload(), props.interrupt);
   };
 
   const handleSkip = () => {
+    if (pendingAction.value !== null) return;
+    pendingAction.value = 'skip';
     props.onResume?.(buildSkipPayload(), props.interrupt);
   };
 </script>

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -108,10 +108,12 @@ ToolApprovalCard
 ├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
 ├── 处理人：当前处理人（overflow-tips 省略）
-└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly）
+└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交）
 ```
 
 `readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏「取消审批」按钮，不接受审批取消交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+
+取消审批为同步 `onInterruptResume`，组件无法在回调内获知请求结果。点击后「取消审批」按钮立即进入 loading 并忽略重复点击；待后台刷新使卡片卸载/重建后状态随实例销毁。
 
 状态徽章样式：
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
@@ -94,6 +94,7 @@ sinceVersion: 1.0.0
 - **自定义作答形态**：通过 `#question` slot 可替换默认选择题，渲染任意表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
 - **完成校验**：所有题目均已作答（`setAnswer` 收到有效答案）后才允许点击「完成」。
 - **跳过**：点击「跳过」返回 `status: 'cancelled'` 与空 `answers`。
+- **提交 loading**：完成/跳过为同步 `onResume`，组件无法在回调内获知请求结果。点击后当前按钮进入 loading、另一按钮禁用，并忽略重复点击；待后台刷新使 `UserQuestionCard` 卸载后状态随实例销毁。
 - **输入框发送**：存在待回答 UserQuestion 时，用户也可在 `ChatInput` 直接发送；`ChatContainer` 会调用 `onSendMessage` 并在第三参数附带与「跳过」等价的 skip `payload` 及 `interrupt`，输入框内容不会自动清空。
 
 ## 数据协议


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】中断 resume 按钮 loading 防重复提交（1070093903135573171）

Human-in-the-loop 中断卡片（工具审批、用户问题）的 resume 为同步回调，组件无法在回调内获知请求结果，快速重复点击可能触发多次 resume，且缺少 loading 反馈。

## 改动
- `ToolApprovalCard`：取消审批点击后进入 loading，忽略重复点击
- `UserQuestionCard`：完成/跳过点击后当前按钮 loading、另一按钮禁用，忽略重复点击
- 同步 `interrupt-message.spec.ts`、`user-question-card.spec.ts` 单测
- 同步 `tool-approval-card.md`、`user-question-card.md` wiki 文档

## 影响面
- 仅影响 `InterruptReason.AIDevToolApproval` 与 `UserQuestion` 中断卡片的提交交互态
- 无新增 Props/Events，行为向后兼容

## 测试
- [x] `interrupt-message.spec.ts` 22 用例通过
- [x] `user-question-card.spec.ts` 相关 loading/防重复用例通过

Made with [Cursor](https://cursor.com)