### PR TITLE
refactor: chat-x组件根样式统一ai-前缀 --story=136095476

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -123,7 +123,7 @@ describe('FileUploadBtn', () => {
     it('应该正确渲染组件根元素', () => {
       wrapper = mount(FileUploadBtn);
 
-      expect(wrapper.find('.file-upload-btn').exists()).toBe(true);
+      expect(wrapper.find('.ai-file-upload-btn').exists()).toBe(true);
     });
 
     it('应该渲染隐藏的 file input', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="file-upload-btn">
+  <div class="ai-file-upload-btn">
     <input
       ref="fileInputRef"
       :accept="accept"
@@ -89,7 +89,7 @@
   };
 </script>
 <style lang="scss">
-  .file-upload-btn {
+  .ai-file-upload-btn {
     display: flex;
     align-items: center;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-btns/shortcut-btns.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-btns/shortcut-btns.spec.ts
@@ -144,7 +144,7 @@ describe('ShortcutBtns', () => {
         props: { shortcuts },
       });
 
-      expect(wrapper.find('.shortcut-btns').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-btns').exists()).toBe(true);
     });
 
     it('应该渲染所有快捷指令按钮', () => {
@@ -219,7 +219,7 @@ describe('ShortcutBtns', () => {
         props: { shortcuts },
       });
 
-      expect(wrapper.find('.shortcut-btns').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-btns').exists()).toBe(true);
     });
 
     it('每个按钮应该有 shortcut-btns-item 类名', () => {
@@ -229,7 +229,7 @@ describe('ShortcutBtns', () => {
         props: { shortcuts },
       });
 
-      expect(wrapper.find('.shortcut-btns-item').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-btns-item').exists()).toBe(true);
     });
   });
 
@@ -239,7 +239,7 @@ describe('ShortcutBtns', () => {
         props: { shortcuts: [] },
       });
 
-      expect(wrapper.find('.shortcut-btns').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-btns').exists()).toBe(true);
       expect(wrapper.findAll('.mock-shortcut-btn').length).toBe(0);
     });
 
@@ -260,7 +260,7 @@ describe('ShortcutBtns', () => {
         props: { shortcuts },
       });
 
-      expect(wrapper.find('.shortcut-btns').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-btns').exists()).toBe(true);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-btns/shortcut-btns.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-btns/shortcut-btns.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="containerRef"
-    class="shortcut-btns"
+    class="ai-shortcut-btns"
   >
     <template
       v-for="(shortcut, index) in shortcuts"
@@ -9,7 +9,7 @@
     >
       <ShortcutBtn
         :ref="el => setItemRef(el, index)"
-        :class="['shortcut-btns-item', { 'shortcut-btns-item-hidden': !visibleItems.includes(shortcut) }]"
+        :class="['ai-shortcut-btns-item', { 'ai-shortcut-btns-item-hidden': !visibleItems.includes(shortcut) }]"
         :shortcut="shortcut"
         @click="handleSelectShortcut(shortcut)"
       />
@@ -32,14 +32,14 @@
     >
       <ShortcutBtn
         ref="moreBtnRef"
-        class="shortcut-btns-item shortcut-btns-more"
+        class="ai-shortcut-btns-item ai-shortcut-btns-more"
         @click="handleToggleMoreMenu"
       >
-        <MoreAgentIcon class="shortcut-btns-more-icon" />
+        <MoreAgentIcon class="ai-shortcut-btns-more-icon" />
         <span>{{ t('更多') }}</span>
       </ShortcutBtn>
       <template #content>
-        <div class="shortcut-menu">
+        <div class="ai-shortcut-menu">
           <ShortcutBtn
             v-for="shortcut in hiddenShortcuts"
             :key="shortcut.id"
@@ -131,7 +131,7 @@
   @use '../../../styles/variables.scss' as variables;
   @use '../../../styles/border.scss' as border;
 
-  .shortcut-btns {
+  .ai-shortcut-btns {
     position: relative;
     display: flex;
     gap: 4px;
@@ -186,7 +186,7 @@
     }
   }
 
-  .shortcut-menu {
+  .ai-shortcut-menu {
     @include menu.ai-common-menu-style;
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.spec.ts
@@ -236,7 +236,7 @@ describe('ShortcutRender', () => {
         },
       });
 
-      expect(wrapper.find('.shortcut-render').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render').exists()).toBe(true);
     });
 
     it('应该正确渲染标题', () => {
@@ -487,9 +487,9 @@ describe('ShortcutRender', () => {
         },
       });
 
-      expect(wrapper.find('.shortcut-render').exists()).toBe(true);
-      expect(wrapper.find('.shortcut-render-header').exists()).toBe(true);
-      expect(wrapper.find('.shortcut-render-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render-header').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render-content').exists()).toBe(true);
     });
   });
 
@@ -503,7 +503,7 @@ describe('ShortcutRender', () => {
         },
       });
 
-      expect(wrapper.find('.shortcut-render').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render').exists()).toBe(true);
     });
 
     it('应该处理空 name', () => {
@@ -514,7 +514,7 @@ describe('ShortcutRender', () => {
         },
       });
 
-      expect(wrapper.find('.shortcut-render').exists()).toBe(true);
+      expect(wrapper.find('.ai-shortcut-render').exists()).toBe(true);
     });
 
     it('应该处理特殊字符的 name', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-shortcut/shortcut-render/shortcut-render.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="shortcut-render">
-    <div class="shortcut-render-header">
+  <div class="ai-shortcut-render">
+    <div class="ai-shortcut-render-header">
       <ThinkingIcon class="header-icon" />
       <span class="header-name">{{ alias || name }}</span>
       <CloseIcon
@@ -8,7 +8,7 @@
         @click="handleClose"
       />
     </div>
-    <div class="shortcut-render-content">
+    <div class="ai-shortcut-render-content">
       <Form
         ref="formRef"
         class="shortcut-render-form"
@@ -196,7 +196,7 @@
 <style lang="scss">
   @use '../../../styles/border.scss' as border;
 
-  .shortcut-render {
+  .ai-shortcut-render {
     position: relative;
     display: flex;
     flex-direction: column;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -821,7 +821,7 @@
         // overflow: visible;
 
         // 空态下快捷指令保持在输入框位置（贴底），内容过高时向上生长并遮挡欢迎内容，而非被压缩
-        .shortcut-render.is-welcome-overlay {
+        .ai-shortcut-render.is-welcome-overlay {
           position: absolute;
           right: 8px;
           bottom: 8px;
@@ -833,7 +833,7 @@
           max-height: calc(100% - 16px);
 
           // 高度随内容自然撑开，超过可视高度时由外层 max-height 兜底滚动
-          .shortcut-render-content {
+          .ai-shortcut-render-content {
             max-height: none;
           }
         }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.spec.ts
@@ -232,7 +232,7 @@ describe('FlowAgentContent', () => {
       });
 
       expect(wrapper.find('.mock-activity-layout').exists()).toBe(true);
-      expect(wrapper.find('.flow-agent-activity').exists()).toBe(true);
+      expect(wrapper.find('.ai-flow-agent-activity').exists()).toBe(true);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-content.vue
@@ -2,7 +2,7 @@
   <ActivityLayout
     v-model:collapsed="collapsed"
     :activity-type="MessageContentType.FlowAgent"
-    class="flow-agent-activity"
+    class="ai-flow-agent-activity"
   >
     <template #title>
       <!-- hover 整条执行情况栏展示统计 tooltip（设计稿 annotation） -->
@@ -286,7 +286,7 @@
     border-radius: 50%;
   }
 
-  .flow-agent-activity {
+  .ai-flow-agent-activity {
     $color-text: #4d4f56;
     $color-text-secondary: #979ba5;
     $color-primary: #3a84ff;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.spec.ts
@@ -114,7 +114,7 @@ describe('FlowAgentNodeDetail', () => {
         props: baseProps,
       });
 
-      expect(wrapper.find('.flow-agent-node-detail').exists()).toBe(true);
+      expect(wrapper.find('.ai-flow-agent-node-detail').exists()).toBe(true);
     });
 
     it('应该渲染节点标题', () => {
@@ -318,7 +318,7 @@ describe('FlowAgentNodeDetail', () => {
         props: baseProps,
       });
 
-      expect(wrapper.find('.flow-agent-node-detail').exists()).toBe(true);
+      expect(wrapper.find('.ai-flow-agent-node-detail').exists()).toBe(true);
     });
 
     it('loading 时不应该渲染数据内容', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/flow-agent-content/flow-agent-node-detail.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flow-agent-node-detail">
+  <div class="ai-flow-agent-node-detail">
     <h3 class="detail-title">
       <template v-if="loading">
         <span>{{ t('节点') }}：</span>
@@ -238,7 +238,7 @@
 <style lang="scss">
   @use '../../../styles/variables.scss' as variables;
 
-  .flow-agent-node-detail {
+  .ai-flow-agent-node-detail {
     display: flex;
     flex-direction: column;
     height: 100%;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/knowledge-rag-content/knowledge-rag-content.vue
@@ -12,7 +12,7 @@
         {{ title }}
       </span>
     </template>
-    <div class="knowledge-rag-content">
+    <div class="ai-knowledge-rag-content">
       <MarkdownContent :content="content?.content || ''" />
     </div>
     <ReferenceContent :content="content?.referenceDocument || []" />
@@ -48,7 +48,7 @@
   });
 </script>
 <style lang="scss">
-  .knowledge-rag-content {
+  .ai-knowledge-rag-content {
     display: flex;
     flex-direction: column;
     padding: 6px 14px;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/text-content/text-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/text-content/text-content.spec.ts
@@ -46,7 +46,7 @@ describe('TextContent', () => {
         props: { content: '文本内容' },
       });
 
-      expect(wrapper.find('.text-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-text-content').exists()).toBe(true);
     });
 
     it('应该正确渲染 content 内容', () => {
@@ -78,7 +78,7 @@ describe('TextContent', () => {
         props: { content: '' },
       });
 
-      expect(wrapper.find('.text-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-text-content').exists()).toBe(true);
       expect(wrapper.text()).toBe('');
     });
 
@@ -131,7 +131,7 @@ describe('TextContent', () => {
         props: { content: '文本' },
       });
 
-      expect(wrapper.find('.text-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-text-content').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/text-content/text-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/text-content/text-content.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="text-content">
+  <div class="ai-text-content">
     {{ content }}
   </div>
 </template>
@@ -9,7 +9,7 @@
   }>();
 </script>
 <style lang="scss">
-  .text-content {
+  .ai-text-content {
     display: flex;
     width: fit-content;
     padding: 8px 12px;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -283,7 +283,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该渲染 chat-input 容器', () => {
@@ -365,7 +365,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该正确接收 prompts', () => {
@@ -378,7 +378,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该正确接收 resources', () => {
@@ -391,7 +391,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该正确接收 shortcuts', () => {
@@ -437,7 +437,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该正确接收 tippyOptions 属性', () => {
@@ -448,7 +448,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('应该正确接收 skills 属性', () => {
@@ -463,7 +463,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
   });
 
@@ -824,7 +824,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('无 shortcuts 时不应该渲染 ShortcutBtns', () => {
@@ -847,7 +847,7 @@ describe('ChatInput', () => {
 
       // v-if="shortcuts && !selectedShortcut" - 空数组也是 falsy 在渲染条件里
       // 需要确认实际逻辑
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('shortcutId 对应的 shortcut 不存在时不应该显示 ShortcutBtn', () => {
@@ -875,7 +875,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
       expect(wrapper.find('.chat-input').exists()).toBe(true);
     });
   });
@@ -1036,7 +1036,7 @@ describe('ChatInput', () => {
         },
       });
 
-      expect(wrapper.find('.chat-input-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-chat-input-container').exists()).toBe(true);
     });
 
     it('有 shortcuts 或 selectedShortcut 时应该显示分隔线', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="chat-input-container"
+    class="ai-chat-input-container"
     :style="{ '--chat-z-index': CHAT_Z_INDEX }"
   >
     <slot name="top" />
@@ -361,7 +361,7 @@ Use Shift + Enter to enter a new line`
   @use '../../styles/variables.scss' as variables;
   @use '../../styles/border.scss' as border;
 
-  .chat-input-container {
+  .ai-chat-input-container {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-info-alert.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-info-alert.spec.ts
@@ -53,9 +53,9 @@ describe('InputInfoAlert', () => {
       },
     });
 
-    expect(wrapper.find('.chat-input-info-alert').exists()).toBe(true);
+    expect(wrapper.find('.ai-chat-input-info-alert').exists()).toBe(true);
     expect(wrapper.find('.mock-info-icon').exists()).toBe(true);
-    expect(wrapper.find('.chat-input-info-alert__text').text()).toBe(
+    expect(wrapper.find('.ai-chat-input-info-alert__text').text()).toBe(
       '当前会话有 1 个待审批单，如需继续，请先取消审批',
     );
   });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-info-alert.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-info-alert.vue
@@ -1,7 +1,7 @@
 <template>
-  <div class="chat-input-info-alert">
-    <InfoIcon class="chat-input-info-alert__icon" />
-    <span class="chat-input-info-alert__text">{{ content }}</span>
+  <div class="ai-chat-input-info-alert">
+    <InfoIcon class="ai-chat-input-info-alert__icon" />
+    <span class="ai-chat-input-info-alert__text">{{ content }}</span>
   </div>
 </template>
 
@@ -15,7 +15,7 @@
 <style lang="scss">
   @use '../../styles/variables.scss' as variables;
 
-  .chat-input-info-alert {
+  .ai-chat-input-info-alert {
     display: flex;
     gap: 8px;
     align-items: flex-start;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/activity-message/activity-message.spec.ts
@@ -381,7 +381,7 @@ describe('ActivityMessage', () => {
         },
       });
 
-      expect(wrapper.find('.knowledge-rag-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-knowledge-rag-content').exists()).toBe(true);
       expect(wrapper.find('.mock-markdown-content').exists()).toBe(true);
     });
 
@@ -393,7 +393,7 @@ describe('ActivityMessage', () => {
         },
       });
 
-      expect(wrapper.find('.knowledge-rag-content').exists()).toBe(false);
+      expect(wrapper.find('.ai-knowledge-rag-content').exists()).toBe(false);
       expect(wrapper.find('.mock-document-icon').exists()).toBe(true);
     });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.spec.ts
@@ -48,7 +48,7 @@ describe('InfoMessage', () => {
         },
       });
 
-      expect(wrapper.find('.info-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-info-message').exists()).toBe(true);
     });
 
     it('应该正确渲染字符串 content', () => {
@@ -58,7 +58,7 @@ describe('InfoMessage', () => {
         props: { content },
       });
 
-      expect(wrapper.find('.info-message-content').text()).toBe(content);
+      expect(wrapper.find('.ai-info-message-content').text()).toBe(content);
     });
 
     it('应该正确渲染数组 content', () => {
@@ -68,7 +68,7 @@ describe('InfoMessage', () => {
         props: { content },
       });
 
-      const items = wrapper.findAll('.info-message-content');
+      const items = wrapper.findAll('.ai-info-message-content');
       expect(items.length).toBe(3);
       expect(items[0].text()).toBe('消息1');
       expect(items[1].text()).toBe('消息2');
@@ -96,7 +96,7 @@ describe('InfoMessage', () => {
         },
       });
 
-      expect(wrapper.find('.info-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-info-message').exists()).toBe(true);
     });
 
     it('应该处理空数组 content', () => {
@@ -106,8 +106,8 @@ describe('InfoMessage', () => {
         },
       });
 
-      expect(wrapper.find('.info-message').exists()).toBe(true);
-      expect(wrapper.findAll('.info-message-content').length).toBe(0);
+      expect(wrapper.find('.ai-info-message').exists()).toBe(true);
+      expect(wrapper.findAll('.ai-info-message-content').length).toBe(0);
     });
 
     it('应该处理 undefined content', () => {
@@ -115,7 +115,7 @@ describe('InfoMessage', () => {
         props: {},
       });
 
-      expect(wrapper.find('.info-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-info-message').exists()).toBe(true);
     });
 
     it('应该处理单元素数组 content', () => {
@@ -125,8 +125,8 @@ describe('InfoMessage', () => {
         },
       });
 
-      expect(wrapper.findAll('.info-message-content').length).toBe(1);
-      expect(wrapper.find('.info-message-content').text()).toBe('单条消息');
+      expect(wrapper.findAll('.ai-info-message-content').length).toBe(1);
+      expect(wrapper.find('.ai-info-message-content').text()).toBe('单条消息');
     });
 
     it('应该处理特殊字符的 content', () => {
@@ -136,7 +136,7 @@ describe('InfoMessage', () => {
         props: { content },
       });
 
-      expect(wrapper.find('.info-message-content').text()).toBe(content);
+      expect(wrapper.find('.ai-info-message-content').text()).toBe(content);
       expect(wrapper.find('script').exists()).toBe(false);
     });
   });
@@ -149,8 +149,8 @@ describe('InfoMessage', () => {
         },
       });
 
-      expect(wrapper.find('.info-message').exists()).toBe(true);
-      expect(wrapper.find('.info-message-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-info-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-info-message-content').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.vue
@@ -1,9 +1,9 @@
 <template>
-  <div class="info-message">
+  <div class="ai-info-message">
     <div
       v-for="(text, index) in Array.isArray(content) ? content : [content]"
       :key="index"
-      class="info-message-content"
+      class="ai-info-message-content"
     >
       {{ text }}
     </div>
@@ -16,7 +16,7 @@
   defineProps<Partial<InfoMessage>>();
 </script>
 <style lang="scss">
-  .info-message {
+  .ai-info-message {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/tool-message/tool-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/tool-message/tool-message.spec.ts
@@ -73,7 +73,7 @@ describe('ToolMessage', () => {
         },
       });
 
-      expect(wrapper.find('.tool-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-tool-message').exists()).toBe(true);
     });
 
     it('应该渲染 DescPanel 组件', () => {
@@ -190,7 +190,7 @@ describe('ToolMessage', () => {
         },
       });
 
-      expect(wrapper.find('.tool-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-tool-message').exists()).toBe(true);
     });
 
     it('应该处理 undefined content', () => {
@@ -198,7 +198,7 @@ describe('ToolMessage', () => {
         props: {},
       });
 
-      expect(wrapper.find('.tool-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-tool-message').exists()).toBe(true);
     });
 
     it('应该处理特殊字符的 content', () => {
@@ -220,7 +220,7 @@ describe('ToolMessage', () => {
         },
       });
 
-      expect(wrapper.find('.tool-message').exists()).toBe(true);
+      expect(wrapper.find('.ai-tool-message').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/tool-message/tool-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/tool-message/tool-message.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="tool-message">
+  <div class="ai-tool-message">
     <DescPanel
       :desc="content || (typeof error === 'string' ? error : undefined)"
       :title="t('返回内容')"
@@ -14,7 +14,7 @@
   defineProps<Partial<ToolMessage>>();
 </script>
 <style lang="scss">
-  .tool-message {
+  .ai-tool-message {
     display: flex;
     flex-direction: column;
     align-items: flex-start;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -261,7 +261,7 @@
       background-color: #e1ecff;
       border-radius: 4px;
 
-      :deep(.text-content) {
+      :deep(.ai-text-content) {
         width: auto;
         padding: 0;
         background-color: transparent;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.spec.ts
@@ -122,7 +122,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: [] },
       });
 
-      expect(wrapper.find('.execution-summary').exists()).toBe(true);
+      expect(wrapper.find('.ai-execution-summary').exists()).toBe(true);
     });
 
     it('应该渲染搜索输入框', () => {
@@ -143,7 +143,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: groups },
       });
 
-      const items = wrapper.findAll('.execution-summary-content-item');
+      const items = wrapper.findAll('.ai-execution-summary-content-item');
       expect(items.length).toBe(2);
     });
 
@@ -152,7 +152,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: [] },
       });
 
-      expect(wrapper.find('.execution-summary-content-empty').exists()).toBe(true);
+      expect(wrapper.find('.ai-execution-summary-content-empty').exists()).toBe(true);
       expect(wrapper.find('.mock-exception').exists()).toBe(true);
     });
   });
@@ -198,7 +198,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: [group] },
       });
 
-      const item = wrapper.find('.execution-summary-content-item');
+      const item = wrapper.find('.ai-execution-summary-content-item');
       await item.trigger('mouseenter');
 
       const locateBtn = wrapper.find('.content-item-locate');
@@ -215,7 +215,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: [] },
       });
 
-      expect(wrapper.find('.execution-summary-content-empty-text').text()).toContain('暂无数据');
+      expect(wrapper.find('.ai-execution-summary-content-empty-text').text()).toContain('暂无数据');
     });
   });
 
@@ -230,7 +230,7 @@ describe('ExecutionSummary', () => {
         props: { messageGroups: groups },
       });
 
-      const items = wrapper.findAll('.execution-summary-content-item');
+      const items = wrapper.findAll('.ai-execution-summary-content-item');
       expect(items[0]?.find('.timeline-line').exists()).toBe(true);
       expect(items[1]?.find('.timeline-line').exists()).toBe(false);
     });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/execution-summary/execution-summary.vue
@@ -1,20 +1,20 @@
 <template>
-  <div class="execution-summary">
-    <div class="execution-summary-header">
+  <div class="ai-execution-summary">
+    <div class="ai-execution-summary-header">
       <Input
         v-model="keyword"
-        class="execution-summary-header-input"
+        class="ai-execution-summary-header-input"
         clearable
         :placeholder="t('搜索 关键字')"
         @update:model-value="emits('updateKeyword', $event)"
       />
     </div>
-    <div class="execution-summary-content">
+    <div class="ai-execution-summary-content">
       <template v-if="messageGroups.length">
         <div
           v-for="(group, index) in messageGroups"
           :key="group.uid"
-          class="execution-summary-content-item"
+          class="ai-execution-summary-content-item"
           @mouseenter="hoverGroupId = group.uid"
           @mouseleave="hoverGroupId = undefined"
         >
@@ -52,12 +52,12 @@
         </div>
       </template>
       <template v-else>
-        <div class="execution-summary-content-empty">
+        <div class="ai-execution-summary-content-empty">
           <Exception
             class="empty-exception"
             type="empty"
           />
-          <div class="execution-summary-content-empty-text">
+          <div class="ai-execution-summary-content-empty-text">
             {{ keyword ? t('搜索结果为空') : t('暂无数据') }}
             <Button
               v-if="keyword"
@@ -116,7 +116,7 @@
   };
 </script>
 <style lang="scss">
-  .execution-summary {
+  .ai-execution-summary {
     display: flex;
     flex: 1;
     flex-direction: column;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.spec.ts
@@ -114,7 +114,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
     });
 
     it('应该渲染 pre 和 code 元素', () => {
@@ -267,7 +267,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
     });
 
     it('应该处理空内容', () => {
@@ -283,7 +283,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
     });
 
     it('应该处理没有语言的代码块', () => {
@@ -315,7 +315,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
     });
 
     it('应该处理多行代码', () => {
@@ -349,7 +349,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
     });
   });
 
@@ -466,7 +466,7 @@ describe('CodeContent', () => {
         },
       });
 
-      expect(wrapper.find('.code-content-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-code-content-wrapper').exists()).toBe(true);
       expect(wrapper.find('.hljs-pre').exists()).toBe(true);
     });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/code-content/code-content.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="code-content-wrapper">
+  <div class="ai-code-content-wrapper">
     <div class="code-content-header">
       <span class="code-header-language">{{ language }}</span>
       <slot
@@ -248,7 +248,7 @@
 </script>
 
 <style lang="scss">
-  .code-content-wrapper {
+  .ai-code-content-wrapper {
     width: 100%;
     margin-bottom: 12px;
 
@@ -273,7 +273,7 @@
     }
   }
 
-  .ai-message-container .code-content-wrapper {
+  .ai-message-container .ai-code-content-wrapper {
     .hljs-pre {
       padding: 8px 16px;
       margin: 0;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/image-content/image-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/image-content/image-content.spec.ts
@@ -79,7 +79,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
   });
 
@@ -124,7 +124,7 @@ describe('ImageContent', () => {
       });
 
       // 应该开始加载
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
 
     it('应该接受 https:// URL', () => {
@@ -134,7 +134,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
 
     it('应该接受 data: URL', () => {
@@ -144,7 +144,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
 
     it('应该接受相对路径', () => {
@@ -154,7 +154,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
 
     it('应该接受带扩展名的文件路径', () => {
@@ -164,7 +164,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
   });
 
@@ -211,7 +211,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
 
     it('应该处理 localhost URL', () => {
@@ -221,7 +221,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
   });
 
@@ -233,7 +233,7 @@ describe('ImageContent', () => {
         },
       });
 
-      expect(wrapper.find('.md-image-wrapper').exists()).toBe(true);
+      expect(wrapper.find('.ai-md-image-wrapper').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/image-content/image-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/image-content/image-content.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="md-image-wrapper">
+  <span class="ai-md-image-wrapper">
     <!-- 加载中、URL 不完整、或 URL 不稳定时显示 Loading -->
     <span
       v-if="showLoading"
@@ -215,7 +215,7 @@
 </script>
 
 <style lang="scss">
-  .md-image-wrapper {
+  .ai-md-image-wrapper {
     display: inline-block;
     vertical-align: middle;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/latex-content/latex-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/latex-content/latex-content.spec.ts
@@ -81,7 +81,7 @@ describe('LatexContent', () => {
         },
       });
 
-      expect(wrapper.find('.inline-latex-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-inline-latex-content').exists()).toBe(true);
     });
 
     it('应该渲染块级公式', () => {
@@ -96,7 +96,7 @@ describe('LatexContent', () => {
         },
       });
 
-      expect(wrapper.find('.block-latex-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-block-latex-content').exists()).toBe(true);
     });
   });
 
@@ -128,7 +128,7 @@ describe('LatexContent', () => {
         },
       });
 
-      expect(wrapper.html()).toContain('block-latex-wrapper');
+      expect(wrapper.html()).toContain('ai-block-latex-wrapper');
     });
 
     it('应该解析带 meta displayMode 的 token', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/latex-content/latex-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/latex-content/latex-content.vue
@@ -331,13 +331,13 @@
 
     const result = tryRenderKatex(content, displayMode);
     if (result && !hasKatexError(result)) {
-      const className = displayMode ? 'block-katex' : 'inline-katex';
+      const className = displayMode ? 'ai-block-katex' : 'ai-inline-katex';
       return `<span class="${className}">${result}</span>`;
     }
 
     // 渲染失败，返回原始内容
     const escapedContent = content.replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    return `<span class="katex-loading" style="color: #666; font-style: italic;">${escapedContent}</span>`;
+    return `<span class="ai-katex-loading" style="color: #666; font-style: italic;">${escapedContent}</span>`;
   };
 
   /**
@@ -403,7 +403,7 @@
       if (!token) continue;
 
       if (token.type === 'math_block') {
-        html += `<div class="block-latex-wrapper">${renderLatexToken(token)}</div>`;
+        html += `<div class="ai-block-latex-wrapper">${renderLatexToken(token)}</div>`;
       } else if (token.type === 'math_inline') {
         html += renderLatexToken(token);
       } else if (token.type === 'inline' && token.children) {
@@ -434,7 +434,7 @@
   });
 
   const wrapperTag = computed(() => (isBlockOnly.value ? 'div' : 'span'));
-  const wrapperClass = computed(() => (isBlockOnly.value ? 'block-latex-content' : 'inline-latex-content'));
+  const wrapperClass = computed(() => (isBlockOnly.value ? 'ai-block-latex-content' : 'ai-inline-latex-content'));
 
   /**
    * 节流的 LaTeX 渲染函数
@@ -460,7 +460,7 @@
 </script>
 
 <style lang="scss">
-  .inline-latex-content {
+  .ai-inline-latex-content {
     display: inline;
     vertical-align: baseline;
 
@@ -470,7 +470,7 @@
     }
   }
 
-  .block-latex-content {
+  .ai-block-latex-content {
     display: block;
     width: 100%;
     margin: 16px 0;
@@ -482,22 +482,22 @@
     }
   }
 
-  .block-latex-wrapper {
+  .ai-block-latex-wrapper {
     display: block;
     width: 100%;
     margin: 16px 0;
     text-align: center;
   }
 
-  .inline-katex {
+  .ai-inline-katex {
     display: inline;
   }
 
-  .block-katex {
+  .ai-block-katex {
     display: block;
   }
 
-  .katex-loading {
+  .ai-katex-loading {
     display: inline;
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/mermaid-content/mermaid-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/mermaid-content/mermaid-content.spec.ts
@@ -74,7 +74,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
   });
 
@@ -92,7 +92,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
 
     it('应该忽略非 mermaid fence', () => {
@@ -108,7 +108,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
   });
 
@@ -141,7 +141,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
 
     it('应该处理空内容', () => {
@@ -157,7 +157,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
 
     it('应该处理没有 info 的 token', () => {
@@ -172,7 +172,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
   });
 
@@ -190,7 +190,7 @@ describe('MermaidContent', () => {
         },
       });
 
-      expect(wrapper.find('.mermaid-content').exists()).toBe(true);
+      expect(wrapper.find('.ai-mermaid-content').exists()).toBe(true);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/mermaid-content/mermaid-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/markdown-token/mermaid-content/mermaid-content.vue
@@ -2,7 +2,7 @@
   <div
     :key="svgDomStr"
     ref="mermaidContentRef"
-    class="mermaid-content"
+    class="ai-mermaid-content"
     v-html="svgDomStr"
   />
 </template>
@@ -117,7 +117,7 @@
 </script>
 
 <style lang="scss">
-  .mermaid-content {
+  .ai-mermaid-content {
     width: 100%;
     min-height: 0;
     padding: 8px 12px;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/message-tools/message-tools.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/message-tools/message-tools.spec.ts
@@ -186,7 +186,7 @@ describe('MessageTools', () => {
     it('应该正确渲染组件', () => {
       wrapper = mount(MessageTools);
 
-      expect(wrapper.find('.message-tools-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-message-tools-container').exists()).toBe(true);
     });
 
     it('应该渲染默认的 messageTools', () => {
@@ -303,7 +303,7 @@ describe('MessageTools', () => {
         },
       });
 
-      expect(wrapper.find('.message-tools-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-message-tools-container').exists()).toBe(true);
     });
 
     it('应该处理空的 updateTools', () => {
@@ -313,7 +313,7 @@ describe('MessageTools', () => {
         },
       });
 
-      expect(wrapper.find('.message-tools-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-message-tools-container').exists()).toBe(true);
     });
   });
 
@@ -354,7 +354,7 @@ describe('MessageTools', () => {
     it('应该具有正确的类名结构', () => {
       wrapper = mount(MessageTools);
 
-      expect(wrapper.find('.message-tools-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-message-tools-container').exists()).toBe(true);
       expect(wrapper.findAll('.message-tools').length).toBe(2);
     });
 
@@ -475,7 +475,7 @@ describe('MessageTools', () => {
     it('不传 tippyOptions 时组件应正常渲染', () => {
       wrapper = mount(MessageTools);
 
-      expect(wrapper.find('.message-tools-container').exists()).toBe(true);
+      expect(wrapper.find('.ai-message-tools-container').exists()).toBe(true);
       expect(wrapper.props().tippyOptions).toBeUndefined();
     });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/message-tools/message-tools.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/message-tools/message-tools.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="messageToolsRef"
-    class="message-tools-container"
+    class="ai-message-tools-container"
   >
     <div
       class="message-tools"
@@ -187,7 +187,7 @@
   });
 </script>
 <style lang="scss">
-  .message-tools-container {
+  .ai-message-tools-container {
     display: flex;
     align-items: center;
     width: 100%;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.spec.ts
@@ -49,7 +49,7 @@ describe('DescPanel', () => {
         },
       });
 
-      expect(wrapper.find('.toolcall-desc').exists()).toBe(true);
+      expect(wrapper.find('.ai-toolcall-desc').exists()).toBe(true);
     });
 
     it('应该渲染标题', () => {
@@ -159,7 +159,7 @@ describe('DescPanel', () => {
         },
       });
 
-      expect(wrapper.find('.toolcall-desc').exists()).toBe(true);
+      expect(wrapper.find('.ai-toolcall-desc').exists()).toBe(true);
     });
 
     it('应该处理 undefined desc', () => {
@@ -169,7 +169,7 @@ describe('DescPanel', () => {
         },
       });
 
-      expect(wrapper.find('.toolcall-desc').exists()).toBe(true);
+      expect(wrapper.find('.ai-toolcall-desc').exists()).toBe(true);
     });
 
     it('应该处理空对象 JSON', () => {
@@ -220,7 +220,7 @@ describe('DescPanel', () => {
         },
       });
 
-      expect(wrapper.find('.toolcall-desc').exists()).toBe(true);
+      expect(wrapper.find('.ai-toolcall-desc').exists()).toBe(true);
       expect(wrapper.find('.desc-title').exists()).toBe(true);
       expect(wrapper.find('.desc-panel').exists()).toBe(true);
     });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/desc-panel/desc-panel.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="toolcall-desc">
+  <div class="ai-toolcall-desc">
     <div class="desc-title">{{ title }}</div>
     <div class="desc-panel">
       <!-- null 的 typeof 为 object，需排除，避免 v-for 异常；键/值统一转字符串以满足 HighlightKeyword -->
@@ -52,7 +52,7 @@
   });
 </script>
 <style lang="scss">
-  .toolcall-desc {
+  .ai-toolcall-desc {
     display: flex;
     flex-direction: column;
     gap: 4px;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/execution-summary.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/execution-summary.md
@@ -160,10 +160,10 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-execution-summary
-├── execution-summary-header
+ai-execution-summary
+├── ai-execution-summary-header
 │   └── Input（关键词搜索框，clearable）
-└── execution-summary-content
+└── ai-execution-summary-content
     ├── 有数据时：
     │   └── content-item × N（时间线节点）
     │       ├── timeline-dot（时间节点圆点）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/message-tools.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/message-tools.md
@@ -72,7 +72,7 @@ AI 消息的操作工具栏组件，由**左侧消息工具区**和**右侧更�
 
 ```
 ┌─────────────────────────────────────────────────────┐
-│  .message-tools-container                           │
+│  .ai-message-tools-container                           │
 │  ┌─────────────────────┐  │  ┌───────────────────┐ │
 │  │  messageTools        │  │  │  updateTools      │ │
 │  │  copy cite rebuild…  │  │  │  like unlike del  │ │

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -91,7 +91,7 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-chat-input-container
+ai-chat-input-container
 ├── slot#top（容器顶部，在输入框框体外侧）
 ├── slot#interrupt（容器顶部，在输入框框体外侧，通常展示中断/审批提示）
 └── chat-input（框体，受 inputMaxHeight 控制）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
@@ -39,7 +39,7 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-.file-upload-btn（display: flex，align-items: center）
+.ai-file-upload-btn（display: flex，align-items: center）
 ├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
 │     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
 └── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/shortcut-btns.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/shortcut-btns.md
@@ -109,18 +109,18 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-div.shortcut-btns（flex，gap: 4px，width: 100%，min-width: 168px，max-width: 1000px，overflow: hidden）
+div.ai-shortcut-btns（flex，gap: 4px，width: 100%，min-width: 168px，max-width: 1000px，overflow: hidden）
   │
-  ├── ShortcutBtn.shortcut-btns-item × N（每个快捷指令）
+  ├── ShortcutBtn.ai-shortcut-btns-item × N（每个快捷指令）
   │     height: 24px，padding: 0 6px，white-space: nowrap，background: #fff，border-radius: 4px
-  │     溢出时追加 .shortcut-btns-item-hidden（position: absolute; visibility: hidden; pointer-events: none; opacity: 0）
+  │     溢出时追加 .ai-shortcut-btns-item-hidden（position: absolute; visibility: hidden; pointer-events: none; opacity: 0）
   │       注意：隐藏项仍在 DOM 中，仅通过 CSS 不可见，offsetWidth 仍可读
   │
   └── [hiddenShortcuts.length > 0] Tippy（trigger="manual"，append-to="body"，interactive）
         │  offset=[0,6]，z-index=SHORTCUT_MENU_Z_INDEX，theme="ai-chat-box-light light"
-        ├── ShortcutBtn.shortcut-btns-more（触发按钮）
+        ├── ShortcutBtn.ai-shortcut-btns-more（触发按钮）
         │     MoreAgentIcon（rotate(90deg)） + "更多"
-        └── #content: div.shortcut-menu
+        └── #content: div.ai-shortcut-menu
               ShortcutBtn（mode="menu"） × 隐藏数量
 ```
 
@@ -347,16 +347,16 @@ interface BaseShortcutComponent<T> {
 
 | 类名                         | 样式                                                                       | 说明                                               |
 | ---------------------------- | -------------------------------------------------------------------------- | -------------------------------------------------- |
-| `.shortcut-btns`             | `width: 100%; min-width: 168px; max-width: 1000px; overflow: hidden`       | 容器，宽度撑满父元素，超出 1000px 截断             |
-| `.shortcut-btns-item`        | `height: 24px; padding: 0 6px; background: #fff; border-radius: 4px`       | 每个快捷指令按钮的外层包装 class                   |
-| `.shortcut-btns-item-hidden` | `position: absolute; visibility: hidden; pointer-events: none; opacity: 0` | 溢出按钮的隐藏态；仍在 DOM 中以便 offsetWidth 计算 |
-| `.shortcut-btns-more`        | `flex-shrink: 0; padding: 0 6px`                                           | "更多"按钮，`MoreAgentIcon` 旋转 90°               |
-| `.shortcut-menu`             | `@include menu.ai-common-menu-style`                                       | 下拉菜单容器样式                                   |
+| `.ai-shortcut-btns`             | `width: 100%; min-width: 168px; max-width: 1000px; overflow: hidden`       | 容器，宽度撑满父元素，超出 1000px 截断             |
+| `.ai-shortcut-btns-item`        | `height: 24px; padding: 0 6px; background: #fff; border-radius: 4px`       | 每个快捷指令按钮的外层包装 class                   |
+| `.ai-shortcut-btns-item-hidden` | `position: absolute; visibility: hidden; pointer-events: none; opacity: 0` | 溢出按钮的隐藏态；仍在 DOM 中以便 offsetWidth 计算 |
+| `.ai-shortcut-btns-more`        | `flex-shrink: 0; padding: 0 6px`                                           | "更多"按钮，`MoreAgentIcon` 旋转 90°               |
+| `.ai-shortcut-menu`             | `@include menu.ai-common-menu-style`                                       | 下拉菜单容器样式                                   |
 
 ## 注意事项
 
 1. **`key` 字段优先于 `id`**：`v-for` 使用 `shortcut.key || shortcut.id`，当多个指令 `id` 相同但代表不同实例时，可通过 `key` 字段区分
-2. **溢出项不可交互**：`.shortcut-btns-item-hidden` 通过 `pointer-events: none` 屏蔽点击，不会误触发事件
+2. **溢出项不可交互**：`.ai-shortcut-btns-item-hidden` 通过 `pointer-events: none` 屏蔽点击，不会误触发事件
 3. **"更多"菜单 Teleport 至 body**：Tippy 使用 `append-to="body"`，避免被父容器的 `overflow: hidden` 裁剪
 4. **容器宽度限制**：`min-width: 168px` 和 `max-width: 1000px` 来自 `$chat-input-min-width` / `$chat-input-max-width` 变量，与输入框宽度保持一致
 5. **表单流程在外部**：`ShortcutBtns` 只负责显示和触发事件，`components` 的表单弹窗逻辑需配合 `ShortcutRender` 实现（`ChatInput` 已内置此流程）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/shortcut-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/shortcut-render.md
@@ -129,10 +129,10 @@ sinceVersion: 1.0.0
 
 ```
 ┌─────────────────────────────────────────────────┐
-│  .shortcut-render-header（渐变左边框）            │
+│  .ai-shortcut-render-header（渐变左边框）            │
 │  ✧ ThinkingIcon  快捷指令名称           ✕ Close  │
 ├─────────────────────────────────────────────────┤
-│  .shortcut-render-content（max-height: 424px，   │
+│  .ai-shortcut-render-content（max-height: 424px，   │
 │   overflow-y: auto）                             │
 │  ┌─────────────┬─────────────┐                   │
 │  │ FormItem    │ FormItem    │  ← 两列网格        │

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/image-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/image-content.md
@@ -50,7 +50,7 @@ Markdown Token 层的图片渲染基础组件，被 `MarkdownContent` 在解析�
 ## 组件结构
 
 ```
-span.md-image-wrapper（inline-block，vertical-align: middle）
+span.ai-md-image-wrapper（inline-block，vertical-align: middle）
 ├── [showLoading] span.md-image-loading（inline-flex，gap: 6px，padding: 4px 8px，bg: #f5f7fa）
 │     ├── bkui-vue Loading（spin，mini，primary）
 │     └── "图片加载中..."

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/code-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/code-content.md
@@ -147,16 +147,16 @@ export function useCounter(initial = 0) {
 
 ## 组件结构
 
-根类名为 **`.code-content-wrapper`**：外层宽度、下边距以及 **`.code-content-header`**（深色顶栏）在任意父级下均生效。**代码区** `.hljs-pre`、行内高亮等样式选择器为 **`.ai-message-container .code-content-wrapper`**，仅在消息列表（`MessageContainer` 根上的 `ai-message-container`）内与对话区一致。Wiki 与业务中若要完整还原代码区外观，请将 `CodeContent` 包在带 `ai-message-container` 类名的父节点内。
+根类名为 **`.ai-code-content-wrapper`**：外层宽度、下边距以及 **`.code-content-header`**（深色顶栏）在任意父级下均生效。**代码区** `.hljs-pre`、行内高亮等样式选择器为 **`.ai-message-container .ai-code-content-wrapper`**，仅在消息列表（`MessageContainer` 根上的 `ai-message-container`）内与对话区一致。Wiki 与业务中若要完整还原代码区外观，请将 `CodeContent` 包在带 `ai-message-container` 类名的父节点内。
 
 ```
-.code-content-wrapper
+.ai-code-content-wrapper
 ├── .code-content-header（深色顶栏；不依赖 .ai-message-container）
 │     ├── .code-header-language（token.info）
 │     ├── slot#header（{ language, token }）
 │     └── ToolBtn id="copy"
 │
-└── .hljs-pre（完整 padding / 背景 / code 字体：需父级为 .ai-message-container .code-content-wrapper）
+└── .hljs-pre（完整 padding / 背景 / code 字体：需父级为 .ai-message-container .ai-code-content-wrapper）
       └── <code class="hljs language-{raw-info}">
             ├── v-for completedLines → <span class="code-line" />
             └── v-if currentLineText → <span class="code-line current-line" />

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/desc-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/desc-panel.md
@@ -37,7 +37,7 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-.toolcall-desc（flex column，gap: 4px，padding: 12px，background: #f5f7fa）
+.ai-toolcall-desc（flex column，gap: 4px，padding: 12px，background: #f5f7fa）
 ├── .desc-title（font-size: 12px，font-weight: bold，color: #313238，margin-bottom: 6px）
 │     └── {{ title }}
 └── .desc-panel（flex column，gap: 4px）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/latex-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/latex-content.md
@@ -89,12 +89,12 @@ Markdown Token 层的 LaTeX 公式渲染基础组件，基于 **KaTeX** 实现�
 props.token（Token[]）
 │
 ├─ token.type === 'math_block'（单块且 token.length ≤ 1）
-│    wrapperTag = 'div'，wrapperClass = 'block-latex-content'
-│    └─ <div class="block-latex-wrapper">
+│    wrapperTag = 'div'，wrapperClass = 'ai-block-latex-content'
+│    └─ <div class="ai-block-latex-wrapper">
 │          └─ renderLatexToken(token) → <span class="block-katex">KaTeX HTML</span>
 │
 ├─ token.type === 'math_inline'（或混合 token 数组）
-│    wrapperTag = 'span'，wrapperClass = 'inline-latex-content'
+│    wrapperTag = 'span'，wrapperClass = 'ai-inline-latex-content'
 │    └─ renderLatexToken(token) → <span class="inline-katex">KaTeX HTML</span>
 │
 ├─ token.type === 'inline'（含 children）
@@ -144,7 +144,7 @@ const displayMode = token.type === 'math_block' || token.meta?.displayMode === t
 
 ## 行内公式
 
-`math_inline` 类型，包装为 `span.inline-latex-content`，嵌入文字流中渲染：
+`math_inline` 类型，包装为 `span.ai-inline-latex-content`，嵌入文字流中渲染：
 
 ```vue
 <template>
@@ -290,9 +290,9 @@ const displayMode = token.type === 'math_block' || token.meta?.displayMode === t
 
 | 类名                    | 标签   | 作用                                                                                        |
 | ----------------------- | ------ | ------------------------------------------------------------------------------------------- |
-| `.block-latex-content`  | `div`  | 单一 `math_block` 时的外层，`text-align: center`，`overflow: auto hidden`，`margin: 16px 0` |
-| `.inline-latex-content` | `span` | 混合/行内时的外层，`display: inline`，`vertical-align: baseline`                            |
-| `.block-latex-wrapper`  | `div`  | 每个 `math_block` token 的包装，`text-align: center`，`margin: 16px 0`                      |
+| `.ai-block-latex-content`  | `div`  | 单一 `math_block` 时的外层，`text-align: center`，`overflow: auto hidden`，`margin: 16px 0` |
+| `.ai-inline-latex-content` | `span` | 混合/行内时的外层，`display: inline`，`vertical-align: baseline`                            |
+| `.ai-block-latex-wrapper`  | `div`  | 每个 `math_block` token 的包装，`text-align: center`，`margin: 16px 0`                      |
 | `.block-katex`          | `span` | 块级 KaTeX 输出                                                                             |
 | `.inline-katex`         | `span` | 行内 KaTeX 输出                                                                             |
 | `.katex-loading`        | `span` | 渲染失败降级态，斜体灰色显示原始 LaTeX 文本                                                 |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/mermaid-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/mermaid-content.md
@@ -164,7 +164,7 @@ props.token（Token[]）
              nextTick → emit('mounted', { get el() { return mermaidContentRef.value } })
 
 模板：
-div.mermaid-content（:key="svgDomStr"，v-html="svgDomStr"）
+div.ai-mermaid-content（:key="svgDomStr"，v-html="svgDomStr"）
   注：:key 绑定 svgDomStr，每次 SVG 变化会重建 div 而非就地 patch
 ```
 
@@ -195,7 +195,7 @@ div.mermaid-content（:key="svgDomStr"，v-html="svgDomStr"）
   ];
 
   const handleMounted = ({ el }: { el: HTMLElement | null }) => {
-    // el 是 lazy getter，值为渲染后的 .mermaid-content 元素
+    // el 是 lazy getter，值为渲染后的 .ai-mermaid-content 元素
     console.log('渲染完成:', el);
   };
 </script>
@@ -298,7 +298,7 @@ div.mermaid-content（:key="svgDomStr"，v-html="svgDomStr"）
 
 | 事件名  | 参数                          | 触发时机                                                                           |
 | ------- | ----------------------------- | ---------------------------------------------------------------------------------- |
-| mounted | `{ el: HTMLElement \| null }` | SVG 更新后的 `nextTick`；`el` 为 lazy getter，返回当前 `.mermaid-content` 元素引用 |
+| mounted | `{ el: HTMLElement \| null }` | SVG 更新后的 `nextTick`；`el` 为 lazy getter，返回当前 `.ai-mermaid-content` 元素引用 |
 
 ### Token 结构
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/text-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/text-content.md
@@ -35,7 +35,7 @@ sinceVersion: 1.0.0
 ## 组件结构
 
 ```
-div.text-content
+div.ai-text-content
   display: flex; width: fit-content
   padding: 8px 12px; border-radius: 4px
   background-color: #e1ecff（浅蓝色气泡）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/theme/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/theme/index.md
@@ -14,7 +14,7 @@
 
 ```scss
 // 自定义输入框样式
-.chat-input-container .chat-input {
+.ai-chat-input-container .chat-input {
   background: #fafafa;
   border-radius: 12px;
 }
@@ -29,7 +29,7 @@
 
 ```scss
 .dark-theme {
-  .chat-input-container .chat-input {
+  .ai-chat-input-container .chat-input {
     background: #2d2d2d;
   }
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/theme/theme.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/theme/theme.md
@@ -136,7 +136,7 @@ $selection-z-index: $shortcut-menu-z-index + 1;
 
 ```scss
 // 覆盖输入框容器样式
-.chat-input-container {
+.ai-chat-input-container {
   .chat-input {
     min-height: 120px; // 自定义最小高度
     max-height: 250px; // 自定义最大高度
@@ -175,7 +175,7 @@ $selection-z-index: $shortcut-menu-z-index + 1;
 
 ```scss
 // 快捷指令按钮
-.shortcut-btns {
+.ai-shortcut-btns {
   &-item {
     background: linear-gradient(135deg, #667eea, #764ba2);
     color: #fff;
@@ -250,7 +250,7 @@ $selection-z-index: $shortcut-menu-z-index + 1;
 // 暗色主题变量
 .dark-theme {
   // 输入框
-  .chat-input-container .chat-input {
+  .ai-chat-input-container .chat-input {
     background: #2d2d2d;
 
     &::before {
@@ -293,7 +293,7 @@ $selection-z-index: $shortcut-menu-z-index + 1;
   }
 
   // 快捷指令
-  .shortcut-btns-item {
+  .ai-shortcut-btns-item {
     background: #3d3d3d;
     color: #e0e0e0;
 
@@ -412,12 +412,12 @@ $selection-z-index: $shortcut-menu-z-index + 1;
 ```scss
 // 移动端适配
 @media (max-width: 768px) {
-  .chat-input-container .chat-input {
+  .ai-chat-input-container .chat-input {
     min-width: 100%;
     max-width: 100%;
   }
 
-  .shortcut-btns {
+  .ai-shortcut-btns {
     min-width: 100%;
     max-width: 100%;
   }


### PR DESCRIPTION
## Summary
- 将 chat-x 18 个组件的根节点 class / 样式最外层选择器统一为 `ai-` 前缀，避免全局样式污染宿主环境
- 同步更新 colocated spec、wiki 文档与主题覆盖示例
- 关联修正 `user-message`、`chat-container` 中对旧 class 的样式覆盖

## TAPD
1070093903136095476

## 破坏性变更
业务方若通过旧 class 名做 CSS 主题覆盖，需改为新 `ai-` 前缀选择器（详见 `wikis/theme` 与组件文档）。

## Test plan
- [x] pre-commit 相关 vitest / wiki 校验通过
- [x] 对话主流程 UI 抽查：文本/工具/info 消息、快捷指令、代码块/图片/Mermaid/LaTeX、FlowAgent、知识召回、执行摘要侧栏
- [x] 业务自定义主题覆盖回归（如有）


Made with [Cursor](https://cursor.com)