### PR TITLE
feat: 【chat-x】share 模式禁用审批卡片取消按钮 --story=135575899

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -73,6 +73,7 @@
       <Button
         v-if="isPendingApproval && !readonly"
         class="ai-tool-approval-card__cancel"
+        :disabled="cancelling || isShareContext"
         :loading="cancelling"
         outline
         theme="primary"
@@ -93,8 +94,9 @@
   import { APPROVAL_STATUS_MAP } from '../../../ag-ui/types/constants';
   import { APPROVAL_STATUS } from '../../../ag-ui/types/constants';
   import { InterruptResumeOperation } from '../../../ag-ui/types/interrupt';
+  import { RenderMode } from '../../../common/constants';
   import { useClipboard } from '../../../composables';
-  import { useCommonTippyInject } from '../../../composables/use-common';
+  import { useCommonTippyInject, useRenderModeInject } from '../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../directives/overflow-tips';
   import { CheckCircleFillIcon, CloseCircleFillIcon, CopyIcon, RevokedIcon, TimeIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
@@ -109,6 +111,9 @@
   }>();
 
   const commonTippyOptions = useCommonTippyInject();
+  const renderMode = useRenderModeInject();
+  // 只读分享渲染（RenderMode.Share）下禁用审批单的交互按钮
+  const isShareContext = computed(() => renderMode.value === RenderMode.Share);
   const { copy } = useClipboard();
   const pendingStatusSet = new Set([APPROVAL_STATUS.PENDING, APPROVAL_STATUS.DRAFT]);
   const dangerStatusSet = new Set([

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -108,10 +108,12 @@ ToolApprovalCard
 ├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
 ├── 处理人：当前处理人（overflow-tips 省略）
-└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交）
+└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交；分享只读渲染下禁用）
 ```
 
 `readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏「取消审批」按钮，不接受审批取消交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+
+分享只读渲染模式（注入的 `RenderMode.Share`）下，「取消审批」按钮**保持可见但禁用**（区别于 `readonly` 的直接隐藏），避免在分享回显场景误触发取消。该渲染模式由 [ChatContainer](/components/setup/chat-container) 等容器通过 `useRenderModeProvider` 注入，组件内部经 `useRenderModeInject` 读取，业务侧无需手动设置。
 
 取消审批为同步 `onInterruptResume`，组件无法在回调内获知请求结果。点击后「取消审批」按钮立即进入 loading 并忽略重复点击；待后台刷新使卡片卸载/重建后状态随实例销毁。
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】share只读渲染下禁用审批卡片取消审批交互（1070093903135575899）

share（分享）只读渲染模式 `RenderMode.Share` 用于会话分享回显，应禁用所有交互入口，避免查看者误触发实际操作。延续已合入需求 159831775「share 模式隐藏交互元素」，本次补齐 ToolApprovalCard（工具审批卡片）遗漏的「取消审批」按钮。

## 改动
- `tool-approval-card.vue`：通过 `useRenderModeInject` 读取渲染模式，新增 `isShareContext`（`RenderMode.Share`）；「取消审批」按钮 disabled 条件由 `cancelling` 扩展为 `cancelling || isShareContext`，share 模式下按钮保持可见但禁用（区别于 `readonly` 的直接隐藏）。
- 同步更新组件 wiki 文档 `wikis/components/agent/tool-approval-card.md`。

## 影响面
- 仅 ToolApprovalCard 组件；渲染模式经 provide/inject 注入，业务侧无需改动。

## 测试
- [ ] share 只读渲染下审批卡片「取消审批」按钮可见但禁用、无法触发取消 resume
- [ ] 普通对话渲染（RenderMode.Chat）下「取消审批」按钮交互不受影响

Made with [Cursor](https://cursor.com)