### PR TITLE
feat: 【小鲸】侧栏Tab排序显隐可关闭 --story=135675503

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
@@ -73,6 +73,7 @@ declare global {
 export type BkFlowMessageContent = BkFlowTask[];
 
 export type BkFlowNode = {
+  closable?: boolean; // 是否可关闭 缺省为 true
   elapsed_time: number;
   finish_time: string;
   id: string;
@@ -82,10 +83,12 @@ export type BkFlowNode = {
   skip: boolean;
   start_time: string;
   state: string;
+  tab_order?: number; // 排序 越小 越在前
   type: string;
 };
 
 export type BkFlowTask = {
+  closable?: boolean; // 是否可关闭 缺省为 true
   confidence_title?: string; // 有效证据标题
   has_confidence?: boolean; // 是否有有效证据， 置信度
   is_active?: boolean; // 是否默认激活
@@ -94,6 +97,7 @@ export type BkFlowTask = {
     state_counts: Record<string, number>;
     total: number;
   };
+  tab_order?: number; // 排序 越小 越在前
   task_id: number;
   task_name: string;
   task_outputs: unknown;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -193,48 +193,75 @@ vi.mock('../../directives', () => ({
 
 vi.mock('../../composables/use-custom-tab', () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const { shallowRef, ref: deepRef, provide } = require('vue');
+  const { shallowRef, ref: deepRef, computed, provide } = require('vue');
   const CUSTOM_TAB_TOKEN = Symbol('CUSTOM_TAB_TOKEN');
   const EXECUTION_TAB_NAME = 'execution';
+  const DEFAULT_TAB_ORDER = 100;
   return {
     CUSTOM_TAB_TOKEN,
+    DEFAULT_TAB_ORDER,
     EXECUTION_TAB_NAME,
-    useCustomTabProvider: vi.fn((_options: { onTabChange?: (tab: unknown) => void }) => {
-      const EXECUTION_TAB = { label: '执行情况', name: EXECUTION_TAB_NAME };
-      const tabs = shallowRef([EXECUTION_TAB]);
-      const selectedTab = deepRef(EXECUTION_TAB);
-      const isCollapse = shallowRef(true);
+    useCustomTabProvider: vi.fn(
+      (_options: { executionTabVisible?: () => boolean | undefined; onTabChange?: (tab: unknown) => void }) => {
+        const EXECUTION_TAB = { closable: false, label: '执行情况', name: EXECUTION_TAB_NAME, order: 0 };
+        const tabs = shallowRef([EXECUTION_TAB]);
+        const selectedTab = deepRef(EXECUTION_TAB);
+        const isCollapse = shallowRef(true);
 
-      const addCustomTab = vi.fn((tab: { label: string; name: string }) => {
-        if (!tabs.value.find((t: { name: string }) => t.name === tab.name)) {
-          tabs.value = [...tabs.value, tab];
-        }
-        isCollapse.value = false;
-      });
-      const removeCustomTab = vi.fn((name: string) => {
-        tabs.value = tabs.value.filter((t: { name: string }) => t.name !== name);
-      });
-      const selectCustomTab = vi.fn((tab: unknown) => {
-        selectedTab.value = tab ?? EXECUTION_TAB;
-        _options.onTabChange?.(tab);
-      });
-      const resetCustomTab = vi.fn(() => {
-        tabs.value = [EXECUTION_TAB];
-        selectedTab.value = EXECUTION_TAB;
-        isCollapse.value = true;
-      });
+        const isExecutionVisible = () => _options.executionTabVisible?.() ?? true;
+        const displayTabs = computed(() =>
+          tabs.value
+            .filter((tab: { name: string; visible?: boolean }) =>
+              tab.name === EXECUTION_TAB_NAME ? isExecutionVisible() : tab.visible !== false,
+            )
+            .slice()
+            .sort(
+              (a: { order?: number }, b: { order?: number }) =>
+                (a.order ?? DEFAULT_TAB_ORDER) - (b.order ?? DEFAULT_TAB_ORDER),
+            ),
+        );
 
-      provide(CUSTOM_TAB_TOKEN, {
-        tabs,
-        selectedTab,
-        addCustomTab,
-        removeCustomTab,
-        selectCustomTab,
-        resetCustomTab,
-      });
+        const addCustomTab = vi.fn((tab: { label: string; name: string }) => {
+          if (!tabs.value.find((t: { name: string }) => t.name === tab.name)) {
+            tabs.value = [...tabs.value, tab];
+          }
+          isCollapse.value = false;
+        });
+        const removeCustomTab = vi.fn((name: string) => {
+          tabs.value = tabs.value.filter((t: { name: string }) => t.name !== name);
+        });
+        const selectCustomTab = vi.fn((tab: unknown) => {
+          selectedTab.value = tab ?? EXECUTION_TAB;
+          _options.onTabChange?.(tab);
+        });
+        const resetCustomTab = vi.fn(() => {
+          tabs.value = [EXECUTION_TAB];
+          selectedTab.value = EXECUTION_TAB;
+          isCollapse.value = true;
+        });
 
-      return { tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab };
-    }),
+        provide(CUSTOM_TAB_TOKEN, {
+          tabs,
+          displayTabs,
+          selectedTab,
+          addCustomTab,
+          removeCustomTab,
+          selectCustomTab,
+          resetCustomTab,
+        });
+
+        return {
+          tabs,
+          displayTabs,
+          selectedTab,
+          isCollapse,
+          addCustomTab,
+          removeCustomTab,
+          selectCustomTab,
+          resetCustomTab,
+        };
+      },
+    ),
     useCustomTabConsumer: vi.fn(() => undefined),
   };
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -14,14 +14,21 @@
       class="ai-chat-container-resize-layout"
       :class="{
         'ai-is-collapse':
-          isCollapse || (!keyword?.length && executionGroups?.length < 1) || renderMode === RenderMode.Share,
+          isCollapse ||
+          (displayTabs.length > 0 && !keyword?.length && executionGroups?.length < 1) ||
+          renderMode === RenderMode.Share,
       }"
       v-bind="resizeProps"
       @resizing="handleResizing"
     >
       <template #aside>
         <div
-          v-if="!isCollapse && (executionGroups?.length || keyword?.length) && renderMode !== RenderMode.Share"
+          v-if="
+            !isCollapse &&
+            displayTabs.length > 0 &&
+            (executionGroups?.length || keyword?.length) &&
+            renderMode !== RenderMode.Share
+          "
           ref="fullScreenRef"
           class="ai-full-screen-wrapper"
         >
@@ -33,7 +40,7 @@
             @change="handleUpdateTabActive"
           >
             <TabPanel
-              v-for="tab in tabs"
+              v-for="tab in displayTabs"
               :key="tab.name"
               class="ai-chat-container-tab-panel"
               :label="
@@ -62,7 +69,7 @@
                         ),
                         [[vOverflowTips, { ...commonTippyOptions, text: tab.label ?? '' }]],
                       ),
-                      tab.name !== EXECUTION_TAB_NAME
+                      tab.closable !== false && tab.name !== EXECUTION_TAB_NAME
                         ? h(CloseIcon, {
                             class: 'ai-execution-close-icon',
                             onClick: () => {
@@ -97,7 +104,7 @@
               </div>
             </template>
           </Tab>
-          <template v-if="selectedTab?.name === EXECUTION_TAB_NAME">
+          <template v-if="selectedTab?.name === EXECUTION_TAB_NAME && executionTabVisible !== false">
             <ExecutionSummary
               v-if="!isCollapse"
               :message-groups="executionGroups"
@@ -132,7 +139,7 @@
           </template>
         </div>
         <div
-          v-if="executionGroups?.length && renderMode !== RenderMode.Share"
+          v-if="displayTabs.length > 0 && executionGroups?.length && renderMode !== RenderMode.Share"
           class="collapse-button"
           :class="{ 'is-right': placement === 'right', 'is-collapsed': isCollapse }"
           @click="handleCollapse"
@@ -299,6 +306,8 @@
   export type ChatContainerProps = {
     chatLoading?: boolean;
     commonTippyOptions?: AITippyProps;
+    // 执行情况 Tab 是否展示，缺省 true；为 false 时从 Tab 栏隐藏，选中态自动切到首个可见 Tab
+    executionTabVisible?: boolean;
     // 用于获取侧边栏组件的渲染
     getSideRenderComponent?: (createElement: typeof h, props?: Record<string, unknown>) => undefined | VNode;
     // 用于获取侧边栏 tab 的渲染
@@ -353,6 +362,7 @@
     >(),
     {
       placement: 'left',
+      executionTabVisible: true,
     },
   );
   const renderMode = defineModel<RenderMode>('renderMode', {
@@ -399,8 +409,9 @@
 
   useCommonTippyProvider({ tippyOptions: computed(() => props.commonTippyOptions ?? {}) });
 
-  const { tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
+  const { displayTabs, tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
     useCustomTabProvider<CustomBkFlowTabData>({
+      executionTabVisible: () => props.executionTabVisible,
       onTabChange: async tab => {
         const tabProps = selectedTab.value.data?.props || {
           loading: true,
@@ -799,8 +810,8 @@
       flex-direction: column;
       align-items: center;
       width: 100%;
-      min-height: 0;
       max-width: 1000px;
+      min-height: 0;
       padding: 16px;
       margin: 0 auto;
       text-align: center;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-tab.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-tab.ts
@@ -26,7 +26,7 @@
 
 import { type Ref, computed, onMounted, onUnmounted, shallowRef, watch } from 'vue';
 
-import { useContainerScrollConsumer, useCustomTabConsumer } from '../../../composables';
+import { DEFAULT_TAB_ORDER, useContainerScrollConsumer, useCustomTabConsumer } from '../../../composables';
 import { t } from '../../../lang/lang';
 import BkFlowNodeDetail from './flow-agent-node-detail.vue';
 
@@ -86,8 +86,12 @@ export const useFlowTab = (options: { messageUid: Ref<string | undefined>; taskL
     if (taskId == null) return;
     markUserTabSelection();
     customTab.addCustomTab?.({
+      // 是否可关闭由后端下发的 closable 控制，缺省（undefined）保持默认可关闭
+      closable: node.closable,
       label: node.name,
       name: buildNodeTabName(task, node),
+      // 排序优先采用后端下发的 tab_order（越小越靠前），缺省回退默认权重
+      order: node.tab_order ?? DEFAULT_TAB_ORDER,
       data: {
         component: BkFlowNodeDetail,
         messageUid: messageUid.value,
@@ -108,8 +112,13 @@ export const useFlowTab = (options: { messageUid: Ref<string | undefined>; taskL
     if (!taskId) return;
     markUserTabSelection();
     customTab.addCustomTab?.({
+      // 是否可关闭由后端下发的 closable 控制，缺省（undefined）保持默认可关闭
+      closable: task.closable,
       label: t('有效证据'),
       name: buildConfidenceTabName(task),
+      // 排序优先采用后端下发的 tab_order（越小越靠前）；
+      // 缺省回退 10，固定排在「执行情况」(order 0) 之后、节点详情(默认 100)之前
+      order: task.tab_order ?? 10,
       data: {
         component: BkFlowNodeDetail,
         messageUid: messageUid.value,

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.spec.ts
@@ -23,7 +23,7 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, h, nextTick } from 'vue';
+import { type Ref, defineComponent, h, nextTick, ref } from 'vue';
 
 import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -44,6 +44,30 @@ const createProviderComponent = (onTabChange?: (tab: unknown) => void) =>
       return h('div', { class: 'provider' }, this.$slots.default?.());
     },
   });
+
+/** 支持注入 executionTabVisible（响应式）的 Provider，便于测试显隐与排序 */
+const createConfigurableProvider = (executionVisible: Ref<boolean>) =>
+  defineComponent({
+    setup() {
+      const result = useCustomTabProvider({
+        executionTabVisible: () => executionVisible.value,
+      });
+      return { providerResult: result };
+    },
+    render() {
+      return h('div', { class: 'provider' });
+    },
+  });
+
+type ProviderVm = {
+  providerResult: {
+    addCustomTab: (tab: { label: string; name: string; order?: number; visible?: boolean }) => void;
+    displayTabs: { value: { label: string; name: string }[] };
+    selectCustomTab: (tab: { name: string }) => void;
+    selectedTab: { value: { name: string } };
+    tabs: { value: { label: string; name: string }[] };
+  };
+};
 
 const createConsumerComponent = () =>
   defineComponent({
@@ -194,6 +218,106 @@ describe('useCustomTab', () => {
       expect(vm.providerResult.tabs.value[0]?.name).toBe(EXECUTION_TAB_NAME);
       expect(vm.providerResult.selectedTab.value.name).toBe(EXECUTION_TAB_NAME);
       expect(vm.providerResult.isCollapse.value).toBe(true);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('displayTabs 排序与显隐', () => {
+    it('displayTabs 应按 order 升序排序（执行情况 order 0 居首）', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      vm.providerResult.addCustomTab({ label: 'A', name: 'a' }); // 默认 order 100
+      await nextTick();
+      vm.providerResult.addCustomTab({ label: 'B', name: 'b', order: 10 });
+      await nextTick();
+
+      expect(vm.providerResult.displayTabs.value.map(tab => tab.name)).toEqual([EXECUTION_TAB_NAME, 'b', 'a']);
+
+      wrapper.unmount();
+    });
+
+    it('同 order 应保持插入顺序（稳定排序）', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      vm.providerResult.addCustomTab({ label: 'A', name: 'a', order: 50 });
+      await nextTick();
+      vm.providerResult.addCustomTab({ label: 'B', name: 'b', order: 50 });
+      await nextTick();
+
+      expect(vm.providerResult.displayTabs.value.map(tab => tab.name)).toEqual([EXECUTION_TAB_NAME, 'a', 'b']);
+
+      wrapper.unmount();
+    });
+
+    it('visible 为 false 的 Tab 不应出现在 displayTabs，但仍保留在 tabs', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      vm.providerResult.addCustomTab({ label: '隐藏', name: 'hidden', visible: false });
+      await nextTick();
+
+      expect(vm.providerResult.tabs.value.some(tab => tab.name === 'hidden')).toBe(true);
+      expect(vm.providerResult.displayTabs.value.some(tab => tab.name === 'hidden')).toBe(false);
+
+      wrapper.unmount();
+    });
+
+    it('executionTabVisible 为 false 时执行情况不在 displayTabs', async () => {
+      const executionVisible = ref(false);
+      const Provider = createConfigurableProvider(executionVisible);
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      expect(vm.providerResult.displayTabs.value.some(tab => tab.name === EXECUTION_TAB_NAME)).toBe(false);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('addCustomTab 合并更新', () => {
+    it('同名 Tab 应合并更新 label / order / visible 而非追加', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      vm.providerResult.addCustomTab({ label: 'L1', name: 'x' });
+      await nextTick();
+      vm.providerResult.addCustomTab({ label: 'L2', name: 'x', order: 5 });
+      await nextTick();
+
+      expect(vm.providerResult.tabs.value.length).toBe(2);
+      const target = vm.providerResult.tabs.value.find(tab => tab.name === 'x') as { label: string; order?: number };
+      expect(target.label).toBe('L2');
+      expect(target.order).toBe(5);
+
+      wrapper.unmount();
+    });
+  });
+
+  describe('选中 Tab 被隐藏时回退', () => {
+    it('当前选中的执行情况被配置隐藏时应自动切到首个可见 Tab', async () => {
+      const executionVisible = ref(true);
+      const Provider = createConfigurableProvider(executionVisible);
+      const wrapper = mount(Provider);
+      const vm = wrapper.vm as unknown as ProviderVm;
+
+      vm.providerResult.addCustomTab({ label: '节点1', name: 'node-1' });
+      await nextTick();
+      // 回到执行情况 Tab
+      vm.providerResult.selectCustomTab({ name: EXECUTION_TAB_NAME });
+      expect(vm.providerResult.selectedTab.value.name).toBe(EXECUTION_TAB_NAME);
+
+      // 隐藏执行情况 → 选中态应回退到唯一可见的 node-1
+      executionVisible.value = false;
+      await nextTick();
+
+      expect(vm.providerResult.selectedTab.value.name).toBe('node-1');
 
       wrapper.unmount();
     });

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
@@ -24,7 +24,17 @@
  * IN THE SOFTWARE.
  */
 
-import { type ShallowRef, ref as deepRef, inject, nextTick, provide, shallowRef } from 'vue';
+import {
+  type ComputedRef,
+  type ShallowRef,
+  computed,
+  ref as deepRef,
+  inject,
+  nextTick,
+  provide,
+  shallowRef,
+  watch,
+} from 'vue';
 
 import { t } from '../lang/lang';
 
@@ -32,29 +42,60 @@ import type { CustomTab } from '../types';
 
 export const CUSTOM_TAB_TOKEN = Symbol('CUSTOM_TAB_TOKEN');
 export const EXECUTION_TAB_NAME = 'execution';
+/** 自定义 Tab 默认排序权重；执行情况固定为 0，业务自定义 Tab 缺省回退到此值 */
+export const DEFAULT_TAB_ORDER = 100;
 
 export function useCustomTabProvider<T extends Record<string, unknown>>(options: {
+  /** 执行情况 Tab 是否展示，缺省 true；传 getter 以保持响应式 */
+  executionTabVisible?: () => boolean | undefined;
   onTabChange?: (tab: CustomTab<T>) => void;
 }) {
   const EXECUTION_TAB: CustomTab<T> = {
+    closable: false,
     label: t('执行情况'),
     name: EXECUTION_TAB_NAME,
+    order: 0,
   };
   const tabs = shallowRef<CustomTab<T>[]>([EXECUTION_TAB]);
   const selectedTab = deepRef<CustomTab<T>>(EXECUTION_TAB);
   const isCollapse = shallowRef(true);
 
+  /** 执行情况显隐由外部配置控制，缺省可见 */
+  const isExecutionVisible = computed(() => options.executionTabVisible?.() ?? true);
+  const isTabVisible = (tab: CustomTab<T>) =>
+    tab.name === EXECUTION_TAB_NAME ? isExecutionVisible.value : tab.visible !== false;
+
+  /**
+   * Tab 栏实际展示列表：过滤掉不可见 Tab，并按 order 升序稳定排序（同 order 保持插入顺序）。
+   * 原始 tabs 仍保留全部 Tab，供程序化选中与查找。
+   */
+  const displayTabs = computed(() =>
+    tabs.value
+      .filter(isTabVisible)
+      .slice()
+      .sort((a, b) => (a.order ?? DEFAULT_TAB_ORDER) - (b.order ?? DEFAULT_TAB_ORDER)),
+  );
+
   const addCustomTab = (tab: CustomTab<T>) => {
-    if (!tabs.value.find(t => t.name === tab.name)) {
+    const index = tabs.value.findIndex(item => item.name === tab.name);
+    if (index === -1) {
       tabs.value = [...tabs.value, tab];
+    } else {
+      // 同名 Tab 合并更新，支持运行时调整 order / visible / label 等元信息
+      const next = tabs.value.slice();
+      next[index] = { ...next[index], ...tab };
+      tabs.value = next;
     }
     isCollapse.value = false;
     nextTick(() => {
-      selectCustomTab(tab);
+      selectCustomTab(tabs.value.find(item => item.name === tab.name)!);
     });
   };
   const removeCustomTab = (tabName: CustomTab<T>['name']) => {
     tabs.value = tabs.value.filter(tab => tab.name !== tabName);
+    if (displayTabs.value.length === 0) {
+      isCollapse.value = true;
+    }
   };
   const selectCustomTab = (tab: CustomTab<T>) => {
     selectedTab.value = tab ?? EXECUTION_TAB;
@@ -67,8 +108,22 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
     isCollapse.value = true;
   };
 
+  /**
+   * 选中 Tab 被隐藏时（如执行情况被配置隐藏），不渲染其内容，自动切到首个可见 Tab；
+   * 无可见 Tab 时保持原选中，由模板内容守卫兜底为空。
+   */
+  watch(displayTabs, list => {
+    if (isTabVisible(selectedTab.value)) {
+      return;
+    }
+    if (list.length) {
+      selectCustomTab(list[0]);
+    }
+  });
+
   provide(CUSTOM_TAB_TOKEN, {
     tabs,
+    displayTabs,
     selectedTab,
     addCustomTab,
     removeCustomTab,
@@ -78,6 +133,7 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
 
   return {
     tabs,
+    displayTabs,
     selectedTab,
     isCollapse,
     addCustomTab,
@@ -92,6 +148,7 @@ export const useCustomTabConsumer = <T extends Record<string, unknown>>() => {
     | undefined
     | {
         addCustomTab: (tab: CustomTab<T>) => void;
+        displayTabs: ComputedRef<CustomTab<T>[]>;
         removeCustomTab: (tabName: CustomTab<T>['name']) => void;
         selectCustomTab: (tab: CustomTab<T>) => void;
         selectedTab: ShallowRef<CustomTab<T> | null>;

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/custom.ts
@@ -37,10 +37,13 @@ export type CustomBkFlowTabData = CustomTabData<{
 }>;
 
 export type CustomTab<T extends CustomTabData<Record<string, unknown>>> = {
+  closable?: boolean; // 是否可关闭，缺省 true；执行情况 Tab 强制不可关闭
   data?: T & { messageUid?: string };
   icon?: string;
   label: string; // 显示标签
   name: string; // 唯一标识
+  order?: number; // 排序权重，升序，越小越靠前；缺省 100，执行情况默认 0
+  visible?: boolean; // 是否在 Tab 栏展示，缺省 true；false 时仍可被程序化选中，但内容不渲染、会自动切到首个可见 Tab
 };
 
 export type CustomTabData<T extends Record<string, unknown>> = {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/activity-message.md
@@ -409,7 +409,7 @@ const messages = [
 | 场景       | `tab.name` 格式                          |
 | ---------- | ---------------------------------------- |
 | 任务详情   | `{task_id}`                              |
-| 有效证据   | `{task_id}`（与任务 Tab 同名，label 为「有效证据」） |
+| 有效证据   | `{task_id}`（与任务 Tab 同名，label 为「有效证据」，`order: 10` 固定排在「执行情况」之后、节点详情之前） |
 | 节点详情   | `{task_id}\|{node.id}\|{node.name}`      |
 
 `CustomBkFlowTabData` 支持 `has_confidence?: boolean`，用于侧栏详情组件区分证据视图与节点视图。应用层可通过 `ChatContainer` 的 `getSideRenderComponent` 覆盖渲染组件。

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/molecular/chat-container.md
@@ -395,6 +395,20 @@ ai-chat-container
 
 通过 `ref` 获取组件实例后，使用 `addCustomTab` / `removeCustomTab` 动态管理侧边栏 Tab。若 **`executionGroups` 变为空且搜索词已清空**，容器会清空自定义 Tab 状态（与侧栏执行数据联动，见上文「侧边栏与执行摘要」）。
 
+### Tab 排序与显隐
+
+`CustomTab` 支持 `order` / `visible` / `closable` 三个可选字段，用于控制 Tab 栏的排序与显隐：
+
+| 字段 | 默认值 | 说明 |
+| ---- | ------ | ---- |
+| `order` | `100` | 排序权重，升序，越小越靠前。「执行情况」固定 `0`；FlowAgent「有效证据」固定 `10`（紧随执行情况），节点详情走默认 `100` |
+| `visible` | `true` | 是否在 Tab 栏展示。`false` 时从栏内隐藏，但仍可被 `addCustomTab` / `selectCustomTab` 程序化选中；若被隐藏的 Tab 当前正被选中，则自动切到首个可见 Tab、内容不再渲染 |
+| `closable` | `true` | 是否展示关闭按钮。「执行情况」强制不可关闭 |
+
+- 排序为稳定排序，`order` 相同的 Tab 保持插入先后顺序。
+- 「执行情况」Tab 的显隐统一由 `executionTabVisible` Prop 控制（见 Props 表），不通过 `visible` 字段配置。
+- 同名（同 `name`）`addCustomTab` 会**合并更新**已有 Tab，可用于运行时调整 `order` / `visible` / `label`。
+
 ### 侧栏渲染扩展
 
 应用层可通过以下 Props 覆盖默认 Tab 标签与侧栏内容区的渲染逻辑（例如 FlowAgent 节点详情使用业务自定义组件）：
@@ -712,6 +726,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | ------------------ | ---------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
 | chatLoading                 | `boolean`                                                                    | —        | 整体加载状态，`true` 时显示 Loading 遮罩                                                                                                      |
 | commonTippyOptions          | `AITippyProps`                                                               | —        | 通用 Tippy 配置（`appendTo` / `placement` / `zIndex`），传入的选项会注入到所有使用 `v-overflow-tips` 的子组件中                                 |
+| executionTabVisible         | `boolean`                                                                    | `true`   | 「执行情况」Tab 是否展示；为 `false` 时从 Tab 栏隐藏，若其正被选中则自动切到首个可见 Tab，内容不再渲染                                          |
 | getSideRenderComponent      | `(h, props?) => VNode \| undefined`                                          | —        | 自定义侧栏内容区渲染；未返回时使用 `selectedTab.data.component`                                                                               |
 | getSideTabRenderComponent   | `(h, tab, { removeCustomTab }) => VNode \| undefined`                        | —        | 自定义侧栏 Tab 标签渲染；未返回时使用默认图标 + 文案 + 关闭按钮                                                                               |
 | openingRemark               | `string`                                                                     | —        | 开场白，无消息时显示，支持 Markdown                                                                                                           |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
@@ -27,9 +27,12 @@ Provider/Consumer 模式的自定义 Tab 管理，用于 `ChatContainer` 侧边�
 
 ```typescript
 function useCustomTabProvider<T extends Record<string, unknown>>(options: {
+  // 执行情况 Tab 是否展示，缺省 true；传 getter 以保持响应式
+  executionTabVisible?: () => boolean | undefined;
   onTabChange?: (tab: CustomTab<T>) => void;
 }): {
   tabs: ShallowRef<CustomTab<T>[]>;
+  displayTabs: ComputedRef<CustomTab<T>[]>;
   selectedTab: Ref<CustomTab<T>>;
   isCollapse: ShallowRef<boolean>;
   addCustomTab: (tab: CustomTab<T>) => void;
@@ -46,6 +49,7 @@ function useCustomTabConsumer<T extends Record<string, unknown>>():
   | undefined
   | {
       tabs: ShallowRef<CustomTab<T>[]>;
+      displayTabs: ComputedRef<CustomTab<T>[]>;
       selectedTab: ShallowRef<CustomTab<T> | null>;
       addCustomTab: (tab: CustomTab<T>) => void;
       removeCustomTab: (tabName: string) => void;
@@ -94,19 +98,21 @@ tabManager?.removeCustomTab('node-detail-123');
 
 ## 内置常量
 
-| 常量名               | 值            | 说明                      |
-| -------------------- | ------------- | ------------------------- |
-| `EXECUTION_TAB_NAME` | `'execution'` | 执行情况 Tab 的固定标识   |
-| `CUSTOM_TAB_TOKEN`   | `Symbol`      | provide/inject 注入 Token |
+| 常量名               | 值            | 说明                                       |
+| -------------------- | ------------- | ------------------------------------------ |
+| `EXECUTION_TAB_NAME` | `'execution'` | 执行情况 Tab 的固定标识                    |
+| `DEFAULT_TAB_ORDER`  | `100`         | Tab 默认排序权重；执行情况固定为 `0`       |
+| `CUSTOM_TAB_TOKEN`   | `Symbol`      | provide/inject 注入 Token                  |
 
 ## 返回值说明
 
 | 属性/方法名     | 类型                        | 说明                                              |
 | --------------- | --------------------------- | ------------------------------------------------- |
-| tabs            | `ShallowRef<CustomTab[]>`   | 所有 Tab 列表（含默认的执行情况 Tab）             |
-| selectedTab     | `Ref<CustomTab>`            | 当前选中的 Tab                                    |
+| tabs            | `ShallowRef<CustomTab[]>`   | 所有 Tab 列表（含默认的执行情况 Tab，保留隐藏项） |
+| displayTabs     | `ComputedRef<CustomTab[]>`  | Tab 栏实际展示列表：过滤 `visible === false`，按 `order` 升序稳定排序 |
+| selectedTab     | `Ref<CustomTab>`            | 当前选中的 Tab；选中项被隐藏时自动回退到首个可见 Tab |
 | isCollapse      | `ShallowRef<boolean>`       | 侧边栏折叠状态；`addCustomTab` 时自动设为 `false` |
-| addCustomTab    | `(tab: CustomTab) => void`  | 添加 Tab（同名 Tab 不重复添加）                   |
+| addCustomTab    | `(tab: CustomTab) => void`  | 添加 Tab；同名 Tab 合并更新（可改 `order` / `visible` / `label`） |
 | removeCustomTab | `(tabName: string) => void` | 移除指定 Tab                                      |
 | selectCustomTab | `(tab: CustomTab) => void`  | 切换到指定 Tab，触发 `onTabChange` 回调           |
 | resetCustomTab  | `() => void`                  | 重置为仅保留「执行情况」Tab、折叠侧栏并选中默认 Tab；`ChatContainer` 在卸载时调用，避免残留自定义 Tab |
@@ -119,14 +125,23 @@ interface CustomTab<T = Record<string, unknown>> {
   name: string;
   /** 可与 `component` / `props` 并列；用于侧栏「在对话中定位」与主消息 `message.uid` 对齐 */
   data?: T & { messageUid?: string };
+  /** 排序权重，升序，越小越靠前；缺省 100，执行情况默认 0 */
+  order?: number;
+  /** 是否在 Tab 栏展示，缺省 true；false 时仍可被程序化选中，但内容不渲染、会自动切到首个可见 Tab */
+  visible?: boolean;
+  /** 是否可关闭，缺省 true；执行情况强制不可关闭 */
+  closable?: boolean;
 }
 ```
 
 ## 设计特点
 
 - `tabs` 使用 `shallowRef`，`addCustomTab` 通过展开新数组触发更新，避免 `UnwrapRef<T>` 类型问题
-- 默认的「执行情况」Tab 始终存在且不可关闭
-- `addCustomTab` 同时展开侧边栏（`isCollapse = false`）并在 `nextTick` 后自动选中新 Tab
+- 默认的「执行情况」Tab 始终存在且不可关闭，`order` 固定 `0`；可通过 `executionTabVisible` 配置显隐
+- `displayTabs` 负责「过滤显隐 + 按 `order` 排序」；原始 `tabs` 仍保留全部 Tab 供程序化选中与查找
+- 排序为稳定排序，`order` 相同的 Tab 保持插入先后顺序
+- 选中的 Tab 被配置隐藏时，内容不再渲染，自动切换到首个可见 Tab
+- `addCustomTab` 同时展开侧边栏（`isCollapse = false`）并在 `nextTick` 后自动选中目标 Tab；同名 Tab 合并更新
 
 ## 关联组件
 


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】FlowAgent 侧栏 Tab 支持排序、显隐与可关闭配置（1070093903135675503）

FlowAgent 侧栏自定义 Tab 此前缺少统一的排序、显隐与可关闭控制能力，无法按后端下发策略灵活展示。

## 改动
- `CustomTab` 新增 `order` / `visible` / `closable` 字段
- `useCustomTabProvider` 新增 `displayTabs`、`executionTabVisible` 与同名 Tab 合并更新
- `ChatContainer` 新增 `executionTabVisible` Prop，侧栏改用 `displayTabs` 渲染
- FlowAgent 对接后端 `tab_order` / `closable`，有效证据 Tab 默认 `order=10`
- 同步 `use-custom-tab.spec.ts`、`chat-container.spec.ts` 与 wiki 文档

## 影响面
- `@blueking/chat-x`：`ChatContainer`、`useCustomTabProvider`、FlowAgent `use-flow-tab`
- 消费方 `@blueking/ai-blueking` 可通过 `executionTabVisible` Prop 控制执行情况 Tab 显隐

## 测试
- [x] `use-custom-tab.spec.ts` 覆盖排序、显隐、合并更新、选中回退
- [x] `chat-container.spec.ts` mock 同步 `displayTabs`
- [ ] FlowAgent 场景：有效证据 Tab 排在执行情况之后、节点详情之前
- [ ] 后端下发 `tab_order` / `closable` 时正确生效

Made with [Cursor](https://cursor.com)