### PR TITLE
fix: RabbitMQ SSE 队列长度根治（MySQL 持久日志 + 落库即 prune） --story=1070093903135579259

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -498,6 +498,19 @@ class ChatCompletionAgent(BaseModel):
             thread_id=queue_thread_id or agent_input.thread_id,
             defer_cleanup_on_complete=background_only,
         )
+
+        # 落库后裁剪 RabbitMQ 已提交前缀：writer 每落库一条消息，就把已落库 messageId 集合
+        # 回调给 message_handler，从主队列头部删掉这些消息，避免长会话队列无限堆积。
+        # 已删内容必可由 MySQL 快照恢复；handler 不支持 prune 时为 no-op。
+        qtid = queue_thread_id or agent_input.thread_id
+        if isinstance(self.event_handler, BaseSessionWriter):
+            message_handler = helper.message_handler
+
+            def _prune_committed(committed_message_ids: set[str]) -> None:
+                message_handler.prune_committed(qtid, committed_message_ids)
+
+            self.event_handler.commit_hook = _prune_committed
+
         producer = self._build_resume_aware_producer(
             agui_entry, agent_input, agent_e=agent_e, cfg=cfg, resume=resume
         )

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -23,6 +23,7 @@ from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
     InterruptMessage,
+    MessageSnapshotEventExtend,
     RunFinishedSuccessOutcome,
     serialize_run_finished_outcome,
 )
@@ -531,7 +532,42 @@ class ChatCompletionAgent(BaseModel):
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+        # gap 兜底：队列头被 prune 后若慢消费者游标落到被删段之前，用当前 graph checkpoint
+        # 重建一份 MESSAGES_SNAPSHOT 让前端 reset，再从队列尾续读，避免丢内容。
+        snapshot_provider = self._make_gap_snapshot_provider(agent_e, cfg)
+        yield from helper.stream(
+            remaining_producer, on_complete=self._on_complete, snapshot_provider=snapshot_provider
+        )
+
+    def _make_gap_snapshot_provider(
+        self, agent_e: Runnable | None, cfg: RunnableConfig | None
+    ) -> Callable[[], list] | None:
+        """构造 replay gap 兜底用的快照 provider：从 graph checkpoint 重建当前 MESSAGES_SNAPSHOT。
+
+        数据源为 LangGraph checkpoint state 的 messages（已落库消息的事实源，与终态快照同源），
+        经 ``langchain_messages_to_agui`` 转为 AG-UI 消息后编码为一帧 SSE。任何异常/无消息返回空，
+        消费端据此优雅降级。返回 None 表示缺少 graph/cfg，无法重建（消费端将跳过被删段）。
+        """
+        if agent_e is None or cfg is None:
+            return None
+
+        def _provider() -> list:
+            try:
+                state = run_coro_sync(agent_e.aget_state(cfg), timeout=5)
+                values = getattr(state, "values", None) or {}
+                messages = values.get("messages", []) if isinstance(values, dict) else []
+                agui_messages = langchain_messages_to_agui(messages)
+                if not agui_messages:
+                    return []
+                frame = EventEncoder().encode(
+                    MessageSnapshotEventExtend(type=EventType.MESSAGES_SNAPSHOT, messages=agui_messages)
+                )
+                return [frame]
+            except Exception:
+                logger.exception("[GapResync] rebuild snapshot failed")
+                return []
+
+        return _provider
 
     @staticmethod
     def _collect_replay_message_ids(message_handler: Any, thread_id: str | None) -> set[str]:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -505,11 +505,76 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 1：同步拉取头部帧并直接 yield ----
         head_frames = []
         remaining_producer = self._extract_head_frames(producer, head_frames)
+        # 多端 replay 去重：阶段 1 现发的 MESSAGES_SNAPSHOT 由本连接 input.messages（DB 状态）
+        # 构造，可能已含当前 run 那条半截 assistant 消息；而阶段 2 replay 会从头把同一条
+        # （同 message_id）完整重放。若不处理，前端会“快照已有该 id + replay 又 START(同 id)”
+        # 而产生重复消息。这里在直传快照前，剔除 replay 缓存中将被重放的 message_id，让 replay
+        # 成为该消息的唯一来源（内容完整，无需 offset 对齐），保证本连接输出流自洽、零重叠。
+        replay_message_ids = self._collect_replay_message_ids(
+            helper.message_handler, queue_thread_id or agent_input.thread_id
+        )
+        head_frames = self._dedup_snapshot_head_frames(head_frames, replay_message_ids)
         for frame in head_frames:
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+
+    @staticmethod
+    def _collect_replay_message_ids(message_handler: Any, thread_id: str | None) -> set[str]:
+        """收集阶段 2 replay 将从头重放的 ``TEXT_MESSAGE_START`` 的 message_id。
+
+        仅当存在待重放消息时才非破坏性 peek 缓存日志；handler 不支持 peek、超时或任何异常
+        一律按“无重放”处理（返回空集），回退到原有行为，绝不影响正常流。
+        """
+        if not thread_id:
+            return set()
+        try:
+            if not message_handler.has_pending_messages(thread_id):
+                return set()
+            cached, _ = message_handler.get_messages_since(thread_id, 0, timeout=0.5)
+        except Exception:
+            return set()
+
+        message_ids: set[str] = set()
+        for frame in cached or []:
+            if not isinstance(frame, str) or '"type":"TEXT_MESSAGE_START"' not in frame:
+                continue
+            try:
+                payload = json.loads(frame[len("data: ") :] if frame.startswith("data: ") else frame)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            message_id = payload.get("messageId") or payload.get("message_id")
+            if message_id:
+                message_ids.add(message_id)
+        return message_ids
+
+    @staticmethod
+    def _dedup_snapshot_head_frames(head_frames: list, replay_message_ids: set[str]) -> list:
+        """从阶段 1 头部帧的 ``MESSAGES_SNAPSHOT`` 中剔除将被 replay 重放的消息，避免重复。"""
+        if not replay_message_ids:
+            return head_frames
+        return [ChatCompletionAgent._strip_snapshot_messages(f, replay_message_ids) for f in head_frames]
+
+    @staticmethod
+    def _strip_snapshot_messages(frame: Any, exclude_ids: set[str]) -> Any:
+        """若 ``frame`` 是 ``MESSAGES_SNAPSHOT``，剔除 id ∈ ``exclude_ids`` 的消息后重新编码。
+
+        非快照帧、无法解析或无需改动时原样返回，保持其余帧字节不变。
+        """
+        if not isinstance(frame, str) or '"type":"MESSAGES_SNAPSHOT"' not in frame:
+            return frame
+        body = frame[len("data: ") :] if frame.startswith("data: ") else frame
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return frame
+        messages = data.get("messages") or []
+        kept = [m for m in messages if (m.get("messageId") or m.get("id")) not in exclude_ids]
+        if len(kept) == len(messages):
+            return frame
+        data["messages"] = kept
+        return f"data: {json.dumps(data, ensure_ascii=False, separators=(',', ':'))}\n\n"
 
     @staticmethod
     def _extract_head_frames(

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -136,8 +136,21 @@ class BaseSessionWriter(ABC):
         # 用于追踪已写入的 assistant 消息的 builtin_property，以便后续追加 tool_calls 时合并
         # key: assistant_message_id, value: builtin_property dict
         self._assistant_builtin_properties: dict[str, dict] = {}
+        # 可选的「落库后」回调：入参为当前已落库 messageId 集合。
+        # 上层(如流式链路)据此裁剪 RabbitMQ 已提交前缀，避免长会话队列堆积；默认关闭。
+        self.commit_hook: Callable[[set[str]], None] | None = None
 
     # ---------- 公共事件入口 ----------
+
+    def _notify_committed(self) -> None:
+        """落库有新增时，把当前已落库 messageId 集合通知给 commit_hook（如 RabbitMQ prune）。"""
+        hook = self.commit_hook
+        if hook is None or not self._written_message_ids:
+            return
+        try:
+            hook(set(self._written_message_ids))
+        except Exception:
+            logger.exception("commit_hook failed for session_code=%s", self.session_code)
 
     def set_tools(self, tools: list | None) -> None:
         self._tools_mapping = {tool.name: tool for tool in tools} if tools else {}
@@ -148,6 +161,7 @@ class BaseSessionWriter(ABC):
         Args:
             event: AG-UI 事件
         """
+        committed_before = len(self._written_message_ids)
         if event.type == EventType.RAW:
             self._dispatch_raw_event(event)
         elif event.type == EventType.CUSTOM:
@@ -168,6 +182,10 @@ class BaseSessionWriter(ABC):
             self.handle_thinking_message_end(event)
         elif event.type == EventType.RUN_FINISHED:
             self.handle_run_finished(event)
+
+        # 本次事件若产生了新的落库消息，通知 commit_hook（用于裁剪已提交队列前缀）
+        if len(self._written_message_ids) > committed_before:
+            self._notify_committed()
 
     def _dispatch_raw_event(self, event: RawEvent) -> None:
         """分发原始事件到类型化处理方法"""

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -242,6 +242,14 @@ class BaseMessageQueueHandler(ABC):
         """
         return False
 
+    def prune_committed(self, thread_id: str, committed_message_ids: set[str]) -> int:
+        """删除队列头部「messageId 已落库」的消息前缀，返回删除条数。
+
+        默认 no-op（返回 0）。支持从头 prune 已提交日志的处理器应覆盖此方法，
+        使 RabbitMQ 只保留未落库的在途消息，避免队列随长会话无限堆积。
+        """
+        return 0
+
     @abstractmethod
     def get_dlq_messages(self, thread_id: str) -> list[Any]:
         """获取死信队列中的所有消息（不移除）

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -234,6 +234,14 @@ class BaseMessageQueueHandler(ABC):
         """
         return False
 
+    def has_active_producer(self, thread_id: str) -> bool:
+        """检查指定 thread_id 当前是否仍有活跃 producer 在生产。
+
+        默认返回 False。支持跨进程生产者互斥的消息处理器应覆盖此方法，
+        供延迟清理线程判断，避免删掉仍在生产中的会话。
+        """
+        return False
+
     @abstractmethod
     def get_dlq_messages(self, thread_id: str) -> list[Any]:
         """获取死信队列中的所有消息（不移除）

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -36,6 +36,22 @@ class StreamCancelledError(Exception):
     """流被用户主动取消（停止会话）"""
 
 
+class ReplayGapError(Exception):
+    """消费者游标落在已被 prune 的段之前，无法从队列续读。
+
+    发生在「producer 落库后裁剪队列头部」时，慢消费者的游标落后于队列当前最小 seq：
+    此时缺失的 seq 段只能由 MySQL 快照恢复，上层需重拉快照补齐，再从 ``min_seq`` 续读。
+    """
+
+    def __init__(self, thread_id: str, since_seq: int, min_seq: int):
+        self.thread_id = thread_id
+        self.since_seq = since_seq
+        self.min_seq = min_seq
+        super().__init__(
+            f"replay gap for thread_id={thread_id}: since_seq={since_seq} < min_seq={min_seq}"
+        )
+
+
 @runtime_checkable
 class ConsumerManagementProtocol(Protocol):
     """消费者管理协议

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -17,7 +17,7 @@ from urllib.parse import quote
 import pika
 from environs import Env
 
-from .base import BaseMessageQueueHandler, QueueTTLConfig
+from .base import BaseMessageQueueHandler, QueueTTLConfig, ReplayGapError
 from .constants import HEARTBEAT_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
@@ -1178,6 +1178,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         since_seq = max(offset, 0)
 
         while True:
+            items: Optional[list[tuple[int, Any]]] = None
             try:
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
@@ -1192,14 +1193,21 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             restored,
                         )
                         items = self._peek_queue_messages(channel, main_queue_name)
-
-                if items:
-                    max_seq = max(seq for seq, _ in items)
-                    if max_seq > since_seq:
-                        payloads = [message for seq, message in items if seq > since_seq]
-                        return payloads, max_seq
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
+                items = None
+
+            # gap 检测与返回放在 try 之外：ReplayGapError 需向上层传播（不被上面的 except 吞掉）
+            if items:
+                seqs = [seq for seq, _ in items]
+                max_seq = max(seqs)
+                min_seq = min(seqs)
+                # 消费者游标落在「已被 prune 的段」之前：队列已无法续读，需上层重拉 MySQL 快照补齐
+                if since_seq > 0 and min_seq > since_seq + 1:
+                    raise ReplayGapError(thread_id=thread_id, since_seq=since_seq, min_seq=min_seq)
+                if max_seq > since_seq:
+                    payloads = [message for seq, message in items if seq > since_seq]
+                    return payloads, max_seq
 
             if deadline is not None and time.time() >= deadline:
                 raise TimeoutError("No message available within timeout")

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -336,6 +336,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         self._buffer_lock = threading.Lock()
         self._buffer_condition = threading.Condition(self._buffer_lock)
         self._flushing_threads: set[str] = set()
+        # 每个 thread 的单调递增消息序号：publish 时写入 message header，
+        # 消费者据此做 prune-稳定续读（seq > since_seq），不再依赖队列 list 下标。
+        self._seq_counters: dict[str, int] = {}
+        self._seq_lock = threading.Lock()
         self._replay_wait_condition = threading.Condition()
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
@@ -867,12 +871,15 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     queue_name = self._ensure_queue(channel, thread_id)
 
                     for message in messages_to_flush:
+                        seq = self._next_seq(thread_id)
                         body = pickle.dumps(message)
                         channel.basic_publish(
                             exchange="",
                             routing_key=queue_name,
                             body=body,
-                            properties=pika.BasicProperties(delivery_mode=2),
+                            properties=pika.BasicProperties(
+                                delivery_mode=2, headers={self._MSG_SEQ_HEADER: seq}
+                            ),
                         )
 
                     logger.debug(f"Flushed {len(messages_to_flush)} messages to queue {queue_name}")
@@ -1034,6 +1041,20 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             self._flushing_threads.discard(thread_id)
             self._buffer_condition.notify_all()
 
+    # 消息序号所用的 RabbitMQ message header key
+    _MSG_SEQ_HEADER = "x-msg-seq"
+
+    def _next_seq(self, thread_id: str) -> int:
+        """分配该 thread 的下一个单调递增消息序号。
+
+        publish 顺序即 seq 顺序（同一 thread 的 flush 由 ``_flushing_threads`` 串行化），
+        供消费者按 seq 续读；``clear`` 时会重置计数器（新 producer 启动前会 clear 队列）。
+        """
+        with self._seq_lock:
+            nxt = self._seq_counters.get(thread_id, 0) + 1
+            self._seq_counters[thread_id] = nxt
+            return nxt
+
     def flush(self, thread_id: Optional[str] = None) -> None:
         """立即推送缓冲区中的消息到 RabbitMQ
 
@@ -1051,12 +1072,15 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     queue_name = self._ensure_queue(channel, thread_id)
 
                     for message in messages_to_flush:
+                        seq = self._next_seq(thread_id)
                         body = pickle.dumps(message)
                         channel.basic_publish(
                             exchange="",
                             routing_key=queue_name,
                             body=body,
-                            properties=pika.BasicProperties(delivery_mode=2),
+                            properties=pika.BasicProperties(
+                                delivery_mode=2, headers={self._MSG_SEQ_HEADER: seq}
+                            ),
                         )
             except Exception as e:
                 logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1114,51 +1138,66 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
 
             return messages
 
-    def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。"""
-        messages = []
+    def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[tuple[int, Any]]:
+        """非破坏性读取队列中的全部消息，返回 ``(seq, message)`` 有序列表。
+
+        ``seq`` 取自 publish 时写入的 message header；对升级前无 header 的旧消息，
+        按 peek 顺序回退为 1-based 位置序号（未 prune 时与旧 list 下标行为一致）。
+        """
+        items: list[tuple[int, Any]] = []
         delivery_tags = []
 
         try:
             queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
             message_count = queue_info.method.message_count
-            for _ in range(message_count):
-                method_frame, _, body = channel.basic_get(queue=queue_name, auto_ack=False)
+            for idx in range(1, message_count + 1):
+                method_frame, properties, body = channel.basic_get(queue=queue_name, auto_ack=False)
                 if not method_frame:
                     break
                 delivery_tags.append(method_frame.delivery_tag)
-                messages.append(pickle.loads(body))
+                seq = None
+                headers = getattr(properties, "headers", None) if properties is not None else None
+                if headers:
+                    seq = headers.get(self._MSG_SEQ_HEADER)
+                items.append((seq if isinstance(seq, int) else idx, pickle.loads(body)))
         finally:
             for tag in delivery_tags:
                 channel.basic_nack(delivery_tag=tag, requeue=True)
 
-        return messages
+        return items
 
     def get_messages_since(self, thread_id: str, offset: int, timeout: Optional[float] = None) -> tuple[list[Any], int]:
-        """从会话日志的指定 offset 开始读取消息，读取后不删除底层缓存。"""
+        """从会话日志的指定 seq 游标之后读取消息，读取后不删除底层缓存。
+
+        ``offset`` 是消费者的 seq 游标（``since_seq``，0 表示从头）；返回 ``(payloads, cursor)``，
+        其中 ``payloads`` 为 ``seq > since_seq`` 的消息体，``cursor`` 为本轮可见的最大 seq。
+        采用 seq（而非 list 下标）使得队列头部被 prune 后消费者仍能正确续读、不重不漏。
+        """
         start_time = time.time()
         deadline = start_time + timeout if timeout is not None else None
-        offset = max(offset, 0)
+        since_seq = max(offset, 0)
 
         while True:
             try:
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
-                    all_messages = self._peek_queue_messages(channel, main_queue_name)
+                    items = self._peek_queue_messages(channel, main_queue_name)
 
                     # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                    if not all_messages and self._get_dlq_count(thread_id) > 0:
+                    if not items and self._get_dlq_count(thread_id) > 0:
                         restored = self._restore_from_dlq(thread_id)
                         logger.info(
                             "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
                             thread_id,
                             restored,
                         )
-                        all_messages = self._peek_queue_messages(channel, main_queue_name)
+                        items = self._peek_queue_messages(channel, main_queue_name)
 
-                next_offset = len(all_messages)
-                if next_offset > offset:
-                    return all_messages[offset:], next_offset
+                if items:
+                    max_seq = max(seq for seq, _ in items)
+                    if max_seq > since_seq:
+                        payloads = [message for seq, message in items if seq > since_seq]
+                        return payloads, max_seq
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
 
@@ -1432,6 +1471,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         with self._buffer_lock:
             if thread_id in self._message_buffer:
                 self._message_buffer[thread_id] = []
+
+        # 重置该 thread 的消息序号（新 producer 启动前会 clear，seq 从 1 重新计起）
+        with self._seq_lock:
+            self._seq_counters.pop(thread_id, None)
 
         # 检查并迁移不兼容的旧队列
         self._migrate_queue_if_needed(thread_id)

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -334,14 +334,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 消息缓冲队列：用于批量推送
         self._message_buffer: dict[str, list[Any]] = {}
         self._buffer_lock = threading.Lock()
+        self._buffer_condition = threading.Condition(self._buffer_lock)
+        self._flushing_threads: set[str] = set()
         self._replay_wait_condition = threading.Condition()
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
-
-        # flush 与 peek+buffer 合并的互斥锁（per thread_id，进程内）
-        # 防止 flush 在 peek 和 buffer 合并之间清空 buffer 导致消息丢失/重复
-        self._flush_peek_locks: dict[str, threading.Lock] = {}
-        self._flush_peek_locks_guard = threading.Lock()
 
         # 后台守护线程
         self._daemon_thread: Optional[threading.Thread] = None
@@ -400,13 +397,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """获取多消费者活跃状态队列名。"""
         return f"{self.ACTIVE_CONSUMER_PREFIX}{thread_id}"
 
-    def _get_flush_peek_lock(self, thread_id: str) -> threading.Lock:
-        """获取指定 thread_id 的 flush/peek 互斥锁（进程内，惰性创建）。"""
-        with self._flush_peek_locks_guard:
-            if thread_id not in self._flush_peek_locks:
-                self._flush_peek_locks[thread_id] = threading.Lock()
-            return self._flush_peek_locks[thread_id]
-
     def _create_dedicated_connection(self) -> pika.BlockingConnection:
         """创建不进入连接池的 RabbitMQ 连接，用于 exclusive queue 生命周期。"""
         params = pika.URLParameters(self._rabbitmq_url)
@@ -464,8 +454,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     def _wait_for_replay_retry(self, deadline: float | None, interval: float) -> None:
         """等待下一次 replay 检查。
 
-        本进程内有 buffer 写入或 replay lock 释放时会提前唤醒；跨进程 RabbitMQ 写入
-        无法通过本地 Condition 感知，因此仍保留短超时作为兜底重试。
+        本进程内有 RabbitMQ 提交或 replay lock 释放时会提前唤醒；跨进程 RabbitMQ
+        写入无法通过本地 Condition 感知，因此仍保留短超时作为兜底重试。
         """
         wait_time = interval
         if deadline is not None:
@@ -831,52 +821,44 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             logger.error(f"Error flushing messages on daemon exit: {e}")
 
     def _flush_messages(self) -> None:
-        """批量推送缓冲区中的所有消息到 RabbitMQ
-
-        对每个 thread_id，在 _flush_peek_lock 内完成"取出 buffer + publish"的原子操作，
-        确保与 get_messages_since（peek + buffer 合并）互斥，避免消息丢失/重复。
-        """
-        # 快速检查是否有消息需要 flush
+        """批量推送缓冲区中的所有消息到 RabbitMQ"""
         with self._buffer_lock:
             if not self._message_buffer:
                 return
-            thread_ids_to_flush = list(self._message_buffer.keys())
+            thread_ids = [thread_id for thread_id, messages in self._message_buffer.items() if messages]
 
-        # 按 thread_id 逐个 flush，每个 thread_id 在 flush_peek_lock 内完成
-        # "取出 buffer + publish" 的原子操作
-        any_flushed = False
-        for thread_id in thread_ids_to_flush:
-            flush_peek_lock = self._get_flush_peek_lock(thread_id)
+        if not thread_ids:
+            return
+
+        flushed = False
+        for thread_id in thread_ids:
+            messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
+            if not messages_to_flush:
+                continue
+
             try:
-                with flush_peek_lock:
-                    # 在 flush_peek_lock 内取出该 thread_id 的 buffer
-                    with self._buffer_lock:
-                        messages = self._message_buffer.pop(thread_id, [])
-                    if not messages:
-                        continue
+                with self._with_channel() as channel:
+                    queue_name = self._ensure_queue(channel, thread_id)
 
-                    # 在同一个 flush_peek_lock 内 publish 到 RabbitMQ
-                    with self._with_channel() as channel:
-                        queue_name = self._ensure_queue(channel, thread_id)
-                        for message in messages:
-                            body = pickle.dumps(message)
-                            channel.basic_publish(
-                                exchange="",
-                                routing_key=queue_name,
-                                body=body,
-                                properties=pika.BasicProperties(delivery_mode=2),
-                            )
-                    logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
-                    any_flushed = True
+                    for message in messages_to_flush:
+                        body = pickle.dumps(message)
+                        channel.basic_publish(
+                            exchange="",
+                            routing_key=queue_name,
+                            body=body,
+                            properties=pika.BasicProperties(delivery_mode=2),
+                        )
+
+                    logger.debug(f"Flushed {len(messages_to_flush)} messages to queue {queue_name}")
             except Exception as e:
-                logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
-                # 推送失败，将消息放回缓冲区（放到前面保持顺序）
-                with self._buffer_lock:
-                    if thread_id not in self._message_buffer:
-                        self._message_buffer[thread_id] = []
-                    self._message_buffer[thread_id] = messages + self._message_buffer[thread_id]
+                logger.error(f"Error flushing messages to RabbitMQ: {e}")
+                self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+                self._notify_replay_waiters()
+            else:
+                self._finish_thread_flush(thread_id)
+                flushed = True
 
-        if any_flushed:
+        if flushed:
             self._notify_replay_waiters()
 
     # ================== 死信队列操作 ==================
@@ -1002,7 +984,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if thread_id not in self._message_buffer:
                 self._message_buffer[thread_id] = []
             self._message_buffer[thread_id].append(message)
-        self._notify_replay_waiters()
+
+    def _take_thread_buffer_for_flush(self, thread_id: str) -> list[Any]:
+        """取出一个 thread 的待发布 buffer，并标记本进程内该 thread 正在 flush。"""
+        with self._buffer_condition:
+            if thread_id in self._flushing_threads:
+                return []
+
+            messages_to_flush = self._message_buffer.get(thread_id, [])
+            if not messages_to_flush:
+                return []
+
+            self._message_buffer[thread_id] = []
+            self._flushing_threads.add(thread_id)
+            return messages_to_flush
+
+    def _finish_thread_flush(self, thread_id: str, messages_to_restore: Optional[list[Any]] = None) -> None:
+        """结束一个 thread 的本地 flush；失败时把本批消息放回 buffer 头部。"""
+        with self._buffer_condition:
+            if messages_to_restore:
+                current_messages = self._message_buffer.get(thread_id, [])
+                self._message_buffer[thread_id] = messages_to_restore + current_messages
+            self._flushing_threads.discard(thread_id)
+            self._buffer_condition.notify_all()
 
     def flush(self, thread_id: Optional[str] = None) -> None:
         """立即推送缓冲区中的消息到 RabbitMQ
@@ -1011,39 +1015,31 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             thread_id: 如果指定，只推送该 thread_id 的消息；否则推送所有消息
         """
         if thread_id:
-            # 只推送指定 thread_id 的消息，在 flush_peek_lock 内原子完成
-            flush_peek_lock = self._get_flush_peek_lock(thread_id)
-            with flush_peek_lock:
-                with self._buffer_lock:
-                    messages_to_flush = self._message_buffer.pop(thread_id, [])
+            messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
+            if not messages_to_flush:
+                return
 
-                if not messages_to_flush:
-                    return
+            try:
+                with self._with_channel() as channel:
+                    logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
+                    queue_name = self._ensure_queue(channel, thread_id)
 
-                logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
-
-                try:
-                    with self._with_channel() as channel:
-                        queue_name = self._ensure_queue(channel, thread_id)
-
-                        for message in messages_to_flush:
-                            body = pickle.dumps(message)
-                            channel.basic_publish(
-                                exchange="",
-                                routing_key=queue_name,
-                                body=body,
-                                properties=pika.BasicProperties(delivery_mode=2),
-                            )
-                    self._notify_replay_waiters()
-                except Exception as e:
-                    logger.error(f"Error flushing messages for {thread_id}: {e}")
-                    # 推送失败，放回缓冲区
-                    with self._buffer_lock:
-                        if thread_id not in self._message_buffer:
-                            self._message_buffer[thread_id] = []
-                        self._message_buffer[thread_id] = messages_to_flush + self._message_buffer[thread_id]
-                    self._notify_replay_waiters()
-                    raise
+                    for message in messages_to_flush:
+                        body = pickle.dumps(message)
+                        channel.basic_publish(
+                            exchange="",
+                            routing_key=queue_name,
+                            body=body,
+                            properties=pika.BasicProperties(delivery_mode=2),
+                        )
+            except Exception as e:
+                logger.error(f"Error flushing messages for {thread_id}: {e}")
+                self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+                self._notify_replay_waiters()
+                raise
+            else:
+                self._finish_thread_flush(thread_id)
+                self._notify_replay_waiters()
         else:
             # 推送所有消息
             self._flush_messages()
@@ -1117,30 +1113,22 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         start_time = time.time()
         deadline = start_time + timeout if timeout is not None else None
         offset = max(offset, 0)
-        flush_peek_lock = self._get_flush_peek_lock(thread_id)
 
         while True:
             try:
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
+                    all_messages = self._peek_queue_messages(channel, main_queue_name)
 
-                    # flush_peek_lock 保护 peek + buffer 合并这两步的原子性，
-                    # 防止 flush 在 peek 之后、buffer 合并之前清空 buffer 导致消息丢失。
-                    with flush_peek_lock:
+                    # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
+                    if not all_messages and self._get_dlq_count(thread_id) > 0:
+                        restored = self._restore_from_dlq(thread_id)
+                        logger.info(
+                            "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
+                            thread_id,
+                            restored,
+                        )
                         all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if not all_messages and self._get_dlq_count(thread_id) > 0:
-                            restored = self._restore_from_dlq(thread_id)
-                            logger.info(
-                                "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
-                                thread_id,
-                                restored,
-                            )
-                            all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        with self._buffer_lock:
-                            all_messages.extend(self._message_buffer.get(thread_id, []))
 
                 next_offset = len(all_messages)
                 if next_offset > offset:
@@ -1219,6 +1207,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 检查本地缓冲区
         with self._buffer_lock:
             if thread_id in self._message_buffer and self._message_buffer[thread_id]:
+                return True
+            if thread_id in self._flushing_threads:
                 return True
 
         # 检查 RabbitMQ 主队列和死信队列
@@ -1371,10 +1361,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
 
         self._purge_all_queues(thread_id, include_cancel_queue=True)
         self._delete_all_resources(thread_id)
-
-        # 清理 flush_peek_lock（session 已结束，不再需要）
-        with self._flush_peek_locks_guard:
-            self._flush_peek_locks.pop(thread_id, None)
 
     def request_cancel(self, thread_id: str) -> None:
         """请求取消该 thread_id 的流。幂等：向取消队列投递一条消息，生产者轮询时消费到即退出。"""

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -340,6 +340,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 消费者据此做 prune-稳定续读（seq > since_seq），不再依赖队列 list 下标。
         self._seq_counters: dict[str, int] = {}
         self._seq_lock = threading.Lock()
+        # 每个 thread 的 flush 计时：{"start": 会话首次进入 buffer 的时刻, "last": 上次 daemon flush 时刻}
+        # 用于 daemon 的自适应 flush 间隔（前密后疏）；显式 flush 不受此限。
+        self._thread_flush_ts: dict[str, dict] = {}
+        self._flush_ts_lock = threading.Lock()
         self._replay_wait_condition = threading.Condition()
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
@@ -839,8 +843,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if self._daemon_stop_event.wait(timeout=0.1):
                     break
 
-                # 批量推送消息
-                self._flush_messages()
+                # 批量推送消息（daemon 走自适应间隔：前密后疏）
+                self._flush_messages(respect_interval=True)
             except Exception as e:
                 logger.error(f"Error in daemon worker: {e}")
 
@@ -850,8 +854,13 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         except Exception as e:
             logger.error(f"Error flushing messages on daemon exit: {e}")
 
-    def _flush_messages(self) -> None:
-        """批量推送缓冲区中的所有消息到 RabbitMQ"""
+    def _flush_messages(self, respect_interval: bool = False) -> None:
+        """批量推送缓冲区中的所有消息到 RabbitMQ
+
+        respect_interval=True（daemon tick）：每个 thread 按自适应间隔（前密后疏）决定本轮是否
+        flush，未到间隔的留在 buffer 下轮再推。显式 flush / daemon 退出前的兜底 flush 传 False，
+        无条件推送所有消息，保证收尾不残留。
+        """
         with self._buffer_lock:
             if not self._message_buffer:
                 return
@@ -860,8 +869,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         if not thread_ids:
             return
 
+        now = time.time()
         flushed = False
         for thread_id in thread_ids:
+            if respect_interval and not self._should_flush_now(thread_id, now):
+                continue
             messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
             if not messages_to_flush:
                 continue
@@ -1054,6 +1066,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             nxt = self._seq_counters.get(thread_id, 0) + 1
             self._seq_counters[thread_id] = nxt
             return nxt
+
+    # daemon flush 自适应间隔：从 MIN 在 RAMP 秒内线性增到 MAX（前期 token 快达，后期降 IO）
+    _FLUSH_INTERVAL_MIN = 0.1
+    _FLUSH_INTERVAL_MAX = 0.5
+    _FLUSH_INTERVAL_RAMP_SECONDS = 10.0
+
+    def _adaptive_flush_interval(self, age_seconds: float) -> float:
+        if age_seconds <= 0:
+            return self._FLUSH_INTERVAL_MIN
+        ratio = min(age_seconds / self._FLUSH_INTERVAL_RAMP_SECONDS, 1.0)
+        return self._FLUSH_INTERVAL_MIN + (self._FLUSH_INTERVAL_MAX - self._FLUSH_INTERVAL_MIN) * ratio
+
+    def _should_flush_now(self, thread_id: str, now: float) -> bool:
+        """daemon tick 时判断该 thread 是否到达自适应 flush 间隔（首次立即 flush）。"""
+        with self._flush_ts_lock:
+            state = self._thread_flush_ts.get(thread_id)
+            if state is None:
+                self._thread_flush_ts[thread_id] = {"start": now, "last": now}
+                return True
+            if now - state["last"] >= self._adaptive_flush_interval(now - state["start"]):
+                state["last"] = now
+                return True
+            return False
 
     def flush(self, thread_id: Optional[str] = None) -> None:
         """立即推送缓冲区中的消息到 RabbitMQ
@@ -1541,6 +1576,9 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 重置该 thread 的消息序号（新 producer 启动前会 clear，seq 从 1 重新计起）
         with self._seq_lock:
             self._seq_counters.pop(thread_id, None)
+        # 重置该 thread 的 flush 计时，下轮从 MIN 间隔重新起步
+        with self._flush_ts_lock:
+            self._thread_flush_ts.pop(thread_id, None)
 
         # 检查并迁移不兼容的旧队列
         self._migrate_queue_if_needed(thread_id)

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -735,6 +735,32 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             logger.warning(f"Error checking active consumers for thread_id={thread_id}: {e}")
             return False
 
+    def has_active_producer(self, thread_id: str) -> bool:
+        """检查是否有活跃 producer 正在生产该会话（支持跨进程）。
+
+        producer 通过一个绑定 dedicated connection 的 exclusive queue 持有生产权
+        （见 acquire_producer / release_producer）。该队列存在即代表某进程仍在生产：
+        - passive 声明成功 → 队列存在 → 仍在生产；
+        - RESOURCE_LOCKED(405) → 队列被生产者连接独占 → 仍在生产；
+        - NOT_FOUND(404) → 无活跃 producer。
+
+        供延迟清理线程判断，避免删掉仍在生产中的会话日志。
+        """
+        lock_queue = self._get_producer_lock_queue_name(thread_id)
+        try:
+            with self._with_channel() as channel:
+                try:
+                    channel.queue_declare(queue=lock_queue, passive=True)
+                    return True
+                except pika.exceptions.ChannelClosedByBroker as e:
+                    return getattr(e, "reply_code", None) == 405
+        except pika.exceptions.ChannelClosedByBroker as e:
+            return getattr(e, "reply_code", None) == 405
+        except Exception as e:
+            logger.warning(f"Error checking active producer for thread_id={thread_id}: {e}")
+            # 探测失败时保守认为可能仍在生产，避免误删；由 TTL 兜底回收
+            return True
+
     @contextmanager
     def _with_replay_lock(self, thread_id: str, timeout: float = 3.0) -> Iterator[Any]:
         """串行化同一会话的非破坏性 replay，避免并发 peek 分摊消息。"""

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -18,7 +18,7 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import QueueNamePrefixes
+from .constants import HEARTBEAT_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
@@ -1205,6 +1205,64 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 raise TimeoutError("No message available within timeout")
 
             self._wait_for_replay_retry(deadline, self.REPLAY_MESSAGE_RETRY_INTERVAL)
+
+    @staticmethod
+    def _extract_message_id(message: Any) -> Optional[str]:
+        """从队列中的 SSE 字符串块解析 messageId；控制块/非文本块返回 None。"""
+        if not isinstance(message, str) or not message.startswith("data: "):
+            return None
+        try:
+            payload = json.loads(message[len("data: ") :])
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if not isinstance(payload, dict):
+            return None
+        return payload.get("messageId") or payload.get("message_id")
+
+    def prune_committed(self, thread_id: str, committed_message_ids: set[str]) -> int:
+        """从主队列头部破坏性删除「已落库消息」的前缀，遇到未落库消息立即停止。
+
+        逐条从队列头判断（任一不满足即停止，保留该条及其后所有消息）：
+          - 心跳块（``HEARTBEAT_CHUNK``）：瞬时块，删除；
+          - 文本事件且其 ``messageId ∈ committed_message_ids``：内容已落 MySQL，删除。
+        保留并停止：``EOD``/``CANCELLED`` 等控制块、``messageId`` 未落库、以及无法识别的块。
+
+        已删内容一定能由 MySQL 快照恢复，故删除安全；慢消费者若游标落到被删段之前，
+        由上层「检测 gap → 重拉快照」兜底（见消费循环）。返回删除条数。
+        """
+        if not committed_message_ids:
+            return 0
+
+        pruned = 0
+        try:
+            with self._with_replay_lock(thread_id) as channel:
+                main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
+                while True:
+                    method_frame, _, body = channel.basic_get(queue=main_queue_name, auto_ack=False)
+                    if not method_frame:
+                        break
+                    try:
+                        message = pickle.loads(body)
+                    except Exception:
+                        channel.basic_nack(delivery_tag=method_frame.delivery_tag, requeue=True)
+                        break
+
+                    message_id = self._extract_message_id(message)
+                    prunable = message == HEARTBEAT_CHUNK or (
+                        message_id is not None and message_id in committed_message_ids
+                    )
+                    if prunable:
+                        channel.basic_ack(delivery_tag=method_frame.delivery_tag)
+                        pruned += 1
+                    else:
+                        channel.basic_nack(delivery_tag=method_frame.delivery_tag, requeue=True)
+                        break
+        except Exception:
+            logger.exception("Error pruning committed messages for thread_id=%s", thread_id)
+
+        if pruned:
+            logger.debug("[RabbitMQ] pruned %d committed messages from head thread_id=%s", pruned, thread_id)
+        return pruned
 
     def _get_block(self, thread_id: str, timeout: Optional[float] = None) -> list[Any]:
         """阻塞方式获取消息

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -773,6 +773,10 @@ class GeneratorStreamingHelper:
                     logger.exception(f"Error joining producer thread for thread_id={self.thread_id}: {e}")
             if consumer_exit_reason == "completed":
                 self._cleanup_replay_session_if_idle()
+            elif self._supports_replay_from_start() and producer_thread is None and consumer_exit_reason is None:
+                # Existing replay logs have no producer to run the normal orphan-cleanup finally block.
+                # If this consumer disconnects before EOD, schedule the same delayed cleanup path here.
+                self._schedule_session_cleanup(done_event_seen=False)
 
     def _schedule_session_cleanup(self, done_event_seen: bool = False) -> None:
         """生产者完成后延迟清理孤立的会话资源。

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -9,7 +9,7 @@ from ag_ui.encoder import EventEncoder
 
 from aidev_agent.utils.event import RunId, emit_run_finished_event
 
-from .base import BaseMessageQueueHandler, ConsumerPreemptedError
+from .base import BaseMessageQueueHandler, ConsumerPreemptedError, ReplayGapError
 from .constants import (
     CANCELLED_CHUNK,
     EOD_CHUNK,
@@ -508,6 +508,7 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        snapshot_provider: Callable[[], list] | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -661,6 +662,35 @@ class GeneratorStreamingHelper:
                                 yielded_total,
                             )
                         _maybe_log_progress()
+                except ReplayGapError as gap:
+                    # 队列头部已被 prune，本消费者游标落在被删段之前：重拉一份当前 DB 快照让前端
+                    # reset，再把游标跳到队列当前最小 seq 之前，从队列尾续读（被删段由快照补齐）。
+                    logger.warning(
+                        "[RabbitMQ] replay gap thread_id=%s consumer_id=%s since_seq=%d min_seq=%d, re-sync snapshot",
+                        self.thread_id,
+                        consumer_id_short,
+                        gap.since_seq,
+                        gap.min_seq,
+                    )
+                    if snapshot_provider is not None:
+                        try:
+                            for frame in snapshot_provider() or []:
+                                yield frame
+                                yielded_total += 1
+                        except Exception:
+                            logger.exception(
+                                "[RabbitMQ] snapshot_provider failed on replay gap thread_id=%s", self.thread_id
+                            )
+                    else:
+                        logger.warning(
+                            "[RabbitMQ] replay gap without snapshot_provider thread_id=%s, "
+                            "pruned segment [%d,%d) will be skipped",
+                            self.thread_id,
+                            gap.since_seq + 1,
+                            gap.min_seq,
+                        )
+                    replay_offset = max(gap.min_seq - 1, 0)
+                    continue
                 except ConsumerPreemptedError:
                     logger.info(
                         f"Consumer {consumer_id[:8]} preempted for thread_id={self.thread_id}, yielding to new consumer"
@@ -719,6 +749,7 @@ class GeneratorStreamingHelper:
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        snapshot_provider: Callable[[], list] | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -729,6 +760,9 @@ class GeneratorStreamingHelper:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+            snapshot_provider: 可选的「重拉当前 DB 快照」回调，返回若干 SSE 帧。
+                当队列头部被 prune、消费者游标落到被删段之前（``ReplayGapError``）时调用，
+                yield 一份最新快照让前端 reset，再从队列尾续读，避免丢内容。
 
         Yields:
             生成器产生的数据
@@ -769,6 +803,7 @@ class GeneratorStreamingHelper:
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
+                snapshot_provider=snapshot_provider,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -270,6 +270,21 @@ class GeneratorStreamingHelper:
         except Exception:
             return False
 
+    def _has_active_producer(self) -> bool:
+        """当前是否仍有活跃 producer 在生产（可能位于其他进程）。
+
+        延迟清理线程用它避免删掉仍在生产中的会话日志；不支持探测的 handler 返回 False，
+        沿用旧行为。探测异常时保守返回 True，宁可交由 TTL 兜底也不误删。
+        """
+        checker = getattr(self.message_handler, "has_active_producer", None)
+        if not callable(checker):
+            return False
+        try:
+            return bool(checker(self.thread_id))
+        except Exception:
+            logger.exception("Error checking active producer for thread_id=%s", self.thread_id)
+            return True
+
     def _get_consumer_messages(
         self,
         *,
@@ -773,9 +788,15 @@ class GeneratorStreamingHelper:
                     logger.exception(f"Error joining producer thread for thread_id={self.thread_id}: {e}")
             if consumer_exit_reason == "completed":
                 self._cleanup_replay_session_if_idle()
-            elif self._supports_replay_from_start() and producer_thread is None and consumer_exit_reason is None:
-                # Existing replay logs have no producer to run the normal orphan-cleanup finally block.
-                # If this consumer disconnects before EOD, schedule the same delayed cleanup path here.
+            elif (
+                self._supports_replay_from_start()
+                and not should_consume_stopped
+                and producer_thread is None
+                and consumer_exit_reason is None
+            ):
+                # 纯 replay 消费者（本进程未起 producer）在读到 EOD 之前断开时，没有 producer 的
+                # finally 兜底清理孤立日志，这里补一次延迟清理。排除 should_consume_stopped：
+                # 已停止会话是用户主动查看的历史内容，保留到 TTL，不在查看后主动回收。
                 self._schedule_session_cleanup(done_event_seen=False)
 
     def _schedule_session_cleanup(self, done_event_seen: bool = False) -> None:
@@ -819,6 +840,23 @@ class GeneratorStreamingHelper:
                     )
                     deadline_hit = now >= deadline
                     if fast_grace_hit or deadline_hit:
+                        # 到达清理时机：仅当会话确实孤立（无活跃 consumer、无活跃 producer）才回收。
+                        # 若仍有 producer 在生产，或有消费者正在 replay，则不删，交由各自的清理路径兜底：
+                        # producer 完成后会自调度清理；活跃消费者完成时走 _cleanup_replay_session_if_idle、
+                        # 断开时会重新调度清理。这样避免删掉进行中的会话或活跃消费者所需的日志。
+                        producer_active = self._has_active_producer()
+                        if has_active_consumer or producer_active:
+                            logger.info(
+                                "[RabbitMQ] orphan cleanup deferred thread_id=%s elapsed=%.1fs "
+                                "reason=%s had_active_consumer=%s producer_active=%s consumer_ever_seen=%s",
+                                thread_id,
+                                now - start_time,
+                                "fast_grace" if fast_grace_hit and not deadline_hit else "deadline",
+                                has_active_consumer,
+                                producer_active,
+                                consumer_ever_seen,
+                            )
+                            return
                         should_cleanup_now = True
                         trigger_reason = "fast_grace" if fast_grace_hit and not deadline_hit else "deadline"
 

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -5,9 +5,26 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
+from ag_ui.core import (
+    EventType,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    TextMessageContentEvent,
+    TextMessageStartEvent,
+)
+from ag_ui.encoder import EventEncoder
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
+from langchain_core.tools import ToolException, tool
+from langgraph.checkpoint.memory import MemorySaver
+
 from aidev_agent.config import settings
-from aidev_agent.core.ag_ui.types import CustomMessageType
+from aidev_agent.core.ag_ui.types import (
+    CustomMessageType,
+    ExtendAssistantMessage,
+    ExtendUserMessage,
+    MessageSnapshotEventExtend,
+)
 from aidev_agent.enums import PromptRole
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.packages.langchain_core.models.mock import MockChatModel, MockResponse
@@ -24,9 +41,6 @@ from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
 from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
 from aidev_agent.utils.event import RunId
-from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
-from langchain_core.tools import ToolException, tool
-from langgraph.checkpoint.memory import MemorySaver
 
 
 class _ConcreteWriter(BaseSessionWriter):
@@ -2269,3 +2283,140 @@ class TestTerminalResumeReplay:
         mock_replay.assert_not_called()
         mock_astream.assert_not_called()
         agui_entry.run.assert_not_called()
+
+
+def _snapshot_frame(messages) -> str:
+    return EventEncoder().encode(
+        MessageSnapshotEventExtend(type=EventType.MESSAGES_SNAPSHOT, messages=messages)
+    )
+
+
+def _start_frame(message_id: str) -> str:
+    return EventEncoder().encode(
+        TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id, role="assistant")
+    )
+
+
+def _content_frame(message_id: str, delta: str) -> str:
+    return EventEncoder().encode(
+        TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta)
+    )
+
+
+def _snapshot_ids(frame: str) -> set[str]:
+    data = _parse_sse(frame)
+    return {(m.get("messageId") or m.get("id")) for m in data.get("messages", [])}
+
+
+class TestSnapshotReplayDedup:
+    """多端场景：阶段1现发的 MESSAGES_SNAPSHOT 含半截 mid，阶段2 replay 又从头 START(mid)，
+    前端会因“快照已有该 id + replay 又 START 同 id”产生重复消息。修复：阶段1快照剔除
+    replay 将重放的 message_id，让 replay 成为该消息唯一来源。"""
+
+    def test_reproduce_snapshot_replay_id_overlap(self):
+        """复现前提：现发快照里的 assistant id 与 replay 缓存里的 START id 相同（会重复）。"""
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        replay_ids = ChatCompletionAgent._collect_replay_message_ids(
+            _FakeReplayHandler([_start_frame("mid"), _content_frame("mid", "完整回答")]),
+            "t1",
+        )
+        # bug 前提成立：快照 id 与 replay id 有交集
+        assert _snapshot_ids(snapshot) & replay_ids == {"mid"}
+
+    def test_dedup_removes_replayed_id_from_snapshot(self):
+        """去重后：快照剔除 mid（由 replay 完整重建），保留历史/用户消息。"""
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        run_started = EventEncoder().encode(
+            RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1")
+        )
+        head_frames = [snapshot, run_started]
+
+        deduped = ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, {"mid"})
+
+        assert _snapshot_ids(deduped[0]) == {"u1"}
+        assert "mid" not in _snapshot_ids(deduped[0])
+        # 非快照帧不受影响
+        assert deduped[1] == run_started
+
+    def test_dedup_noop_without_replay_ids(self):
+        """没有 replay（例如首个消费者）时不改动快照。"""
+        snapshot = _snapshot_frame(
+            [ExtendAssistantMessage(id="mid", role="assistant", content="hi", status="complete")]
+        )
+        head_frames = [snapshot]
+        assert ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, set()) == head_frames
+
+    def test_collect_replay_ids_returns_empty_when_no_pending(self):
+        handler = _FakeReplayHandler([_start_frame("mid")], has_pending=False)
+        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+
+    def test_collect_replay_ids_swallows_handler_errors(self):
+        """handler 不支持 peek / 抛异常时按“无重放”处理，回退原行为。"""
+        handler = MagicMock()
+        handler.has_pending_messages.side_effect = RuntimeError("boom")
+        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+
+    def test_stream_with_queue_emits_non_overlapping_stream(self):
+        """端到端复现 + 修复验证：第二端连接输出流中，快照 id 与 START id 零重叠。"""
+        agent = _seed_agent()
+        agui_entry = _mock_agui_entry()
+        agent_input = SimpleNamespace(thread_id="t1", run_id="r1")
+
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        run_started = EventEncoder().encode(
+            RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1")
+        )
+        replay_frames = [_start_frame("mid"), _content_frame("mid", "完整回答")]
+
+        fake_handler = _FakeReplayHandler(replay_frames)
+        fake_helper = MagicMock()
+        fake_helper.message_handler = fake_handler
+        fake_helper.stream.return_value = iter(replay_frames)
+
+        with (
+            patch(f"{_CHAT_MODULE}.GeneratorStreamingHelper", return_value=fake_helper),
+            patch.object(agent, "_build_resume_aware_producer", return_value=iter([snapshot, run_started])),
+        ):
+            out = list(agent._stream_with_queue(agui_entry, agent_input))
+
+        snap_ids: set[str] = set()
+        start_ids: set[str] = set()
+        for frame in out:
+            data = _parse_sse(frame)
+            if data["type"] == EventType.MESSAGES_SNAPSHOT:
+                snap_ids |= {(m.get("messageId") or m.get("id")) for m in data.get("messages", [])}
+            if data["type"] == EventType.TEXT_MESSAGE_START:
+                start_ids.add(data.get("messageId"))
+
+        assert "mid" in start_ids  # replay 仍完整重建该消息
+        assert "mid" not in snap_ids  # 快照不再含 mid
+        assert snap_ids & start_ids == set()  # 零重叠，前端不会重复
+
+
+class _FakeReplayHandler:
+    """最小 replay handler 替身：模拟缓存里已有从头重放的 SSE 帧。"""
+
+    def __init__(self, cached_frames, has_pending: bool = True):
+        self._cached = list(cached_frames)
+        self._has_pending = has_pending
+
+    def has_pending_messages(self, thread_id):  # noqa: ARG002
+        return self._has_pending
+
+    def get_messages_since(self, thread_id, offset, timeout=None):  # noqa: ARG002
+        return self._cached[offset:], len(self._cached)

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2420,3 +2420,38 @@ class _FakeReplayHandler:
 
     def get_messages_since(self, thread_id, offset, timeout=None):  # noqa: ARG002
         return self._cached[offset:], len(self._cached)
+
+
+class TestGapSnapshotProvider:
+    """replay gap 兜底 provider：从 graph checkpoint 重建当前 MESSAGES_SNAPSHOT。"""
+
+    def test_builds_snapshot_frame_from_checkpoint(self):
+        agent = _seed_agent()
+        state = SimpleNamespace(values={"messages": [AIMessage(content="hi", id="a1")]})
+        provider = agent._make_gap_snapshot_provider(MagicMock(), {"configurable": {}})
+        with patch(f"{_CHAT_MODULE}.run_coro_sync", return_value=state):
+            frames = provider()
+
+        assert len(frames) == 1
+        data = _parse_sse(frames[0])
+        assert data["type"] == EventType.MESSAGES_SNAPSHOT
+        ids = [(m.get("messageId") or m.get("id")) for m in data["messages"]]
+        assert "a1" in ids
+
+    def test_returns_none_without_graph_or_cfg(self):
+        agent = _seed_agent()
+        assert agent._make_gap_snapshot_provider(None, {"configurable": {}}) is None
+        assert agent._make_gap_snapshot_provider(MagicMock(), None) is None
+
+    def test_returns_empty_on_error(self):
+        agent = _seed_agent()
+        provider = agent._make_gap_snapshot_provider(MagicMock(), {"configurable": {}})
+        with patch(f"{_CHAT_MODULE}.run_coro_sync", side_effect=RuntimeError("boom")):
+            assert provider() == []
+
+    def test_returns_empty_when_no_messages(self):
+        agent = _seed_agent()
+        state = SimpleNamespace(values={"messages": []})
+        provider = agent._make_gap_snapshot_provider(MagicMock(), {"configurable": {}})
+        with patch(f"{_CHAT_MODULE}.run_coro_sync", return_value=state):
+            assert provider() == []

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -465,6 +465,24 @@ class TestRabbitMQMessageHandler:
         assert [handler._extract_message_id(m) for m in msgs] == ["m4"]
         assert cursor == 4
 
+    def test_adaptive_flush_interval_ramps_min_to_max(self, handler):
+        """flush 间隔随会话时长从 MIN 线性升到 MAX。"""
+        assert handler._adaptive_flush_interval(0) == handler._FLUSH_INTERVAL_MIN
+        assert handler._adaptive_flush_interval(-1) == handler._FLUSH_INTERVAL_MIN
+        assert handler._adaptive_flush_interval(handler._FLUSH_INTERVAL_RAMP_SECONDS) == handler._FLUSH_INTERVAL_MAX
+        assert handler._adaptive_flush_interval(10 * handler._FLUSH_INTERVAL_RAMP_SECONDS) == handler._FLUSH_INTERVAL_MAX
+        mid = handler._adaptive_flush_interval(handler._FLUSH_INTERVAL_RAMP_SECONDS / 2)
+        assert handler._FLUSH_INTERVAL_MIN < mid < handler._FLUSH_INTERVAL_MAX
+
+    def test_should_flush_now_first_immediate_then_gated(self, handler, thread_id):
+        """首次立即 flush；未到自适应间隔则跳过，超过则再次 flush。"""
+        t0 = 1000.0
+        assert handler._should_flush_now(thread_id, t0) is True
+        # 距上次仅 0.05s < MIN(0.1s) → 不 flush
+        assert handler._should_flush_now(thread_id, t0 + 0.05) is False
+        # 距上次 0.2s > 早期间隔(~0.1s) → flush
+        assert handler._should_flush_now(thread_id, t0 + 0.25) is True
+
     def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
         """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""
         handler.put(thread_id, "seed")

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -1,10 +1,12 @@
 import asyncio
 import contextlib
 import os
+import pickle
 import threading
 import time
 
 import pytest
+
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
@@ -35,6 +37,30 @@ def thread_id(request, handler):
         handler.mark_completed(tid)
 
 
+class DelayedPublishChannel:
+    def __init__(self, channel, target_message, publish_started, allow_publish):
+        self._channel = channel
+        self._target_message = target_message
+        self._publish_started = publish_started
+        self._allow_publish = allow_publish
+
+    def __getattr__(self, name):
+        return getattr(self._channel, name)
+
+    def basic_publish(self, *args, **kwargs):
+        body = kwargs.get("body")
+        if body is None and len(args) >= 3:
+            body = args[2]
+        try:
+            is_target = pickle.loads(body) == self._target_message
+        except Exception:
+            is_target = False
+        if is_target:
+            self._publish_started.set()
+            assert self._allow_publish.wait(timeout=3)
+        return self._channel.basic_publish(*args, **kwargs)
+
+
 class TestRabbitMQMessageHandler:
     def _get_open_channel_count(self, handler: RabbitMQMessageHandler) -> int:
         """Return open AMQP channels held by one pooled connection."""
@@ -52,6 +78,28 @@ class TestRabbitMQMessageHandler:
                 return
             time.sleep(0.1)
         assert handler.is_empty(thread_id) is True
+
+    def _consume_since_offset(self, handler, thread_id, offset, result, error):
+        try:
+            result.append(handler.get_messages_since(thread_id, offset, timeout=1))
+        except Exception as exc:
+            error.append(exc)
+
+    def _patch_delayed_publish(self, monkeypatch, handler, target_message):
+        publish_started = threading.Event()
+        allow_publish = threading.Event()
+
+        def wrap_context(context_factory):
+            @contextlib.contextmanager
+            def wrapped(*args, **kwargs):
+                with context_factory(*args, **kwargs) as channel:
+                    yield DelayedPublishChannel(channel, target_message, publish_started, allow_publish)
+
+            return wrapped
+
+        monkeypatch.setattr(handler, "_with_channel", wrap_context(handler._with_channel))
+        monkeypatch.setattr(handler, "_with_replay_lock", wrap_context(handler._with_replay_lock))
+        return publish_started, allow_publish
 
     def test_repeated_operations_do_not_accumulate_open_channels(self, handler, thread_id):
         """Repeated RabbitMQ operations should close their temporary AMQP channels."""
@@ -210,6 +258,142 @@ class TestRabbitMQMessageHandler:
         assert all(result == expected for result in results)
 
         self._wait_until_empty(handler, thread_id)
+
+    def test_single_consumer_waits_for_in_flight_flush_before_later_buffer(self, handler, thread_id, monkeypatch):
+        """单个 consumer 不应在旧 flush 批次发布完成前先吐出后续未提交消息。"""
+        handler.put(thread_id, "msg_0")
+        handler.flush(thread_id)
+        first_messages, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert first_messages == ["msg_0"]
+
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+        try:
+            handler.put(thread_id, "msg_1")
+            publish_started, allow_publish = self._patch_delayed_publish(monkeypatch, handler, "msg_1")
+            result: list[tuple[list[str], int]] = []
+            error: list[Exception] = []
+            flush_thread = threading.Thread(target=handler.flush, args=(thread_id,), daemon=True)
+            consumer_thread = threading.Thread(
+                target=self._consume_since_offset, args=(handler, thread_id, offset, result, error), daemon=True
+            )
+            flush_thread.start()
+            assert publish_started.wait(timeout=3)
+            handler.put(thread_id, "msg_2")
+            consumer_thread.start()
+            try:
+                consumer_thread.join(timeout=0.3)
+                assert consumer_thread.is_alive(), f"consumer returned too early: result={result}, error={error}"
+            finally:
+                allow_publish.set()
+                flush_thread.join(timeout=3)
+                consumer_thread.join(timeout=3)
+
+            assert error == []
+            assert result == [(["msg_1"], 2)]
+
+            handler.flush(thread_id)
+            second_messages, next_offset = handler.get_messages_since(thread_id, 2, timeout=1)
+
+            assert second_messages == ["msg_2"]
+            assert next_offset == 3
+        finally:
+            handler._start_daemon()
+
+    def test_replay_reads_only_rabbitmq_committed_messages(self, handler, thread_id, monkeypatch):
+        """Replay 只能读取 RabbitMQ 已提交日志，不能读取本进程未 flush 的 buffer。"""
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+
+        try:
+            handler.put(thread_id, "buffered_only")
+
+            with pytest.raises(TimeoutError):
+                handler.get_messages_since(thread_id, 0, timeout=0.2)
+
+            handler.flush(thread_id)
+            messages, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+
+            assert messages == ["buffered_only"]
+            assert offset == 1
+        finally:
+            with handler._buffer_lock:
+                handler._message_buffer.pop(thread_id, None)
+            handler._start_daemon()
+
+    def test_has_pending_messages_includes_in_flight_flush(self, handler, thread_id):
+        """本批消息从 buffer 取走但尚未 publish 时，仍应被视为 pending。"""
+        handler._stop_daemon()
+        try:
+            with handler._buffer_lock:
+                handler._message_buffer[thread_id] = ["in_flight_msg"]
+
+            messages_to_flush = handler._take_thread_buffer_for_flush(thread_id)
+            try:
+                assert messages_to_flush == ["in_flight_msg"]
+                assert handler.has_pending_messages(thread_id) is True
+            finally:
+                handler._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+        finally:
+            handler._start_daemon()
+
+    def test_disconnected_replay_consumer_schedules_orphan_cleanup(self, handler, thread_id, monkeypatch):
+        """已有 pending 日志的 replay consumer 中途断开后，也应延迟清理孤儿队列。"""
+        for message in ["msg_1", "msg_2", "msg_3"]:
+            handler.put(thread_id, message)
+        handler.flush(thread_id)
+
+        helper = GeneratorStreamingHelper(handler, thread_id)
+        monkeypatch.setattr(helper, "_PRODUCER_CLEANUP_DELAY", 0.2)
+        monkeypatch.setattr(helper, "_ORPHAN_CLEANUP_POLL_INTERVAL", 0.05)
+
+        stream = helper.stream(iter(()))
+        assert next(stream) == "msg_1"
+        stream.close()
+
+        self._wait_until_empty(handler, thread_id, timeout=1.0)
+
+    def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
+        """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""
+        handler.put(thread_id, "seed")
+        handler.flush(thread_id)
+        _, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+
+        original_peek = handler._peek_queue_messages
+        reader_holding_snapshot = threading.Event()
+        release_reader_snapshot = threading.Event()
+
+        def slow_peek(channel, queue_name):
+            reader_holding_snapshot.set()
+            assert release_reader_snapshot.wait(timeout=3)
+            return original_peek(channel, queue_name)
+
+        monkeypatch.setattr(handler, "_peek_queue_messages", slow_peek)
+
+        reader_result: list[tuple[list[str], int]] = []
+        reader_error: list[Exception] = []
+        reader_thread = threading.Thread(
+            target=self._consume_since_offset,
+            args=(handler, thread_id, offset, reader_result, reader_error),
+            daemon=True,
+        )
+        reader_thread.start()
+        assert reader_holding_snapshot.wait(timeout=3)
+
+        handler.put(thread_id, "msg_after_refresh")
+        flush_thread = threading.Thread(target=handler.flush, args=(thread_id,), daemon=True)
+        flush_thread.start()
+
+        try:
+            flush_thread.join(timeout=0.3)
+            assert not flush_thread.is_alive(), "producer flush was blocked by a replay reader snapshot"
+        finally:
+            release_reader_snapshot.set()
+            flush_thread.join(timeout=3)
+            reader_thread.join(timeout=3)
+
+        assert reader_error == []
+        assert reader_result == [(["msg_after_refresh"], offset + 1)]
 
     def test_consumer_reconnect_with_dlq(self, handler, thread_id):
         """测试消费者断开后重连可以从死信队列恢复消息

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -12,6 +12,7 @@ from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.messages_handler import EOD_CHUNK, GeneratorStreamingHelper
+from aidev_agent.services.messages_handler.base import ReplayGapError
 from aidev_agent.services.messages_handler.constants import HEARTBEAT_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
 from aidev_agent.utils.async_utils import async_to_sync_generator
@@ -443,6 +444,26 @@ class TestRabbitMQMessageHandler:
         handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
         handler.flush(thread_id)
         assert handler.prune_committed(thread_id, set()) == 0
+
+    def test_get_messages_since_raises_replay_gap_after_prune(self, handler, thread_id):
+        """消费者游标落在被 prune 段之前时，get_messages_since 抛 ReplayGapError（需上层重拉快照）。"""
+        for message_id in ["m1", "m2", "m3", "m4"]:
+            handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", message_id))
+        handler.flush(thread_id)
+
+        # 删掉 m1/m2/m3(seq 1-3)，队列最小 seq 变为 4
+        assert handler.prune_committed(thread_id, {"m1", "m2", "m3"}) == 3
+
+        # 游标 since_seq=1 落在被删段 [2,4) 之前 → gap
+        with pytest.raises(ReplayGapError) as exc:
+            handler.get_messages_since(thread_id, 1, timeout=1)
+        assert exc.value.min_seq == 4
+        assert exc.value.since_seq == 1
+
+        # 游标 since_seq=3(恰好 min_seq-1) 不算 gap，正常返回 m4
+        msgs, cursor = handler.get_messages_since(thread_id, 3, timeout=1)
+        assert [handler._extract_message_id(m) for m in msgs] == ["m4"]
+        assert cursor == 4
 
     def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
         """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import os
 import pickle
 import threading
@@ -11,8 +12,19 @@ from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.messages_handler import EOD_CHUNK, GeneratorStreamingHelper
+from aidev_agent.services.messages_handler.constants import HEARTBEAT_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
 from aidev_agent.utils.async_utils import async_to_sync_generator
+
+
+def _sse_event(event_type: str, message_id: str | None = None, delta: str | None = None) -> str:
+    """构造队列里实际存放的 SSE 事件字符串（data: {json}\\n\\n）。"""
+    payload: dict = {"type": event_type}
+    if message_id is not None:
+        payload["messageId"] = message_id
+    if delta is not None:
+        payload["delta"] = delta
+    return f"data: {json.dumps(payload)}\n\n"
 
 # 标记：所有测试均需要 RabbitMQ
 pytestmark = pytest.mark.skipif(
@@ -393,6 +405,44 @@ class TestRabbitMQMessageHandler:
         # 用 cursor=3 续读：无新消息 → 超时（不会把 m3 再发一遍）
         with pytest.raises(TimeoutError):
             handler.get_messages_since(thread_id, 3, timeout=0.3)
+
+    def test_prune_committed_removes_committed_prefix_and_stops(self, handler, thread_id):
+        """prune_committed 删除已落库消息前缀 + 心跳，遇未落库消息即停并保留其及 EOD。"""
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_CONTENT", "m1", "hel"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_END", "m1"))
+        handler.put(thread_id, HEARTBEAT_CHUNK)
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m2"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_CONTENT", "m2", "lo"))
+        handler.put(thread_id, EOD_CHUNK)
+        handler.flush(thread_id)
+
+        # 仅 m1 落库 → 删除 m1 的 3 条 + 心跳，遇未落库的 m2 停止
+        pruned = handler.prune_committed(thread_id, {"m1"})
+        assert pruned == 4
+
+        # 剩余：m2 的 2 条 + EOD（m2 未落库 → 保留；EOD 控制块 → 保留；心跳已删）
+        remaining, _ = handler.get_messages_since(thread_id, 0, timeout=1)
+        ids = [handler._extract_message_id(m) for m in remaining]
+        assert "m1" not in ids
+        assert ids.count("m2") == 2
+        assert EOD_CHUNK in remaining
+        assert HEARTBEAT_CHUNK not in remaining
+
+    def test_prune_committed_noop_when_head_uncommitted(self, handler, thread_id):
+        """队列头即未落库消息时，prune 不删任何东西。"""
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_CONTENT", "m1", "x"))
+        handler.flush(thread_id)
+
+        assert handler.prune_committed(thread_id, {"other"}) == 0
+        remaining, _ = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert len(remaining) == 2
+
+    def test_prune_committed_empty_committed_set_is_noop(self, handler, thread_id):
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
+        handler.flush(thread_id)
+        assert handler.prune_committed(thread_id, set()) == 0
 
     def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
         """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -465,6 +465,30 @@ class TestRabbitMQMessageHandler:
         assert [handler._extract_message_id(m) for m in msgs] == ["m4"]
         assert cursor == 4
 
+    def test_prune_keeps_eod_for_completion(self, handler, thread_id):
+        """全部消息落库后 prune，EOD 仍保留 → 完成判定/pending 判定不受影响。"""
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_END", "m1"))
+        handler.put(thread_id, EOD_CHUNK)
+        handler.flush(thread_id)
+
+        handler.prune_committed(thread_id, {"m1"})  # 删 m1 两条，EOD 保留
+
+        remaining, _ = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert remaining == [EOD_CHUNK]
+        assert handler.has_pending_messages(thread_id) is True
+        assert handler.is_empty(thread_id) is False
+
+    def test_mark_completed_after_prune_clears_all(self, handler, thread_id):
+        """prune 之后 mark_completed 仍能清空所有队列。"""
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_START", "m1"))
+        handler.put(thread_id, _sse_event("TEXT_MESSAGE_END", "m1"))
+        handler.flush(thread_id)
+        handler.prune_committed(thread_id, {"m1"})
+
+        handler.mark_completed(thread_id)
+        assert handler.is_empty(thread_id) is True
+
     def test_adaptive_flush_interval_ramps_min_to_max(self, handler):
         """flush 间隔随会话时长从 MIN 线性升到 MAX。"""
         assert handler._adaptive_flush_interval(0) == handler._FLUSH_INTERVAL_MIN

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -353,6 +353,47 @@ class TestRabbitMQMessageHandler:
 
         self._wait_until_empty(handler, thread_id, timeout=1.0)
 
+    def test_seq_cursor_is_prune_stable(self, handler, thread_id):
+        """seq 游标对头部 prune 稳定：删掉队列头部后，消费者按 seq 续读不重不漏。
+
+        同时验证 publish 写入的 seq header 在多次 peek（basic_nack requeue）后仍存活。
+        这是「producer 落库后 prune RabbitMQ 头部」重构的地基。
+        """
+        for message in ["m1", "m2", "m3"]:
+            handler.put(thread_id, message)
+        handler.flush(thread_id)
+
+        # 首次全量读取：cursor = 最大 seq = 3
+        msgs, cursor = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert msgs == ["m1", "m2", "m3"]
+        assert cursor == 3
+
+        # 再次 peek：seq header 在 requeue 后存活 → cursor 稳定不变
+        msgs_again, cursor_again = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert msgs_again == ["m1", "m2", "m3"]
+        assert cursor_again == 3
+
+        # 模拟头部 prune：破坏性删除队列头 2 条（seq 1、2）
+        main_queue = handler._get_queue_name(thread_id)
+        with handler._with_channel() as channel:
+            for _ in range(2):
+                method_frame, _, _ = channel.basic_get(queue=main_queue, auto_ack=True)
+                assert method_frame is not None
+
+        # prune 后从头读：只剩 m3，且 cursor 仍为 3（seq 不回退）
+        msgs_pruned, cursor_pruned = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert msgs_pruned == ["m3"]
+        assert cursor_pruned == 3
+
+        # 用被 prune 覆盖的旧 cursor=2 续读：仍只得 m3，不重复已删的 m1/m2、不漏 m3
+        msgs_tail, cursor_tail = handler.get_messages_since(thread_id, 2, timeout=1)
+        assert msgs_tail == ["m3"]
+        assert cursor_tail == 3
+
+        # 用 cursor=3 续读：无新消息 → 超时（不会把 m3 再发一遍）
+        with pytest.raises(TimeoutError):
+            handler.get_messages_since(thread_id, 3, timeout=0.3)
+
     def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
         """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""
         handler.put(thread_id, "seed")

--- a/src/agent/tests/services/test_session_writer_commit_hook.py
+++ b/src/agent/tests/services/test_session_writer_commit_hook.py
@@ -1,0 +1,74 @@
+"""BaseSessionWriter.commit_hook 单元测试。
+
+commit_hook 用于「落库后」把已落库 messageId 集合通知给上层（如 RabbitMQ prune），
+仅当本次事件产生新的落库消息时触发。纯内存 writer，不依赖 RabbitMQ。
+"""
+
+from ag_ui.core import EventType, TextMessageContentEvent, TextMessageEndEvent
+
+from aidev_agent.services.event_handlers.base import BaseSessionWriter
+
+
+class _RecordingWriter(BaseSessionWriter):
+    def __init__(self, **kwargs):
+        super().__init__(session_code="s", **kwargs)
+
+    def _do_create_content(self, payload: dict, headers: dict) -> int:
+        return 1
+
+    def _do_update_content(self, content_id: int, payload: dict, headers: dict) -> None:
+        pass
+
+
+class _PersistOnEndWriter(_RecordingWriter):
+    """把 TEXT_MESSAGE_END 当作落库点（测试用），以驱动 commit_hook。"""
+
+    def handle_text_message_end(self, event) -> None:
+        self._written_message_ids.add(event.message_id)
+
+
+class TestCommitHook:
+    def test_hook_fires_after_persist_with_committed_ids(self):
+        seen: list[set[str]] = []
+        writer = _PersistOnEndWriter()
+        writer.commit_hook = lambda committed: seen.append(set(committed))
+
+        writer(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id="mid-1"))
+
+        assert seen == [{"mid-1"}]
+
+    def test_hook_not_fired_without_new_persist(self):
+        """content 事件只累积内存、不落库 → 不触发 hook。"""
+        seen: list = []
+        writer = _RecordingWriter()
+        writer.commit_hook = lambda committed: seen.append(committed)
+
+        writer(TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id="x", delta="a"))
+
+        assert seen == []
+
+    def test_no_hook_is_safe(self):
+        writer = _PersistOnEndWriter()  # commit_hook 默认 None
+        writer(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id="mid-1"))
+        assert "mid-1" in writer._written_message_ids
+
+    def test_hook_exception_is_swallowed(self):
+        """hook 抛异常不得影响主落库流程。"""
+
+        def boom(_committed):
+            raise RuntimeError("prune failed")
+
+        writer = _PersistOnEndWriter()
+        writer.commit_hook = boom
+        writer(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id="mid-1"))
+        assert "mid-1" in writer._written_message_ids
+
+    def test_hook_receives_accumulating_committed_set(self):
+        seen: list[set[str]] = []
+        writer = _PersistOnEndWriter()
+        writer.commit_hook = lambda committed: seen.append(set(committed))
+
+        writer(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id="mid-1"))
+        writer(TextMessageEndEvent(type=EventType.TEXT_MESSAGE_END, message_id="mid-2"))
+
+        assert seen == [{"mid-1"}, {"mid-1", "mid-2"}]

--- a/src/agent/tests/services/test_streaming_helper.py
+++ b/src/agent/tests/services/test_streaming_helper.py
@@ -5,10 +5,12 @@
 （仍有活跃 producer / consumer 时不回收会话日志，避免误删进行中的会话）。
 """
 
+import threading
 import time
 from unittest.mock import MagicMock
 
-from aidev_agent.services.messages_handler import GeneratorStreamingHelper
+from aidev_agent.services.messages_handler import EOD_CHUNK, GeneratorStreamingHelper
+from aidev_agent.services.messages_handler.base import ReplayGapError
 
 
 class _HandlerWithoutProducerAPI:
@@ -108,3 +110,70 @@ class TestOrphanCleanupGuard:
 
         time.sleep(0.3)
         handler.mark_completed.assert_not_called()
+
+
+class TestReplayGapRecovery:
+    """队列头部被 prune、消费者游标落到被删段之前时，消费循环重拉快照补齐再续。"""
+
+    def _make_handler(self, get_side_effect) -> MagicMock:
+        handler = MagicMock()
+        handler.supports_replay_from_start.return_value = True
+        handler.check_cancel_signal.return_value = False
+        handler.is_cancel_requested.return_value = False
+        handler.get_messages_since.side_effect = get_side_effect
+        return handler
+
+    def test_consumer_resyncs_snapshot_on_replay_gap(self):
+        handler = self._make_handler(
+            [
+                ReplayGapError(thread_id="t", since_seq=1, min_seq=4),
+                ([EOD_CHUNK], 4),
+            ]
+        )
+        helper = GeneratorStreamingHelper(handler, "t")
+
+        snapshot_calls = []
+
+        def _provider():
+            snapshot_calls.append(1)
+            return ["data: SNAPSHOT\n\n"]
+
+        gen = helper._consume_stream_messages(
+            consumer_id="c",
+            cancel_event=threading.Event(),
+            is_resuming=True,
+            enable_heartbeat_check=False,
+            snapshot_provider=_provider,
+        )
+        out = list(gen)
+
+        # gap 时重拉了一次快照并 yield 给下游
+        assert snapshot_calls == [1]
+        assert "data: SNAPSHOT\n\n" in out
+        # 第二次读取用重置后的游标 min_seq-1=3
+        assert handler.get_messages_since.call_count == 2
+        second_call = handler.get_messages_since.call_args_list[1]
+        assert second_call.args[1] == 3
+
+    def test_replay_gap_without_provider_skips_segment(self):
+        """无 snapshot_provider 时不崩溃：跳过被删段、游标重置后继续。"""
+        handler = self._make_handler(
+            [
+                ReplayGapError(thread_id="t", since_seq=1, min_seq=4),
+                ([EOD_CHUNK], 4),
+            ]
+        )
+        helper = GeneratorStreamingHelper(handler, "t")
+
+        gen = helper._consume_stream_messages(
+            consumer_id="c",
+            cancel_event=threading.Event(),
+            is_resuming=True,
+            enable_heartbeat_check=False,
+            snapshot_provider=None,
+        )
+        out = list(gen)
+
+        assert out == []  # 无快照可补，但不抛异常
+        assert handler.get_messages_since.call_count == 2
+        assert handler.get_messages_since.call_args_list[1].args[1] == 3

--- a/src/agent/tests/services/test_streaming_helper.py
+++ b/src/agent/tests/services/test_streaming_helper.py
@@ -1,0 +1,110 @@
+"""GeneratorStreamingHelper 队列生命周期相关的单元测试。
+
+这些用例全部使用 mock handler，不依赖真实 RabbitMQ，覆盖“队列过多”修复引入的
+新逻辑：活跃 producer 探测（``_has_active_producer``）与延迟清理的 defer 决策
+（仍有活跃 producer / consumer 时不回收会话日志，避免误删进行中的会话）。
+"""
+
+import time
+from unittest.mock import MagicMock
+
+from aidev_agent.services.messages_handler import GeneratorStreamingHelper
+
+
+class _HandlerWithoutProducerAPI:
+    """不实现 has_active_producer 的旧 handler 替身。"""
+
+
+class TestHasActiveProducer:
+    def test_returns_false_when_handler_lacks_method(self):
+        """handler 不支持探测时按“无活跃 producer”处理，沿用旧行为。"""
+        helper = GeneratorStreamingHelper(_HandlerWithoutProducerAPI(), "tid")
+        assert helper._has_active_producer() is False
+
+    def test_delegates_to_handler_result(self):
+        handler = MagicMock()
+        handler.has_active_producer.return_value = True
+        helper = GeneratorStreamingHelper(handler, "tid")
+        assert helper._has_active_producer() is True
+        handler.has_active_producer.assert_called_once_with("tid")
+
+        handler.has_active_producer.return_value = False
+        assert helper._has_active_producer() is False
+
+    def test_conservative_true_on_exception(self):
+        """探测抛异常时保守返回 True，宁可交由 TTL 兜底也不误删。"""
+        handler = MagicMock()
+        handler.has_active_producer.side_effect = RuntimeError("broker down")
+        helper = GeneratorStreamingHelper(handler, "tid")
+        assert helper._has_active_producer() is True
+
+
+def _make_cleanup_helper(handler: MagicMock) -> GeneratorStreamingHelper:
+    helper = GeneratorStreamingHelper(handler, "tid")
+    # 缩短延迟清理窗口，保证测试快速且确定性
+    helper._PRODUCER_CLEANUP_DELAY = 0.1
+    helper._DONE_ORPHAN_CLEANUP_GRACE = 0.1
+    helper._ORPHAN_CLEANUP_POLL_INTERVAL = 0.02
+    return helper
+
+
+def _wait(predicate, timeout: float = 1.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.02)
+    return predicate()
+
+
+class TestOrphanCleanupGuard:
+    def test_defers_cleanup_while_producer_active(self):
+        """到达清理时机但仍有活跃 producer 时，不得回收会话日志。"""
+        handler = MagicMock()
+        handler.has_pending_messages.return_value = True
+        handler.has_active_consumer.return_value = False
+        handler.has_active_producer.return_value = True
+
+        helper = _make_cleanup_helper(handler)
+        helper._schedule_session_cleanup(done_event_seen=False)
+
+        # 等待超过延迟窗口后，仍不应触发 mark_completed
+        time.sleep(0.4)
+        handler.mark_completed.assert_not_called()
+
+    def test_defers_cleanup_while_consumer_active(self):
+        """仍有活跃 consumer 时同样不回收，交由消费者完成/断开时的清理路径兜底。"""
+        handler = MagicMock()
+        handler.has_pending_messages.return_value = True
+        handler.has_active_consumer.return_value = True
+        handler.has_active_producer.return_value = False
+
+        helper = _make_cleanup_helper(handler)
+        helper._schedule_session_cleanup(done_event_seen=False)
+
+        time.sleep(0.4)
+        handler.mark_completed.assert_not_called()
+
+    def test_cleans_up_when_orphaned(self):
+        """确实孤立（无活跃 consumer、无活跃 producer）时才回收会话日志。"""
+        handler = MagicMock()
+        handler.has_pending_messages.return_value = True
+        handler.has_active_consumer.return_value = False
+        handler.has_active_producer.return_value = False
+
+        helper = _make_cleanup_helper(handler)
+        helper._schedule_session_cleanup(done_event_seen=False)
+
+        assert _wait(lambda: handler.mark_completed.called, timeout=1.0)
+        handler.mark_completed.assert_called_once_with("tid")
+
+    def test_skips_when_no_pending_messages(self):
+        """会话已无 pending 消息时直接跳过，不做任何清理动作。"""
+        handler = MagicMock()
+        handler.has_pending_messages.return_value = False
+
+        helper = _make_cleanup_helper(handler)
+        helper._schedule_session_cleanup(done_event_seen=False)
+
+        time.sleep(0.3)
+        handler.mark_completed.assert_not_called()


### PR DESCRIPTION
## 背景

RabbitMQ message handler 的 replay 采用非破坏性 peek，主队列消息数不随消费下降；长会话/孤儿会话持续累积（曾观测单会话主队列 6667 触发 vhost 告警）。本 PR 从架构上根治：**MySQL 作持久日志，RabbitMQ 只保留未落库的在途消息**。

> **拆分说明**：乱序、重复两个正确性问题已拆到 #672 优先快速合入。本 PR 目前仍包含这两个 commit（`d9d01502` / `c3a69b97`）；待 #672 合入 `develop` 后本 PR 将 rebase 去除它们，仅保留下述队列根治改动。

## 改动内容（队列长度根治）

- **seq 游标**：publish 给每条消息写入 per-thread 单调 `seq`（RabbitMQ message header），`get_messages_since` 改为按 `since_seq` 续读，对头部 prune 稳定（未 prune 时与旧 list 下标等价）。
- **落库即 prune**：`BaseSessionWriter` 落库经 opt-in `commit_hook` 通知，`chat._stream_with_queue` 接到 `prune_committed`——从主队列头部删除「messageId 已落库」的前缀（含心跳），遇未落库/EOD/CANCELLED 即停。队列稳态只留在途消息。
- **gap 兜底**：慢消费者游标落在被 prune 段之前时抛 `ReplayGapError`，消费循环用 `snapshot_provider`（从 graph checkpoint 经 `langchain_messages_to_agui` 重建当前快照）重拉快照让前端 reset，再从队列尾续读，不重不漏；无 provider 时优雅降级不崩溃。
- **自适应 flush**：daemon flush 前期 0.1s（首 token 快达）、10s 内线性升到 0.5s（降后期 IO）；显式 flush 不受限。
- **孤儿清理收敛**：延迟清理仅回收真正孤立会话（无活跃 consumer 且无活跃 producer，新增 `has_active_producer` 跨进程探测）；纯 replay 消费者 EOD 前断开补一次清理并排除 stopped 会话。

## 落库粒度

- assistant 消息在 LangChain `on_chat_model_end`（整条聚合完成的 AIMessage）整条写库，故 prune 粒度 = 一次完整 LLM 调用；在途的当前消息在其 model_end 前整条留在队列（队列大小下界），token 仍逐个实时到达消费者。消费者落后不超过「一个 model_end 周期」即零代价，落后超过则由 gap 重拉快照兜底（不丢不重）。

## 测试

- `test_rabbitmq_handler` / `test_streaming_helper` / `test_chat` / `test_session_writer_commit_hook` 合计 **125 passed, 1 skipped**（排除 live_chat），ruff 通过。
- 关键真机用例：seq header 在 requeue 后存活 + 头部 prune 后续读不重不漏；prune 删已落库前缀+心跳、遇未落库/EOD 即停；`ReplayGapError` 抛出与重拉快照续读；prune 下 EOD 不被误删、`mark_completed` 仍清空。

## 关联

- 乱序 / 重复（正确性修复，优先合入）：#672
- 前端兼容 PR #669 已关闭：snapshot+replay 重叠改由后端去重闭环（在 #672）。
- 后续可选清理：DLQ / 竞争消费遗留移除（RabbitMQ 已不再写 DLQ），需等 rollout + `QUEUE_TTL` 窗口，单独 PR。