### PR TITLE
fix: 【chat-x】AiSlashInput 卸载后延迟任务未清理 --bug=160070420

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
@@ -156,6 +156,19 @@
   let editor: ReturnType<typeof createEditor>;
   /* 清理编辑器 */
   let cleanup: () => void;
+  // 卸载前需清理延迟任务，避免 setTimeout 回调在 window 已销毁后仍执行
+  let suggestionTimer: null | ReturnType<typeof setTimeout> = null;
+  let focusTimer: null | ReturnType<typeof setTimeout> = null;
+  const clearPendingTimers = () => {
+    if (suggestionTimer !== null) {
+      clearTimeout(suggestionTimer);
+      suggestionTimer = null;
+    }
+    if (focusTimer !== null) {
+      clearTimeout(focusTimer);
+      focusTimer = null;
+    }
+  };
   const getBody = () => document.body;
 
   const { commandSelection, GetCursorPosition, GetDocSnapshot, docSnapshot } = useCommandSelection();
@@ -175,7 +188,11 @@
   );
   /* 显示提示 */
   const handleShowSuggestions = () => {
-    setTimeout(() => {
+    if (suggestionTimer !== null) {
+      clearTimeout(suggestionTimer);
+    }
+    suggestionTimer = setTimeout(() => {
+      suggestionTimer = null;
       const mentionState = getMentionState();
       keyword.value = mentionState.query || '';
       // 设置 tippy 位置（仅在 keyword 为空时，即刚输入 '/' 或 '@' 时）
@@ -228,6 +245,8 @@
       rect: null,
       coordinates: null,
     };
+
+    if (typeof window === 'undefined') return defaultState;
 
     const selection = window.getSelection();
     if (!selection || selection.rangeCount === 0) return defaultState;
@@ -302,7 +321,13 @@
     focusToEnd();
   };
   const focusToEnd = () => {
-    setTimeout(() => {
+    if (focusTimer !== null) {
+      clearTimeout(focusTimer);
+    }
+    focusTimer = setTimeout(() => {
+      focusTimer = null;
+      if (typeof window === 'undefined') return;
+
       const selection = window.getSelection();
       const range = document.createRange();
       if (editorRef.value && selection) {
@@ -425,6 +450,7 @@
     editorRef.value?.addEventListener('paste', handlePaste);
   });
   onUnmounted(() => {
+    clearPendingTimers();
     editor.command(ReplaceAll, '');
     cleanup?.();
     editorRef.value?.removeEventListener('paste', handlePaste);

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
@@ -62,7 +62,7 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
 
   /** 执行情况显隐由外部配置控制，缺省可见 */
   const isExecutionVisible = computed(() => options.executionTabVisible?.() ?? true);
-  const isTabVisible = (tab: CustomTab<T>) =>
+  const isTabVisible = (tab: Pick<CustomTab<T>, 'name' | 'visible'>) =>
     tab.name === EXECUTION_TAB_NAME ? isExecutionVisible.value : tab.visible !== false;
 
   /**


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】AiSlashInput 卸载后延迟任务未清理（1070093903160070420）

`AiSlashInput` 在 `handleShowSuggestions`（16ms）与 `focusToEnd`（100ms）中使用裸 `setTimeout`，组件卸载后回调仍可能执行并访问 `window.getSelection()` 或更新 tippy，存在潜在运行时异常。

## 改动
- `ai-slash-input.vue`：引入 `suggestionTimer` / `focusTimer`，`onUnmounted` 统一 `clearPendingTimers`；重复触发前先 `clearTimeout`
- `ai-slash-input.vue`：`getMentionState` / `focusToEnd` 回调增加 `typeof window === 'undefined'` 守卫
- `use-custom-tab.ts`：`isTabVisible` 参数类型收窄为 `Pick<CustomTab, 'name' | 'visible'>`

## 影响面
- `AiSlashInput`：所有使用斜杠/技能/提示词输入的场景（主输入区、用户消息编辑态等）
- `useCustomTabProvider`：类型层面收窄，无运行时行为变化

## 测试
- [x] pre-commit 钩子通过
- [ ] 手动：快速切换会话/关闭侧栏，确认无控制台报错
- [ ] 手动：输入 `/` `@` `\` 触发建议菜单后卸载组件，确认无残留回调

Made with [Cursor](https://cursor.com)