### PR TITLE
fix: 修复 RabbitMQ SSE 乱序与多端重复 --story=1070093903135579259

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -6,7 +6,7 @@ from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
 
-from ag_ui.core import BaseEvent
+from ag_ui.core import BaseEvent, EventType
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, RemoveMessage, SystemMessage, ToolMessage
@@ -142,6 +142,9 @@ class ChatCompletionAgent(BaseModel):
     TOOL_EXECUTION_INTERVAL: ClassVar[int] = 10
     UPLOAD_IMAGE_PROMPT_PREFIX: ClassVar[Any] = "我上传了个图片文件,文件名为{file_name}。"
     SKIP_PROMPT_ROLE: ClassVar[list[str]] = ["guide", "reasoning"]
+    # 与 ag_ui EventEncoder 的 SSE 编码保持一致
+    SSE_DATA_PREFIX: ClassVar[str] = "data: "
+    SSE_FRAME_SUFFIX: ClassVar[str] = "\n\n"
 
     class Config:
         arbitrary_types_allowed = True
@@ -828,49 +831,65 @@ class ChatCompletionAgent(BaseModel):
             replay_head_transform=self._dedup_snapshot_head_frames,
         )
 
-    @staticmethod
-    def _collect_replay_message_ids(cached: list[Any]) -> set[str]:
+    @classmethod
+    def _parse_sse_event(cls, frame: Any, event_type: str) -> Optional[dict]:
+        """把 SSE 帧解析为指定类型的 payload；类型不符或无法解析时返回 None。
+
+        先做子串预筛只为跳过大多数不相关帧，类型判定一律以解析后的 ``type`` 字段为准，
+        不依赖 encoder 的 JSON 分隔符风格。
+        """
+        if not isinstance(frame, str) or event_type not in frame:
+            return None
+        body = frame[len(cls.SSE_DATA_PREFIX) :] if frame.startswith(cls.SSE_DATA_PREFIX) else frame
+        try:
+            payload = json.loads(body)
+        except ValueError:
+            return None
+        if not isinstance(payload, dict) or payload.get("type") != event_type:
+            return None
+        return payload
+
+    @classmethod
+    def _collect_replay_message_ids(cls, cached: list[Any]) -> set[str]:
         """收集实际首批 replay 中 ``TEXT_MESSAGE_START`` 的 message_id。"""
         message_ids: set[str] = set()
         for frame in cached:
-            if not isinstance(frame, str) or '"type":"TEXT_MESSAGE_START"' not in frame:
-                continue
-            try:
-                payload = json.loads(frame[len("data: ") :] if frame.startswith("data: ") else frame)
-            except (json.JSONDecodeError, ValueError):
+            payload = cls._parse_sse_event(frame, EventType.TEXT_MESSAGE_START)
+            if payload is None:
                 continue
             message_id = payload.get("messageId") or payload.get("message_id")
             if message_id:
                 message_ids.add(message_id)
         return message_ids
 
-    @staticmethod
-    def _dedup_snapshot_head_frames(head_frames: list[Any], replay_frames: list[Any]) -> list[Any]:
-        """从阶段 1 头部帧的 ``MESSAGES_SNAPSHOT`` 中剔除将被 replay 重放的消息，避免重复。"""
-        replay_message_ids = ChatCompletionAgent._collect_replay_message_ids(replay_frames)
+    @classmethod
+    def _dedup_snapshot_head_frames(cls, head_frames: list[Any], replay_frames: list[Any]) -> list[Any]:
+        """从阶段 1 头部帧的 ``MESSAGES_SNAPSHOT`` 中剔除将被 replay 重放的消息，避免重复。
+
+        只处理 ``TEXT_MESSAGE_START`` 对应的文本消息；replay 中的工具调用类事件不参与
+        去重，快照里的同 id 工具消息仍可能与 replay 重叠。
+        """
+        replay_message_ids = cls._collect_replay_message_ids(replay_frames)
         if not replay_message_ids:
             return head_frames
-        return [ChatCompletionAgent._strip_snapshot_messages(f, replay_message_ids) for f in head_frames]
+        return [cls._strip_snapshot_messages(f, replay_message_ids) for f in head_frames]
 
-    @staticmethod
-    def _strip_snapshot_messages(frame: Any, exclude_ids: set[str]) -> Any:
+    @classmethod
+    def _strip_snapshot_messages(cls, frame: Any, exclude_ids: set[str]) -> Any:
         """若 ``frame`` 是 ``MESSAGES_SNAPSHOT``，剔除 id ∈ ``exclude_ids`` 的消息后重新编码。
 
         非快照帧、无法解析或无需改动时原样返回，保持其余帧字节不变。
         """
-        if not isinstance(frame, str) or '"type":"MESSAGES_SNAPSHOT"' not in frame:
-            return frame
-        body = frame[len("data: ") :] if frame.startswith("data: ") else frame
-        try:
-            data = json.loads(body)
-        except (json.JSONDecodeError, ValueError):
+        data = cls._parse_sse_event(frame, EventType.MESSAGES_SNAPSHOT)
+        if data is None:
             return frame
         messages = data.get("messages") or []
         kept = [m for m in messages if (m.get("messageId") or m.get("id")) not in exclude_ids]
         if len(kept) == len(messages):
             return frame
         data["messages"] = kept
-        return f"data: {json.dumps(data, ensure_ascii=False, separators=(',', ':'))}\n\n"
+        body = json.dumps(data, ensure_ascii=False, separators=(",", ":"))
+        return f"{cls.SSE_DATA_PREFIX}{body}{cls.SSE_FRAME_SUFFIX}"
 
     @staticmethod
     def _extract_head_frames(

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -819,39 +819,20 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 1：同步拉取头部帧并直接 yield ----
         head_frames = []
         remaining_producer = self._extract_head_frames(producer, head_frames)
-        # 多端 replay 去重：阶段 1 现发的 MESSAGES_SNAPSHOT 由本连接 input.messages（DB 状态）
-        # 构造，可能已含当前 run 那条半截 assistant 消息；而阶段 2 replay 会从头把同一条
-        # （同 message_id）完整重放。若不处理，前端会“快照已有该 id + replay 又 START(同 id)”
-        # 而产生重复消息。这里在直传快照前，剔除 replay 缓存中将被重放的 message_id，让 replay
-        # 成为该消息的唯一来源（内容完整，无需 offset 对齐），保证本连接输出流自洽、零重叠。
-        replay_message_ids = self._collect_replay_message_ids(
-            helper.message_handler, queue_thread_id or agent_input.thread_id
+        # helper 先注册 consumer 并确定实际消费 replay 后，再用同一批 replay 数据过滤快照；
+        # 过滤后的头部帧仍然直接 yield，不进入 RabbitMQ，保持原有两阶段输出顺序。
+        yield from helper.stream(
+            remaining_producer,
+            on_complete=self._on_complete,
+            head_frames=head_frames,
+            replay_head_transform=self._dedup_snapshot_head_frames,
         )
-        head_frames = self._dedup_snapshot_head_frames(head_frames, replay_message_ids)
-        for frame in head_frames:
-            yield frame
-
-        # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
 
     @staticmethod
-    def _collect_replay_message_ids(message_handler: Any, thread_id: str | None) -> set[str]:
-        """收集阶段 2 replay 将从头重放的 ``TEXT_MESSAGE_START`` 的 message_id。
-
-        仅当存在待重放消息时才非破坏性 peek 缓存日志；handler 不支持 peek、超时或任何异常
-        一律按“无重放”处理（返回空集），回退到原有行为，绝不影响正常流。
-        """
-        if not thread_id:
-            return set()
-        try:
-            if not message_handler.has_pending_messages(thread_id):
-                return set()
-            cached, _ = message_handler.get_messages_since(thread_id, 0, timeout=0.5)
-        except Exception:
-            return set()
-
+    def _collect_replay_message_ids(cached: list[Any]) -> set[str]:
+        """收集实际首批 replay 中 ``TEXT_MESSAGE_START`` 的 message_id。"""
         message_ids: set[str] = set()
-        for frame in cached or []:
+        for frame in cached:
             if not isinstance(frame, str) or '"type":"TEXT_MESSAGE_START"' not in frame:
                 continue
             try:
@@ -864,8 +845,9 @@ class ChatCompletionAgent(BaseModel):
         return message_ids
 
     @staticmethod
-    def _dedup_snapshot_head_frames(head_frames: list, replay_message_ids: set[str]) -> list:
+    def _dedup_snapshot_head_frames(head_frames: list[Any], replay_frames: list[Any]) -> list[Any]:
         """从阶段 1 头部帧的 ``MESSAGES_SNAPSHOT`` 中剔除将被 replay 重放的消息，避免重复。"""
+        replay_message_ids = ChatCompletionAgent._collect_replay_message_ids(replay_frames)
         if not replay_message_ids:
             return head_frames
         return [ChatCompletionAgent._strip_snapshot_messages(f, replay_message_ids) for f in head_frames]

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -819,11 +819,76 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 1：同步拉取头部帧并直接 yield ----
         head_frames = []
         remaining_producer = self._extract_head_frames(producer, head_frames)
+        # 多端 replay 去重：阶段 1 现发的 MESSAGES_SNAPSHOT 由本连接 input.messages（DB 状态）
+        # 构造，可能已含当前 run 那条半截 assistant 消息；而阶段 2 replay 会从头把同一条
+        # （同 message_id）完整重放。若不处理，前端会“快照已有该 id + replay 又 START(同 id)”
+        # 而产生重复消息。这里在直传快照前，剔除 replay 缓存中将被重放的 message_id，让 replay
+        # 成为该消息的唯一来源（内容完整，无需 offset 对齐），保证本连接输出流自洽、零重叠。
+        replay_message_ids = self._collect_replay_message_ids(
+            helper.message_handler, queue_thread_id or agent_input.thread_id
+        )
+        head_frames = self._dedup_snapshot_head_frames(head_frames, replay_message_ids)
         for frame in head_frames:
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+
+    @staticmethod
+    def _collect_replay_message_ids(message_handler: Any, thread_id: str | None) -> set[str]:
+        """收集阶段 2 replay 将从头重放的 ``TEXT_MESSAGE_START`` 的 message_id。
+
+        仅当存在待重放消息时才非破坏性 peek 缓存日志；handler 不支持 peek、超时或任何异常
+        一律按“无重放”处理（返回空集），回退到原有行为，绝不影响正常流。
+        """
+        if not thread_id:
+            return set()
+        try:
+            if not message_handler.has_pending_messages(thread_id):
+                return set()
+            cached, _ = message_handler.get_messages_since(thread_id, 0, timeout=0.5)
+        except Exception:
+            return set()
+
+        message_ids: set[str] = set()
+        for frame in cached or []:
+            if not isinstance(frame, str) or '"type":"TEXT_MESSAGE_START"' not in frame:
+                continue
+            try:
+                payload = json.loads(frame[len("data: ") :] if frame.startswith("data: ") else frame)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            message_id = payload.get("messageId") or payload.get("message_id")
+            if message_id:
+                message_ids.add(message_id)
+        return message_ids
+
+    @staticmethod
+    def _dedup_snapshot_head_frames(head_frames: list, replay_message_ids: set[str]) -> list:
+        """从阶段 1 头部帧的 ``MESSAGES_SNAPSHOT`` 中剔除将被 replay 重放的消息，避免重复。"""
+        if not replay_message_ids:
+            return head_frames
+        return [ChatCompletionAgent._strip_snapshot_messages(f, replay_message_ids) for f in head_frames]
+
+    @staticmethod
+    def _strip_snapshot_messages(frame: Any, exclude_ids: set[str]) -> Any:
+        """若 ``frame`` 是 ``MESSAGES_SNAPSHOT``，剔除 id ∈ ``exclude_ids`` 的消息后重新编码。
+
+        非快照帧、无法解析或无需改动时原样返回，保持其余帧字节不变。
+        """
+        if not isinstance(frame, str) or '"type":"MESSAGES_SNAPSHOT"' not in frame:
+            return frame
+        body = frame[len("data: ") :] if frame.startswith("data: ") else frame
+        try:
+            data = json.loads(body)
+        except (json.JSONDecodeError, ValueError):
+            return frame
+        messages = data.get("messages") or []
+        kept = [m for m in messages if (m.get("messageId") or m.get("id")) not in exclude_ids]
+        if len(kept) == len(messages):
+            return frame
+        data["messages"] = kept
+        return f"data: {json.dumps(data, ensure_ascii=False, separators=(',', ':'))}\n\n"
 
     @staticmethod
     def _extract_head_frames(

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -304,6 +304,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     QUEUE_TTL_MS: ClassVar[int] = QueueTTLConfig.QUEUE_EXPIRE_MS
     REPLAY_LOCK_RETRY_INTERVAL: ClassVar[float] = 0.05
     REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.1
+    # 显式 flush 等待同一 thread 的 in-flight 批次发布完成的上限
+    FLUSH_IN_FLIGHT_WAIT_SEC: ClassVar[float] = 5.0
 
     _instance: Optional["RabbitMQMessageHandler"] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
@@ -853,7 +855,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             except Exception as e:
                 logger.error(f"Error flushing messages to RabbitMQ: {e}")
                 self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
-                self._notify_replay_waiters()
             else:
                 self._finish_thread_flush(thread_id)
                 flushed = True
@@ -985,11 +986,30 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 self._message_buffer[thread_id] = []
             self._message_buffer[thread_id].append(message)
 
-    def _take_thread_buffer_for_flush(self, thread_id: str) -> list[Any]:
-        """取出一个 thread 的待发布 buffer，并标记本进程内该 thread 正在 flush。"""
+    def _take_thread_buffer_for_flush(self, thread_id: str, wait_for_in_flight: Optional[float] = None) -> list[Any]:
+        """取出一个 thread 的待发布 buffer，并标记本进程内该 thread 正在 flush。
+
+        Args:
+            thread_id: 目标会话
+            wait_for_in_flight: 该 thread 已有 in-flight 批次时的等待上限（秒）。
+                None 表示直接放弃本轮（daemon 会在下个周期重试）；显式 flush 必须传值，
+                否则调用方以为消息已发布，而 buffer 里的消息（例如 EOD_CHUNK）会滞留到
+                下一个 daemon 周期，daemon 退出后更会永久滞留。
+        """
         with self._buffer_condition:
             if thread_id in self._flushing_threads:
-                return []
+                if wait_for_in_flight is None:
+                    return []
+                if not self._buffer_condition.wait_for(
+                    lambda: thread_id not in self._flushing_threads,
+                    timeout=wait_for_in_flight,
+                ):
+                    logger.warning(
+                        "[RabbitMQ] give up waiting for in-flight flush thread_id=%s timeout=%.1fs",
+                        thread_id,
+                        wait_for_in_flight,
+                    )
+                    return []
 
             messages_to_flush = self._message_buffer.get(thread_id, [])
             if not messages_to_flush:
@@ -1015,7 +1035,9 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             thread_id: 如果指定，只推送该 thread_id 的消息；否则推送所有消息
         """
         if thread_id:
-            messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
+            messages_to_flush = self._take_thread_buffer_for_flush(
+                thread_id, wait_for_in_flight=self.FLUSH_IN_FLIGHT_WAIT_SEC
+            )
             if not messages_to_flush:
                 return
 
@@ -1035,7 +1057,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             except Exception as e:
                 logger.error(f"Error flushing messages for {thread_id}: {e}")
                 self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
-                self._notify_replay_waiters()
                 raise
             else:
                 self._finish_thread_flush(thread_id)

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -334,14 +334,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 消息缓冲队列：用于批量推送
         self._message_buffer: dict[str, list[Any]] = {}
         self._buffer_lock = threading.Lock()
+        self._buffer_condition = threading.Condition(self._buffer_lock)
+        self._flushing_threads: set[str] = set()
         self._replay_wait_condition = threading.Condition()
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
-
-        # flush 与 peek+buffer 合并的互斥锁（per thread_id，进程内）
-        # 防止 flush 在 peek 和 buffer 合并之间清空 buffer 导致消息丢失/重复
-        self._flush_peek_locks: dict[str, threading.Lock] = {}
-        self._flush_peek_locks_guard = threading.Lock()
 
         # 后台守护线程
         self._daemon_thread: Optional[threading.Thread] = None
@@ -400,13 +397,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """获取多消费者活跃状态队列名。"""
         return f"{self.ACTIVE_CONSUMER_PREFIX}{thread_id}"
 
-    def _get_flush_peek_lock(self, thread_id: str) -> threading.Lock:
-        """获取指定 thread_id 的 flush/peek 互斥锁（进程内，惰性创建）。"""
-        with self._flush_peek_locks_guard:
-            if thread_id not in self._flush_peek_locks:
-                self._flush_peek_locks[thread_id] = threading.Lock()
-            return self._flush_peek_locks[thread_id]
-
     def _create_dedicated_connection(self) -> pika.BlockingConnection:
         """创建不进入连接池的 RabbitMQ 连接，用于 exclusive queue 生命周期。"""
         params = pika.URLParameters(self._rabbitmq_url)
@@ -464,8 +454,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     def _wait_for_replay_retry(self, deadline: float | None, interval: float) -> None:
         """等待下一次 replay 检查。
 
-        本进程内有 buffer 写入或 replay lock 释放时会提前唤醒；跨进程 RabbitMQ 写入
-        无法通过本地 Condition 感知，因此仍保留短超时作为兜底重试。
+        本进程内有 RabbitMQ 提交或 replay lock 释放时会提前唤醒；跨进程 RabbitMQ
+        写入无法通过本地 Condition 感知，因此仍保留短超时作为兜底重试。
         """
         wait_time = interval
         if deadline is not None:
@@ -831,52 +821,44 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             logger.error(f"Error flushing messages on daemon exit: {e}")
 
     def _flush_messages(self) -> None:
-        """批量推送缓冲区中的所有消息到 RabbitMQ
-
-        对每个 thread_id，在 _flush_peek_lock 内完成"取出 buffer + publish"的原子操作，
-        确保与 get_messages_since（peek + buffer 合并）互斥，避免消息丢失/重复。
-        """
-        # 快速检查是否有消息需要 flush
+        """批量推送缓冲区中的所有消息到 RabbitMQ"""
         with self._buffer_lock:
             if not self._message_buffer:
                 return
-            thread_ids_to_flush = list(self._message_buffer.keys())
+            thread_ids = [thread_id for thread_id, messages in self._message_buffer.items() if messages]
 
-        # 按 thread_id 逐个 flush，每个 thread_id 在 flush_peek_lock 内完成
-        # "取出 buffer + publish" 的原子操作
-        any_flushed = False
-        for thread_id in thread_ids_to_flush:
-            flush_peek_lock = self._get_flush_peek_lock(thread_id)
+        if not thread_ids:
+            return
+
+        flushed = False
+        for thread_id in thread_ids:
+            messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
+            if not messages_to_flush:
+                continue
+
             try:
-                with flush_peek_lock:
-                    # 在 flush_peek_lock 内取出该 thread_id 的 buffer
-                    with self._buffer_lock:
-                        messages = self._message_buffer.pop(thread_id, [])
-                    if not messages:
-                        continue
+                with self._with_channel() as channel:
+                    queue_name = self._ensure_queue(channel, thread_id)
 
-                    # 在同一个 flush_peek_lock 内 publish 到 RabbitMQ
-                    with self._with_channel() as channel:
-                        queue_name = self._ensure_queue(channel, thread_id)
-                        for message in messages:
-                            body = pickle.dumps(message)
-                            channel.basic_publish(
-                                exchange="",
-                                routing_key=queue_name,
-                                body=body,
-                                properties=pika.BasicProperties(delivery_mode=2),
-                            )
-                    logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
-                    any_flushed = True
+                    for message in messages_to_flush:
+                        body = pickle.dumps(message)
+                        channel.basic_publish(
+                            exchange="",
+                            routing_key=queue_name,
+                            body=body,
+                            properties=pika.BasicProperties(delivery_mode=2),
+                        )
+
+                    logger.debug(f"Flushed {len(messages_to_flush)} messages to queue {queue_name}")
             except Exception as e:
-                logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
-                # 推送失败，将消息放回缓冲区（放到前面保持顺序）
-                with self._buffer_lock:
-                    if thread_id not in self._message_buffer:
-                        self._message_buffer[thread_id] = []
-                    self._message_buffer[thread_id] = messages + self._message_buffer[thread_id]
+                logger.error(f"Error flushing messages to RabbitMQ: {e}")
+                self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+                self._notify_replay_waiters()
+            else:
+                self._finish_thread_flush(thread_id)
+                flushed = True
 
-        if any_flushed:
+        if flushed:
             self._notify_replay_waiters()
 
     # ================== 死信队列操作 ==================
@@ -1002,7 +984,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if thread_id not in self._message_buffer:
                 self._message_buffer[thread_id] = []
             self._message_buffer[thread_id].append(message)
-        self._notify_replay_waiters()
+
+    def _take_thread_buffer_for_flush(self, thread_id: str) -> list[Any]:
+        """取出一个 thread 的待发布 buffer，并标记本进程内该 thread 正在 flush。"""
+        with self._buffer_condition:
+            if thread_id in self._flushing_threads:
+                return []
+
+            messages_to_flush = self._message_buffer.get(thread_id, [])
+            if not messages_to_flush:
+                return []
+
+            self._message_buffer[thread_id] = []
+            self._flushing_threads.add(thread_id)
+            return messages_to_flush
+
+    def _finish_thread_flush(self, thread_id: str, messages_to_restore: Optional[list[Any]] = None) -> None:
+        """结束一个 thread 的本地 flush；失败时把本批消息放回 buffer 头部。"""
+        with self._buffer_condition:
+            if messages_to_restore:
+                current_messages = self._message_buffer.get(thread_id, [])
+                self._message_buffer[thread_id] = messages_to_restore + current_messages
+            self._flushing_threads.discard(thread_id)
+            self._buffer_condition.notify_all()
 
     def flush(self, thread_id: Optional[str] = None) -> None:
         """立即推送缓冲区中的消息到 RabbitMQ
@@ -1011,39 +1015,31 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             thread_id: 如果指定，只推送该 thread_id 的消息；否则推送所有消息
         """
         if thread_id:
-            # 只推送指定 thread_id 的消息，在 flush_peek_lock 内原子完成
-            flush_peek_lock = self._get_flush_peek_lock(thread_id)
-            with flush_peek_lock:
-                with self._buffer_lock:
-                    messages_to_flush = self._message_buffer.pop(thread_id, [])
+            messages_to_flush = self._take_thread_buffer_for_flush(thread_id)
+            if not messages_to_flush:
+                return
 
-                if not messages_to_flush:
-                    return
+            try:
+                with self._with_channel() as channel:
+                    logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
+                    queue_name = self._ensure_queue(channel, thread_id)
 
-                logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
-
-                try:
-                    with self._with_channel() as channel:
-                        queue_name = self._ensure_queue(channel, thread_id)
-
-                        for message in messages_to_flush:
-                            body = pickle.dumps(message)
-                            channel.basic_publish(
-                                exchange="",
-                                routing_key=queue_name,
-                                body=body,
-                                properties=pika.BasicProperties(delivery_mode=2),
-                            )
-                    self._notify_replay_waiters()
-                except Exception as e:
-                    logger.error(f"Error flushing messages for {thread_id}: {e}")
-                    # 推送失败，放回缓冲区
-                    with self._buffer_lock:
-                        if thread_id not in self._message_buffer:
-                            self._message_buffer[thread_id] = []
-                        self._message_buffer[thread_id] = messages_to_flush + self._message_buffer[thread_id]
-                    self._notify_replay_waiters()
-                    raise
+                    for message in messages_to_flush:
+                        body = pickle.dumps(message)
+                        channel.basic_publish(
+                            exchange="",
+                            routing_key=queue_name,
+                            body=body,
+                            properties=pika.BasicProperties(delivery_mode=2),
+                        )
+            except Exception as e:
+                logger.error(f"Error flushing messages for {thread_id}: {e}")
+                self._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+                self._notify_replay_waiters()
+                raise
+            else:
+                self._finish_thread_flush(thread_id)
+                self._notify_replay_waiters()
         else:
             # 推送所有消息
             self._flush_messages()
@@ -1117,30 +1113,22 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         start_time = time.time()
         deadline = start_time + timeout if timeout is not None else None
         offset = max(offset, 0)
-        flush_peek_lock = self._get_flush_peek_lock(thread_id)
 
         while True:
             try:
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
+                    all_messages = self._peek_queue_messages(channel, main_queue_name)
 
-                    # flush_peek_lock 保护 peek + buffer 合并这两步的原子性，
-                    # 防止 flush 在 peek 之后、buffer 合并之前清空 buffer 导致消息丢失。
-                    with flush_peek_lock:
+                    # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
+                    if not all_messages and self._get_dlq_count(thread_id) > 0:
+                        restored = self._restore_from_dlq(thread_id)
+                        logger.info(
+                            "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
+                            thread_id,
+                            restored,
+                        )
                         all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if not all_messages and self._get_dlq_count(thread_id) > 0:
-                            restored = self._restore_from_dlq(thread_id)
-                            logger.info(
-                                "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
-                                thread_id,
-                                restored,
-                            )
-                            all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        with self._buffer_lock:
-                            all_messages.extend(self._message_buffer.get(thread_id, []))
 
                 next_offset = len(all_messages)
                 if next_offset > offset:
@@ -1219,6 +1207,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 检查本地缓冲区
         with self._buffer_lock:
             if thread_id in self._message_buffer and self._message_buffer[thread_id]:
+                return True
+            if thread_id in self._flushing_threads:
                 return True
 
         # 检查 RabbitMQ 主队列和死信队列
@@ -1371,10 +1361,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
 
         self._purge_all_queues(thread_id, include_cancel_queue=True)
         self._delete_all_resources(thread_id)
-
-        # 清理 flush_peek_lock（session 已结束，不再需要）
-        with self._flush_peek_locks_guard:
-            self._flush_peek_locks.pop(thread_id, None)
 
     def request_cancel(self, thread_id: str) -> None:
         """请求取消该 thread_id 的流。幂等：向取消队列投递一条消息，生产者轮询时消费到即退出。"""

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -435,13 +435,13 @@ class GeneratorStreamingHelper:
         producer_acquired: bool,
         on_complete: Callable[[], None] | None = None,
     ) -> tuple[threading.Thread | None, bool]:
-        """根据队列状态决定启动生产者还是恢复旧消息。"""
+        """根据队列状态决定启动生产者还是恢复旧消息。
+
+        调用方必须已经对 ``producer_acquired`` 的连接执行过 ``_reset_queue_for_new_producer()``。
+        """
         supports_replay_from_start = self._supports_replay_from_start()
 
         if producer_acquired:
-            self.message_handler.clear(self.thread_id)
-            self.message_handler.clear_stopped(self.thread_id)
-
             producer_thread = threading.Thread(
                 target=self._producer,
                 args=(generator, cancel_event, on_complete, True),
@@ -713,8 +713,22 @@ class GeneratorStreamingHelper:
         except TimeoutError:
             logger.warning("Replay prefetch timed out; head-frame transform skipped, thread_id=%s", self.thread_id)
             return head_frames, None
+        except Exception:
+            # 头部帧（含 MESSAGES_SNAPSHOT）不依赖队列，队列故障时也要原样送达，
+            # 否则前端连历史消息都拿不到，只能看到连接错误。
+            logger.exception("Replay prefetch failed; head frames sent unchanged, thread_id=%s", self.thread_id)
+            return head_frames, None
 
         return replay_head_transform(head_frames, replay_messages), (replay_messages, replay_offset)
+
+    def _reset_queue_for_new_producer(self) -> None:
+        """本连接取得写入权后重置会话队列。
+
+        必须在向客户端 yield 头部帧之前完成：yield 会把控制权交回 SSE 迭代器，
+        期间其他连接若看到未清理的上一轮残留，会 replay 出上一轮的旧回答。
+        """
+        self.message_handler.clear(self.thread_id)
+        self.message_handler.clear_stopped(self.thread_id)
 
     def stream(
         self,
@@ -771,6 +785,8 @@ class GeneratorStreamingHelper:
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
             if not has_pending:
                 producer_acquired = self.message_handler.acquire_producer(self.thread_id)
+            if producer_acquired:
+                self._reset_queue_for_new_producer()
 
             will_replay = has_pending or not producer_acquired
             prepared_head_frames, initial_replay = self._prepare_head_frames_for_replay(

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -289,6 +289,7 @@ class GeneratorStreamingHelper:
     def _consume_stopped_session(
         self,
         consumer_id: str,
+        initial_replay: tuple[list[Any], int] | None = None,
     ) -> Generator[Any, None, None]:
         """消费已停止会话的消息（内部方法）
 
@@ -302,14 +303,18 @@ class GeneratorStreamingHelper:
         """
         max_empty_rounds = 3  # 最多空轮询3次就结束
         empty_rounds = 0
-        replay_offset = 0
+        buffered_replay, replay_offset = initial_replay if initial_replay is not None else (None, 0)
         supports_replay_from_start = self._supports_replay_from_start()
 
         while True:
             try:
                 if not supports_replay_from_start:
                     self.message_handler.check_consumer(self.thread_id, consumer_id)
-                messages, replay_offset = self._get_consumer_messages(timeout=0.3, replay_offset=replay_offset)
+                if buffered_replay is None:
+                    messages, replay_offset = self._get_consumer_messages(timeout=0.3, replay_offset=replay_offset)
+                else:
+                    messages = buffered_replay
+                    buffered_replay = None
 
                 if not messages:
                     empty_rounds += 1
@@ -427,29 +432,15 @@ class GeneratorStreamingHelper:
         self,
         generator: Generator[Any, None, None],
         cancel_event: threading.Event,
-        has_pending: bool,
+        producer_acquired: bool,
         on_complete: Callable[[], None] | None = None,
-    ) -> tuple[threading.Thread | None, bool, bool]:
+    ) -> tuple[threading.Thread | None, bool]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
-        producer_thread: threading.Thread | None = None
-        is_resuming = False
-        enable_heartbeat_check = False
         supports_replay_from_start = self._supports_replay_from_start()
 
-        if not has_pending:
-            if not self.message_handler.acquire_producer(self.thread_id):
-                logger.info(
-                    "Producer already active for thread_id=%s, consuming existing replay stream",
-                    self.thread_id,
-                )
-                return producer_thread, True, True
-
-            try:
-                self.message_handler.clear(self.thread_id)
-                self.message_handler.clear_stopped(self.thread_id)
-            except Exception:
-                self.message_handler.release_producer(self.thread_id)
-                raise
+        if producer_acquired:
+            self.message_handler.clear(self.thread_id)
+            self.message_handler.clear_stopped(self.thread_id)
 
             producer_thread = threading.Thread(
                 target=self._producer,
@@ -458,25 +449,22 @@ class GeneratorStreamingHelper:
             )
             producer_thread.start()
             logger.info(f"Started producer for thread_id={self.thread_id}")
-            enable_heartbeat_check = True
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return producer_thread, False
 
         if supports_replay_from_start:
-            is_resuming = True
             logger.info(
-                "Pending messages exist for thread_id=%s, replaying cached stream from start",
+                "Existing producer or cached messages found for thread_id=%s, replaying stream from start",
                 self.thread_id,
             )
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return None, True
 
         self.message_handler.wait_for_previous_consumer(self.thread_id, timeout=3.0)
         restored = self.message_handler.restore_messages(self.thread_id)
-        is_resuming = True
         logger.info(
             f"Pending messages exist for thread_id={self.thread_id}, "
             f"restored {restored} messages from DLQ, consuming from start"
         )
-        return producer_thread, is_resuming, enable_heartbeat_check
+        return None, True
 
     # ---- L1 观测：consumer 循环内联耗时 WARNING 阈值（秒），仅日志用途 ----
     _CHECK_CONSUMER_SLOW_SEC = 2.0
@@ -493,6 +481,7 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        initial_replay: tuple[list[Any], int] | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -511,7 +500,7 @@ class GeneratorStreamingHelper:
         yielded_total = 0
         exit_reason = "unknown"
         last_progress_ts = time.time()
-        replay_offset = 0
+        buffered_replay, replay_offset = initial_replay if initial_replay is not None else (None, 0)
         supports_replay_from_start = self._supports_replay_from_start()
 
         logger.info(
@@ -576,7 +565,11 @@ class GeneratorStreamingHelper:
                             )
 
                     t_get = time.time()
-                    messages, replay_offset = self._get_consumer_messages(timeout=0.5, replay_offset=replay_offset)
+                    if buffered_replay is None:
+                        messages, replay_offset = self._get_consumer_messages(timeout=0.5, replay_offset=replay_offset)
+                    else:
+                        messages = buffered_replay
+                        buffered_replay = None
                     get_elapsed = time.time() - t_get
                     if get_elapsed > self._GET_SLOW_SEC:
                         logger.warning(
@@ -700,10 +693,35 @@ class GeneratorStreamingHelper:
         except Exception:
             logger.exception("Error cleaning completed replay session for thread_id=%s", self.thread_id)
 
+    def _prepare_head_frames_for_replay(
+        self,
+        head_frames: list[Any],
+        replay_head_transform: Callable[[list[Any], list[Any]], list[Any]] | None,
+        will_replay: bool,
+    ) -> tuple[list[Any], tuple[list[Any], int] | None]:
+        """用实际首批 replay 转换直传头部帧，并把读取结果交给 consumer 复用。"""
+        if (
+            not head_frames
+            or not will_replay
+            or replay_head_transform is None
+            or not self._supports_replay_from_start()
+        ):
+            return head_frames, None
+
+        try:
+            replay_messages, replay_offset = self._get_consumer_messages(timeout=0.5, replay_offset=0)
+        except TimeoutError:
+            logger.warning("Replay prefetch timed out; head-frame transform skipped, thread_id=%s", self.thread_id)
+            return head_frames, None
+
+        return replay_head_transform(head_frames, replay_messages), (replay_messages, replay_offset)
+
     def stream(
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        head_frames: list[Any] | None = None,
+        replay_head_transform: Callable[[list[Any], list[Any]], list[Any]] | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -714,6 +732,8 @@ class GeneratorStreamingHelper:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+            head_frames: 需要在队列消息前直传的头部帧。
+            replay_head_transform: 使用实际首批 replay 调整头部帧的回调。
 
         Yields:
             生成器产生的数据
@@ -732,28 +752,49 @@ class GeneratorStreamingHelper:
         # 注册为当前活跃消费者
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
+        producer_acquired = False
         consumer_exit_reason: str | None = None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
 
         try:
             if should_consume_stopped:
-                yield from self._consume_stopped_session(consumer_id)
+                prepared_head_frames, initial_replay = self._prepare_head_frames_for_replay(
+                    head_frames or [],
+                    replay_head_transform,
+                    will_replay=True,
+                )
+                yield from prepared_head_frames
+                yield from self._consume_stopped_session(consumer_id, initial_replay=initial_replay)
                 return
 
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
-            producer_thread, is_resuming, enable_heartbeat_check = self._start_or_resume_stream(
+            if not has_pending:
+                producer_acquired = self.message_handler.acquire_producer(self.thread_id)
+
+            will_replay = has_pending or not producer_acquired
+            prepared_head_frames, initial_replay = self._prepare_head_frames_for_replay(
+                head_frames or [],
+                replay_head_transform,
+                will_replay,
+            )
+            yield from prepared_head_frames
+
+            enable_heartbeat_check = not has_pending
+            producer_thread, is_resuming = self._start_or_resume_stream(
                 generator=generator,
                 cancel_event=cancel_event,
-                has_pending=has_pending,
+                producer_acquired=producer_acquired,
                 on_complete=on_complete,
             )
+            producer_acquired = False
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
                 cancel_event=cancel_event,
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
+                initial_replay=initial_replay,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -761,6 +802,8 @@ class GeneratorStreamingHelper:
             raise
         finally:
             self._unregister_cancel_event()
+            if producer_acquired:
+                self.message_handler.release_producer(self.thread_id)
             # 清理跨进程取消信号（避免残留影响下次请求）
             self._clear_cancel_signal_safely("Error clearing cancel signal")
             # 释放消费者（仅当自己仍是活跃消费者时）

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -37,6 +37,7 @@ from aidev_agent.pydantic_models import (
 )
 from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
+from aidev_agent.services.messages_handler.constants import EOD_CHUNK
 from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
 from aidev_agent.utils.event import RunId
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
@@ -2322,21 +2323,6 @@ class TestSnapshotReplayDedup:
     前端会因“快照已有该 id + replay 又 START 同 id”产生重复消息。修复：阶段1快照剔除
     replay 将重放的 message_id，让 replay 成为该消息唯一来源。"""
 
-    def test_reproduce_snapshot_replay_id_overlap(self):
-        """复现前提：现发快照里的 assistant id 与 replay 缓存里的 START id 相同（会重复）。"""
-        snapshot = _snapshot_frame(
-            [
-                ExtendUserMessage(id="u1", role="user", content="问题"),
-                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
-            ]
-        )
-        replay_ids = ChatCompletionAgent._collect_replay_message_ids(
-            _FakeReplayHandler([_start_frame("mid"), _content_frame("mid", "完整回答")]),
-            "t1",
-        )
-        # bug 前提成立：快照 id 与 replay id 有交集
-        assert _snapshot_ids(snapshot) & replay_ids == {"mid"}
-
     def test_dedup_removes_replayed_id_from_snapshot(self):
         """去重后：快照剔除 mid（由 replay 完整重建），保留历史/用户消息。"""
         snapshot = _snapshot_frame(
@@ -2348,7 +2334,7 @@ class TestSnapshotReplayDedup:
         run_started = EventEncoder().encode(RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1"))
         head_frames = [snapshot, run_started]
 
-        deduped = ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, {"mid"})
+        deduped = ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, [_start_frame("mid")])
 
         assert _snapshot_ids(deduped[0]) == {"u1"}
         assert "mid" not in _snapshot_ids(deduped[0])
@@ -2361,24 +2347,45 @@ class TestSnapshotReplayDedup:
             [ExtendAssistantMessage(id="mid", role="assistant", content="hi", status="complete")]
         )
         head_frames = [snapshot]
-        assert ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, set()) == head_frames
+        assert ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, []) == head_frames
 
-    def test_collect_replay_ids_returns_empty_when_no_pending(self):
-        handler = _FakeReplayHandler([_start_frame("mid")], has_pending=False)
-        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+    def test_replay_selected_after_empty_check_still_dedups_snapshot(self):
+        """队列初判为空但 producer 已存在时，实际 replay 仍必须参与快照去重。"""
+        handler = _RacingReplayHandler(has_pending=False)
+        out = self._run_with_real_helper(handler)
 
-    def test_collect_replay_ids_swallows_handler_errors(self):
-        """handler 不支持 peek / 抛异常时按“无重放”处理，回退原行为。"""
-        handler = MagicMock()
-        handler.has_pending_messages.side_effect = RuntimeError("boom")
-        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+        snapshot_ids = _snapshot_ids(out[0])
+        replay_start_ids = {
+            _parse_sse(frame).get("messageId")
+            for frame in out
+            if frame.startswith("data: ") and _parse_sse(frame).get("type") == EventType.TEXT_MESSAGE_START
+        }
+        assert snapshot_ids & replay_start_ids == set()
 
-    def test_stream_with_queue_emits_non_overlapping_stream(self):
-        """端到端复现 + 修复验证：第二端连接输出流中，快照 id 与 START id 零重叠。"""
+    def test_pending_replay_is_read_only_once(self):
+        """预读得到的 replay 首批数据应由 consumer 复用，不能再次全量扫描。"""
+        handler = _RacingReplayHandler(has_pending=True)
+
+        self._run_with_real_helper(handler)
+
+        assert handler.replay_reads == 1
+
+    def test_reserved_producer_is_released_when_client_disconnects_during_head_frames(self):
+        handler = _RacingReplayHandler(has_pending=False, producer_acquired=True)
+        stream = GeneratorStreamingHelper(message_handler=handler, thread_id="t1").stream(
+            iter([]),
+            head_frames=["head"],
+        )
+
+        assert next(stream) == "head"
+        stream.close()
+
+        assert "release_producer" in handler.calls
+        assert "clear" not in handler.calls
+
+    @staticmethod
+    def _run_with_real_helper(handler):
         agent = _seed_agent()
-        agui_entry = _mock_agui_entry()
-        agent_input = SimpleNamespace(thread_id="t1", run_id="r1")
-
         snapshot = _snapshot_frame(
             [
                 ExtendUserMessage(id="u1", role="user", content="问题"),
@@ -2386,42 +2393,72 @@ class TestSnapshotReplayDedup:
             ]
         )
         run_started = EventEncoder().encode(RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1"))
-        replay_frames = [_start_frame("mid"), _content_frame("mid", "完整回答")]
 
-        fake_handler = _FakeReplayHandler(replay_frames)
-        fake_helper = MagicMock()
-        fake_helper.message_handler = fake_handler
-        fake_helper.stream.return_value = iter(replay_frames)
+        def build_helper(**kwargs):
+            return GeneratorStreamingHelper(message_handler=handler, **kwargs)
 
         with (
-            patch(f"{_CHAT_MODULE}.GeneratorStreamingHelper", return_value=fake_helper),
+            patch(f"{_CHAT_MODULE}.GeneratorStreamingHelper", side_effect=build_helper),
             patch.object(agent, "_build_resume_aware_producer", return_value=iter([snapshot, run_started])),
         ):
-            out = list(agent._stream_with_queue(agui_entry, agent_input))
-
-        snap_ids: set[str] = set()
-        start_ids: set[str] = set()
-        for frame in out:
-            data = _parse_sse(frame)
-            if data["type"] == EventType.MESSAGES_SNAPSHOT:
-                snap_ids |= {(m.get("messageId") or m.get("id")) for m in data.get("messages", [])}
-            if data["type"] == EventType.TEXT_MESSAGE_START:
-                start_ids.add(data.get("messageId"))
-
-        assert "mid" in start_ids  # replay 仍完整重建该消息
-        assert "mid" not in snap_ids  # 快照不再含 mid
-        assert snap_ids & start_ids == set()  # 零重叠，前端不会重复
+            return list(agent._stream_with_queue(_mock_agui_entry(), SimpleNamespace(thread_id="t1", run_id="r1")))
 
 
-class _FakeReplayHandler:
-    """最小 replay handler 替身：模拟缓存里已有从头重放的 SSE 帧。"""
+class _RacingReplayHandler:
+    """模拟队列初判与 producer lock 结果不一致的 replay handler。"""
 
-    def __init__(self, cached_frames, has_pending: bool = True):
-        self._cached = list(cached_frames)
+    def __init__(self, has_pending: bool, producer_acquired: bool = False):
         self._has_pending = has_pending
+        self._producer_acquired = producer_acquired
+        self._cached = [_start_frame("mid"), _content_frame("mid", "完整回答"), EOD_CHUNK]
+        self.calls: list[str] = []
+        self.replay_reads = 0
+        self._consumer_acquired = False
+
+    def supports_replay_from_start(self):
+        return True
 
     def has_pending_messages(self, thread_id):  # noqa: ARG002
+        self.calls.append("has_pending_messages")
         return self._has_pending
 
     def get_messages_since(self, thread_id, offset, timeout=None):  # noqa: ARG002
+        if not self._consumer_acquired:
+            raise RuntimeError("replay read requires an active consumer")
+        self.calls.append("get_messages_since")
+        self.replay_reads += 1
         return self._cached[offset:], len(self._cached)
+
+    def acquire_producer(self, thread_id):  # noqa: ARG002
+        self.calls.append("acquire_producer")
+        return self._producer_acquired
+
+    def release_producer(self, thread_id):  # noqa: ARG002
+        self.calls.append("release_producer")
+
+    def acquire_consumer(self, thread_id):  # noqa: ARG002
+        self.calls.append("acquire_consumer")
+        self._consumer_acquired = True
+        return "consumer-id"
+
+    def release_consumer(self, thread_id, consumer_id):  # noqa: ARG002
+        self.calls.append("release_consumer")
+        self._consumer_acquired = False
+
+    def wait_for_previous_consumer(self, thread_id, timeout=3.0):  # noqa: ARG002
+        return True
+
+    def is_stopped(self, thread_id):  # noqa: ARG002
+        return False
+
+    def clear_cancel_signal(self, thread_id):  # noqa: ARG002
+        return None
+
+    def check_cancel_signal(self, thread_id):  # noqa: ARG002
+        return False
+
+    def has_active_consumer(self, thread_id):  # noqa: ARG002
+        return False
+
+    def mark_completed(self, thread_id):  # noqa: ARG002
+        return None

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -5,10 +5,23 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
+from ag_ui.core import (
+    EventType,
+    RunErrorEvent,
+    RunFinishedEvent,
+    RunStartedEvent,
+    TextMessageContentEvent,
+    TextMessageStartEvent,
+)
+from ag_ui.encoder import EventEncoder
 from aidev_agent.config import settings
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
-from aidev_agent.core.ag_ui.types import CustomMessageType
+from aidev_agent.core.ag_ui.types import (
+    CustomMessageType,
+    ExtendAssistantMessage,
+    ExtendUserMessage,
+    MessageSnapshotEventExtend,
+)
 from aidev_agent.core.nodes.tool.approval_wrapper import TOOL_APPROVAL_REASON
 from aidev_agent.enums import PromptRole
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
@@ -2281,3 +2294,134 @@ class TestTerminalResumeReplay:
         mock_replay.assert_not_called()
         mock_astream.assert_not_called()
         agui_entry.run.assert_not_called()
+
+
+def _snapshot_frame(messages) -> str:
+    return EventEncoder().encode(MessageSnapshotEventExtend(type=EventType.MESSAGES_SNAPSHOT, messages=messages))
+
+
+def _start_frame(message_id: str) -> str:
+    return EventEncoder().encode(
+        TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id=message_id, role="assistant")
+    )
+
+
+def _content_frame(message_id: str, delta: str) -> str:
+    return EventEncoder().encode(
+        TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id=message_id, delta=delta)
+    )
+
+
+def _snapshot_ids(frame: str) -> set[str]:
+    data = _parse_sse(frame)
+    return {(m.get("messageId") or m.get("id")) for m in data.get("messages", [])}
+
+
+class TestSnapshotReplayDedup:
+    """多端场景：阶段1现发的 MESSAGES_SNAPSHOT 含半截 mid，阶段2 replay 又从头 START(mid)，
+    前端会因“快照已有该 id + replay 又 START 同 id”产生重复消息。修复：阶段1快照剔除
+    replay 将重放的 message_id，让 replay 成为该消息唯一来源。"""
+
+    def test_reproduce_snapshot_replay_id_overlap(self):
+        """复现前提：现发快照里的 assistant id 与 replay 缓存里的 START id 相同（会重复）。"""
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        replay_ids = ChatCompletionAgent._collect_replay_message_ids(
+            _FakeReplayHandler([_start_frame("mid"), _content_frame("mid", "完整回答")]),
+            "t1",
+        )
+        # bug 前提成立：快照 id 与 replay id 有交集
+        assert _snapshot_ids(snapshot) & replay_ids == {"mid"}
+
+    def test_dedup_removes_replayed_id_from_snapshot(self):
+        """去重后：快照剔除 mid（由 replay 完整重建），保留历史/用户消息。"""
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        run_started = EventEncoder().encode(RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1"))
+        head_frames = [snapshot, run_started]
+
+        deduped = ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, {"mid"})
+
+        assert _snapshot_ids(deduped[0]) == {"u1"}
+        assert "mid" not in _snapshot_ids(deduped[0])
+        # 非快照帧不受影响
+        assert deduped[1] == run_started
+
+    def test_dedup_noop_without_replay_ids(self):
+        """没有 replay（例如首个消费者）时不改动快照。"""
+        snapshot = _snapshot_frame(
+            [ExtendAssistantMessage(id="mid", role="assistant", content="hi", status="complete")]
+        )
+        head_frames = [snapshot]
+        assert ChatCompletionAgent._dedup_snapshot_head_frames(head_frames, set()) == head_frames
+
+    def test_collect_replay_ids_returns_empty_when_no_pending(self):
+        handler = _FakeReplayHandler([_start_frame("mid")], has_pending=False)
+        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+
+    def test_collect_replay_ids_swallows_handler_errors(self):
+        """handler 不支持 peek / 抛异常时按“无重放”处理，回退原行为。"""
+        handler = MagicMock()
+        handler.has_pending_messages.side_effect = RuntimeError("boom")
+        assert ChatCompletionAgent._collect_replay_message_ids(handler, "t1") == set()
+
+    def test_stream_with_queue_emits_non_overlapping_stream(self):
+        """端到端复现 + 修复验证：第二端连接输出流中，快照 id 与 START id 零重叠。"""
+        agent = _seed_agent()
+        agui_entry = _mock_agui_entry()
+        agent_input = SimpleNamespace(thread_id="t1", run_id="r1")
+
+        snapshot = _snapshot_frame(
+            [
+                ExtendUserMessage(id="u1", role="user", content="问题"),
+                ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+            ]
+        )
+        run_started = EventEncoder().encode(RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t1", run_id="r1"))
+        replay_frames = [_start_frame("mid"), _content_frame("mid", "完整回答")]
+
+        fake_handler = _FakeReplayHandler(replay_frames)
+        fake_helper = MagicMock()
+        fake_helper.message_handler = fake_handler
+        fake_helper.stream.return_value = iter(replay_frames)
+
+        with (
+            patch(f"{_CHAT_MODULE}.GeneratorStreamingHelper", return_value=fake_helper),
+            patch.object(agent, "_build_resume_aware_producer", return_value=iter([snapshot, run_started])),
+        ):
+            out = list(agent._stream_with_queue(agui_entry, agent_input))
+
+        snap_ids: set[str] = set()
+        start_ids: set[str] = set()
+        for frame in out:
+            data = _parse_sse(frame)
+            if data["type"] == EventType.MESSAGES_SNAPSHOT:
+                snap_ids |= {(m.get("messageId") or m.get("id")) for m in data.get("messages", [])}
+            if data["type"] == EventType.TEXT_MESSAGE_START:
+                start_ids.add(data.get("messageId"))
+
+        assert "mid" in start_ids  # replay 仍完整重建该消息
+        assert "mid" not in snap_ids  # 快照不再含 mid
+        assert snap_ids & start_ids == set()  # 零重叠，前端不会重复
+
+
+class _FakeReplayHandler:
+    """最小 replay handler 替身：模拟缓存里已有从头重放的 SSE 帧。"""
+
+    def __init__(self, cached_frames, has_pending: bool = True):
+        self._cached = list(cached_frames)
+        self._has_pending = has_pending
+
+    def has_pending_messages(self, thread_id):  # noqa: ARG002
+        return self._has_pending
+
+    def get_messages_since(self, thread_id, offset, timeout=None):  # noqa: ARG002
+        return self._cached[offset:], len(self._cached)

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2378,10 +2378,24 @@ class TestSnapshotReplayDedup:
         )
 
         assert next(stream) == "head"
+        # 队列重置必须先于头部帧送达：yield 期间其他连接不能再看到上一轮残留
+        assert "clear" in handler.calls
+
         stream.close()
 
         assert "release_producer" in handler.calls
-        assert "clear" not in handler.calls
+
+    def test_head_frames_survive_replay_prefetch_failure(self):
+        """预读 replay 失败时头部帧仍要原样送达，否则前端连历史消息都拿不到。"""
+        handler = _RacingReplayHandler(has_pending=True, replay_error=RuntimeError("broker unavailable"))
+        stream = GeneratorStreamingHelper(message_handler=handler, thread_id="t1").stream(
+            iter([]),
+            head_frames=["head"],
+            replay_head_transform=ChatCompletionAgent._dedup_snapshot_head_frames,
+        )
+
+        assert next(stream) == "head"
+        stream.close()
 
     @staticmethod
     def _run_with_real_helper(handler):
@@ -2407,9 +2421,10 @@ class TestSnapshotReplayDedup:
 class _RacingReplayHandler:
     """模拟队列初判与 producer lock 结果不一致的 replay handler。"""
 
-    def __init__(self, has_pending: bool, producer_acquired: bool = False):
+    def __init__(self, has_pending: bool, producer_acquired: bool = False, replay_error: Exception | None = None):
         self._has_pending = has_pending
         self._producer_acquired = producer_acquired
+        self._replay_error = replay_error
         self._cached = [_start_frame("mid"), _content_frame("mid", "完整回答"), EOD_CHUNK]
         self.calls: list[str] = []
         self.replay_reads = 0
@@ -2427,6 +2442,8 @@ class _RacingReplayHandler:
             raise RuntimeError("replay read requires an active consumer")
         self.calls.append("get_messages_since")
         self.replay_reads += 1
+        if self._replay_error is not None:
+            raise self._replay_error
         return self._cached[offset:], len(self._cached)
 
     def acquire_producer(self, thread_id):  # noqa: ARG002
@@ -2435,6 +2452,12 @@ class _RacingReplayHandler:
 
     def release_producer(self, thread_id):  # noqa: ARG002
         self.calls.append("release_producer")
+
+    def clear(self, thread_id):  # noqa: ARG002
+        self.calls.append("clear")
+
+    def clear_stopped(self, thread_id):  # noqa: ARG002
+        self.calls.append("clear_stopped")
 
     def acquire_consumer(self, thread_id):  # noqa: ARG002
         self.calls.append("acquire_consumer")

--- a/src/agent/tests/services/test_rabbitmq_buffer_state.py
+++ b/src/agent/tests/services/test_rabbitmq_buffer_state.py
@@ -1,0 +1,129 @@
+"""RabbitMQ handler 进程内 buffer 状态机测试。
+
+与 ``test_rabbitmq_handler.py`` 不同，这里不连接真实 broker，因此在没有
+``RABBITMQ_HOST`` 的 CI 上同样执行，用于守住 flush / in-flight 的并发语义。
+"""
+
+import contextlib
+import pickle
+import threading
+from typing import Any
+
+import pytest
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+THREAD_ID = "buffer-state-thread"
+
+
+@pytest.fixture()
+def handler(monkeypatch):
+    """构造不连接 broker 的 handler，只保留进程内 buffer 行为。"""
+    monkeypatch.setattr(RabbitMQMessageHandler, "_instance", None)
+    monkeypatch.setattr(RabbitMQMessageHandler, "_start_daemon", lambda self: None)
+    monkeypatch.setattr(RabbitMQMessageHandler, "_ensure_daemon_alive", lambda self: None)
+    return RabbitMQMessageHandler()
+
+
+def _install_fake_channel(handler, monkeypatch, fail: bool = False) -> list[Any]:
+    """把 publish 路径换成内存记录，返回已发布消息列表。"""
+    published: list[Any] = []
+
+    class _FakeChannel:
+        def basic_publish(self, exchange, routing_key, body, properties=None):  # noqa: ARG002
+            if fail:
+                raise RuntimeError("publish failed")
+            published.append(pickle.loads(body))
+
+    @contextlib.contextmanager
+    def fake_with_channel():
+        yield _FakeChannel()
+
+    monkeypatch.setattr(handler, "_with_channel", fake_with_channel)
+    monkeypatch.setattr(handler, "_ensure_queue", lambda channel, thread_id: f"queue-{thread_id}")
+    return published
+
+
+def _trace_take_entry(handler, monkeypatch) -> threading.Event:
+    """在 flush 真正尝试取 buffer 时置位，避免用 sleep 猜测线程进度。"""
+    entered = threading.Event()
+    original = handler._take_thread_buffer_for_flush
+
+    def traced(thread_id, wait_for_in_flight=None):
+        entered.set()
+        return original(thread_id, wait_for_in_flight=wait_for_in_flight)
+
+    monkeypatch.setattr(handler, "_take_thread_buffer_for_flush", traced)
+    return entered
+
+
+class TestFlushInFlightSemantics:
+    def test_explicit_flush_waits_for_in_flight_batch(self, handler, monkeypatch):
+        """daemon 批次在途时，显式 flush 必须等它结束并把后到的消息发出去。
+
+        直接跳过会让 producer 收尾投递的 EOD_CHUNK 滞留在 buffer。
+        """
+        published = _install_fake_channel(handler, monkeypatch)
+        handler.put(THREAD_ID, "msg_0")
+        assert handler._take_thread_buffer_for_flush(THREAD_ID) == ["msg_0"]
+
+        handler.put(THREAD_ID, "msg_1")
+        entered = _trace_take_entry(handler, monkeypatch)
+        flush_thread = threading.Thread(target=handler.flush, args=(THREAD_ID,), daemon=True)
+        flush_thread.start()
+
+        assert entered.wait(timeout=3)
+        handler._finish_thread_flush(THREAD_ID)
+        flush_thread.join(timeout=3)
+
+        assert not flush_thread.is_alive()
+        assert published == ["msg_1"]
+
+    def test_explicit_flush_gives_up_after_wait_timeout(self, handler, monkeypatch):
+        """in-flight 迟迟不结束时，显式 flush 超时放弃而不是无限期挂住调用方。"""
+        _install_fake_channel(handler, monkeypatch)
+        monkeypatch.setattr(RabbitMQMessageHandler, "FLUSH_IN_FLIGHT_WAIT_SEC", 0.1)
+        handler.put(THREAD_ID, "msg_0")
+        handler._take_thread_buffer_for_flush(THREAD_ID)
+        handler.put(THREAD_ID, "msg_1")
+
+        handler.flush(THREAD_ID)
+
+        with handler._buffer_lock:
+            assert handler._message_buffer[THREAD_ID] == ["msg_1"]
+
+    def test_daemon_flush_skips_thread_with_in_flight_batch(self, handler, monkeypatch):
+        """daemon 轮询遇到 in-flight 直接跳过，不阻塞其它 thread 的推送。"""
+        published = _install_fake_channel(handler, monkeypatch)
+        handler.put(THREAD_ID, "msg_0")
+        handler._take_thread_buffer_for_flush(THREAD_ID)
+        handler.put(THREAD_ID, "msg_1")
+        handler.put("other-thread", "other_0")
+
+        handler._flush_messages()
+
+        assert published == ["other_0"]
+
+    def test_in_flight_batch_counts_as_pending(self, handler):
+        """消息已从 buffer 取走但尚未 publish 时仍属于 pending。"""
+        handler.put(THREAD_ID, "msg_0")
+        handler._take_thread_buffer_for_flush(THREAD_ID)
+
+        assert handler.has_pending_messages(THREAD_ID) is True
+
+    def test_failed_flush_restores_batch_ahead_of_later_messages(self, handler, monkeypatch):
+        """publish 失败要把本批放回 buffer 头部，保持会话日志顺序。"""
+        _install_fake_channel(handler, monkeypatch, fail=True)
+        handler.put(THREAD_ID, "msg_0")
+
+        def put_later_message(*args, **kwargs):  # noqa: ARG001
+            handler.put(THREAD_ID, "msg_1")
+            return f"queue-{THREAD_ID}"
+
+        monkeypatch.setattr(handler, "_ensure_queue", put_later_message)
+
+        with pytest.raises(RuntimeError):
+            handler.flush(THREAD_ID)
+
+        with handler._buffer_lock:
+            assert handler._message_buffer[THREAD_ID] == ["msg_0", "msg_1"]
+            assert THREAD_ID not in handler._flushing_threads

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -1,10 +1,12 @@
 import asyncio
 import contextlib
 import os
+import pickle
 import threading
 import time
 
 import pytest
+
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
@@ -35,6 +37,30 @@ def thread_id(request, handler):
         handler.mark_completed(tid)
 
 
+class DelayedPublishChannel:
+    def __init__(self, channel, target_message, publish_started, allow_publish):
+        self._channel = channel
+        self._target_message = target_message
+        self._publish_started = publish_started
+        self._allow_publish = allow_publish
+
+    def __getattr__(self, name):
+        return getattr(self._channel, name)
+
+    def basic_publish(self, *args, **kwargs):
+        body = kwargs.get("body")
+        if body is None and len(args) >= 3:
+            body = args[2]
+        try:
+            is_target = pickle.loads(body) == self._target_message
+        except Exception:
+            is_target = False
+        if is_target:
+            self._publish_started.set()
+            assert self._allow_publish.wait(timeout=3)
+        return self._channel.basic_publish(*args, **kwargs)
+
+
 class TestRabbitMQMessageHandler:
     def _get_open_channel_count(self, handler: RabbitMQMessageHandler) -> int:
         """Return open AMQP channels held by one pooled connection."""
@@ -52,6 +78,28 @@ class TestRabbitMQMessageHandler:
                 return
             time.sleep(0.1)
         assert handler.is_empty(thread_id) is True
+
+    def _consume_since_offset(self, handler, thread_id, offset, result, error):
+        try:
+            result.append(handler.get_messages_since(thread_id, offset, timeout=1))
+        except Exception as exc:
+            error.append(exc)
+
+    def _patch_delayed_publish(self, monkeypatch, handler, target_message):
+        publish_started = threading.Event()
+        allow_publish = threading.Event()
+
+        def wrap_context(context_factory):
+            @contextlib.contextmanager
+            def wrapped(*args, **kwargs):
+                with context_factory(*args, **kwargs) as channel:
+                    yield DelayedPublishChannel(channel, target_message, publish_started, allow_publish)
+
+            return wrapped
+
+        monkeypatch.setattr(handler, "_with_channel", wrap_context(handler._with_channel))
+        monkeypatch.setattr(handler, "_with_replay_lock", wrap_context(handler._with_replay_lock))
+        return publish_started, allow_publish
 
     def test_repeated_operations_do_not_accumulate_open_channels(self, handler, thread_id):
         """Repeated RabbitMQ operations should close their temporary AMQP channels."""
@@ -210,6 +258,126 @@ class TestRabbitMQMessageHandler:
         assert all(result == expected for result in results)
 
         self._wait_until_empty(handler, thread_id)
+
+    def test_single_consumer_waits_for_in_flight_flush_before_later_buffer(self, handler, thread_id, monkeypatch):
+        """单个 consumer 不应在旧 flush 批次发布完成前先吐出后续未提交消息。"""
+        handler.put(thread_id, "msg_0")
+        handler.flush(thread_id)
+        first_messages, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+        assert first_messages == ["msg_0"]
+
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+        try:
+            handler.put(thread_id, "msg_1")
+            publish_started, allow_publish = self._patch_delayed_publish(monkeypatch, handler, "msg_1")
+            result: list[tuple[list[str], int]] = []
+            error: list[Exception] = []
+            flush_thread = threading.Thread(target=handler.flush, args=(thread_id,), daemon=True)
+            consumer_thread = threading.Thread(
+                target=self._consume_since_offset, args=(handler, thread_id, offset, result, error), daemon=True
+            )
+            flush_thread.start()
+            assert publish_started.wait(timeout=3)
+            handler.put(thread_id, "msg_2")
+            consumer_thread.start()
+            try:
+                consumer_thread.join(timeout=0.3)
+                assert consumer_thread.is_alive(), f"consumer returned too early: result={result}, error={error}"
+            finally:
+                allow_publish.set()
+                flush_thread.join(timeout=3)
+                consumer_thread.join(timeout=3)
+
+            assert error == []
+            assert result == [(["msg_1"], 2)]
+
+            handler.flush(thread_id)
+            second_messages, next_offset = handler.get_messages_since(thread_id, 2, timeout=1)
+
+            assert second_messages == ["msg_2"]
+            assert next_offset == 3
+        finally:
+            handler._start_daemon()
+
+    def test_replay_reads_only_rabbitmq_committed_messages(self, handler, thread_id, monkeypatch):
+        """Replay 只能读取 RabbitMQ 已提交日志，不能读取本进程未 flush 的 buffer。"""
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+
+        try:
+            handler.put(thread_id, "buffered_only")
+
+            with pytest.raises(TimeoutError):
+                handler.get_messages_since(thread_id, 0, timeout=0.2)
+
+            handler.flush(thread_id)
+            messages, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+
+            assert messages == ["buffered_only"]
+            assert offset == 1
+        finally:
+            with handler._buffer_lock:
+                handler._message_buffer.pop(thread_id, None)
+            handler._start_daemon()
+
+    def test_has_pending_messages_includes_in_flight_flush(self, handler, thread_id):
+        """本批消息从 buffer 取走但尚未 publish 时，仍应被视为 pending。"""
+        handler._stop_daemon()
+        try:
+            with handler._buffer_lock:
+                handler._message_buffer[thread_id] = ["in_flight_msg"]
+
+            messages_to_flush = handler._take_thread_buffer_for_flush(thread_id)
+            try:
+                assert messages_to_flush == ["in_flight_msg"]
+                assert handler.has_pending_messages(thread_id) is True
+            finally:
+                handler._finish_thread_flush(thread_id, messages_to_restore=messages_to_flush)
+        finally:
+            handler._start_daemon()
+
+    def test_replay_reader_does_not_block_producer_flush(self, handler, thread_id, monkeypatch):
+        """正在等待增量的 replay consumer 不应阻塞 producer flush 新消息。"""
+        handler.put(thread_id, "seed")
+        handler.flush(thread_id)
+        _, offset = handler.get_messages_since(thread_id, 0, timeout=1)
+
+        original_peek = handler._peek_queue_messages
+        reader_holding_snapshot = threading.Event()
+        release_reader_snapshot = threading.Event()
+
+        def slow_peek(channel, queue_name):
+            reader_holding_snapshot.set()
+            assert release_reader_snapshot.wait(timeout=3)
+            return original_peek(channel, queue_name)
+
+        monkeypatch.setattr(handler, "_peek_queue_messages", slow_peek)
+
+        reader_result: list[tuple[list[str], int]] = []
+        reader_error: list[Exception] = []
+        reader_thread = threading.Thread(
+            target=self._consume_since_offset,
+            args=(handler, thread_id, offset, reader_result, reader_error),
+            daemon=True,
+        )
+        reader_thread.start()
+        assert reader_holding_snapshot.wait(timeout=3)
+
+        handler.put(thread_id, "msg_after_refresh")
+        flush_thread = threading.Thread(target=handler.flush, args=(thread_id,), daemon=True)
+        flush_thread.start()
+
+        try:
+            flush_thread.join(timeout=0.3)
+            assert not flush_thread.is_alive(), "producer flush was blocked by a replay reader snapshot"
+        finally:
+            release_reader_snapshot.set()
+            flush_thread.join(timeout=3)
+            reader_thread.join(timeout=3)
+
+        assert reader_error == []
+        assert reader_result == [(["msg_after_refresh"], offset + 1)]
 
     def test_consumer_reconnect_with_dlq(self, handler, thread_id):
         """测试消费者断开后重连可以从死信队列恢复消息

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -1,11 +1,20 @@
 import asyncio
 import contextlib
+import json
+import multiprocessing
 import os
 import pickle
 import threading
 import time
 
 import pytest
+from ag_ui.core import EventType, TextMessageContentEvent, TextMessageStartEvent
+from ag_ui.encoder import EventEncoder
+from aidev_agent.core.ag_ui.types import (
+    ExtendAssistantMessage,
+    ExtendUserMessage,
+    MessageSnapshotEventExtend,
+)
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
@@ -58,6 +67,74 @@ class DelayedPublishChannel:
             self._publish_started.set()
             assert self._allow_publish.wait(timeout=3)
         return self._channel.basic_publish(*args, **kwargs)
+
+
+def _hold_producer_lock_and_publish(env_vars, thread_id, messages, publish_event, release_event, result_queue):
+    """模拟另一个 worker：持有 producer lock，收到信号后向真实 RabbitMQ 发布 replay。"""
+    for key, value in env_vars.items():
+        os.environ[key] = value
+    RabbitMQMessageHandler._instance = None
+    handler = RabbitMQMessageHandler()
+    acquired = handler.acquire_producer(thread_id)
+    result_queue.put(("acquired", acquired))
+    if not acquired:
+        return
+
+    try:
+        if not publish_event.wait(timeout=5):
+            result_queue.put(("error", "publish signal timeout"))
+            return
+        for message in messages:
+            handler.put(thread_id, message)
+        handler.flush(thread_id)
+        result_queue.put(("published", len(messages)))
+        release_event.wait(timeout=5)
+    finally:
+        handler.release_producer(thread_id)
+
+
+def _run_remote_producer_race(handler, thread_id, monkeypatch, head_frames, replay_frames):
+    env_keys = ["RABBITMQ_HOST", "RABBITMQ_PORT", "RABBITMQ_USER", "RABBITMQ_PASSWORD", "RABBITMQ_VHOST"]
+    env_vars = {key: os.environ[key] for key in env_keys if key in os.environ}
+    ctx = multiprocessing.get_context("spawn")
+    publish_event = ctx.Event()
+    release_event = ctx.Event()
+    result_queue = ctx.Queue()
+    process = ctx.Process(
+        target=_hold_producer_lock_and_publish,
+        args=(env_vars, thread_id, replay_frames, publish_event, release_event, result_queue),
+    )
+    original_acquire_producer = handler.acquire_producer
+
+    def acquire_producer_then_publish(current_thread_id):
+        acquired = original_acquire_producer(current_thread_id)
+        if not acquired:
+            publish_event.set()
+        return acquired
+
+    monkeypatch.setattr(handler, "acquire_producer", acquire_producer_then_publish)
+    process.start()
+    try:
+        assert result_queue.get(timeout=5) == ("acquired", True)
+        assert handler.has_pending_messages(thread_id) is False
+        output = list(
+            GeneratorStreamingHelper(handler, thread_id).stream(
+                iter(()),
+                head_frames=head_frames,
+                replay_head_transform=ChatCompletionAgent._dedup_snapshot_head_frames,
+            )
+        )
+        assert result_queue.get(timeout=5) == ("published", len(replay_frames))
+        return output
+    finally:
+        publish_event.set()
+        release_event.set()
+        process.join(timeout=5)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=2)
+            raise AssertionError("remote producer process did not exit")
+        assert process.exitcode == 0
 
 
 class TestRabbitMQMessageHandler:
@@ -257,6 +334,39 @@ class TestRabbitMQMessageHandler:
         assert all(result == expected for result in results)
 
         self._wait_until_empty(handler, thread_id)
+
+    def test_pr672_empty_queue_remote_producer_replay_dedups_snapshot(self, handler, thread_id, monkeypatch):
+        """PR #672：远端 producer 持锁但队列尚空时，第二连接仍不能输出重复 messageId。"""
+        encoder = EventEncoder()
+        snapshot = encoder.encode(
+            MessageSnapshotEventExtend(
+                type=EventType.MESSAGES_SNAPSHOT,
+                messages=[
+                    ExtendUserMessage(id="u1", role="user", content="问题"),
+                    ExtendAssistantMessage(id="mid", role="assistant", content="半截", status="streaming"),
+                ],
+            )
+        )
+        replay_frames = [
+            encoder.encode(
+                TextMessageStartEvent(type=EventType.TEXT_MESSAGE_START, message_id="mid", role="assistant")
+            ),
+            encoder.encode(
+                TextMessageContentEvent(type=EventType.TEXT_MESSAGE_CONTENT, message_id="mid", delta="完整回答")
+            ),
+            EOD_CHUNK,
+        ]
+
+        output = _run_remote_producer_race(handler, thread_id, monkeypatch, [snapshot], replay_frames)
+        payloads = [json.loads(frame.removeprefix("data: ")) for frame in output]
+        snapshot_ids = {message.get("messageId") or message.get("id") for message in payloads[0]["messages"]}
+        replay_ids = {
+            payload.get("messageId") for payload in payloads if payload["type"] == EventType.TEXT_MESSAGE_START
+        }
+
+        assert snapshot_ids == {"u1"}
+        assert replay_ids == {"mid"}
+        assert snapshot_ids.isdisjoint(replay_ids)
 
     def test_single_consumer_waits_for_in_flight_flush_before_later_buffer(self, handler, thread_id, monkeypatch):
         """单个 consumer 不应在旧 flush 批次发布完成前先吐出后续未提交消息。"""

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -6,7 +6,6 @@ import threading
 import time
 
 import pytest
-
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent


### PR DESCRIPTION
## 背景

RabbitMQ message handler 的 SSE 链路在最新 `develop` 上仍有两类用户可见的正确性问题：

1. `get_messages_since()` 会把 RabbitMQ 主队列与本进程尚未提交的 `_message_buffer` 拼成同一回放视图。队列与 buffer 的提交时序不一致时，消费者可能提前看到后续消息，破坏单一有序日志语义。
2. 多端进入同一会话时，新连接先直传 `MESSAGES_SNAPSHOT`，随后又从 RabbitMQ 日志开头 replay；快照和 `TEXT_MESSAGE_START` 可能包含同一个 `messageId`，导致前端重复展示。

## 改动

- RabbitMQ replay 只读取已经发布到主队列的消息，不再混入本进程 `_message_buffer`。
- flush 按 `thread_id` 标记 in-flight 状态；失败时把本批消息放回 buffer 头部，`has_pending_messages()` 同时识别 in-flight 消息。
- 直传 `MESSAGES_SNAPSHOT` 前收集 replay 中的 `TEXT_MESSAGE_START.messageId`，从快照中剔除即将被 replay 完整重建的同 ID 消息。
- 增加真实 RabbitMQ 并发回归测试和多端快照/replay 零重叠测试。

## 范围

- 本 PR 只解决 SSE 顺序一致性和多端重复，不包含 producer 线程的 Django 数据库连接生命周期改动。
- 本 PR 不解决 RabbitMQ 队列长度增长/资源回收问题；相关 seq、prune、gap 和孤儿清理改动仍由 #668 处理。

## commits

- `706187ff` fix: keep RabbitMQ replay on committed queue log
- `55728400` fix: dedup snapshot against replay to prevent duplicate messages

## 验证

- 最新 `develop` 最小复现：回放可读到尚未 flush 的本地 buffer；多端快照与 replay 的 ID 交集为 `{"mid"}`。
- `tests/services/test_chat.py`：`83 passed, 1 skipped`。
- 顺序与多端去重组合回归（真实 RabbitMQ）：`11 passed`。
- 本 PR 4 个改动文件的 Ruff、Ruff format、merge-conflict hook：全部通过。
- 全仓 `pre-commit run -a` 仍被 `develop` 现有问题阻断，包括 wxbot 测试文件语法错误及若干既有 Ruff 告警；本 PR 未修改这些文件。
