### PR TITLE
feat: 【小鲸】分享态开放流程智能体查看能力 --story=135703256

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -174,9 +174,7 @@ vi.mock('../../composables', () => ({
         }, 0),
       );
       const pendingApprovalTipText = computed(() =>
-        pendingApprovalCount.value
-          ? `当前会话有 ${pendingApprovalCount.value} 个待审批单，如需继续，请先取消审批`
-          : '',
+        pendingApprovalCount.value ? `当前会话有 ${pendingApprovalCount.value} 个待审批单，如需继续，请先取消审批` : '',
       );
       const activeUserQuestionInterrupt = computed(() => {
         for (let index = _options.messages.value.length - 1; index >= 0; index--) {
@@ -803,9 +801,7 @@ describe('ChatContainer', () => {
     });
 
     it('应该将 skills 属性透传给 ChatInput', () => {
-      const skills = [
-        { skill_code: 'test_skill', skill_name: 'Test Skill', description: 'A test skill', icon: '' },
-      ];
+      const skills = [{ skill_code: 'test_skill', skill_name: 'Test Skill', description: 'A test skill', icon: '' }];
 
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, skills },
@@ -1120,25 +1116,37 @@ describe('ChatContainer', () => {
       expect(providerOptions.renderMode.value).toBe(RenderMode.Share);
     });
 
-    it('renderMode 为 Share 时侧边栏 Tab 和折叠按钮不应渲染', () => {
+    it('renderMode 为 Share 且有 executionGroups 时应开放折叠按钮与侧栏 Tab（只读查看）', async () => {
       const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      mockExecutionGroupsRef.value = [{ id: 'group-1' }];
 
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, messages, renderMode: RenderMode.Share },
       });
+      await nextTick();
 
-      expect(wrapper.find('.ai-chat-container-tab').exists()).toBe(false);
-      expect(wrapper.find('.collapse-button').exists()).toBe(false);
+      // 折叠按钮开放
+      expect(wrapper.find('.collapse-button').exists()).toBe(true);
+
+      // 展开侧栏后，Tab（节点详情/证据/执行情况面板）在分享态可见
+      getChatContainerExposed(wrapper).addCustomTab({ label: '自定义 Tab', name: 'custom-tab' });
+      await nextTick();
+      expect(wrapper.find('.ai-chat-container-tab').exists()).toBe(true);
     });
 
-    it('renderMode 为 Share 时 ResizeLayout 应应用 ai-is-collapse（与 executionGroups 无关）', () => {
+    it('renderMode 为 Share 时不再强制 ai-is-collapse（展开后侧栏展开）', async () => {
       const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+      mockExecutionGroupsRef.value = [{ id: 'group-1' }];
 
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, messages, renderMode: RenderMode.Share },
       });
+      await nextTick();
 
-      expect(wrapper.find('.ai-chat-container-resize-layout').classes()).toContain('ai-is-collapse');
+      getChatContainerExposed(wrapper).addCustomTab({ label: '自定义 Tab', name: 'custom-tab' });
+      await nextTick();
+
+      expect(wrapper.find('.ai-chat-container-resize-layout').classes()).not.toContain('ai-is-collapse');
     });
 
     it('renderMode 为 Share 时底部输入区域（ChatInput、SelectionFooter、ShortcutRender）不应渲染', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -14,22 +14,14 @@
       v-else
       class="ai-chat-container-resize-layout"
       :class="{
-        'ai-is-collapse':
-          isCollapse ||
-          (displayTabs.length > 0 && !keyword?.length && executionGroups?.length < 1) ||
-          renderMode === RenderMode.Share,
+        'ai-is-collapse': isCollapse || (displayTabs.length > 0 && !keyword?.length && executionGroups?.length < 1),
       }"
       v-bind="resizeProps"
       @resizing="handleResizing"
     >
       <template #aside>
         <div
-          v-if="
-            !isCollapse &&
-            displayTabs.length > 0 &&
-            (executionGroups?.length || keyword?.length) &&
-            renderMode !== RenderMode.Share
-          "
+          v-if="!isCollapse && displayTabs.length > 0 && (executionGroups?.length || keyword?.length)"
           ref="fullScreenRef"
           class="ai-full-screen-wrapper"
         >
@@ -140,7 +132,7 @@
           </template>
         </div>
         <div
-          v-if="displayTabs.length > 0 && executionGroups?.length && renderMode !== RenderMode.Share"
+          v-if="displayTabs.length > 0 && executionGroups?.length"
           class="collapse-button"
           :class="{ 'is-right': placement === 'right', 'is-collapsed': isCollapse }"
           @click="handleCollapse"

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
@@ -84,8 +84,9 @@ vi.mock('../../../ag-ui/types/constants', () => ({
   },
 }));
 
-// use-flow-tab 从 composables 桶导出消费 useCustomTabConsumer / useContainerScrollConsumer
+// use-flow-tab 从 composables 桶导出消费 useCustomTabConsumer / useContainerScrollConsumer / DEFAULT_TAB_ORDER
 vi.mock('../../../composables', () => ({
+  DEFAULT_TAB_ORDER: 100,
   useContainerScrollConsumer: () => mockScrollRef,
   useCustomTabConsumer: () => ({
     addCustomTab: mockAddCustomTab,
@@ -411,25 +412,35 @@ describe('FlowAgentContent', () => {
       expectTaskNodesExpanded(wrapper, 0);
     });
 
-    it('renderMode 为 Share 时不应渲染节点耗时和详情入口', () => {
+    it('renderMode 为 Share 时应保留节点耗时与详情查看入口，但隐藏重试/跳过', () => {
       const Parent = defineComponent({
         setup() {
           useRenderModeProvider({ renderMode: RenderMode.Share });
           return () =>
             h(FlowAgentContent, {
-              content: createContent(),
+              // 失败可重试/可跳过节点：非分享态会出现重试/跳过，用于验证分享态被过滤
+              content: createContent({
+                nodes: {
+                  n1: createNode({ id: 'n1', name: '失败节点', state: 'FAILED', retryable: true, skippable: true }),
+                },
+              }),
             });
         },
       });
 
       wrapper = mount(Parent);
 
-      expect(wrapper.find('.flow-agent-node-trailing').exists()).toBe(false);
-      expect(wrapper.find('.flow-agent-node-time').exists()).toBe(false);
-      expect(wrapper.find('.flow-agent-node-actions').exists()).toBe(false);
+      // 只读查看入口保留：行尾容器、耗时、详情按钮
+      expect(wrapper.find('.flow-agent-node-trailing').exists()).toBe(true);
+      expect(wrapper.find('.flow-agent-node-time').exists()).toBe(true);
+      const actionTexts = wrapper.findAll('.flow-agent-node-action-btn').map(btn => btn.text());
+      expect(actionTexts).toContain('详情');
+      // 交互式 resume 操作被过滤
+      expect(actionTexts).not.toContain('重试');
+      expect(actionTexts).not.toContain('跳过');
     });
 
-    it('renderMode 为 Share 时不应渲染任务耗时和有效证据入口', () => {
+    it('renderMode 为 Share 时应保留任务耗时与有效证据查看入口', () => {
       const Parent = defineComponent({
         setup() {
           useRenderModeProvider({ renderMode: RenderMode.Share });
@@ -442,9 +453,9 @@ describe('FlowAgentContent', () => {
 
       wrapper = mount(Parent);
 
-      expect(wrapper.find('.flow-agent-task-trailing').exists()).toBe(false);
-      expect(wrapper.find('.flow-agent-task-time').exists()).toBe(false);
-      expect(wrapper.find('.flow-agent-task-confidence-btn').exists()).toBe(false);
+      expect(wrapper.find('.flow-agent-task-trailing').exists()).toBe(true);
+      expect(wrapper.find('.flow-agent-task-time').exists()).toBe(true);
+      expect(wrapper.find('.flow-agent-task-confidence-btn').exists()).toBe(true);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
@@ -123,10 +123,7 @@
         >
           <HighlightKeyword :text="task.taskName" />
         </span>
-        <span
-          v-if="showActions"
-          class="flow-agent-task-trailing"
-        >
+        <span class="flow-agent-task-trailing">
           <span class="flow-agent-task-time">{{ task.totalTimeText }}</span>
           <span
             v-if="task.hasConfidence"
@@ -171,10 +168,7 @@
           >
             <HighlightKeyword :text="node.name" />
           </span>
-          <span
-            v-if="showActions"
-            class="flow-agent-node-trailing"
-          >
+          <span class="flow-agent-node-trailing">
             <span class="flow-agent-node-time">{{ node.elapsedTimeText }}</span>
             <span class="flow-agent-node-actions">
               <span
@@ -249,8 +243,8 @@
   });
 
   const renderMode = useRenderModeInject();
-  /** 分享态下隐藏耗时与详情等交互入口 */
-  const showActions = computed(() => renderMode.value !== RenderMode.Share);
+  /** 分享态只读：保留「详情 / 有效证据 / 耗时」查看入口，仅隐藏「重试 / 跳过」等交互操作 */
+  const isShareMode = computed(() => renderMode.value === RenderMode.Share);
 
   const isLoading = computed(() => props.status === MessageStatus.Pending || props.status === MessageStatus.Streaming);
 
@@ -265,8 +259,9 @@
     taskList,
   });
 
-  // 节点行尾操作层：聚合「详情 / 重试 / 跳过」为声明式操作列表
+  // 节点行尾操作层：聚合「详情 / 重试 / 跳过」为声明式操作列表；分享态隐藏交互式 resume 操作
   const { getNodeActions, isNodePending } = useFlowNodeActions({
+    hideResumeActions: isShareMode,
     onInterruptResume: toRef(props, 'onInterruptResume'),
     openNodeDetail,
   });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-node-actions.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-node-actions.spec.ts
@@ -95,6 +95,7 @@ const createTaskVM = (overrides: Partial<FlowTaskVM> = {}): FlowTaskVM =>
   }) as FlowTaskVM;
 
 const mountActions = (options?: {
+  hideResumeActions?: boolean;
   node?: Partial<FlowNodeVM>;
   onInterruptResume?: ReturnType<typeof vi.fn>;
 }) => {
@@ -106,6 +107,7 @@ const mountActions = (options?: {
     defineComponent({
       setup() {
         apiRef.value = useFlowNodeActions({
+          hideResumeActions: ref(options?.hideResumeActions ?? false),
           onInterruptResume: ref(onInterruptResume),
           openNodeDetail,
         });
@@ -157,6 +159,15 @@ describe('useFlowNodeActions', () => {
       node: { retryable: false, skippable: false },
     });
 
+    expect(actions.map(action => action.id)).toEqual(['detail']);
+
+    wrapper.unmount();
+  });
+
+  it('hideResumeActions 为 true（分享态）时应过滤重试/跳过，仅保留详情', () => {
+    const { actions, wrapper } = mountActions({ hideResumeActions: true });
+
+    // 即便节点失败可重试/可跳过，分享态也只保留详情查看入口
     expect(actions.map(action => action.id)).toEqual(['detail']);
 
     wrapper.unmount();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-node-actions.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/use-flow-node-actions.ts
@@ -118,12 +118,14 @@ const nodePendingKey = (task: BkFlowTask, node: BkFlowNode) => `${task.task_id}:
  * 操作列表，组件层只需遍历渲染，显隐与点击行为均收敛于此，便于复用、单测与扩展。
  */
 export const useFlowNodeActions = (options: {
+  /** 隐藏重试 / 跳过等交互式 resume 操作（分享态只读，仅保留「详情」查看入口） */
+  hideResumeActions?: Ref<boolean>;
   /** resume 回调（与第三方审批取消同一回调，按 payload.operation 分流） */
   onInterruptResume: Ref<OnInterruptResume | undefined>;
   /** 打开节点详情侧栏（复用 useFlowTab 的能力） */
   openNodeDetail: (task: BkFlowTask, node: BkFlowNode) => void;
 }) => {
-  const { onInterruptResume, openNodeDetail } = options;
+  const { hideResumeActions, onInterruptResume, openNodeDetail } = options;
 
   /** node 键 -> 进行中的 resume 操作；点击后写入，收到后端新状态（键变化）后自动失效 */
   const pendingMap = shallowRef<Record<string, FlowNodePendingOp>>({});
@@ -146,21 +148,25 @@ export const useFlowNodeActions = (options: {
   /** 计算单个节点行尾应展示的操作列表（重试 / 跳过按需，详情恒在末尾） */
   const getNodeActions = (task: FlowTaskVM, node: FlowNodeVM): FlowNodeActionVM[] => {
     const pendingOp = pendingMap.value[nodePendingKey(task.raw, node.raw)];
-    const actions: FlowNodeActionVM[] = RESUME_ACTION_DEFS.filter(def => def.visible(node)).map(def => {
-      const isSelfPending = pendingOp === def.id;
-      // 另一操作进行中：本按钮禁用并给出 hover 提示
-      const isBlockedByOther = pendingOp !== undefined && !isSelfPending;
-      return {
-        // 任一 resume 操作进行中，重试 / 跳过均禁用
-        disabled: pendingOp !== undefined,
-        icon: def.icon,
-        id: def.id,
-        label: isSelfPending ? def.pendingLabel() : def.label(),
-        loading: isSelfPending,
-        run: () => resume(def.id, task.raw, node.raw),
-        tooltip: isBlockedByOther ? def.blockedTip() : undefined,
-      };
-    });
+    // 分享态只读：过滤掉重试 / 跳过等交互式 resume 操作，仅保留「详情」查看入口
+    const resumeDefs = hideResumeActions?.value ? [] : RESUME_ACTION_DEFS;
+    const actions: FlowNodeActionVM[] = resumeDefs
+      .filter(def => def.visible(node))
+      .map(def => {
+        const isSelfPending = pendingOp === def.id;
+        // 另一操作进行中：本按钮禁用并给出 hover 提示
+        const isBlockedByOther = pendingOp !== undefined && !isSelfPending;
+        return {
+          // 任一 resume 操作进行中，重试 / 跳过均禁用
+          disabled: pendingOp !== undefined,
+          icon: def.icon,
+          id: def.id,
+          label: isSelfPending ? def.pendingLabel() : def.label(),
+          loading: isSelfPending,
+          run: () => resume(def.id, task.raw, node.raw),
+          tooltip: isBlockedByOther ? def.blockedTip() : undefined,
+        };
+      });
     actions.push({
       disabled: false,
       icon: NodeOutputIcon,

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/flow-agent-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/flow-agent-content.md
@@ -90,7 +90,7 @@ sinceVersion: 1.0.0
 - **节点行尾操作**：hover 失败节点行显示「重试 / 跳过 / 详情」按钮组（间距 12px）；成功 / 运行中等非失败节点仅显示「详情」。重试 / 跳过依赖节点 `retryable` / `skippable` 能力位，通过 `onInterruptResume` 回传 Agent
 - **重试 / 跳过进行中态**：点击后节点行进入 `is-pending`，按钮组常驻显示（无需 hover）；进行中按钮切换为 loading +「重试中 / 跳过中」，重试与跳过互斥禁用；被阻塞按钮 hover 显示提示（如「任务正在重试中，不可跳过」）；详情不受影响。pending 以 `task_id:node_id:retry` 为键，后端 `retry` 计数变化后自动失效
 - **详情入口联动**：「详情」按钮点击后通过自定义 Tab 挂载 `FlowAgentNodeDetail`
-- **分享态降级**：`RenderMode.Share` 下隐藏耗时与行尾操作按钮，仅保留只读的执行状态
+- **分享态只读查看**：`RenderMode.Share` 下保留耗时、「详情」「有效证据」等只读查看入口，仅隐藏「重试 / 跳过」等交互式 resume 操作
 
 ## 状态映射
 
@@ -203,7 +203,7 @@ onInterruptResume?.({
 | ---- | ------------------------------------- | ---------------------------------- | ---------------------- |
 | 重试 | 失败态且 `node.retryable === true`    | loading +「重试中」，二者均禁用    | `flow_node_retry`      |
 | 跳过 | 失败态且 `node.skippable === true`    | loading +「跳过中」，二者均禁用    | `flow_node_skip`       |
-| 详情 | 始终展示（Share 模式除外）            | 不受 pending 影响                  | —（打开侧栏 Tab，不走 resume） |
+| 详情 | 始终展示（含 Share 分享态）           | 不受 pending 影响                  | —（打开侧栏 Tab，不走 resume） |
 
 行尾操作由内部 composable [`useFlowNodeActions`](/composables/use-flow-node-actions) 聚合为声明式列表，组件层仅遍历渲染。
 
@@ -249,12 +249,12 @@ ActivityLayout（activity-type=flow_agent，v-model:collapsed）
         └── flow-agent-node-item × N（节点；`is-pending` 时按钮组常驻）
             ├── node-status（Loading / 状态圆点）
             ├── node-name（HighlightKeyword + 溢出提示）
-            └── node-trailing（非 Share 态）
+            └── node-trailing（含 Share 分享态）
                 ├── node-time（节点耗时，hover / pending 时隐藏）
                 └── node-actions（hover 或 `is-pending` 时显示，间距 12px）
-                    ├── node-action-btn「重试」（失败 + retryable；进行中 loading + 禁用）
-                    ├── node-action-btn「跳过」（失败 + skippable；进行中 loading + 禁用）
-                    └── node-action-btn「详情」（始终可用，点击挂载详情 Tab）
+                    ├── node-action-btn「重试」（失败 + retryable；Share 态隐藏；进行中 loading + 禁用）
+                    ├── node-action-btn「跳过」（失败 + skippable；Share 态隐藏；进行中 loading + 禁用）
+                    └── node-action-btn「详情」（始终可用，含 Share 态，点击挂载详情 Tab）
 ```
 
 ## API
@@ -329,7 +329,7 @@ interface BkFlowNode {
 3. **任务总耗时为节点累加**：`task-time` 由各节点 `elapsed_time` 求和得到，并非任务级独立字段。
 4. **`task_outputs` 暂不渲染**：模板中任务输出展示区块已注释，传入也不会显示。
 5. **未知状态兜底为 `running`**：`getConvergedState` 对未识别的原始状态统一归为运行中。
-6. **Share 模式降级**：`RenderMode.Share` 下不渲染节点耗时与行尾操作按钮（重试 / 跳过 / 详情），仅保留只读执行状态。
+6. **Share 模式只读查看**：`RenderMode.Share` 下保留节点/任务耗时与「详情」「有效证据」查看入口，仅过滤「重试 / 跳过」等交互式 resume 操作（由 `useFlowNodeActions` 的 `hideResumeActions` 收敛）。
 7. **`onInterruptResume` 透传链路**：`MessageRender` → `ActivityMessage` → `FlowAgentContent`；未传入时重试 / 跳过按钮仍展示但点击无回调。
 8. **pending 自动收敛**：`useFlowNodeActions` 以 `task_id:node_id:retry` 为 pending 键；节点重试再次失败（`retry` +1）后键变化，进行中态自动解除，无需手动清理。
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -239,7 +239,7 @@ sinceVersion: 1.0.0
 - **侧栏全屏**：Tab 栏右侧提供全屏/退出全屏按钮，基于 `useFullScreen` 将侧栏区域（`.ai-full-screen-wrapper`）以浏览器原生全屏展示；全屏时 Tippy 的 `appendTo` 自动切换为全屏容器，避免 tooltip 被遮挡
 - **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
 - **分享模式**：内置消息多选分享流程，选中用户消息后确认分享
-- **渲染模式注入**：`renderMode` 会通过内部 Provider 下传给后代内容组件；例如 FlowAgent 节点在 `Share` 模式下隐藏耗时和「详情」入口
+- **渲染模式注入**：`renderMode` 会通过内部 Provider 下传给后代内容组件；`Share` 分享态开放流程智能体只读查看（侧栏 Tab / 执行情况 / 节点「详情」「有效证据」/ 耗时均保留），仅隐藏底部输入区与「重试 / 跳过」等交互操作
 - **字号主题**：通过 `size` 控制 `small`（默认 12px）/ `normal`（14px）两档字号；根节点设置 `data-ai-size`，子组件通过 CSS 变量（`--ai-font-size` 等）响应式缩放；浮层（Tippy / Teleport）会同步 `document.body.dataset.aiSize`，卸载时自动清理
 - **空状态欢迎页**：无消息时展示欢迎语和开场白
 
@@ -399,7 +399,7 @@ ai-chat-container（:data-ai-size="size"）
 
 侧边栏默认包含「执行情况」Tab，展示所有工具调用和 FlowAgent 类型的 Activity 消息。支持关键词搜索过滤和点击定位到对话中的消息位置。
 
-**展示条件**：当 `executionGroups` 为空且 `keyword` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。用户在执行情况中输入搜索词后，侧栏会保持展示以显示「搜索结果为空」等状态。`renderMode === Share` 时侧栏隐藏，且分栏会应用与折叠一致的样式。
+**展示条件**：当 `executionGroups` 为空且 `keyword` 为空时，不渲染侧栏 Tab 与 `ExecutionSummary`（折叠按钮亦隐藏）；主区域仍可正常展示 `messages` 中的对话内容。用户在执行情况中输入搜索词后，侧栏会保持展示以显示「搜索结果为空」等状态。`renderMode === Share` 分享态同样按上述执行数据条件展示侧栏（开放只读查看流程智能体详情/证据/执行情况），不再强制隐藏折叠；仅底部输入区保持隐藏。
 
 **自定义 Tab 联动**：当 `executionGroups` 变为空且搜索词已清空时，容器会**自动重置自定义 Tab**（`resetCustomTab`），避免残留节点详情等 Tab；若用户仍在搜索（`keyword` 非空），不会触发重置。
 
@@ -974,7 +974,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | modelValue       | `string \| TagSchema` | 输入框内容，支持纯文本或标签结构                             |
 | selectedShortcut | `Shortcut \| null`    | 当前选中的快捷指令                                           |
 | cite             | `string`              | 引用内容                                                     |
-| renderMode       | `RenderMode`          | 渲染模式（默认 `Chat`）。`Share` 模式隐藏侧边栏和折叠按钮；`Test` 模式隐藏分享按钮 |
+| renderMode       | `RenderMode`          | 渲染模式（默认 `Chat`）。`Share` 分享态开放侧栏只读查看（流程智能体详情/证据/执行情况），隐藏底部输入区与「重试/跳过」等交互；`Test` 模式隐藏分享按钮 |
 
 ### Events
 
@@ -1017,7 +1017,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | `renderMode` | 侧边栏 Tab / 折叠按钮 | 底部输入区域                      | MessageTools 工具栏   | 说明                             |
 | ------------ | ---------------------- | --------------------------------- | --------------------- | -------------------------------- |
 | `Chat`       | 正常显示               | 正常显示（ChatInput / ShortcutRender / SelectionFooter） | 全部工具按钮          | 默认对话模式                     |
-| `Share`      | **隐藏**               | **隐藏**                          | **隐藏**（多选模式）  | 分享预览模式，仅展示消息；FlowAgent 节点会隐藏耗时和「详情」入口 |
+| `Share`      | **按执行数据展示**（开放只读查看） | **隐藏**             | **隐藏**（多选模式）  | 分享预览模式；开放流程智能体侧栏详情/证据/执行情况与耗时，仅隐藏「重试/跳过」等交互 |
 | `Test`       | 正常显示               | 正常显示                          | 过滤掉「分享」按钮    | 测试/嵌入模式，隐藏分享入口     |
 
 ```vue

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-flow-node-actions.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-flow-node-actions.md
@@ -26,6 +26,8 @@ sinceVersion: 2.0.0
 
 ```typescript
 function useFlowNodeActions(options: {
+  /** 隐藏重试 / 跳过等交互式 resume 操作（分享态只读，仅保留「详情」查看入口） */
+  hideResumeActions?: Ref<boolean>;
   /** resume 回调（与第三方审批取消同一回调，按 payload.operation 分流） */
   onInterruptResume: Ref<OnInterruptResume | undefined>;
   /** 打开节点详情侧栏（复用 useFlowTab 的能力） */
@@ -76,9 +78,11 @@ interface FlowNodeActionVM {
 | ---- | ------------------ | ------------------------------------------ | --------------------------------------------- |
 | 重试 | `flow_node_retry`  | `convergedState === 'failed'` 且 `retryable` | 调用 `onInterruptResume`，**不传** `interrupt` |
 | 跳过 | `flow_node_skip`   | `convergedState === 'failed'` 且 `skippable` | 同上                                          |
-| 详情 | `detail`           | 始终（Share 模式由上层组件隐藏整组）       | 调用 `openNodeDetail(task.raw, node.raw)`     |
+| 详情 | `detail`           | 始终（含 Share 分享态）                     | 调用 `openNodeDetail(task.raw, node.raw)`     |
 
 展示顺序：重试 → 跳过 → 详情。
+
+> **分享态过滤**：传入 `hideResumeActions`（`Ref<boolean>`，如 `RenderMode.Share`）为 `true` 时，`getNodeActions` 直接过滤掉重试 / 跳过，仅返回「详情」查看入口；用于只读分享场景放开查看、禁止交互。
 
 ## pending 态与防重复提交
 
@@ -117,6 +121,8 @@ import { useFlowNodeActions } from '@blueking/chat-x';
 // 或相对路径：'./use-flow-node-actions'
 
 const { getNodeActions, isNodePending } = useFlowNodeActions({
+  // 分享态只读：过滤重试 / 跳过，仅保留详情
+  hideResumeActions: computed(() => renderMode.value === RenderMode.Share),
   onInterruptResume: toRef(props, 'onInterruptResume'),
   openNodeDetail,
 });


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】分享态开放流程智能体查看能力（1070093903135703256）

分享（share）渲染态下，流程智能体（flow-agent）当前会隐藏节点详情/有效证据入口、右侧详情面板与左侧「执行情况」总览，导致被分享方无法查看智能体执行过程。

## 改动
- `flow-agent-content.vue`：去掉行尾区域的整块 `showActions` gating，分享态保留耗时 + 「详情」+「有效证据」查看入口。
- `use-flow-node-actions.ts`：新增 `hideResumeActions` 选项，分享态过滤掉「重试 / 跳过」等交互式 resume 操作，仅保留「详情」。
- `chat-container.vue`：移除分享态对侧栏面板（Tab + 节点详情/证据 + 执行情况总览）与折叠按钮的屏蔽，`ai-is-collapse` 不再被分享态强制；**保留** 底部输入区（ChatInput/SelectionFooter/ShortcutRender）在分享态隐藏。
- 同步更新 colocated 单测（flow-agent-content / use-flow-node-actions / chat-container）与 wiki 文档。

## 影响面
- `flow-agent-content` / `chat-container` 为通用组件，改动仅作用于 `RenderMode.Share`，Chat/Test 态行为不变。
- 纯放开、无 API 破坏；`@blueking/ai-blueking`（chat-x peerDep）消费方无需改动。

## 测试
- [x] 分享态可点击「详情」「有效证据」并在右侧面板查看内容
- [x] 分享态左侧「执行情况」总览可见、可折叠
- [x] 分享态仍不出现「重试 / 跳过」按钮与输入框/分享底部操作栏
- [x] `pnpm test:ui` 全量通过（1112 passed）

Made with [Cursor](https://cursor.com)