### PR TITLE
feat: 【小鲸】工具审批卡支持展示工具参数 --story=135922101

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -175,7 +175,7 @@
     UserQuestionChoice,
   } from '../src';
   import CustomTabContent from './custom-tab-content.vue';
-  import { MOCK_INTERRUPT_MESSAGES } from './interrupt';
+  import { MOCK_APPROVAL_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
   import { MOCK_PROMPTS, MOCK_RESOURCES } from './mock';
   import { uploadFileToSession } from './upload-file';
@@ -192,399 +192,8 @@
   const cite = shallowRef('');
   const userInput = shallowRef<string | TagSchema>('');
   const selectedShortcut = deepRef<null | Shortcut>(null);
-  const messages = deepRef<Message[]>([
-    // 第一轮：用户提问 + assistant 调用工具 + tool 返回
-    {
-      id: 'msg_user_1',
-      role: MessageRole.User,
-      status: MessageStatus.Complete,
-      content: '帮我分析一下最近的 Trace 数据，并帮我查询一下慢请求的详细信息，并检查下服务健康状况',
-      messageId: 'msg_user_1',
-    },
-    // {
-    //   id: 'msg_assistant_1',
-    //   role: MessageRole.Assistant,
-    //   content: '好的，我来帮您分析 Trace 数据，需要先调用相关工具获取信息。',
-    //   status: MessageStatus.Complete,
-    //   messageId: 'msg_assistant_1',
-    //   toolCalls: [
-    //     {
-    //       id: 'tc_1',
-    //       type: MessageContentType.Function,
-    //       function: {
-    //         name: 'Trace 分析',
-    //         arguments: JSON.stringify({ app_code: 'bk-monitor', time_range: '1h' }),
-    //         description: '分析应用的 Trace 数据，获取慢请求和错误请求',
-    //       },
-    //     },
-    //     {
-    //       id: 'tc_2',
-    //       type: MessageContentType.Function,
-    //       function: {
-    //         name: '日志查询',
-    //         arguments: JSON.stringify({ keyword: 'error', count: 20 }),
-    //         description: '查询应用的错误日志',
-    //         mcpName: 'bk-log',
-    //       },
-    //     },
-    //   ],
-    // } as AssistantMessage,
-    {
-      id: 'msg_tool_1',
-      role: MessageRole.Tool,
-      content: JSON.stringify({ total: 1523, slow_requests: 12, error_requests: 3, p99: '230ms' }),
-      status: MessageStatus.Complete,
-      messageId: 'msg_tool_1',
-      toolCallId: 'tc_1',
-      duration: 2300,
-    } as ToolMessage,
-    {
-      id: 'msg_tool_2',
-      role: MessageRole.Tool,
-      content: JSON.stringify({ logs: ['[ERROR] Connection timeout', '[ERROR] Service unavailable'] }),
-      status: MessageStatus.Error,
-      messageId: 'msg_tool_2',
-      toolCallId: 'tc_2',
-      duration: 5100,
-      error: '日志服务响应超时',
-    } as ToolMessage,
-    {
-      id: 'msg_assistant_2',
-      role: MessageRole.Assistant,
-      content:
-        '根据 Trace 分析结果：\n- 最近 1 小时共 **1523** 条 Trace\n- 慢请求 **12** 条，错误请求 **3** 条\n- P99 延迟为 **230ms**\n\n日志查询出现超时，建议稍后重试。',
-      status: MessageStatus.Complete,
-      messageId: 'msg_assistant_2',
-    },
-
-    // 第二轮：用户追问 + assistant 调用工具 + tool 返回
-    {
-      id: 'msg_user_2',
-      role: MessageRole.User,
-      content: '帮我看看慢请求的详细信息，并检查下服务健康状况',
-      status: MessageStatus.Complete,
-      messageId: 'msg_user_2',
-    },
-    {
-      id: 'msg_assistant_3',
-      role: MessageRole.Assistant,
-      // content: '正在查询慢请求详情和服务健康状态。',
-      status: MessageStatus.Complete,
-      messageId: 'msg_assistant_3',
-      toolCalls: [
-        {
-          id: 'tc_3',
-          type: MessageContentType.Function,
-          function: {
-            name: '慢请求详情',
-            arguments: JSON.stringify({ app_code: 'bk-monitor', threshold: '200ms' }),
-            description: '获取超过阈值的慢请求详细信息',
-          },
-        },
-        {
-          id: 'tc_4',
-          type: MessageContentType.Function,
-          function: {
-            name: '服务健康检查',
-            arguments: JSON.stringify({ service: 'bk-monitor-web' }),
-            description: '检查服务运行状态和健康指标',
-            mcpName: 'bk-monitor',
-          },
-        },
-        {
-          id: 'tc_5',
-          type: MessageContentType.Function,
-          function: {
-            name: '告警查询',
-            arguments: JSON.stringify({ biz_id: 2, status: 'abnormal' }),
-            description: '查询当前活跃的告警事件',
-          },
-        },
-      ],
-    } as AssistantMessage,
-    {
-      id: 'msg_tool_3',
-      role: MessageRole.Tool,
-      content: JSON.stringify([
-        { trace_id: 'abc123', duration: '350ms', endpoint: '/api/query' },
-        { trace_id: 'def456', duration: '280ms', endpoint: '/api/search' },
-      ]),
-      status: MessageStatus.Complete,
-      messageId: 'msg_tool_3',
-      toolCallId: 'tc_3',
-      duration: 1800,
-    } as ToolMessage,
-    {
-      id: 'msg_tool_4',
-      role: MessageRole.Tool,
-      content: JSON.stringify({ status: 'healthy', cpu: '45%', memory: '62%', uptime: '72h' }),
-      status: MessageStatus.Complete,
-      messageId: 'msg_tool_4',
-      toolCallId: 'tc_4',
-      duration: 800,
-    } as ToolMessage,
-    {
-      id: 'msg_tool_5',
-      role: MessageRole.Tool,
-      content: JSON.stringify({ alerts: [{ name: 'CPU 使用率过高', level: 'warning' }] }),
-      status: MessageStatus.Pending,
-      messageId: 'msg_tool_5',
-      toolCallId: 'tc_5',
-      duration: 0,
-    } as ToolMessage,
-    {
-      id: 'msg_assistant_4',
-      role: MessageRole.Assistant,
-      content:
-        '慢请求分析：\n1. `/api/query` 耗时 350ms（trace_id: abc123）\n2. `/api/search` 耗时 280ms（trace_id: def456）\n\n服务健康状态良好，CPU 45%，内存 62%，已运行 72 小时。告警查询仍在进行中。',
-      status: MessageStatus.Complete,
-      messageId: 'msg_assistant_4',
-    },
-
-    // Activity Messages
-    {
-      id: 'msg_activity_bkflow',
-      role: MessageRole.Activity,
-      activityType: MessageContentType.FlowAgent,
-      content: [
-        {
-          task_id: 634859,
-          has_confidence: true,
-          is_active: true,
-          task_name: 'benny-flow7_20260202160324',
-          task_state: 'FAILED',
-          nodes: {
-            n4a62453cafb35859861dc0e3aa5e62d: {
-              id: 'n4a62453cafb35859861dc0e3aa5e62d',
-              name: 'deepseek-v3-0324',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:03:31 +0800',
-              finish_time: '2026-02-02 16:03:31 +0800',
-              elapsed_time: 0,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            n3fafcafa4063431b1eeab8659f8edda: {
-              id: 'n3fafcafa4063431b1eeab8659f8edda',
-              name: 'deepseek-r1',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:03:31 +0800',
-              finish_time: '2026-02-02 16:03:35 +0800',
-              elapsed_time: 4,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            n9967f451c043155bcba6f969f48417f: {
-              id: 'n9967f451c043155bcba6f969f48417f',
-              name: 'qwen3',
-              type: 'ServiceActivity',
-              state: 'FAILED',
-              start_time: '2026-02-02 16:03:36 +0800',
-              finish_time: '2026-02-02 16:08:36 +0800',
-              elapsed_time: 300,
-              loop: 1,
-              retry: 0,
-              retryable: true,
-              skip: false,
-              skippable: true,
-            },
-            n1a2b3c4d5e6f7890abcdef12345678: {
-              id: 'n1a2b3c4d5e6f7890abcdef12345678',
-              name: 'claude-4-opus',
-              type: 'ServiceActivity',
-              state: 'RUNNING',
-              start_time: '2026-02-02 16:08:40 +0800',
-              finish_time: '',
-              elapsed_time: 62,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            nfedcba0987654321abcdef00000001: {
-              id: 'nfedcba0987654321abcdef00000001',
-              name: 'gemini-2.5-pro',
-              type: 'ServiceActivity',
-              state: 'SUSPENDED',
-              start_time: '2026-02-02 16:09:00 +0800',
-              finish_time: '',
-              elapsed_time: 86520,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            n00000000000000000000000000000002: {
-              id: 'n00000000000000000000000000000002',
-              name: '待调度工具节点',
-              type: 'ServiceActivity',
-              state: 'PENDING',
-              start_time: '',
-              finish_time: '',
-              elapsed_time: 0,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-          },
-          statistics: {
-            total: 6,
-            state_counts: {
-              FINISHED: 2,
-              FAILED: 1,
-              RUNNING: 1,
-              SUSPENDED: 1,
-              PENDING: 1,
-            },
-          },
-          task_outputs: [],
-          confidence_title: '证据汇总',
-        },
-        {
-          task_id: 634860,
-          confidence_title: '证据汇总',
-          task_name: '模型评估流_20260202161510',
-          task_state: 'FINISHED',
-          nodes: {
-            nflow860_prepare: {
-              id: 'nflow860_prepare',
-              name: '准备评估数据集',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:15:10 +0800',
-              finish_time: '2026-02-02 16:15:35 +0800',
-              elapsed_time: 25,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            nflow860_eval: {
-              id: 'nflow860_eval',
-              name: '执行模型质量评估',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:15:36 +0800',
-              finish_time: '2026-02-02 16:18:18 +0800',
-              elapsed_time: 162,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            nflow860_report: {
-              id: 'nflow860_report',
-              name: '生成评估报告',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:18:19 +0800',
-              finish_time: '2026-02-02 16:18:31 +0800',
-              elapsed_time: 12,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-          },
-          statistics: {
-            total: 3,
-            state_counts: {
-              FINISHED: 3,
-            },
-          },
-          task_outputs: {
-            score: 0.92,
-            report_url: 'https://example.com/reports/model-eval-634860',
-          },
-        },
-        {
-          task_id: 634861,
-          task_name: '告警收敛流_20260202162045',
-          task_state: 'RUNNING',
-          nodes: {
-            nflow861_collect: {
-              id: 'nflow861_collect',
-              name: '拉取告警事件',
-              type: 'ServiceActivity',
-              state: 'FINISHED',
-              start_time: '2026-02-02 16:20:45 +0800',
-              finish_time: '2026-02-02 16:21:03 +0800',
-              elapsed_time: 18,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            nflow861_group: {
-              id: 'nflow861_group',
-              name: '按服务与维度聚合',
-              type: 'ServiceActivity',
-              state: 'RUNNING',
-              start_time: '2026-02-02 16:21:04 +0800',
-              finish_time: '',
-              elapsed_time: 47,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-            nflow861_notify: {
-              id: 'nflow861_notify',
-              name: '发送收敛结果通知',
-              type: 'ServiceActivity',
-              state: 'PENDING',
-              start_time: '',
-              finish_time: '',
-              elapsed_time: 0,
-              loop: 1,
-              retry: 0,
-              skip: false,
-            },
-          },
-          statistics: {
-            total: 3,
-            state_counts: {
-              FINISHED: 1,
-              RUNNING: 1,
-              PENDING: 1,
-            },
-          },
-          task_outputs: [],
-        },
-      ],
-      status: MessageStatus.Complete,
-      messageId: 'msg_activity_bkflow',
-    } as ActivityMessage,
-    {
-      id: 'msg_activity_rag',
-      role: MessageRole.Activity,
-      activityType: MessageContentType.KnowledgeRag,
-      content: {
-        content:
-          '根据知识库检索到以下相关内容：\n\n**Trace 数据分析指南**\n\n在蓝鲸监控中，Trace 数据可以通过 APM 模块进行查询和分析...',
-        referenceDocument: [
-          { name: 'Trace 数据分析指南', originFile: 'trace-guide.md', url: 'https://example.com/docs/trace-guide' },
-          { name: 'APM 接入文档', originFile: 'apm-setup.md', url: 'https://example.com/docs/apm-setup' },
-        ],
-      },
-      status: MessageStatus.Complete,
-      messageId: 'msg_activity_rag',
-    } as ActivityMessage,
-    {
-      id: 'msg_activity_ref',
-      role: MessageRole.Activity,
-      activityType: MessageContentType.ReferenceDocument,
-      content: [
-        {
-          name: '蓝鲸监控产品白皮书',
-          originFile: 'bkmonitor-whitepaper.pdf',
-          url: 'https://example.com/docs/whitepaper',
-        },
-        { name: '告警策略配置手册', originFile: 'alert-config.md', url: 'https://example.com/docs/alert-config' },
-        { name: 'SLI/SLO 最佳实践', originFile: 'sli-slo-best-practice.md', url: 'https://example.com/docs/sli-slo' },
-      ],
-      status: MessageStatus.Complete,
-      messageId: 'msg_activity_ref',
-    } as ActivityMessage,
-    ...MOCK_INTERRUPT_MESSAGES,
-  ]);
+  // playground 调试：挂载审批单据全状态 + 参数展示 mock
+  const messages = deepRef<Message[]>([...MOCK_APPROVAL_MESSAGES]);
 
   const handleInterruptResume: OnInterruptResume = (payload, interrupt) => {
     // 取消审批与流程节点重试 / 跳过复用同一回调，业务侧按 payload.operation 分流处理
@@ -1349,30 +958,30 @@
     messages.value = [];
   };
 
-  onMounted(() => {
-    let content = '';
-    const chunkSize = 1999999999;
-    const interval = setInterval(() => {
-      content += streamContent.slice(content.length, content.length + chunkSize);
-      const status = content.length >= streamContent.length ? MessageStatus.Complete : MessageStatus.Streaming;
-      const message = messages.value.find(m => m.id === 'stream_assistant');
-      if (message) {
-        message.content = content;
-        message.status = status;
-      } else {
-        messages.value.push({
-          id: 'stream_assistant',
-          role: MessageRole.Assistant,
-          messageId: 'stream_assistant',
-          status,
-          content,
-        } as AssistantMessage);
-      }
-      if (content.length >= streamContent.length) {
-        clearInterval(interval);
-      }
-    }, 16);
-  });
+  // onMounted(() => {
+  //   let content = '';
+  //   const chunkSize = 1999999999;
+  //   const interval = setInterval(() => {
+  //     content += streamContent.slice(content.length, content.length + chunkSize);
+  //     const status = content.length >= streamContent.length ? MessageStatus.Complete : MessageStatus.Streaming;
+  //     const message = messages.value.find(m => m.id === 'stream_assistant');
+  //     if (message) {
+  //       message.content = content;
+  //       message.status = status;
+  //     } else {
+  //       messages.value.push({
+  //         id: 'stream_assistant',
+  //         role: MessageRole.Assistant,
+  //         messageId: 'stream_assistant',
+  //         status,
+  //         content,
+  //       } as AssistantMessage);
+  //     }
+  //     if (content.length >= streamContent.length) {
+  //       clearInterval(interval);
+  //     }
+  //   }, 16);
+  // });
 </script>
 
 <style lang="scss">

--- a/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
@@ -43,7 +43,44 @@ type ApprovalInterruptOptions = {
   sn: string;
   status: APPROVAL_STATUS;
   title?: string;
+  toolArgs?: Record<string, unknown>;
   toolCallId?: string;
+};
+
+/** 短参数：JSON ≤3 行，参数区不出现展开/收起 */
+const MOCK_TOOL_ARGS_SHORT: Record<string, unknown> = {
+  a: 1,
+  b: 2,
+};
+
+/** 长参数：JSON >3 行，用于验证参数区折叠/展开 */
+const MOCK_TOOL_ARGS_LONG: Record<string, unknown> = {
+  algorithm: 'bubble_sort',
+  language: 'typescript',
+  optimization: {
+    early_exit: true,
+    cocktail: false,
+  },
+  dataset: {
+    size: 10000,
+    distribution: 'partially_sorted',
+    seed: {
+      size: 10000,
+      distribution: 'partially_sorted',
+      seed: {
+        size: 10000,
+        distribution:
+          'partially_sortedpartially_sortedpartially_sortedpartially_sortedpartially_sortedpartially_sortedpartially_sortedpartially_sortedpartially_sorted',
+        seed: 42,
+      },
+    },
+  },
+  benchmarks: [
+    { name: 'random', expected_ms: 120 },
+    { name: 'nearly_sorted', expected_ms: 30 },
+    { name: 'reversed', expected_ms: 200 },
+  ],
+  notes: '请重点评审提前终止标志位与边界条件处理是否正确',
 };
 
 /** 构造 AI Dev 工具审批类 Interrupt */
@@ -61,6 +98,8 @@ const createApprovalInterrupt = (options: ApprovalInterruptOptions): AIDevToolAp
       title: options.title ?? '算法方案评审单',
       url: `https://example.com/review-tickets/${options.sn}`,
     },
+    // 未传 toolArgs 时不写入字段，方便覆盖「无参数不渲染」场景
+    ...(options.toolArgs ? { toolArgs: options.toolArgs } : {}),
   },
 });
 
@@ -108,64 +147,84 @@ const createInterruptScenario = (params: {
   ];
 };
 
-// —— 场景 1：待审批（outcome.interrupt，消息 Pending，等待 resume）——
+// —— 场景 1：待审批 + 长参数（可展开/收起）——
 const pendingInterrupt = createApprovalInterrupt({
   id: 'interrupt_pending',
   sn: 'REV-2026-04-24-001',
   status: APPROVAL_STATUS.PENDING,
   message: '算法方案评审单正在评审中',
+  toolArgs: MOCK_TOOL_ARGS_LONG,
 });
 const pendingScenario = createInterruptScenario({
   scenarioId: 'interrupt_pending',
-  intro: '【待审批】已生成算法方案，关联评审单待您处理：',
+  intro: '【待审批 · 长参数】已生成算法方案，关联评审单待您处理：',
   interrupt: pendingInterrupt,
   outcome: { type: 'interrupt', interrupts: [pendingInterrupt] },
   status: MessageStatus.Pending,
 });
 
-// —— 场景 2：已批准（单据 approved，仍展示审批卡片）——
+// —— 场景 2：草稿（与 pending 同属待审批交互）+ 长参数 ——
+const draftInterrupt = createApprovalInterrupt({
+  id: 'interrupt_draft',
+  sn: 'REV-2026-04-24-000',
+  status: APPROVAL_STATUS.DRAFT,
+  message: '算法方案评审单草稿待提交审批',
+  toolArgs: MOCK_TOOL_ARGS_LONG,
+});
+const draftScenario = createInterruptScenario({
+  scenarioId: 'interrupt_draft',
+  intro: '【草稿 · 长参数】评审单处于草稿态，交互同待审批：',
+  interrupt: draftInterrupt,
+  outcome: { type: 'interrupt', interrupts: [draftInterrupt] },
+  status: MessageStatus.Pending,
+});
+
+// —— 场景 3：已批准 + 短参数（无展开）——
 const approvedInterrupt = createApprovalInterrupt({
   id: 'interrupt_approved',
   sn: 'REV-2026-04-24-002',
   status: APPROVAL_STATUS.APPROVED,
   message: '算法方案评审单已通过',
+  toolArgs: MOCK_TOOL_ARGS_SHORT,
 });
 const approvedScenario = createInterruptScenario({
   scenarioId: 'interrupt_approved',
-  intro: '【已批准】评审单已通过，可继续后续流程：',
+  intro: '【已批准 · 短参数】评审单已通过，可继续后续流程：',
   interrupt: approvedInterrupt,
   outcome: { type: 'interrupt', interrupts: [approvedInterrupt] },
 });
 
-// —— 场景 3：已拒绝 ——
+// —— 场景 4：已拒绝 + 短参数 ——
 const rejectedInterrupt = createApprovalInterrupt({
   id: 'interrupt_rejected',
   sn: 'REV-2026-04-24-003',
   status: APPROVAL_STATUS.REJECTED,
   message: '算法方案评审单已被拒绝',
+  toolArgs: MOCK_TOOL_ARGS_SHORT,
 });
 const rejectedScenario = createInterruptScenario({
   scenarioId: 'interrupt_rejected',
-  intro: '【已拒绝】评审单未通过，请根据意见调整后重提：',
+  intro: '【已拒绝 · 短参数】评审单未通过，请根据意见调整后重提：',
   interrupt: rejectedInterrupt,
   outcome: { type: 'interrupt', interrupts: [rejectedInterrupt] },
 });
 
-// —— 场景 4：已取消 ——
+// —— 场景 5：已取消 + 短参数 ——
 const cancelledInterrupt = createApprovalInterrupt({
   id: 'interrupt_cancelled',
   sn: 'REV-2026-04-24-004',
   status: APPROVAL_STATUS.CANCELLED,
   message: '算法方案评审单已取消',
+  toolArgs: MOCK_TOOL_ARGS_SHORT,
 });
 const cancelledScenario = createInterruptScenario({
   scenarioId: 'interrupt_cancelled',
-  intro: '【已取消】该评审单已被发起人撤销：',
+  intro: '【已取消 · 短参数】该评审单已被发起人取消：',
   interrupt: cancelledInterrupt,
   outcome: { type: 'interrupt', interrupts: [cancelledInterrupt] },
 });
 
-// —— 场景 5：已撤销 ——
+// —— 场景 6：已撤销 · 无参数（不渲染参数区）——
 const revokedInterrupt = createApprovalInterrupt({
   id: 'interrupt_revoked',
   sn: 'REV-2026-04-24-005',
@@ -177,19 +236,50 @@ if (revokedInterrupt.metadata) {
 }
 const revokedScenario = createInterruptScenario({
   scenarioId: 'interrupt_revoked',
-  intro: '【已撤销】该评审单已由发起人自行撤销：',
+  intro: '【已撤销 · 无参数】该评审单已由发起人自行撤销：',
   interrupt: revokedInterrupt,
   outcome: { type: 'interrupt', interrupts: [revokedInterrupt] },
 });
 
-// —— 场景 6：用户已 resume（outcome.success + result，不渲染中断卡片）——
+// —— 场景 7：已过期 + 短参数 ——
+const expiredInterrupt = createApprovalInterrupt({
+  id: 'interrupt_expired',
+  sn: 'REV-2026-04-24-007',
+  status: APPROVAL_STATUS.EXPIRED,
+  message: '算法方案评审单已过期',
+  toolArgs: MOCK_TOOL_ARGS_SHORT,
+});
+const expiredScenario = createInterruptScenario({
+  scenarioId: 'interrupt_expired',
+  intro: '【已过期 · 短参数】评审单已超过审批时效：',
+  interrupt: expiredInterrupt,
+  outcome: { type: 'interrupt', interrupts: [expiredInterrupt] },
+});
+
+// —— 场景 8：已废弃 + 短参数 ——
+const abandonedInterrupt = createApprovalInterrupt({
+  id: 'interrupt_abandoned',
+  sn: 'REV-2026-04-24-008',
+  status: APPROVAL_STATUS.ABANDONED,
+  message: '算法方案评审单已废弃',
+  toolArgs: MOCK_TOOL_ARGS_SHORT,
+});
+const abandonedScenario = createInterruptScenario({
+  scenarioId: 'interrupt_abandoned',
+  intro: '【已废弃 · 短参数】评审单已被废弃，无法继续流转：',
+  interrupt: abandonedInterrupt,
+  outcome: { type: 'interrupt', interrupts: [abandonedInterrupt] },
+});
+
+// —— 场景 9：outcome.success 回显审批单（短参数）——
 const resumedScenario = createInterruptScenario({
   scenarioId: 'interrupt_resumed',
-  intro: '【已处理】您已确认关注该评审单，Agent 将继续执行：',
+  intro: '【已处理 · success 回显】您已确认关注该评审单，Agent 将继续执行：',
   interrupt: createApprovalInterrupt({
     id: 'interrupt_resumed',
     sn: 'REV-2026-04-24-006',
     status: APPROVAL_STATUS.PENDING,
+    toolArgs: MOCK_TOOL_ARGS_SHORT,
   }),
   outcome: { type: 'success' },
   result: {
@@ -206,6 +296,7 @@ const resumedScenario = createInterruptScenario({
           title: '算法方案评审单',
           url: 'https://example.com/review-tickets/REV-2026-04-24-006',
         },
+        toolArgs: MOCK_TOOL_ARGS_SHORT,
       },
     },
   } satisfies AIDevToolApprovalResume,
@@ -317,14 +408,22 @@ const userQuestionAnsweredScenario = createInterruptScenario({
   result: userQuestionAnsweredResult,
 });
 
-/** playground 全量中断 mock：覆盖审批态 + resume 态 + 兜底态 + 用户回答问题 */
-export const MOCK_INTERRUPT_MESSAGES: Message[] = [
+/** playground 审批单据专用 mock：覆盖全状态 + 长/短/无参数展示 */
+export const MOCK_APPROVAL_MESSAGES: Message[] = [
   ...pendingScenario,
+  ...draftScenario,
   ...approvedScenario,
   ...rejectedScenario,
   ...cancelledScenario,
   ...revokedScenario,
+  ...expiredScenario,
+  ...abandonedScenario,
   ...resumedScenario,
+];
+
+/** playground 全量中断 mock：审批 + resume + 兜底 + 用户回答问题 */
+export const MOCK_INTERRUPT_MESSAGES: Message[] = [
+  ...MOCK_APPROVAL_MESSAGES,
   ...unsupportedScenario,
   ...userQuestionScenario,
   ...userQuestionAnsweredScenario,

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/interrupt.ts
@@ -69,6 +69,10 @@ export type AIDevToolApprovalInterruptPayloadMetaData = {
     // 单据链接
     url: string;
   };
+  /**
+   * 工具参数
+   */
+  toolArgs?: Record<string, any>;
 };
 
 /**

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/interrupt-message.spec.ts
@@ -145,6 +145,49 @@ describe('InterruptMessage', () => {
     expect(wrapper.text()).toContain('REV-2026-04-24-001');
     expect(wrapper.text()).toContain('2026-04-24 14:30:15');
     expect(wrapper.text()).toContain('张三、李四、王五');
+    // 默认 fixture 无 toolArgs，不渲染参数区
+    expect(wrapper.find('.ai-tool-approval-args').exists()).toBe(false);
+  });
+
+  it('存在 metadata.toolArgs 时应渲染工具参数，空对象不渲染', () => {
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [
+          {
+            ...approvalInterrupt,
+            metadata: {
+              ...approvalInterrupt.metadata!,
+              toolArgs: { path: '/tmp/demo.py', force: true },
+            },
+          },
+        ],
+      }),
+    });
+
+    const args = wrapper.find('.ai-tool-approval-args');
+    expect(args.exists()).toBe(true);
+    expect(args.text()).toContain('参数');
+    expect(args.text()).toContain('"path": "/tmp/demo.py"');
+    expect(args.text()).toContain('"force": true');
+
+    wrapper.unmount();
+    wrapper = mount(InterruptMessage, {
+      props: buildInterruptProps({
+        type: 'interrupt',
+        interrupts: [
+          {
+            ...approvalInterrupt,
+            metadata: {
+              ...approvalInterrupt.metadata!,
+              toolArgs: {},
+            },
+          },
+        ],
+      }),
+    });
+
+    expect(wrapper.find('.ai-tool-approval-args').exists()).toBe(false);
   });
 
   it('revoked 状态应该显示已撤销并使用独立状态样式', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-args.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-args.vue
@@ -1,0 +1,198 @@
+<template>
+  <div
+    v-if="hasArgs"
+    class="ai-tool-approval-args"
+  >
+    <!-- 参数标题：文件图标 + 「参数：」 -->
+    <div class="ai-tool-approval-args-header">
+      <ToolApprovalArgsIcon class="ai-tool-approval-args-header-icon" />
+      <span class="ai-tool-approval-args-header-label">{{ t('参数') }}：</span>
+    </div>
+
+    <!-- 参数内容：格式化 JSON，默认最多 3 行，超出后可展开/收起 -->
+    <div class="ai-tool-approval-args-body">
+      <pre
+        ref="codeRef"
+        class="ai-tool-approval-args-code"
+        :class="{ 'is-collapsed': isCollapsed, 'is-expanded': isExpanded }"
+        v-text="formattedArgs"
+      />
+      <div
+        v-if="hasOverflow"
+        class="ai-tool-approval-args-toggle"
+        @click="toggle"
+      >
+        <span class="ai-tool-approval-args-toggle-text">{{ expanded ? t('收起') : t('展开更多') }}</span>
+        <ArrowLeftIcon
+          class="ai-tool-approval-args-toggle-icon"
+          :class="{ 'is-expanded': expanded }"
+        />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { computed, onBeforeUnmount, onMounted, shallowRef, useTemplateRef, watch } from 'vue';
+
+  import { ArrowLeftIcon, ToolApprovalArgsIcon } from '../../../icons';
+  import { t } from '../../../lang/lang';
+
+  // 折叠态最多显示 3 行，行高固定 18px，故折叠高度阈值为 3 * 18 = 54px
+  const COLLAPSED_MAX_HEIGHT = 90;
+
+  const props = defineProps<{
+    // 工具参数，来源于中断 metadata.toolArgs
+    toolArgs?: Record<string, unknown>;
+  }>();
+
+  const codeRef = useTemplateRef<HTMLElement>('codeRef');
+  // 用户是否点击展开
+  const expanded = shallowRef(false);
+  // 内容是否超过 3 行（超出才需要展开/收起）
+  const hasOverflow = shallowRef(false);
+
+  const hasArgs = computed(() => !!props.toolArgs && Object.keys(props.toolArgs).length > 0);
+  // 参数以两空格缩进的 JSON 美化展示，异常兜底为空串
+  const formattedArgs = computed(() => {
+    if (!hasArgs.value) return '';
+    try {
+      return JSON.stringify(props.toolArgs, null, 2);
+    } catch {
+      return '';
+    }
+  });
+
+  const isCollapsed = computed(() => hasOverflow.value && !expanded.value);
+  const isExpanded = computed(() => hasOverflow.value && expanded.value);
+
+  // 以内容完整高度（scrollHeight）与阈值比较判断是否溢出；折叠态下 scrollHeight 仍为完整内容高度
+  const measureOverflow = () => {
+    const el = codeRef.value;
+    if (!el) return;
+    hasOverflow.value = el.scrollHeight > COLLAPSED_MAX_HEIGHT;
+  };
+
+  const toggle = () => {
+    expanded.value = !expanded.value;
+  };
+
+  // 卡片可能位于可拖拽面板中，宽度变化会影响换行进而改变行数，用 ResizeObserver 精准重算，避免深监听/轮询
+  let resizeObserver: ResizeObserver | undefined;
+
+  onMounted(() => {
+    measureOverflow();
+    if (typeof ResizeObserver !== 'undefined' && codeRef.value) {
+      resizeObserver = new ResizeObserver(() => measureOverflow());
+      resizeObserver.observe(codeRef.value);
+    }
+  });
+
+  onBeforeUnmount(() => resizeObserver?.disconnect());
+
+  // 参数内容变化时重置展开态并重新测量
+  watch(formattedArgs, () => {
+    expanded.value = false;
+    measureOverflow();
+  });
+</script>
+
+<style lang="scss">
+  .ai-tool-approval-args {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+    padding: 12px;
+    background: #fff;
+    border: 1px solid #f0f1f5;
+    border-radius: 4px;
+
+    &-header {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+    }
+
+    &-header-icon {
+      flex: 0 0 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &-header-label {
+      font-size: var(--ai-font-size, 12px);
+      line-height: 18px;
+      color: #666;
+    }
+
+    &-body {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      width: 100%;
+      padding: 12px 0 12px 8px;
+      background: #f5f7fa;
+    }
+
+    &-code {
+      width: 100%;
+      margin: 0;
+      overflow: hidden;
+      font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+      font-size: var(--ai-font-size, 12px);
+      line-height: 18px;
+      color: #666;
+      overflow-wrap: break-word;
+      white-space: pre-wrap;
+
+      // 折叠态：最多 3 行（54px），超出裁剪
+      &.is-collapsed {
+        max-height: 54px;
+      }
+
+      // 展开态：限制最大高度并滚动，避免超长参数把卡片撑爆
+      &.is-expanded {
+        max-height: 300px;
+        overflow-y: auto;
+      }
+    }
+
+    // 文字与箭头统一继承 toggle 的 color，hover 时整体变色，避免选择器特异性顺序问题
+    &-toggle {
+      display: flex;
+      gap: 4px;
+      align-items: center;
+      justify-content: center;
+      width: 100%;
+      color: #3a84ff;
+      cursor: pointer;
+      user-select: none;
+
+      &:hover {
+        color: #1768ef;
+      }
+    }
+
+    &-toggle-text {
+      font-size: var(--ai-font-size, 12px);
+      line-height: 18px;
+    }
+
+    &-toggle-icon {
+      width: 12px;
+      height: 12px;
+      transform: rotate(-90deg);
+      transition: transform 0.2s ease;
+
+      path {
+        stroke-width: 120;
+      }
+
+      // 展开态箭头向上
+      &.is-expanded {
+        transform: rotate(90deg);
+      }
+    }
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/tool-approval-card.vue
@@ -57,7 +57,8 @@
         <dd>{{ ticket.submit_time || '--' }}</dd>
       </div>
     </dl>
-
+    <!-- 工具参数展示：内容超过 3 行时支持展开/收起，无参数时不渲染 -->
+    <ToolApprovalArgs :tool-args="interrupt.metadata?.toolArgs" />
     <div
       v-if="isPendingApproval"
       class="ai-tool-approval-card__processor"
@@ -134,6 +135,7 @@
     TimeIcon,
   } from '../../../icons';
   import { t } from '../../../lang/lang';
+  import ToolApprovalArgs from './tool-approval-args.vue';
 
   import type { AIDevToolApprovalInterrupt, OnInterruptResume } from '../../../ag-ui/types/interrupt';
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/icons/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/icons/interrupt.ts
@@ -171,3 +171,20 @@ export const SkipIcon = h(
     }),
   ],
 );
+
+export const ToolApprovalArgsIcon = h(
+  'svg',
+  {
+    ...commonSVGProps,
+    class: {
+      [commonSVGProps.class]: true,
+      'ai-tool-approval-args-icon': true,
+    },
+  },
+  [
+    h('path', {
+      d: 'M672 64L896 288.384V928a32 32 0 0 1-32 32h-704a30.72 30.72 0 0 1-32-30.4V94.464A32 32 0 0 1 160 64h512zM576 128.128H192v767.744h640v-511.36H608a32 32 0 0 1-32-32V128.128z m160 512.896v64.128H272v-64.128h464z m-80-128.256v64.128h-384V512.768h384zM432 384.64V448.64h-160V384.576h160zM640 128.128v190.72l192 1.6-192-192.32z',
+      fill: '#3A84FF',
+    }),
+  ],
+);

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -123,6 +123,8 @@ export const lang = {
   已取消审批: 'Approval Cancelled',
   刷新单据状态: 'Refresh Ticket Status',
   单据已取消审批: 'Approval Cancelled',
+  展开更多: 'Show More',
+  收起: 'Collapse',
   '该单据已被拒绝，无法取消': 'This ticket has been rejected and cannot be cancelled',
   '该单据已通过，无法取消': 'This ticket has been approved and cannot be cancelled',
   '单据已取消，无需重复点击': 'This ticket has been cancelled, no need to click again',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/tool-approval-card.md
@@ -3,9 +3,9 @@ name: ToolApprovalCard 工具审批卡片
 slug: tool-approval-card
 kind: component
 domain: agent
-description: 渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作，readonly prop 支持纯只读展示。
+description: 渲染 AIDevToolApproval 中断的审批信息、可选工具参数与取消/刷新操作，readonly prop 支持纯只读展示。
 aiSummary: >
-  渲染 AIDevToolApproval 中断的审批信息与取消/刷新操作；readonly prop 可用于纯只读展示（outcome.success 回显已改为可交互，不再使用 readonly）。
+  渲染 AIDevToolApproval 中断的审批信息、可选 metadata.toolArgs 工具参数与取消/刷新操作；readonly prop 可用于纯只读展示（outcome.success 回显已改为可交互，不再使用 readonly）。
   源码位置：src/components/chat-message/interrupt-message/tool-approval-card.vue。
 relatedComponents:
   - slug: interrupt-message
@@ -29,6 +29,12 @@ sinceVersion: 1.0.0
         submit_time: '2026-04-24 14:30:15',
         title: '算法方案评审单',
         url: 'https://example.com/review-tickets/REV-2026-04-24-001',
+      },
+      // 可选工具参数：有内容时审批卡片内展示格式化 JSON
+      toolArgs: {
+        path: '/tmp/demo.py',
+        force: true,
+        timeout: 30,
       },
     },
   }
@@ -107,9 +113,12 @@ AI Dev 第三方工具审批（`InterruptReason.AIDevToolApproval`）专用卡�
 ToolApprovalCard
 ├── 标题栏：左侧色条 + 单据标题 + 复制图标 + 状态徽章（审批中/已通过/已拒绝/已撤销等）
 ├── 字段区：单据编号、提交时间
+├── ToolApprovalArgs：有 metadata.toolArgs 时展示格式化 JSON（超高可展开/收起）；无参数或空对象不渲染
 ├── 处理人：仅 `pending` / `draft` 时展示当前处理人（overflow-tips 省略）
 └── 操作区：查看单据详情（新窗口打开 url）、取消审批（仅 pending / draft 且非 readonly；点击后 loading 防重复提交；分享只读渲染下禁用）
 ```
+
+**工具参数区**（内部子组件 `ToolApprovalArgs`，未对外导出）：读取 `interrupt.metadata.toolArgs`，以两空格缩进 JSON 展示。内容超过折叠高度时可「展开更多 / 收起」；`toolArgs` 缺省或为空对象时整块不渲染。
 
 **标题栏刷新图标**（仅 `pending` / `draft` 且非 `readonly` 时展示，复制图标右侧）：取消审批为后端轮询、状态无法实时返回，用户可点击刷新图标主动拉取单据最新状态，`hover` 显示 tooltip「刷新单据状态」。刷新做 **2s 冷却节流**（冷却中图标置灰不可点）；点击「取消审批」也会触发一次 2s 冷却，即取消后需间隔 2s 才能继续刷新。分享只读渲染下刷新图标禁用。
 
@@ -180,6 +189,11 @@ ToolApprovalCard
         submit_time: '2026-04-24 14:30:15',
         title: '算法方案评审单',
         url: 'https://example.com/tickets/001',
+      },
+      toolArgs: {
+        path: '/tmp/demo.py',
+        force: true,
+        timeout: 30,
       },
     },
   };
@@ -262,7 +276,7 @@ ToolApprovalCard
 
 | 属性名            | 类型                         | 默认值 | 说明                                         |
 | ----------------- | ---------------------------- | ------ | -------------------------------------------- |
-| interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`               |
+| interrupt         | `AIDevToolApprovalInterrupt` | —      | **必填**，含 `metadata.ticket`；可选 `metadata.toolArgs`（有内容时渲染参数区） |
 | onInterruptResume | `OnInterruptResume`          | —      | 取消审批 / 刷新时触发，签名为 `(payload, interrupt)`，payload 为 `{ operation, payload: { interrupt_id } }`，`operation` 取 `InterruptResumeOperation.ApprovalCancel`（取消）或 `InterruptResumeOperation.ApprovalRefresh`（刷新），两者 payload 结构一致 |
 | readonly          | `boolean`                    | —      | 纯只读展示：隐藏取消 / 刷新按钮，不接受交互（`outcome.success` 回显已改为可交互，框架内部不再传入） |
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
@@ -94,6 +94,8 @@ type AIDevToolApprovalInterruptPayloadMetaData = {
     title: string;
     url: string;
   };
+  /** 工具参数，审批卡片内格式化 JSON 展示，缺省或空对象时不渲染参数区 */
+  toolArgs?: Record<string, any>;
 };
 
 type AIDevToolApprovalInterrupt = BaseInterrupt<
@@ -104,7 +106,7 @@ type AIDevToolApprovalInterrupt = BaseInterrupt<
 
 ## AIDevToolApprovalResume
 
-AI Dev 第三方工具审批中断响应（resume 后用于 `outcome.success` 时会话内回显审批单）。`payload.metadata` 透传中断时的 `metadata`（含 `ticket`），以便复用 `ToolApprovalCard` 只读渲染：
+AI Dev 第三方工具审批中断响应（resume 后用于 `outcome.success` 时会话内回显审批单）。`payload.metadata` 透传中断时的 `metadata`（含 `ticket` 与可选 `toolArgs`），以便复用 `ToolApprovalCard` 渲染：
 
 ```typescript
 type AIDevToolApprovalResume = BaseResume<


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】工具审批卡支持展示工具参数（1070093903135922101）

AI Dev 工具审批中断场景下，审批人需要在会话内直接看到本次工具调用入参，便于核对后再处理单据。

## 改动
- `AIDevToolApprovalInterruptPayloadMetaData` 扩展可选字段 `toolArgs`
- 新增 `ToolApprovalArgs` 子组件：格式化 JSON 展示，超长支持展开/收起，无参数或空对象不渲染
- `ToolApprovalCard` 接入参数区
- 同步 i18n（展开更多/收起）、图标、单测、wiki 与 playground mock 场景

## 影响面
- `ToolApprovalCard` / `InterruptMessage`（AIDevToolApproval）
- 后端需下发 `metadata.toolArgs` 才展示参数区；缺省行为与改前一致

## 测试
- [x] pending/draft 等状态有 toolArgs 时正确展示参数
- [x] toolArgs 缺省或空对象不渲染参数区
- [x] 长参数可展开/收起，短参数无展开入口
- [x] 相关 vitest 通过


Made with [Cursor](https://cursor.com)