### PR TITLE
feat: 支持模型请求失败自动切换 --story=1070093903135947140

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -111,6 +111,13 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         messages_dict = [_convert_message_to_dict(m) for m in messages]
         return self.get_num_tokens(json.dumps(messages_dict))
 
+    def _get_request_payload(self, *args, **kwargs) -> dict:
+        payload = super()._get_request_payload(*args, **kwargs)
+        # 部分 langchain-openai 版本会将子类扩展字段合并到 OpenAI 请求参数中。
+        # fallback_model 仅用于 SDK 内部切换，不能透传给 OpenAI 客户端。
+        payload.pop("fallback_model", None)
+        return payload
+
     def _create_chat_result(
         self,
         response: Union[dict, openai.BaseModel],

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -17,6 +17,7 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import json
+import logging
 import os
 from typing import AsyncIterator, Iterator, Optional, Type, Union
 
@@ -33,6 +34,8 @@ from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
 from aidev_agent.exceptions import AIDevException
 from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
+
+logger = logging.getLogger(__name__)
 
 
 class ApiGwMixin(BaseModel):
@@ -62,6 +65,7 @@ class ApiGwMixin(BaseModel):
 class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
+    fallback_model: str | None = None
 
     @model_validator(mode="before")
     @classmethod
@@ -124,6 +128,41 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
 
         return rtn
 
+    def _get_fallback_model(self) -> "ChatModel | None":
+        if not self.fallback_model or self.fallback_model == self.model_name:
+            return None
+        return self.model_copy(update={"model_name": self.fallback_model, "fallback_model": None})
+
+    def _generate(self, *args, **kwargs) -> ChatResult:
+        try:
+            return super()._generate(*args, **kwargs)
+        except Exception:
+            fallback = self._get_fallback_model()
+            if fallback is None:
+                raise
+            logger.warning(
+                "LLM request failed, switching to fallback model: primary=%s fallback=%s",
+                self.model_name,
+                fallback.model_name,
+                exc_info=True,
+            )
+            return fallback._generate(*args, **kwargs)
+
+    async def _agenerate(self, *args, **kwargs) -> ChatResult:
+        try:
+            return await super()._agenerate(*args, **kwargs)
+        except Exception:
+            fallback = self._get_fallback_model()
+            if fallback is None:
+                raise
+            logger.warning(
+                "Async LLM request failed, switching to fallback model: primary=%s fallback=%s",
+                self.model_name,
+                fallback.model_name,
+                exc_info=True,
+            )
+            return await fallback._agenerate(*args, **kwargs)
+
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,
@@ -175,21 +214,50 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         """对reasoning_content字段进行时间统计"""
         reasoning_start_time = 0
         last_reasoning_content = ""
-        for chunk in super()._stream(*args, **kwargs):
-            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                chunk, reasoning_start_time, last_reasoning_content
+        emitted = False
+        try:
+            for chunk in super()._stream(*args, **kwargs):
+                emitted = True
+                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                    chunk, reasoning_start_time, last_reasoning_content
+                )
+                yield chunk
+        except Exception:
+            fallback = self._get_fallback_model()
+            if emitted or fallback is None:
+                raise
+            logger.warning(
+                "Streaming LLM request failed before output, switching to fallback model: primary=%s fallback=%s",
+                self.model_name,
+                fallback.model_name,
+                exc_info=True,
             )
-            yield chunk
+            yield from fallback._stream(*args, **kwargs)
 
     async def _astream(self, *args, **kwargs) -> AsyncIterator[ChatGenerationChunk]:
         """对reasoning_content字段进行时间统计"""
         reasoning_start_time = 0
         last_reasoning_content = ""
-        async for chunk in super()._astream(*args, **kwargs):
-            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                chunk, reasoning_start_time, last_reasoning_content
+        emitted = False
+        try:
+            async for chunk in super()._astream(*args, **kwargs):
+                emitted = True
+                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                    chunk, reasoning_start_time, last_reasoning_content
+                )
+                yield chunk
+        except Exception:
+            fallback = self._get_fallback_model()
+            if emitted or fallback is None:
+                raise
+            logger.warning(
+                "Async streaming LLM request failed before output, switching to fallback model: primary=%s fallback=%s",
+                self.model_name,
+                fallback.model_name,
+                exc_info=True,
             )
-            yield chunk
+            async for chunk in fallback._astream(*args, **kwargs):
+                yield chunk
 
 
 class Embeddings(RawOpenAIEmbeddings, ApiGwMixin):

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -17,14 +17,15 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import json
-import logging
 import os
 from typing import AsyncIterator, Iterator, Optional, Type, Union
 
 import openai
 import requests
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessageChunk, BaseMessage
 from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
@@ -34,8 +35,6 @@ from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
 from aidev_agent.exceptions import AIDevException
 from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
-
-logger = logging.getLogger(__name__)
 
 
 class ApiGwMixin(BaseModel):
@@ -66,6 +65,15 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
+
+    @classmethod
+    def get_setup_instance(cls, **kwargs) -> "ChatModel | RunnableWithFallbacks":
+        """创建网关模型；配置备用模型时返回 LangChain fallback Runnable。"""
+        model = super().get_setup_instance(**kwargs)
+        fallback = model._get_fallback_model()
+        if fallback is None:
+            return model
+        return model.with_fallbacks([fallback])
 
     @model_validator(mode="before")
     @classmethod
@@ -140,36 +148,6 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
             return None
         return self.model_copy(update={"model_name": self.fallback_model, "fallback_model": None})
 
-    def _generate(self, *args, **kwargs) -> ChatResult:
-        try:
-            return super()._generate(*args, **kwargs)
-        except Exception:
-            fallback = self._get_fallback_model()
-            if fallback is None:
-                raise
-            logger.warning(
-                "LLM request failed, switching to fallback model: primary=%s fallback=%s",
-                self.model_name,
-                fallback.model_name,
-                exc_info=True,
-            )
-            return fallback._generate(*args, **kwargs)
-
-    async def _agenerate(self, *args, **kwargs) -> ChatResult:
-        try:
-            return await super()._agenerate(*args, **kwargs)
-        except Exception:
-            fallback = self._get_fallback_model()
-            if fallback is None:
-                raise
-            logger.warning(
-                "Async LLM request failed, switching to fallback model: primary=%s fallback=%s",
-                self.model_name,
-                fallback.model_name,
-                exc_info=True,
-            )
-            return await fallback._agenerate(*args, **kwargs)
-
     def _convert_chunk_to_generation_chunk(
         self,
         chunk: dict,
@@ -221,50 +199,24 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         """对reasoning_content字段进行时间统计"""
         reasoning_start_time = 0
         last_reasoning_content = ""
-        emitted = False
-        try:
-            for chunk in super()._stream(*args, **kwargs):
-                emitted = True
-                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                    chunk, reasoning_start_time, last_reasoning_content
-                )
-                yield chunk
-        except Exception:
-            fallback = self._get_fallback_model()
-            if emitted or fallback is None:
-                raise
-            logger.warning(
-                "Streaming LLM request failed before output, switching to fallback model: primary=%s fallback=%s",
-                self.model_name,
-                fallback.model_name,
-                exc_info=True,
+        for chunk in super()._stream(*args, **kwargs):
+            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                chunk, reasoning_start_time, last_reasoning_content
             )
-            yield from fallback._stream(*args, **kwargs)
+            yield chunk
 
     async def _astream(self, *args, **kwargs) -> AsyncIterator[ChatGenerationChunk]:
         """对reasoning_content字段进行时间统计"""
         reasoning_start_time = 0
         last_reasoning_content = ""
-        emitted = False
-        try:
-            async for chunk in super()._astream(*args, **kwargs):
-                emitted = True
-                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                    chunk, reasoning_start_time, last_reasoning_content
-                )
-                yield chunk
-        except Exception:
-            fallback = self._get_fallback_model()
-            if emitted or fallback is None:
-                raise
-            logger.warning(
-                "Async streaming LLM request failed before output, switching to fallback model: primary=%s fallback=%s",
-                self.model_name,
-                fallback.model_name,
-                exc_info=True,
+        async for chunk in super()._astream(*args, **kwargs):
+            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                chunk, reasoning_start_time, last_reasoning_content
             )
-            async for chunk in fallback._astream(*args, **kwargs):
-                yield chunk
+            yield chunk
+
+
+ChatModelRunnable = RunnableWithFallbacks | BaseChatModel
 
 
 class Embeddings(RawOpenAIEmbeddings, ApiGwMixin):

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -345,6 +345,7 @@ class BaseResourceManager(abc.ABC):
             agent_code=agent_code,
             agent_name=res["agent_name"],
             chat_model=prompt_setting.get("llm_code", ""),
+            fallback_llm_code=prompt_setting.get("fallback_llm_code"),
             non_thinking_llm=prompt_setting.get("non_thinking_llm") or prompt_setting.get("llm_code", ""),
             role_prompts=role_prompts or None,
             knowledgebase_ids=res["knowledgebase_settings"]["knowledgebases"],

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -345,7 +345,7 @@ class BaseResourceManager(abc.ABC):
             agent_code=agent_code,
             agent_name=res["agent_name"],
             chat_model=prompt_setting.get("llm_code", ""),
-            fallback_llm_code=prompt_setting.get("fallback_llm_code"),
+            fallback_model=prompt_setting.get("fallback_model"),
             non_thinking_llm=prompt_setting.get("non_thinking_llm") or prompt_setting.get("llm_code", ""),
             role_prompts=role_prompts or None,
             knowledgebase_ids=res["knowledgebase_settings"]["knowledgebases"],

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -391,7 +391,7 @@ class AgentConfig(BaseModel):
     agent_code: str = Field(..., description="智能体代码")
     agent_name: str = Field(..., description="智能体名称")
     chat_model: str = Field(..., description="LLM模型名称")
-    fallback_llm_code: str | None = Field(default=None, description="主模型请求失败时使用的备用模型")
+    fallback_model: str | None = Field(default=None, description="主模型请求失败时使用的备用模型")
     non_thinking_llm: str = Field(..., description="非深度思考模型")
     role_prompts: list[dict[Literal["role", "content"], str]] | None = Field(None, description="角色提示词(平台)")
     model_context_options_data: dict = Field(

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -255,7 +255,6 @@ class KnowledgeSettings(BaseModel):
     )
 
 
-
 class IntentRecognition(BaseModel):
     """旧版意图识别配置兼容模型。
 
@@ -392,6 +391,7 @@ class AgentConfig(BaseModel):
     agent_code: str = Field(..., description="智能体代码")
     agent_name: str = Field(..., description="智能体名称")
     chat_model: str = Field(..., description="LLM模型名称")
+    fallback_llm_code: str | None = Field(default=None, description="主模型请求失败时使用的备用模型")
     non_thinking_llm: str = Field(..., description="非深度思考模型")
     role_prompts: list[dict[Literal["role", "content"], str]] | None = Field(None, description="角色提示词(平台)")
     model_context_options_data: dict = Field(

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1116,7 +1116,7 @@ class ChatAgentBuilder:
 
         kwargs: dict[str, Any] = {
             "model": config.chat_model,
-            "fallback_model": config.fallback_llm_code,
+            "fallback_model": config.fallback_model,
             "base_url": settings.LLM_GW_ENDPOINT,
         }
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -36,7 +36,7 @@ from aidev_agent.core.tools.a2a_tools.types import AgentBackendType, AgentSpec
 from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
 from aidev_agent.enums import AgentType, PromptRole
 from aidev_agent.exceptions import AgentException
-from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
+from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel, ChatModelRunnable
 from aidev_agent.packages.langgraph.streaming.streaming_protocol import AgentStreamAdapter
 from aidev_agent.packages.resource_manager.registry import resource_manager
 from aidev_agent.pydantic_models import (
@@ -93,9 +93,9 @@ class ChatCompletionAgent(BaseModel):
     agent_type: ClassVar[AgentType] = AgentType.CHAT
 
     thread_id: str = Field(default_factory=lambda: str(uuid.uuid4()))
-    chat_model: BaseChatModel | None = None
+    chat_model: ChatModelRunnable | None = None
     """聊天模型；种子实例（``ChatCompletionAgent()``）为 ``None``，``build(ctx)``
-    装配后由 :meth:`ChatAgentBuilder.build_chat_model` 填充为非空 ``BaseChatModel``。
+    装配后由 :meth:`ChatAgentBuilder.build_chat_model` 填充为非空聊天模型 Runnable。
     种子实例不可执行（``execute()`` 假设非空）。"""
     chat_model_non_thinking: BaseChatModel | None = None
     """非思考模型；由 :meth:`ChatAgentBuilder.build_chat_model_non_thinking` 填充。"""
@@ -1106,7 +1106,7 @@ class ChatAgentBuilder:
 
     # ---------- 公共：装配方法（被 ChatCompletionAgent.build 调用） ----------
 
-    def build_chat_model(self) -> BaseChatModel:
+    def build_chat_model(self) -> ChatModelRunnable:
         """构建聊天模型"""
         config = self.ctx.agent_config
         chat = self.ctx.chat or ChatBuildExtras()

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1116,6 +1116,7 @@ class ChatAgentBuilder:
 
         kwargs: dict[str, Any] = {
             "model": config.chat_model,
+            "fallback_model": config.fallback_llm_code,
             "base_url": settings.LLM_GW_ENDPOINT,
         }
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -11,6 +11,7 @@ from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, RemoveMessage, SystemMessage, ToolMessage
 from langchain_core.runnables import Runnable, RunnableConfig
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_core.stores import ByteStore
 from langchain_core.tools import StructuredTool
 from langgraph.checkpoint.base import BaseCheckpointSaver
@@ -201,7 +202,13 @@ class ChatCompletionAgent(BaseModel):
         if not self.messages:
             self.messages = self.convert_history_to_messages()
         messages = self.messages
-        self.chat_model.callbacks = self.callbacks
+        chat_models = (
+            (self.chat_model.runnable, *self.chat_model.fallbacks)
+            if isinstance(self.chat_model, RunnableWithFallbacks)
+            else (self.chat_model,)
+        )
+        for chat_model in chat_models:
+            chat_model.callbacks = self.callbacks
         return self._execute(messages, execute_kwargs)
 
     def stop(self):

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
@@ -1,7 +1,8 @@
 import pytest
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
-from langchain_core.messages import AIMessageChunk
-from langchain_core.outputs import ChatGenerationChunk
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai import ChatOpenAI
 
 
@@ -12,41 +13,48 @@ def test_fallback_model_is_not_forwarded_to_openai_request(monkeypatch):
     monkeypatch.setattr(ChatOpenAI, "_get_request_payload", fake_get_request_payload)
     model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
 
-    assert model._get_request_payload([]) == {"model": "primary-model"}
-    assert model._get_fallback_model()._get_request_payload([]) == {"model": "fallback-model"}
+    assert isinstance(model, RunnableWithFallbacks)
+    assert model.runnable._get_request_payload([]) == {"model": "primary-model"}
+    assert model.fallbacks[0]._get_request_payload([]) == {"model": "fallback-model"}
+
+
+@pytest.mark.parametrize("fallback_model", [None, "primary-model"])
+def test_setup_returns_original_model_without_distinct_fallback(fallback_model):
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model=fallback_model)
+
+    assert isinstance(model, ChatModel)
 
 
 def test_generate_switches_to_fallback_model(monkeypatch):
     calls = []
-    expected = object()
 
     def fake_generate(model, *args, **kwargs):
         calls.append(model.model_name)
         if model.model_name == "primary-model":
             raise RuntimeError("primary unavailable")
-        return expected
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="fallback"))])
 
     monkeypatch.setattr(ChatOpenAI, "_generate", fake_generate)
     model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
 
-    assert model._generate([]) is expected
+    assert model.invoke([HumanMessage(content="hello")]).content == "fallback"
     assert calls == ["primary-model", "fallback-model"]
 
 
 async def test_agenerate_switches_to_fallback_model(monkeypatch):
     calls = []
-    expected = object()
 
     async def fake_agenerate(model, *args, **kwargs):
         calls.append(model.model_name)
         if model.model_name == "primary-model":
             raise RuntimeError("primary unavailable")
-        return expected
+        return ChatResult(generations=[ChatGeneration(message=AIMessage(content="fallback"))])
 
     monkeypatch.setattr(ChatOpenAI, "_agenerate", fake_agenerate)
     model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
 
-    assert await model._agenerate([]) is expected
+    response = await model.ainvoke([HumanMessage(content="hello")])
+    assert response.content == "fallback"
     assert calls == ["primary-model", "fallback-model"]
 
 
@@ -68,10 +76,10 @@ def test_stream_only_falls_back_before_first_output(monkeypatch, fail_after_outp
 
     if fail_after_output:
         with pytest.raises(RuntimeError, match="primary unavailable"):
-            list(model._stream([]))
+            list(model.stream([HumanMessage(content="hello")]))
         assert calls == ["primary-model"]
     else:
-        assert list(model._stream([])) == [chunk]
+        assert "".join(item.content for item in model.stream([HumanMessage(content="hello")])) == "ok"
         assert calls == ["primary-model", "fallback-model"]
 
 
@@ -93,8 +101,45 @@ async def test_astream_only_falls_back_before_first_output(monkeypatch, fail_aft
 
     if fail_after_output:
         with pytest.raises(RuntimeError, match="primary unavailable"):
-            [item async for item in model._astream([])]
+            [item async for item in model.astream([HumanMessage(content="hello")])]
         assert calls == ["primary-model"]
     else:
-        assert [item async for item in model._astream([])] == [chunk]
+        items = [item async for item in model.astream([HumanMessage(content="hello")])]
+        assert "".join(item.content for item in items) == "ok"
         assert calls == ["primary-model", "fallback-model"]
+
+
+async def test_astream_events_emit_fallback_chat_model_chunks(monkeypatch):
+    async def fake_astream(model, *args, **kwargs):
+        if model.model_name == "primary-model":
+            raise RuntimeError("primary unavailable")
+        yield ChatGenerationChunk(message=AIMessageChunk(content="fallback"))
+
+    monkeypatch.setattr(ChatOpenAI, "_astream", fake_astream)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    events = [event async for event in model.astream_events([HumanMessage(content="hello")])]
+    chunks = [event["data"]["chunk"].content for event in events if event["event"] == "on_chat_model_stream"]
+
+    assert "".join(chunks) == "fallback"
+
+
+def test_bind_tools_is_applied_to_primary_and_fallback():
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+    tool = {"type": "function", "function": {"name": "ping", "parameters": {"type": "object"}}}
+
+    bound = model.bind_tools([tool])
+
+    assert isinstance(bound, RunnableWithFallbacks)
+    assert bound.runnable.bound.model_name == "primary-model"
+    assert bound.fallbacks[0].bound.model_name == "fallback-model"
+
+
+def test_fallback_runnable_can_be_attached_to_chat_agent():
+    from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    agent = ChatCompletionAgent(chat_model=model)
+
+    assert agent.chat_model is model

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
@@ -1,0 +1,89 @@
+import pytest
+from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
+from langchain_core.messages import AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk
+from langchain_openai import ChatOpenAI
+
+
+def test_generate_switches_to_fallback_model(monkeypatch):
+    calls = []
+    expected = object()
+
+    def fake_generate(model, *args, **kwargs):
+        calls.append(model.model_name)
+        if model.model_name == "primary-model":
+            raise RuntimeError("primary unavailable")
+        return expected
+
+    monkeypatch.setattr(ChatOpenAI, "_generate", fake_generate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    assert model._generate([]) is expected
+    assert calls == ["primary-model", "fallback-model"]
+
+
+async def test_agenerate_switches_to_fallback_model(monkeypatch):
+    calls = []
+    expected = object()
+
+    async def fake_agenerate(model, *args, **kwargs):
+        calls.append(model.model_name)
+        if model.model_name == "primary-model":
+            raise RuntimeError("primary unavailable")
+        return expected
+
+    monkeypatch.setattr(ChatOpenAI, "_agenerate", fake_agenerate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    assert await model._agenerate([]) is expected
+    assert calls == ["primary-model", "fallback-model"]
+
+
+@pytest.mark.parametrize("fail_after_output", [False, True])
+def test_stream_only_falls_back_before_first_output(monkeypatch, fail_after_output):
+    calls = []
+    chunk = ChatGenerationChunk(message=AIMessageChunk(content="ok"))
+
+    def fake_stream(model, *args, **kwargs):
+        calls.append(model.model_name)
+        if model.model_name == "primary-model" and fail_after_output:
+            yield chunk
+        if model.model_name == "primary-model":
+            raise RuntimeError("primary unavailable")
+        yield chunk
+
+    monkeypatch.setattr(ChatOpenAI, "_stream", fake_stream)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    if fail_after_output:
+        with pytest.raises(RuntimeError, match="primary unavailable"):
+            list(model._stream([]))
+        assert calls == ["primary-model"]
+    else:
+        assert list(model._stream([])) == [chunk]
+        assert calls == ["primary-model", "fallback-model"]
+
+
+@pytest.mark.parametrize("fail_after_output", [False, True])
+async def test_astream_only_falls_back_before_first_output(monkeypatch, fail_after_output):
+    calls = []
+    chunk = ChatGenerationChunk(message=AIMessageChunk(content="ok"))
+
+    async def fake_astream(model, *args, **kwargs):
+        calls.append(model.model_name)
+        if model.model_name == "primary-model" and fail_after_output:
+            yield chunk
+        if model.model_name == "primary-model":
+            raise RuntimeError("primary unavailable")
+        yield chunk
+
+    monkeypatch.setattr(ChatOpenAI, "_astream", fake_astream)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    if fail_after_output:
+        with pytest.raises(RuntimeError, match="primary unavailable"):
+            [item async for item in model._astream([])]
+        assert calls == ["primary-model"]
+    else:
+        assert [item async for item in model._astream([])] == [chunk]
+        assert calls == ["primary-model", "fallback-model"]

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
@@ -5,6 +5,17 @@ from langchain_core.outputs import ChatGenerationChunk
 from langchain_openai import ChatOpenAI
 
 
+def test_fallback_model_is_not_forwarded_to_openai_request(monkeypatch):
+    def fake_get_request_payload(model, *args, **kwargs):
+        return {"model": model.model_name, "fallback_model": model.fallback_model}
+
+    monkeypatch.setattr(ChatOpenAI, "_get_request_payload", fake_get_request_payload)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    assert model._get_request_payload([]) == {"model": "primary-model"}
+    assert model._get_fallback_model()._get_request_payload([]) == {"model": "fallback-model"}
+
+
 def test_generate_switches_to_fallback_model(monkeypatch):
     calls = []
     expected = object()

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway_fallback.py
@@ -1,5 +1,6 @@
 import pytest
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage
 from langchain_core.outputs import ChatGeneration, ChatGenerationChunk, ChatResult
 from langchain_core.runnables.fallbacks import RunnableWithFallbacks
@@ -143,3 +144,17 @@ def test_fallback_runnable_can_be_attached_to_chat_agent():
     agent = ChatCompletionAgent(chat_model=model)
 
     assert agent.chat_model is model
+
+
+def test_agent_execute_updates_callbacks_for_primary_and_fallback(monkeypatch):
+    from aidev_agent.pydantic_models import ExecuteKwargs
+    from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+    callbacks = [BaseCallbackHandler()]
+    agent = ChatCompletionAgent(chat_model=model, callbacks=callbacks, messages=[HumanMessage(content="hello")])
+    monkeypatch.setattr(ChatCompletionAgent, "_execute", lambda *args: "ok")
+
+    assert agent.execute(ExecuteKwargs()) == "ok"
+    assert model.runnable.callbacks == callbacks
+    assert model.fallbacks[0].callbacks == callbacks

--- a/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
+++ b/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
@@ -131,7 +131,7 @@ class TestChatAgentBuilderTransparentSessionCode:
 
     def test_fallback_model_forwarded_to_get_setup_instance(self):
         ctx = _make_chat_ctx(session_code="conv-fallback")
-        ctx.agent_config.fallback_llm_code = "backup-llm"
+        ctx.agent_config.fallback_model = "backup-llm"
         builder = ChatAgentBuilder(ctx)
 
         with patch.object(ChatModel, "get_setup_instance", return_value=MagicMock()) as mocked:

--- a/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
+++ b/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
@@ -129,6 +129,16 @@ class TestChatAgentBuilderTransparentSessionCode:
         kwargs = mocked.call_args.kwargs
         assert "session_code" not in kwargs
 
+    def test_fallback_model_forwarded_to_get_setup_instance(self):
+        ctx = _make_chat_ctx(session_code="conv-fallback")
+        ctx.agent_config.fallback_llm_code = "backup-llm"
+        builder = ChatAgentBuilder(ctx)
+
+        with patch.object(ChatModel, "get_setup_instance", return_value=MagicMock()) as mocked:
+            builder.build_chat_model()
+
+        assert mocked.call_args.kwargs["fallback_model"] == "backup-llm"
+
     def test_empty_session_code_in_ctx_no_kwarg_passed(self):
         ctx = _make_chat_ctx(session_code="")
         builder = ChatAgentBuilder(ctx)


### PR DESCRIPTION
## 需求

为 Agent 模型配置新增可空的 `fallback_model`，在主模型请求异常时自动切换到备用模型。

## 实现

- 对外保留明确的 `fallback_model=` 配置方式
- 模型工厂内部复用 LangChain `with_fallbacks()` 组合主模型和备用模型
- 未配置备用模型或备用模型与主模型相同时，继续返回原始 `ChatModel`
- 同步、异步和流式调用遵循 LangChain 原生 fallback 语义；流式调用只在首个输出前切换
- `bind_tools` 自动同时应用于主模型和备用模型，事件流继续输出聊天模型事件
- 请求载荷移除 `fallback_model`，避免把 SDK 配置透传给 OpenAI-compatible 服务
- Agent 模型类型兼容 `RunnableWithFallbacks` 和已有 `BaseChatModel` 扩展

## 验证

- fallback、请求头和 Agent 装配相关测试通过
- Agent 服务和模型节点非慢速回归通过
- 变更文件提交前检查通过
