### PR TITLE
feat: 【小鲸】优化会话回显审批单交互与终态取消文案 --story=135900634

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -253,7 +253,7 @@ describe('InterruptMessage', () => {
           {
             ...approvalInterrupt,
             metadata: {
-              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.APPROVED },
+              ticket: { ...approvalInterrupt.metadata?.ticket, status: APPROVAL_STATUS.APPROVED },
             },
           },
         ],
@@ -271,7 +271,7 @@ describe('InterruptMessage', () => {
           {
             ...approvalInterrupt,
             metadata: {
-              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.REJECTED },
+              ticket: { ...approvalInterrupt.metadata?.ticket, status: APPROVAL_STATUS.REJECTED },
             },
           },
         ],
@@ -291,7 +291,7 @@ describe('InterruptMessage', () => {
           {
             ...approvalInterrupt,
             metadata: {
-              ticket: { ...approvalInterrupt.metadata!.ticket, status: APPROVAL_STATUS.CANCELLED },
+              ticket: { ...approvalInterrupt.metadata?.ticket, status: APPROVAL_STATUS.CANCELLED },
             },
           },
         ],
@@ -376,20 +376,32 @@ describe('InterruptMessage', () => {
     expect(wrapper.text()).toContain('Rust');
   });
 
-  it('success outcome 存在 AIDevToolApproval resume 时应只读回显审批单', () => {
+  it('success outcome 存在 AIDevToolApproval resume 时应可交互回显审批单', async () => {
+    const onInterruptResume = vi.fn();
     wrapper = mount(InterruptMessage, {
       props: {
         content: {
           outcome: { type: 'success' },
           result: approvalResume,
         },
+        onInterruptResume,
       },
     });
 
     expect(wrapper.find('.ai-tool-approval-card').exists()).toBe(true);
     expect(wrapper.find('.ai-tool-approval-card__title').text()).toBe('算法方案评审单');
     expect(wrapper.text()).toContain('REV-2026-04-24-001');
-    expect(wrapper.find('.ai-tool-approval-card__cancel').exists()).toBe(false);
+    // readonly=false：回显审批单仍可交互，pending 态展示可点击的取消审批按钮与刷新图标
+    expect(wrapper.find('.ai-tool-approval-card__refresh-icon').exists()).toBe(true);
+    const cancelBtn = wrapper.find('.ai-tool-approval-card__cancel');
+    expect(cancelBtn.exists()).toBe(true);
+
+    // 点击取消审批应透传取消动作，interrupt 由 result.payload.metadata 还原
+    await cancelBtn.trigger('click');
+    expect(onInterruptResume).toHaveBeenCalledWith(
+      { operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: approvalResume.interruptId } },
+      expect.objectContaining({ id: approvalResume.interruptId, reason: InterruptReason.AIDevToolApproval }),
+    );
   });
 
   it('content.message 存在时应渲染提示文案', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
@@ -87,7 +87,7 @@
   const resultRenderers: Partial<Record<InterruptReason, ResultRenderer>> = {
     [InterruptReason.AIDevToolApproval]: result => ({
       component: ToolApprovalCard,
-      props: { interrupt: toApprovalInterrupt(result as AIDevToolApprovalResume), readonly: true },
+      props: { interrupt: toApprovalInterrupt(result as AIDevToolApprovalResume), readonly: false },
     }),
     [InterruptReason.UserQuestion]: result => ({
       component: UserQuestionAnsweredCard,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -177,9 +177,9 @@
   // 各终态下「取消审批」置灰按钮的 hover 提示；未覆盖的终态（已废弃 / 已过期等）走通用兜底文案
   const cancelDisabledTipMap: Partial<Record<APPROVAL_STATUS, string>> = {
     [APPROVAL_STATUS.APPROVED]: t('该单据已通过，无法取消'),
-    [APPROVAL_STATUS.CANCELLED]: t('单据已取消，无需重复点击'),
+    [APPROVAL_STATUS.CANCELLED]: t('单据已取消审批'),
     [APPROVAL_STATUS.REJECTED]: t('该单据已被拒绝，无法取消'),
-    [APPROVAL_STATUS.REVOKED]: t('单据已取消，无需重复点击'),
+    [APPROVAL_STATUS.REVOKED]: t('单据已取消审批'),
   };
 
   const isPendingApproval = computed(() => pendingStatusSet.has(ticket.value.status));

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -122,6 +122,7 @@ export const lang = {
   取消审批: 'Cancel Approval',
   已取消审批: 'Approval Cancelled',
   刷新单据状态: 'Refresh Ticket Status',
+  单据已取消审批: 'Approval Cancelled',
   '该单据已被拒绝，无法取消': 'This ticket has been rejected and cannot be cancelled',
   '该单据已通过，无法取消': 'This ticket has been approved and cannot be cancelled',
   '单据已取消，无需重复点击': 'This ticket has been cancelled, no need to click again',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
@@ -195,14 +195,14 @@ InterruptMessageRender
 
 content.outcome.type === 'success'
 └── resultRenderers[result.reason]
-      ├── aidev:tool_approval → ToolApprovalCard（readonly，隐藏取消审批）
+      ├── aidev:tool_approval → ToolApprovalCard（可交互回显，透传 onInterruptResume）
       └── aidev:user_question → UserQuestionAnsweredCard（支持 #answeredQuestion 透传 #answer）
 ```
 
 | `InterruptReason`              | 子组件              |
 | ------------------------------ | ------------------- |
 | `aidev:tool_approval`（待审批） | `ToolApprovalCard`  |
-| `aidev:tool_approval`（已处理） | `ToolApprovalCard`（`readonly`，只读回显） |
+| `aidev:tool_approval`（已处理） | `ToolApprovalCard`（可交互回显，仍可取消 / 刷新） |
 | `aidev:user_question`（待回答） | 输入区 `UserQuestionCard`，本组件不渲染 |
 | `aidev:user_question`（已回答） | `UserQuestionAnsweredCard` |
 | 其他 / 未注册                  | 兜底文案区域        |
@@ -296,7 +296,7 @@ content.outcome.type === 'success'
 
 ## AIDevToolApproval 已处理回显（outcome.success）
 
-`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以只读 `ToolApprovalCard` 回显审批单。`result.payload.metadata` 需透传中断时的 `metadata`（含 `ticket`）：
+`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以可交互 `ToolApprovalCard` 回显审批单（`readonly: false`）：待审批态仍可取消 / 刷新，终态展示置灰的取消按钮。`result.payload.metadata` 需透传中断时的 `metadata`（含 `ticket`）：
 
 ```vue
 <InterruptMessageRender

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -3,9 +3,9 @@ name: ToolApprovalCard 工具审批卡片
 slug: tool-approval-card
 kind: component
 domain: agent
-description: 渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作，支持只读回显态。
+description: 渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作，readonly prop 支持纯只读展示。
 aiSummary: >
-  渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作；outcome.success 回显时以 readonly 只读展示。
+  渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作；readonly prop 可用于纯只读展示（outcome.success 回显已改为可交互，不再使用 readonly）。
   源码位置：src/components/chat-message/interrupt-message/tool-approval-card.vue。
 relatedComponents:
   - slug: interrupt-message
@@ -91,7 +91,7 @@ sinceVersion: 1.0.0
 
 - **源码位置**：`src/components/chat-message/interrupt-message/tool-approval-card.vue`
 - **能力域**：Agent 能力
-- **能力说明**：渲染 AIDevToolApproval 中断的审批信息与取消操作；`readonly` 时用于 outcome.success 只读回显。
+- **能力说明**：渲染 AIDevToolApproval 中断的审批信息与取消操作；`readonly` prop 用于纯只读展示（outcome.success 回显已改为可交互，不再传入 `readonly`）。
 
 
 
@@ -124,10 +124,10 @@ ToolApprovalCard
 | --------------------- | -------------------------- |
 | `approved`            | 该单据已通过，无法取消     |
 | `rejected`            | 该单据已被拒绝，无法取消   |
-| `cancelled`、`revoked` | 单据已取消，无需重复点击   |
+| `cancelled`、`revoked` | 单据已取消审批             |
 | 其它终态（`expired`、`abandoned`） | 当前状态无法取消审批 |
 
-`readonly` 为 `true` 时用于 `outcome.success` 结果回显：隐藏刷新图标与第二个操作按钮（取消 / 置灰取消均不展示），不接受交互。通常由 [InterruptMessageRender](/components/agent/interrupt-message) 内部传入，业务侧无需手动设置。
+`readonly` 为 `true` 时用于纯只读展示：隐藏刷新图标与第二个操作按钮（取消 / 置灰取消均不展示），不接受交互。注：`outcome.success` 结果回显自 [InterruptMessageRender](/components/agent/interrupt-message) 起已改为**可交互**挂载（`readonly: false`），不再传入 `readonly`；该 prop 仍保留供纯只读预览场景使用。
 
 分享只读渲染模式（注入的 `RenderMode.Share`）下，操作按钮与刷新图标**保持可见但禁用**（区别于 `readonly` 的直接隐藏），避免在分享回显场景误触发。该渲染模式由 [ChatContainer](/components/setup/chat-container) 等容器通过 `useRenderModeProvider` 注入，组件内部经 `useRenderModeInject` 读取，业务侧无需手动设置。
 
@@ -236,9 +236,9 @@ ToolApprovalCard
   <ToolApprovalCard :interrupt="revokedInterrupt" />
 </div>
 
-## 只读回显（readonly）
+## 只读展示（readonly）
 
-`outcome.success` 时 [InterruptMessageRender](/components/agent/interrupt-message) 会将 `AIDevToolApprovalResume.payload.metadata` 还原为 `interrupt` 形态，并以 `readonly` 挂载本组件：
+`readonly` 用于纯只读展示审批单：隐藏刷新图标与「取消审批」按钮，不接受任何交互。注：`outcome.success` 结果回显自 [InterruptMessageRender](/components/agent/interrupt-message) 起已改为**可交互**挂载（不再传 `readonly`），此处仅演示 `readonly` prop 本身的效果：
 
 ```vue
 <ToolApprovalCard
@@ -264,7 +264,7 @@ ToolApprovalCard
 | ----------------- | ---------------------------- | ------ | -------------------------------------------- |
 | interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`               |
 | onInterruptResume | `OnInterruptResume`          | —      | 取消审批 / 刷新时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation, payload: { interrupt_id } }`，`operation` 取 `InterruptResumeOperation.ApprovalCancel`（取消）或 `InterruptResumeOperation.ApprovalRefresh`（刷新），两者 payload 结构一致 |
-| readonly          | `boolean`                    | —      | 只读回显态（`outcome.success` 结果回显）：隐藏取消 / 刷新按钮，不接受交互 |
+| readonly          | `boolean`                    | —      | 纯只读展示：隐藏取消 / 刷新按钮，不接受交互（`outcome.success` 回显已改为可交互，框架内部不再传入） |
 
 ### Events / Slots / Expose
 


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】优化会话回显审批单交互与终态取消文案（1070093903135900634）

会话内 `outcome.success` 回显 `AIDevToolApproval` 审批单原以只读态挂载（`readonly: true`），隐藏取消/刷新，用户无法对回显的待审批单据继续操作。

## 改动
- `interrupt-message.vue`：`resultRenderers[AIDevToolApproval]` 由 `readonly: true` 改为 `readonly: false`，会话回显审批单可交互（待审批态仍可取消审批 / 刷新，终态展示置灰取消按钮）。
- `tool-approval-card.vue`：cancelled / revoked 终态取消置灰提示由「单据已取消，无需重复点击」改为「单据已取消审批」。
- `lang.ts`：新增国际化文案「单据已取消审批」。
- 同步更新 `interrupt-message.spec.ts`（只读断言 → 可交互断言）及 `interrupt-message.md` / `tool-approval-card.md` wiki 文档。

## 影响面
- chat-x：`InterruptMessage` / `ToolApprovalCard`；`readonly` prop 保留供纯只读预览场景，框架内部回显不再传入。
- `@blueking/ai-blueking` 消费方回显交互随之增强。

## 测试
- [x] `interrupt-message.spec.ts` 可交互回显用例通过（点击取消透传 `ApprovalCancel`）

Made with [Cursor](https://cursor.com)