### PR TITLE
feat: 为标准运维插件输入参数补充 placeholder 提示

### DIFF
--- a/template/{{cookiecutter.project_name}}/bk_plugin/versions/assistant.py
+++ b/template/{{cookiecutter.project_name}}/bk_plugin/versions/assistant.py
@@ -31,9 +31,24 @@ POLL_INTERVAL_SECONDS = 5
 
 
 class CommonInputsFormMixin:
-    command = {"ui:component": {"name": "bk-input", "props": {"type": "string"}}}
-    input = {"ui:component": {"name": "bk-input", "props": {"type": "string"}}}
-    session_code = {"ui:component": {"name": "bk-input", "props": {"type": "string"}}}
+    input = {
+        "ui:component": {
+            "name": "bk-input",
+            "props": {"type": "string", "placeholder": "本轮提问内容"},
+        }
+    }
+    session_code = {
+        "ui:component": {
+            "name": "bk-input",
+            "props": {"type": "string", "placeholder": "会话 ID，多轮续聊时填写，单轮建议留空"},
+        }
+    }
+    command = {
+        "ui:component": {
+            "name": "bk-input",
+            "props": {"type": "string", "placeholder": "命令 -- 快捷指令调用"},
+        }
+    }
     chat_history = {
         "type": "array",
         "title": "chat_history",
@@ -41,8 +56,22 @@ class CommonInputsFormMixin:
             "type": "object",
             "title": "history",
             "properties": {
-                "role": {"type": "string", "title": "role"},
-                "content": {"type": "string", "title": "content"},
+                "role": {
+                    "type": "string",
+                    "title": "role",
+                    "ui:component": {
+                        "name": "bk-input",
+                        "props": {"type": "string", "placeholder": "消息角色，如 user / assistant / system"},
+                    },
+                },
+                "content": {
+                    "type": "string",
+                    "title": "content",
+                    "ui:component": {
+                        "name": "bk-input",
+                        "props": {"type": "string", "placeholder": "该条历史消息的文本内容"},
+                    },
+                },
             },
         },
     }


### PR DESCRIPTION
## 变更说明

标准运维调用 AI 插件时，输入参数表单的 `command` / `input` / `session_code` 等字段默认占位符为「请输入」，用户无法直观了解字段含义。本 PR 通过 `ui:component.props.placeholder` 补充明确的输入提示文案。

## 改动点

- `command`：提示"可选，Agent 快捷指令"
- `input`：提示"本轮提问内容"
- `session_code`：提示"会话 ID，多轮续聊时填写，单轮建议留空"
- `chat_history.role` / `chat_history.content`：补充对应提示文案

## 影响范围

仅修改 `template/{{cookiecutter.project_name}}/bk_plugin/versions/assistant.py`（cookiecutter 模板），影响后续新生成的标准运维插件项目的表单展示，不影响运行时逻辑。
