### PR TITLE
fix: 审批回显透传 resume 回调 --bug=160359984

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -396,7 +396,8 @@ describe('InterruptMessage', () => {
     const cancelBtn = wrapper.find('.ai-tool-approval-card__cancel');
     expect(cancelBtn.exists()).toBe(true);
 
-    // 点击取消审批应透传取消动作，interrupt 由 result.payload.metadata 还原
+    // 回归：resultRenderers 须透传 onInterruptResume，否则取消点击调用次数为 0
+    // interrupt 由 result.payload.metadata 还原
     await cancelBtn.trigger('click');
     expect(onInterruptResume).toHaveBeenCalledWith(
       { operation: InterruptResumeOperation.ApprovalCancel, payload: { interrupt_id: approvalResume.interruptId } },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.vue
@@ -73,7 +73,7 @@
     [InterruptReason.AIDevToolApproval]: ToolApprovalCard,
   };
 
-  // 由审批结果还原出 interrupt 形态，复用 ToolApprovalCard 渲染（回显态只读）
+  // 由审批结果还原出 interrupt 形态，复用 ToolApprovalCard 渲染（回显态可交互：取消/刷新）
   const toApprovalInterrupt = (result: AIDevToolApprovalResume): AIDevToolApprovalInterrupt => ({
     id: result.interruptId || result.id || '',
     reason: InterruptReason.AIDevToolApproval,
@@ -87,7 +87,12 @@
   const resultRenderers: Partial<Record<InterruptReason, ResultRenderer>> = {
     [InterruptReason.AIDevToolApproval]: result => ({
       component: ToolApprovalCard,
-      props: { interrupt: toApprovalInterrupt(result as AIDevToolApprovalResume), readonly: false },
+      // 与 interrupt 态一致透传 onInterruptResume，否则取消/刷新点击无回调
+      props: {
+        interrupt: toApprovalInterrupt(result as AIDevToolApprovalResume),
+        onInterruptResume: props.onInterruptResume,
+        readonly: false,
+      },
     }),
     [InterruptReason.UserQuestion]: result => ({
       component: UserQuestionAnsweredCard,

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/interrupt-message.md
@@ -296,7 +296,7 @@ content.outcome.type === 'success'
 
 ## AIDevToolApproval 已处理回显（outcome.success）
 
-`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以可交互 `ToolApprovalCard` 回显审批单（`readonly: false`）：待审批态仍可取消 / 刷新，终态展示置灰的取消按钮。`result.payload.metadata` 需透传中断时的 `metadata`（含 `ticket`）：
+`outcome.type === 'success'` 且 `result.reason === InterruptReason.AIDevToolApproval` 时，会话内以可交互 `ToolApprovalCard` 回显审批单（`readonly: false`）：待审批态仍可取消 / 刷新，终态展示置灰的取消按钮。`resultRenderers` 须与 interrupt 态一样透传 `onInterruptResume`，否则取消 / 刷新无回调。`result.payload.metadata` 需透传中断时的 `metadata`（含 `ticket`）：
 
 ```vue
 <InterruptMessageRender


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】success 回显审批单取消/刷新未透传 onInterruptResume（1070093903160359984）


`outcome.success` 回显审批单为可交互态，但点击「取消审批」/刷新时 `onInterruptResume` 调用次数为 0。

根因：`resultRenderers[AIDevToolApproval]` 只传了 `interrupt` / `readonly`，漏传 `onInterruptResume`。

## 改动
- `interrupt-message.vue`：success 回显补传 `onInterruptResume`
- 同步 wiki 说明与回归用例注释

## 影响面
- 仅 chat-x `InterruptMessage` success 回显审批单的取消/刷新交互
- 不影响 UserQuestion 回显

## 测试
- [x] `interrupt-message.spec.ts` 中 success 回显取消审批用例

Made with [Cursor](https://cursor.com)