### PR TITLE
fix: 兼容 AGUI snapshot 后 replay 重叠 --story=1070093903135579259

### DIFF
--- a/src/frontend/ai-blueking/packages/ai-blueking/src/__tests__/ag-ui-replay.spec.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/__tests__/ag-ui-replay.spec.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { AGUIProtocol, EventType, MessageRole, MessageStatus, useMessage } from '@blueking/chat-helper';
+
+import type { IMediatorModule } from '@blueking/chat-helper';
+
+const createProtocol = () => {
+  const messageModule = useMessage({} as IMediatorModule);
+  const protocol = new AGUIProtocol();
+  protocol.injectMessageModule(messageModule);
+  return { messageModule, protocol };
+};
+
+describe('AGUIProtocol replay after snapshot', () => {
+  it('reuses snapshot text message when replay starts from the same message id', () => {
+    const { messageModule, protocol } = createProtocol();
+
+    protocol.onMessage({
+      messages: [
+        {
+          content: 'cached prefix',
+          id: '1',
+          message_id: 'assistant-mid',
+          role: MessageRole.Assistant,
+          session_code: 'session-1',
+          status: MessageStatus.Streaming,
+        },
+      ],
+      type: EventType.MessagesSnapshot,
+    });
+
+    protocol.onMessage({
+      messageId: 'assistant-mid',
+      role: MessageRole.Assistant,
+      type: EventType.TextMessageStart,
+    });
+    protocol.onMessage({
+      delta: 'cached prefix',
+      messageId: 'assistant-mid',
+      type: EventType.TextMessageContent,
+    });
+    protocol.onMessage({
+      delta: ' new suffix',
+      messageId: 'assistant-mid',
+      type: EventType.TextMessageContent,
+    });
+
+    expect(messageModule.list.value).toHaveLength(1);
+    expect(messageModule.list.value[0]).toMatchObject({
+      content: 'cached prefix new suffix',
+      messageId: 'assistant-mid',
+      status: MessageStatus.Streaming,
+    });
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-helper/src/event/ag-ui.ts
+++ b/src/frontend/ai-blueking/packages/chat-helper/src/event/ag-ui.ts
@@ -464,6 +464,13 @@ export class AGUIProtocol implements ISSEProtocol {
    * 处理文本消息开始事件
    */
   handleTextMessageStartEvent(event: ITextMessageStartEvent) {
+    const message = this.messageModule.getMessageByMessageId(event.messageId);
+    if (message) {
+      message.content = '';
+      message.status = MessageStatus.Streaming;
+      return;
+    }
+
     this.messageModule.plusMessage({
       role: event.role as MessageRole.Assistant,
       content: '',


### PR DESCRIPTION
## 背景

- 每条 SSE 连接启动时后端会先下发 `MESSAGES_SNAPSHOT`。
- 刷新、新开页面或断线重连后，snapshot 可能已经包含当前 streaming message 的部分内容；随后 RabbitMQ replay 又可能从该 message 的 `TEXT_MESSAGE_START` 继续输出。
- 在后端持久化 snapshot 与 RabbitMQ replay offset 尚未完全对齐前，前端需要对同 `messageId` 的 replay start 做幂等兜底，避免重复创建消息。

## 改动内容

- `AGUIProtocol.handleTextMessageStartEvent` 在已有同 `messageId` 时复用当前消息，并重置为 streaming 状态。
- 新增 `ag-ui-replay.spec.ts`，覆盖 snapshot 后同 `messageId` replay start 不重复 push 的场景。

## 说明

- 本 PR 只处理 snapshot + replay 重叠导致的前端重复展示兜底。
- RabbitMQ SSE 乱序的后端根因修复已拆到 PR #668。
- 长期更干净的后端方案仍应是 snapshot 持久化时记录 replay offset，新连接只 replay snapshot 覆盖范围之后的事件。

## 测试验证

- `pnpm exec vitest run src/__tests__/ag-ui-replay.spec.ts`
