### PR TITLE
feat: 【chat-x】工具审批卡支持刷新与终态取消按钮 --story=135857763

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -31,7 +31,7 @@
       }"
       :resources="MOCK_RESOURCES"
       :shortcuts="shortcuts"
-      :size="'normal'"
+      :size="'small'"
       :support-upload="true"
       @delete-shortcut="handleDeleteShortcut"
       @select-shortcut="handleSelectShortcut"

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
@@ -38,6 +38,8 @@ import type { BaseMessage } from './messages';
 export enum InterruptResumeOperation {
   /** 主动取消第三方工具审批：在 interrupt 记录上写入取消结果 */
   ApprovalCancel = 'approval_cancel',
+  /** 刷新第三方工具审批：刷新审批单状态 */
+  ApprovalRefresh = 'approval_refresh',
   /** 重试失败的流程节点：bkflow 节点状态重置为可执行 */
   FlowNodeRetry = 'flow_node_retry',
   /** 跳过失败的流程节点：bkflow 节点标记为已跳过 */
@@ -157,10 +159,11 @@ export type OnInterruptResume = (payload: InterruptResume, interrupt?: Interrupt
 
 export type RunFinishedOutcome = { interrupts: Interrupt[]; type: 'interrupt' } | { type: 'success' };
 /**
- * 第三方工具审批中断的响应负载（取消审批等动作）
+ * 第三方工具审批中断的响应负载（取消审批 / 刷新审批单状态）。
+ * 两种操作 payload 结构一致（仅传 interrupt_id），由 operation 区分动作。
  */
 export type ToolApprovalResume = {
-  operation: InterruptResumeOperation.ApprovalCancel;
+  operation: InterruptResumeOperation.ApprovalCancel | InterruptResumeOperation.ApprovalRefresh;
   payload: { interrupt_id: number | string };
 };
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -215,6 +215,91 @@ describe('InterruptMessage', () => {
     expect(cancelBtn.findComponent(Button).props('loading')).toBe(true);
   });
 
+  it('审批中点击刷新图标透传刷新动作，2s 冷却内不可重复刷新', async () => {
+    const onInterruptResume = vi.fn();
+    wrapper = mount(InterruptMessage, {
+      props: {
+        ...buildInterruptProps({
+          type: 'interrupt',
+          interrupts: [approvalInterrupt],
+        }),
+        onInterruptResume,
+      },
+    });
+
+    const refreshIcon = wrapper.find('.ai-tool-approval-card__refresh-icon');
+    expect(refreshIcon.exists()).toBe(true);
+
+    await refreshIcon.trigger('click');
+    // 冷却中第二次点击不再触发
+    await refreshIcon.trigger('click');
+
+    expect(onInterruptResume).toHaveBeenCalledTimes(1);
+    expect(onInterruptResume).toHaveBeenCalledWith(
+      {
+        operation: InterruptResumeOperation.ApprovalRefresh,
+        payload: { interrupt_id: approvalInterrupt.id },
+      },
+      approvalInterrupt,
+    );
+  });
+
+  it('终态不展示刷新图标', () => {
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [
+          {
+            ...approvalInterrupt,
+            metadata: {
+              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.APPROVED },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(wrapper.find('.ai-tool-approval-card__refresh-icon').exists()).toBe(false);
+  });
+
+  it('终态应保留置灰的取消审批按钮，取消/撤销态文案为已取消审批', () => {
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [
+          {
+            ...approvalInterrupt,
+            metadata: {
+              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.REJECTED },
+            },
+          },
+        ],
+      }),
+    });
+
+    const rejectBtn = wrapper.find('.ai-tool-approval-card__cancel');
+    expect(rejectBtn.exists()).toBe(true);
+    expect(rejectBtn.text()).toBe('取消审批');
+    expect(rejectBtn.findComponent(Button).props('disabled')).toBe(true);
+
+    wrapper.unmount();
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [
+          {
+            ...approvalInterrupt,
+            metadata: {
+              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.CANCELLED },
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(wrapper.find('.ai-tool-approval-card__cancel').text()).toBe('已取消审批');
+  });
+
   it('点击查看单据详情时只打开单据链接，不触发 resume', async () => {
     const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -10,6 +10,14 @@
           :class="{ 'is-disabled': !copyText }"
           @click="handleCopy"
         />
+        <!-- 审批中态提供刷新图标：取消为后端轮询、无法实时返回，用户可手动拉取单据最新状态；每次刷新 2s 冷却 -->
+        <RebuildIcon
+          v-if="isPendingApproval && !readonly"
+          v-tippy="{ ...commonTippyOptions, content: t('刷新单据状态'), theme: 'ai-chat-box', offset: [0, 8] }"
+          class="ai-tool-approval-card__refresh-icon"
+          :class="{ 'is-disabled': refreshCooldown || isShareContext }"
+          @click="handleRefresh"
+        />
       </div>
       <span
         class="ai-tool-approval-card__status"
@@ -68,8 +76,9 @@
         @click="handleOpenDetail"
       >
         {{ t('查看单据详情') }}
-        <span class="ai-tool-approval-card__detail-icon" />
+        <ArrowLeftIcon class="ai-tool-approval-card__detail-icon" />
       </Button>
+      <!-- 待审批态：可点「取消审批」；点击后按钮进入 loading（同步 resume 无结果，防重复提交） -->
       <Button
         v-if="isPendingApproval && !readonly"
         class="ai-tool-approval-card__cancel"
@@ -81,12 +90,26 @@
       >
         {{ t('取消审批') }}
       </Button>
+      <!-- 终态：保留「取消审批」按钮但置灰，hover 显示当前状态无法取消的原因（tooltip 挂在外层 span，规避 disabled 按钮不触发 hover） -->
+      <span
+        v-else-if="!readonly"
+        v-tippy="{ ...commonTippyOptions, content: cancelDisabledTip, theme: 'ai-chat-box', offset: [0, 8] }"
+        class="ai-tool-approval-card__cancel-wrap"
+      >
+        <Button
+          class="ai-tool-approval-card__cancel"
+          disabled
+          outline
+        >
+          {{ cancelButtonText }}
+        </Button>
+      </span>
     </div>
   </section>
 </template>
 
 <script setup lang="ts">
-  import { computed, shallowRef } from 'vue';
+  import { computed, onUnmounted, shallowRef } from 'vue';
 
   import { Button, Loading } from 'bkui-vue';
   import { directive as vTippy } from 'vue-tippy';
@@ -98,10 +121,22 @@
   import { useClipboard } from '../../../composables';
   import { useCommonTippyInject, useRenderModeInject } from '../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../directives/overflow-tips';
-  import { CheckCircleFillIcon, CloseCircleFillIcon, CopyIcon, RevokedIcon, TimeIcon } from '../../../icons';
+  import {
+    ArrowLeftIcon,
+    CheckCircleFillIcon,
+    CloseCircleFillIcon,
+    CopyIcon,
+    RebuildIcon,
+    ReloadIcon,
+    RevokedIcon,
+    TimeIcon,
+  } from '../../../icons';
   import { t } from '../../../lang/lang';
 
   import type { AIDevToolApprovalInterrupt, OnInterruptResume } from '../../../ag-ui/types/interrupt';
+
+  // 刷新单据状态的冷却时长（ms）：取消为后端轮询，短时间内重复刷新无意义
+  const REFRESH_COOLDOWN_MS = 2000;
 
   const props = defineProps<{
     interrupt: AIDevToolApprovalInterrupt;
@@ -135,6 +170,16 @@
       },
   );
 
+  // 用户自行取消 / 撤销后的终态：按钮文案改为「已取消审批」
+  const cancelledStatusSet = new Set([APPROVAL_STATUS.CANCELLED, APPROVAL_STATUS.REVOKED]);
+  // 各终态下「取消审批」置灰按钮的 hover 提示；未覆盖的终态（已废弃 / 已过期等）走通用兜底文案
+  const cancelDisabledTipMap: Partial<Record<APPROVAL_STATUS, string>> = {
+    [APPROVAL_STATUS.APPROVED]: t('该单据已通过，无法取消'),
+    [APPROVAL_STATUS.CANCELLED]: t('单据已取消，无需重复点击'),
+    [APPROVAL_STATUS.REJECTED]: t('该单据已被拒绝，无法取消'),
+    [APPROVAL_STATUS.REVOKED]: t('单据已取消，无需重复点击'),
+  };
+
   const isPendingApproval = computed(() => pendingStatusSet.has(ticket.value.status));
   const statusClass = computed(() => (isPendingApproval.value ? 'pending' : ticket.value.status));
   const statusText = computed(() =>
@@ -142,6 +187,10 @@
   );
   const approverText = computed(() => ticket.value.approvers.filter(Boolean).join('、') || t('无'));
   const copyText = computed(() => ticket.value.url || ticket.value.sn);
+  const cancelButtonText = computed(() =>
+    cancelledStatusSet.has(ticket.value.status) ? t('已取消审批') : t('取消审批'),
+  );
+  const cancelDisabledTip = computed(() => cancelDisabledTipMap[ticket.value.status] ?? t('当前状态无法取消审批'));
 
   const handleOpenDetail = () => {
     if (!ticket.value.url) return;
@@ -153,18 +202,42 @@
     copy(copyText.value);
   };
 
-  // 取消审批为同步 resume，无法拿到请求结果；点击后立即进入 loading 并禁用按钮防重复提交，
+  // 取消审批为同步 resume，无法拿到请求结果；点击后按钮立即进入 loading 并禁用防重复提交，
   // 待后台数据刷新使按钮 v-if 失效（卡片卸载/重建）后该状态随实例销毁自然消失
   const cancelling = shallowRef(false);
+  // 刷新为后端轮询、无法实时返回，故做 2s 冷却节流：冷却中刷新图标置灰不可点
+  const refreshCooldown = shallowRef(false);
+  let cooldownTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const startRefreshCooldown = () => {
+    refreshCooldown.value = true;
+    clearTimeout(cooldownTimer);
+    cooldownTimer = setTimeout(() => {
+      refreshCooldown.value = false;
+    }, REFRESH_COOLDOWN_MS);
+  };
 
   const handleCancelApproval = () => {
     if (cancelling.value) return;
     cancelling.value = true;
+    // 取消后进入后台轮询，2s 内不允许刷新，之后可继续手动刷新拉取最新状态
+    startRefreshCooldown();
     props.onInterruptResume?.(
       { operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: props.interrupt.id } },
       props.interrupt,
     );
   };
+
+  const handleRefresh = () => {
+    if (refreshCooldown.value || isShareContext.value) return;
+    startRefreshCooldown();
+    props.onInterruptResume?.(
+      { operation: InterruptResumeOperation.ApprovalRefresh, payload: { interrupt_id: props.interrupt.id } },
+      props.interrupt,
+    );
+  };
+
+  onUnmounted(() => clearTimeout(cooldownTimer));
 </script>
 
 <style lang="scss">
@@ -215,6 +288,23 @@
     }
 
     &__copy-icon {
+      flex: 0 0 16px;
+      width: 16px;
+      height: 16px;
+      color: #699df4;
+      cursor: pointer;
+
+      &:hover {
+        color: #3a84ff;
+      }
+
+      &.is-disabled {
+        color: #c4c6cc;
+        cursor: not-allowed;
+      }
+    }
+
+    &__refresh-icon {
       flex: 0 0 16px;
       width: 16px;
       height: 16px;
@@ -347,34 +437,33 @@
     }
 
     &__detail {
-      flex: 1 1 auto;
-      min-width: 0;
+      flex: 0 1 auto;
+      width: 296px;
       max-width: 296px;
       background: linear-gradient(90deg, #3a84ff 0%, #5a9cff 100%);
       border-color: transparent;
     }
 
     &__detail-icon {
-      position: relative;
-      width: 16px;
-      height: 16px;
+      width: 12px;
+      height: 12px;
       margin-left: 4px;
+      font-size: 12px;
+      transform: rotate(180deg);
 
-      &::before {
-        position: absolute;
-        top: 4px;
-        left: 4px;
-        width: 7px;
-        height: 7px;
-        content: '';
-        border-top: 2px solid currentcolor;
-        border-right: 2px solid currentcolor;
-        transform: rotate(45deg);
+      path {
+        stroke-width: 120;
       }
     }
 
     &__cancel {
-      flex: 0 0 86px;
+      flex: 1 0 auto;
+      min-width: 86px;
+    }
+
+    &__cancel-wrap {
+      display: inline-flex;
+      flex: 1 0 auto;
     }
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -119,6 +119,12 @@ export const lang = {
   复制单据: 'Copy Ticket',
   复制单据链接: 'Copy Ticket Link',
   取消审批: 'Cancel Approval',
+  已取消审批: 'Approval Cancelled',
+  刷新单据状态: 'Refresh Ticket Status',
+  '该单据已被拒绝，无法取消': 'This ticket has been rejected and cannot be cancelled',
+  '该单据已通过，无法取消': 'This ticket has been approved and cannot be cancelled',
+  '单据已取消，无需重复点击': 'This ticket has been cancelled, no need to click again',
+  当前状态无法取消审批: 'Approval cannot be cancelled in the current status',
   '当前会话有 {count} 个待审批单，如需继续，请先取消审批':
     'There are {count} pending approval tickets in the current conversation. To continue, cancel approval first.',
   暂不支持的中断消息: 'Unsupported interrupt message',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -3,9 +3,9 @@ name: ToolApprovalCard 工具审批卡片
 slug: tool-approval-card
 kind: component
 domain: agent
-description: 渲染 AIDevToolApproval 中断的审批信息与取消操作，支持只读回显态。
+description: 渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作，支持只读回显态。
 aiSummary: >
-  渲染 AIDevToolApproval 中断的审批信息与取消操作；outcome.success 回显时以 readonly 只读展示。
+  渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作；outcome.success 回显时以 readonly 只读展示。
   源码位置：src/components/chat-message/interrupt-message/tool-approval-card.vue。
 relatedComponents:
   - slug: interrupt-message
@@ -82,7 +82,7 @@ sinceVersion: 1.0.0
   }
 
   const handleInterruptResume = async (payload: Record<string, unknown>, interrupt: { id: string }) => {
-    console.log('取消审批:', payload, interrupt.id)
+    console.log('审批操作:', payload, interrupt.id)
   }
 </script>
 
@@ -105,17 +105,33 @@ AI Dev 第三方工具审批（`InterruptReason.AIDevToolApproval`）专用卡�
 
 ```
 ToolApprovalCard
-├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（评审中/已通过/已拒绝/已撤销等）
+├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 刷新图标（仅审批中）+ 状态徽章（审批中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
 ├── 处理人：当前处理人（overflow-tips 省略）
-└── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交；分享只读渲染下禁用）
+└── 操作区：查看单据详情（新窗口打开 url）、取消审批（见下）
 ```
 
-`readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏「取消审批」按钮，不接受审批取消交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+**标题栏刷新图标**（仅 `pending` / `draft` 且非 `readonly` 时展示，复制图标右侧）：取消审批为后端轮询、状态无法实时返回，用户可点击刷新图标主动拉取单据最新状态，`hover` 显示 tooltip「刷新单据状态」。刷新做 **2s 冷却节流**（冷却中图标置灰不可点）；点击「取消审批」也会触发一次 2s 冷却，即取消后需间隔 2s 才能继续刷新。分享只读渲染下刷新图标禁用。
 
-分享只读渲染模式（注入的 `RenderMode.Share`）下，「取消审批」按钮**保持可见但禁用**（区别于 `readonly` 的直接隐藏），避免在分享回显场景误触发取消。该渲染模式由 [ChatContainer](/components/setup/chat-container) 等容器通过 `useRenderModeProvider` 注入，组件内部经 `useRenderModeInject` 读取，业务侧无需手动设置。
+操作区第二个按钮的形态随状态变化（`readonly` 时整体隐藏）：
 
-取消审批为同步 `onInterruptResume`，组件无法在回调内获知请求结果。点击后「取消审批」按钮立即进入 loading 并忽略重复点击；待后台刷新使卡片卸载/重建后状态随实例销毁。
+- **待审批（`pending` / `draft`）**：展示「取消审批」按钮；点击后按钮进入 **loading** 并禁用防重复提交（同步 resume 无法获知结果）。
+- **终态（`approved` / `rejected` / `cancelled` / `revoked` / `expired` / `abandoned`）**：保留「取消审批」按钮但**置灰禁用**，`hover` 显示当前状态无法取消的原因；`cancelled` / `revoked` 态按钮文案为「已取消审批」。
+
+置灰按钮的 tooltip 文案映射：
+
+| `ticket.status`       | 文案                       |
+| --------------------- | -------------------------- |
+| `approved`            | 该单据已通过，无法取消     |
+| `rejected`            | 该单据已被拒绝，无法取消   |
+| `cancelled`、`revoked` | 单据已取消，无需重复点击   |
+| 其它终态（`expired`、`abandoned`） | 当前状态无法取消审批 |
+
+`readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏刷新图标与第二个操作按钮（取消 / 置灰取消均不展示），不接受交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+
+分享只读渲染模式（注入的 `RenderMode.Share`）下，操作按钮与刷新图标**保持可见但禁用**（区别于 `readonly` 的直接隐藏），避免在分享回显场景误触发。该渲染模式由 [ChatContainer](/components/setup/chat-container) 等容器通过 `useRenderModeProvider` 注入，组件内部经 `useRenderModeInject` 读取，业务侧无需手动设置。
+
+取消审批与刷新均为同步 `onInterruptResume`，组件无法在回调内获知请求结果：取消点击后按钮立即进入 loading 防止重复取消；刷新做 2s 冷却节流供用户轮询最新状态；待后台刷新使卡片卸载/重建后交互态随实例销毁。
 
 状态徽章样式：
 
@@ -231,7 +247,7 @@ ToolApprovalCard
 />
 ```
 
-**渲染效果**（待审批态下 readonly 不展示「取消审批」）
+**渲染效果**（待审批态下 readonly 不展示刷新图标与「取消审批」按钮）
 
 <div class="demo">
   <ToolApprovalCard
@@ -247,12 +263,12 @@ ToolApprovalCard
 | 属性名            | 类型                         | 默认值 | 说明                                         |
 | ----------------- | ---------------------------- | ------ | -------------------------------------------- |
 | interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`               |
-| onInterruptResume | `OnInterruptResume`          | —      | 取消审批时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id } }` |
-| readonly          | `boolean`                    | —      | 只读回显态（`outcome.success` 结果回显）：隐藏取消审批按钮，不接受交互 |
+| onInterruptResume | `OnInterruptResume`          | —      | 取消审批 / 刷新时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation, payload: { interrupt_id } }`，`operation` 取 `InterruptResumeOperation.ApprovalCancel`（取消）或 `InterruptResumeOperation.ApprovalRefresh`（刷新），两者 payload 结构一致 |
+| readonly          | `boolean`                    | —      | 只读回显态（`outcome.success` 结果回显）：隐藏取消 / 刷新按钮，不接受交互 |
 
 ### Events / Slots / Expose
 
-无。打开链接、复制剪贴板在组件内部完成；取消审批通过 `onInterruptResume({ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: interrupt.id } }, interrupt)` 通知业务侧处理。
+无。打开链接、复制剪贴板在组件内部完成；取消审批通过 `onInterruptResume({ operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: interrupt.id } }, interrupt)`、刷新单据通过 `onInterruptResume({ operation: InterruptResumeOperation.ApprovalRefresh, payload: { interrupt_id: interrupt.id } }, interrupt)` 通知业务侧处理。
 
 ## 依赖
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
@@ -38,6 +38,8 @@ AG-UI [Interrupts](https://docs.ag-ui.com/drafts/interrupts) 协议相关类型�
 enum InterruptResumeOperation {
   /** 主动取消第三方工具审批 */
   ApprovalCancel = 'approval_cancel',
+  /** 刷新第三方工具审批：刷新审批单状态 */
+  ApprovalRefresh = 'approval_refresh',
   /** 重试失败的流程节点（bkflow） */
   FlowNodeRetry = 'flow_node_retry',
   /** 跳过失败的流程节点（bkflow） */
@@ -173,7 +175,7 @@ type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestionResume;
 
 | 类型                 | `operation` / `reason`              | 说明                                                         |
 | -------------------- | ----------------------------------- | ------------------------------------------------------------ |
-| `ToolApprovalResume` | `InterruptResumeOperation.ApprovalCancel` | 第三方工具审批取消                                           |
+| `ToolApprovalResume` | `InterruptResumeOperation.ApprovalCancel` / `ApprovalRefresh` | 第三方工具审批取消 / 刷新审批单状态                           |
 | `FlowNodeResume`     | `flow_node_retry` / `flow_node_skip` | FlowAgent 失败节点重试 / 跳过；**无**对应 `Interrupt` 项     |
 | `UserQuestionResume` | `InterruptReason.UserQuestion`（`reason` 字段） | 用户回答问题                                                 |
 
@@ -181,7 +183,7 @@ type InterruptResume = FlowNodeResume | ToolApprovalResume | UserQuestionResume;
 
 ```typescript
 type ToolApprovalResume = {
-  operation: InterruptResumeOperation.ApprovalCancel;
+  operation: InterruptResumeOperation.ApprovalCancel | InterruptResumeOperation.ApprovalRefresh;
   payload: { interrupt_id: number | string };
 };
 ```
@@ -362,6 +364,9 @@ const handleInterruptResume: OnInterruptResume = async (payload, interrupt) => {
     switch (payload.operation) {
       case InterruptResumeOperation.ApprovalCancel:
         console.log('取消审批', payload.payload.interrupt_id, interrupt?.id);
+        break;
+      case InterruptResumeOperation.ApprovalRefresh:
+        console.log('刷新审批单', payload.payload.interrupt_id, interrupt?.id);
         break;
       case InterruptResumeOperation.FlowNodeRetry:
       case InterruptResumeOperation.FlowNodeSkip:


### PR DESCRIPTION
## Summary

- 工具审批卡（`ToolApprovalCard`）审批中态新增「刷新单据状态」图标，通过 `InterruptResumeOperation.ApprovalRefresh` 透传 `onInterruptResume`，并做 2s 冷却节流防重复刷新
- 终态保留置灰的「取消审批」按钮，按 `ticket.status` 展示对应 tooltip；`cancelled` / `revoked` 态按钮文案为「已取消审批」
- 同步类型定义、单测、i18n 与 wikis 文档

## Test plan

- [x] `interrupt-message.spec.ts` 覆盖刷新透传、2s 冷却、终态隐藏刷新图标、终态置灰取消按钮
- [ ] playground 审批中态点击刷新图标触发 `approval_refresh`
- [ ] 终态 hover 取消按钮展示对应 tooltip 文案
- [ ] 分享只读模式下刷新/取消按钮保持可见但禁用


Made with [Cursor](https://cursor.com)