### PR TITLE
feat: 【小鲸】工具审批卡待审批态优化 --story=135821374

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -25,9 +25,8 @@
  */
 
 import { type VueWrapper, mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
 import { Button } from 'bkui-vue';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { APPROVAL_STATUS, InterruptReason } from '../../../ag-ui/types/constants';
 import { InterruptResumeOperation } from '../../../ag-ui/types/interrupt';
@@ -141,7 +140,8 @@ describe('InterruptMessage', () => {
 
     expect(wrapper.find('.ai-interrupt-message').exists()).toBe(true);
     expect(wrapper.find('.ai-tool-approval-card__title').text()).toBe('算法方案评审单');
-    expect(wrapper.find('.ai-tool-approval-card__status').text()).toBe('评审中');
+    expect(wrapper.find('.ai-tool-approval-card__status').text()).toBe('审批中');
+    expect(wrapper.find('.ai-tool-approval-card__processor').exists()).toBe(true);
     expect(wrapper.text()).toContain('REV-2026-04-24-001');
     expect(wrapper.text()).toContain('2026-04-24 14:30:15');
     expect(wrapper.text()).toContain('张三、李四、王五');
@@ -169,7 +169,8 @@ describe('InterruptMessage', () => {
     const status = wrapper.find('.ai-tool-approval-card__status');
     expect(status.text()).toBe('已撤销');
     expect(status.classes()).toContain('ai-tool-approval-card__status--revoked');
-    expect(wrapper.text()).toContain('当前处理人：无');
+    // 非 pending/draft 终态不展示当前处理人区域
+    expect(wrapper.find('.ai-tool-approval-card__processor').exists()).toBe(false);
   });
 
   it('待审批状态点击取消审批应透传取消动作，不直接处理平台请求', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -50,7 +50,10 @@
       </div>
     </dl>
 
-    <div class="ai-tool-approval-card__processor">
+    <div
+      v-if="isPendingApproval"
+      class="ai-tool-approval-card__processor"
+    >
       <TimeIcon class="ai-tool-approval-card__processor-icon" />
       <span
         v-overflow-tips="{ ...commonTippyOptions }"
@@ -138,7 +141,7 @@
   const isPendingApproval = computed(() => pendingStatusSet.has(ticket.value.status));
   const statusClass = computed(() => (isPendingApproval.value ? 'pending' : ticket.value.status));
   const statusText = computed(() =>
-    isPendingApproval.value ? t('评审中') : (APPROVAL_STATUS_MAP[ticket.value.status] ?? ticket.value.status),
+    isPendingApproval.value ? t('审批中') : (APPROVAL_STATUS_MAP[ticket.value.status] ?? ticket.value.status),
   );
   const approverText = computed(() => ticket.value.approvers.filter(Boolean).join('、') || t('无'));
   const copyText = computed(() => ticket.value.url || ticket.value.sn);

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -104,6 +104,7 @@ export const lang = {
   更多: 'More',
   算法方案评审单: 'Algorithm Plan Review Ticket',
   评审中: 'Reviewing',
+  审批中: 'Approving',
   已废弃: 'Abandoned',
   已批准: 'Approved',
   已通过: 'Approved',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -105,9 +105,9 @@ AI Dev 第三方工具审批（`InterruptReason.AIDevToolApproval`）专用卡�
 
 ```
 ToolApprovalCard
-├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
+├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（审批中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
-├── 处理人：当前处理人（overflow-tips 省略）
+├── 处理人：仅 `pending` / `draft` 时展示当前处理人（overflow-tips 省略）
 └── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交；分享只读渲染下禁用）
 ```
 
@@ -121,7 +121,7 @@ ToolApprovalCard
 
 | `ticket.status`                         | 视觉     |
 | --------------------------------------- | -------- |
-| `pending`、`draft`                      | 蓝色评审中 |
+| `pending`、`draft`                      | 蓝色审批中 |
 | `approved`                              | 绿色通过 |
 | `rejected`、`cancelled`、`expired`、`abandoned` | 红色终态 |
 | `revoked`                               | 橙色已撤销 |


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】工具审批卡待审批态文案与处理人展示优化（1070093903135821374）

AI Dev 工具审批卡片（ToolApprovalCard）在待审批态展示与终态回显存在体验问题：
1. 待审批状态徽章文案使用「评审中」，与业务语义「审批中」不一致
2. 终态（已通过/已拒绝/已撤销等）仍展示「当前处理人」区域，信息冗余

## 改动
- 待审批（pending/draft）状态徽章文案改为「审批中」，补充 `lang.ts` i18n
- 「当前处理人」区域增加 `v-if="isPendingApproval"`，仅 pending/draft 时展示
- 同步 `interrupt-message.spec.ts` 测试断言
- 同步 `wikis/components/agent/tool-approval-card.md` 文档

## 影响面
- `@blueking/chat-x`：`ToolApprovalCard` 组件展示逻辑
- 消费方 `@blueking/ai-blueking` 无需改动，随 chat-x 升级生效

## 测试
- [x] `interrupt-message.spec.ts` 用例通过
- [x] pre-commit 钩子校验通过

Made with [Cursor](https://cursor.com)