### PR TITLE
fix: 【chat-x】Markdown 渲染含下划线文本多出 _ --bug=159954951

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/stream-markdown-completer.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/stream-markdown-completer.ts
@@ -1095,9 +1095,19 @@ function checkSingleMarker(line: string, marker: string): string {
   for (let i = 0; i < lineWithoutDouble.length; i++) {
     if (lineWithoutDouble[i] === marker) {
       // 检查是否被转义
-      if (i === 0 || lineWithoutDouble[i - 1] !== '\\') {
-        count++;
+      if (i > 0 && lineWithoutDouble[i - 1] === '\\') {
+        continue;
       }
+
+      // 下划线不支持词内强调（CommonMark intraword emphasis）：
+      // 当 `_` 两侧都是单词字符（如 "你好_AA"、"foo_bar"）时，
+      // markdown-it 不会将其识别为强调定界符，因此补全闭合符号会导致多出一个 `_`，
+      // 这里直接跳过，不计入待补全的计数。
+      if (marker === '_' && isWordChar(lineWithoutDouble[i - 1]) && isWordChar(lineWithoutDouble[i + 1])) {
+        continue;
+      }
+
+      count++;
     }
   }
 
@@ -1282,6 +1292,15 @@ function isIncompleteLatexInput(content: string, mathStartPos: number): boolean 
   }
 
   return false;
+}
+
+/**
+ * 判断字符是否为「单词字符」（字母 / 数字，含 CJK 等任意语言文字）。
+ * 用于下划线强调的词内（intraword）判定。
+ */
+function isWordChar(char: string | undefined): boolean {
+  if (!char) return false;
+  return /[\p{L}\p{N}]/u.test(char);
 }
 
 function parseLatexCommand(content: string, startIdx: number): null | { cmd: string; endIdx: number } {


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】Markdown 渲染含下划线文本多出 _（1070093903159954951）

`MarkdownContent` 输入带 `_` 的字符串（如 `你好_AA`），渲染结果会多出一个 `_`，显示为 `你好_AA_`。

## 根因
`stream-markdown-completer.ts` 的 `checkSingleMarker` 在流式补全时，将单个 `_` 误判为未闭合的斜体定界符并补全闭合 `_`。但 CommonMark 规定下划线不支持词内强调（intraword emphasis），`你好_AA` 中的 `_` 不会被 markdown-it 识别为强调，补全后反而多显示一个 `_`。

## 改动
- `checkSingleMarker`：当 `_` 两侧均为单词字符时跳过计数，不再补全闭合符号
- 新增 `isWordChar` 辅助函数（`\p{L}\p{N}`）判定单词字符边界

## 影响面
- 仅影响流式 Markdown 补全逻辑，不影响正常已闭合的斜体语法（如 `_italic`、空格后的 `_text`）

## 测试
- [x] `你好_AA` 不再多出尾部 `_`
- [x] `foo_bar`、`a_b_c` 等词内下划线不再误补全
- [x] 行首/空格后的 `_italic` 流式补全行为保持不变

Made with [Cursor](https://cursor.com)