### PR TITLE
fix: 【chat-x】Markdown 列表序号与项目符号不显示 --bug=160457051

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.vue
@@ -350,6 +350,14 @@
         background-color: #282c34;
       }
 
+      ol > li {
+        list-style: decimal;
+      }
+
+      ul > li {
+        list-style: disc;
+      }
+
       .hljs-left {
         text-align: left;
       }


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】Markdown 列表序号与项目符号不显示（1070093903160457051）

AI 消息 Markdown 渲染区域中，有序/无序列表的序号与项目符号不显示。根因是 `.ai-markdown-body` 内 `ol > li` / `ul > li` 未显式设置 `list-style`，被全局样式重置后列表标记丢失。

## 改动
- 在 `markdown-content.vue` 的 `.ai-markdown-body` 中补充 `ol > li { list-style: decimal; }` 与 `ul > li { list-style: disc; }`

## 影响面
- 影响所有通过 `MarkdownContent` 渲染的 AI 消息列表展示

## 测试
- [x] AI 回复含有序列表时序号正常显示
- [x] AI 回复含无序列表时项目符号正常显示

Made with [Cursor](https://cursor.com)