### PR TITLE
feat: Agent 会话列表接口透传分页参数 --story=136130512

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/constants.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/constants.py
@@ -3,6 +3,10 @@
 # AG-UI 协议版本
 AGUI_PROTOCOL_VERSION = "v2"
 
+# 会话列表默认分页参数
+DEFAULT_SESSION_PAGE = 1
+DEFAULT_SESSION_PAGE_SIZE = 20
+
 # 用户操作类型
 # - FLOW_NODE_RETRY：重试 flow 节点
 # - FLOW_NODE_SKIP：跳过 flow 节点

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -15,6 +15,17 @@ from aidev_bkplugin.utils import is_local_dev
 from aidev_bkplugin.views.base import PluginResourceManager, PluginViewSet, client, logger
 
 
+def _parse_positive_int(value, default):
+    """将分页参数解析为正整数，缺失或非法（非数字、小于 1）时回退默认值"""
+    if value is None:
+        return default
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return parsed if parsed >= 1 else default
+
+
 class ChatSessionViewSet(PluginViewSet):
     session_type: str = "dev" if is_local_dev() else "agent"
 
@@ -33,15 +44,12 @@ class ChatSessionViewSet(PluginViewSet):
         # 兼容旧前端：仅当显式传入 page 或 page_size 时启用分页，否则保持数组返回
         has_pagination = page is not None or page_size is not None
         if has_pagination:
-            params["page"] = page or DEFAULT_SESSION_PAGE
-            params["page_size"] = page_size or DEFAULT_SESSION_PAGE_SIZE
+            params["page"] = _parse_positive_int(page, DEFAULT_SESSION_PAGE)
+            params["page_size"] = _parse_positive_int(page_size, DEFAULT_SESSION_PAGE_SIZE)
         result = client.api.list_chat_session(headers={"X-BKAIDEV-USER": request.user.username}, params=params)
         data = result["data"]
-        if isinstance(data, dict) and "results" in data:
-            data["results"] = [
-                each for each in data["results"] if each.get("protocol_version") == AGUI_PROTOCOL_VERSION
-            ]
-        else:
+        if not isinstance(data, dict):
+            # 旧后端未分页（返回数组）：在 Agent 侧过滤协议版本
             data = [each for each in data if each.get("protocol_version") == AGUI_PROTOCOL_VERSION]
         return Response(data=data)
 

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -9,7 +9,7 @@ from rest_framework.decorators import action
 from rest_framework.parsers import FileUploadParser
 from rest_framework.views import Response
 
-from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION
+from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION, DEFAULT_SESSION_PAGE, DEFAULT_SESSION_PAGE_SIZE
 from aidev_bkplugin.services.agent_config import AgentConfigFetcher
 from aidev_bkplugin.utils import is_local_dev
 from aidev_bkplugin.views.base import PluginResourceManager, PluginViewSet, client, logger
@@ -24,11 +24,26 @@ class ChatSessionViewSet(PluginViewSet):
         return ChannelType.POPUP.value
 
     def list(self, request):
-        result = client.api.list_chat_session(
-            headers={"X-BKAIDEV-USER": request.user.username}, params={"session_type": self.session_type}
-        )
-        result["data"] = [each for each in result["data"] if each.get("protocol_version") == AGUI_PROTOCOL_VERSION]
-        return Response(data=result["data"])
+        params = {
+            "session_type": self.session_type,
+            "protocol_version": AGUI_PROTOCOL_VERSION,
+        }
+        page = request.query_params.get("page")
+        page_size = request.query_params.get("page_size")
+        # 兼容旧前端：仅当显式传入 page 或 page_size 时启用分页，否则保持数组返回
+        has_pagination = page is not None or page_size is not None
+        if has_pagination:
+            params["page"] = page or DEFAULT_SESSION_PAGE
+            params["page_size"] = page_size or DEFAULT_SESSION_PAGE_SIZE
+        result = client.api.list_chat_session(headers={"X-BKAIDEV-USER": request.user.username}, params=params)
+        data = result["data"]
+        if isinstance(data, dict) and "results" in data:
+            data["results"] = [
+                each for each in data["results"] if each.get("protocol_version") == AGUI_PROTOCOL_VERSION
+            ]
+        else:
+            data = [each for each in data if each.get("protocol_version") == AGUI_PROTOCOL_VERSION]
+        return Response(data=data)
 
     @action(["POST"], url_path="batch_delete", detail=False)
     def batch_delete(self, request):

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from django.conf import settings
+
+if not settings.configured:
+    settings.configure(
+        DEFAULT_CHARSET="utf-8",
+        INSTALLED_APPS=[],
+        PLATFORM_CODE="00",
+        REST_FRAMEWORK={},
+        USE_I18N=False,
+    )
+
+base_mod = types.ModuleType("aidev_bkplugin.views.base")
+base_mod.PluginResourceManager = MagicMock()
+base_mod.PluginViewSet = object
+base_mod.client = SimpleNamespace(api=MagicMock())
+base_mod.logger = MagicMock()
+sys.modules["aidev_bkplugin.views.base"] = base_mod
+
+agent_config_mod = types.ModuleType("aidev_bkplugin.services.agent_config")
+agent_config_mod.AgentConfigFetcher = MagicMock()
+sys.modules["aidev_bkplugin.services.agent_config"] = agent_config_mod
+
+from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION  # noqa: E402
+from aidev_bkplugin.views import session as session_mod  # noqa: E402
+
+
+def _request(query_params=None, username="alice"):
+    return SimpleNamespace(query_params=query_params or {}, user=SimpleNamespace(username=username))
+
+
+def _session(session_code, protocol_version=AGUI_PROTOCOL_VERSION):
+    return {"session_code": session_code, "protocol_version": protocol_version}
+
+
+def test_list_without_pagination_returns_legacy_array(monkeypatch):
+    api = MagicMock()
+    api.list_chat_session.return_value = {"data": [_session("v2"), _session("v1", "v1")]}
+    monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
+    view = session_mod.ChatSessionViewSet()
+
+    response = view.list(_request())
+
+    assert response.data == [_session("v2")]
+    api.list_chat_session.assert_called_once_with(
+        headers={"X-BKAIDEV-USER": "alice"},
+        params={"session_type": view.session_type, "protocol_version": AGUI_PROTOCOL_VERSION},
+    )
+
+
+def test_list_with_pagination_returns_paginated_data(monkeypatch):
+    api = MagicMock()
+    api.list_chat_session.return_value = {
+        "data": {
+            "page": 1,
+            "num_pages": 1,
+            "count": 2,
+            "results": [_session("v2"), _session("v1", "v1")],
+        }
+    }
+    monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
+    view = session_mod.ChatSessionViewSet()
+
+    response = view.list(_request({"page": "1", "page_size": "20"}))
+
+    assert response.data == {"page": 1, "num_pages": 1, "count": 2, "results": [_session("v2")]}
+    api.list_chat_session.assert_called_once_with(
+        headers={"X-BKAIDEV-USER": "alice"},
+        params={
+            "session_type": view.session_type,
+            "protocol_version": AGUI_PROTOCOL_VERSION,
+            "page": "1",
+            "page_size": "20",
+        },
+    )
+
+
+def test_list_with_pagination_handles_legacy_backend_array(monkeypatch):
+    api = MagicMock()
+    api.list_chat_session.return_value = {"data": [_session("v2"), _session("v1", "v1")]}
+    monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
+
+    response = session_mod.ChatSessionViewSet().list(_request({"page": "1", "page_size": "20"}))
+
+    assert response.data == [_session("v2")]

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
@@ -56,27 +56,27 @@ def test_list_without_pagination_returns_legacy_array(monkeypatch):
 
 def test_list_with_pagination_returns_paginated_data(monkeypatch):
     api = MagicMock()
-    api.list_chat_session.return_value = {
-        "data": {
-            "page": 1,
-            "num_pages": 1,
-            "count": 2,
-            "results": [_session("v2"), _session("v1", "v1")],
-        }
+    # 平台已按 protocol_version 过滤，返回纯 v2 分页结构，Agent 侧原样透传
+    paginated = {
+        "page": 1,
+        "num_pages": 1,
+        "count": 1,
+        "results": [_session("v2")],
     }
+    api.list_chat_session.return_value = {"data": paginated}
     monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
     view = session_mod.ChatSessionViewSet()
 
     response = view.list(_request({"page": "1", "page_size": "20"}))
 
-    assert response.data == {"page": 1, "num_pages": 1, "count": 2, "results": [_session("v2")]}
+    assert response.data == paginated
     api.list_chat_session.assert_called_once_with(
         headers={"X-BKAIDEV-USER": "alice"},
         params={
             "session_type": view.session_type,
             "protocol_version": AGUI_PROTOCOL_VERSION,
-            "page": "1",
-            "page_size": "20",
+            "page": 1,
+            "page_size": 20,
         },
     )
 
@@ -89,3 +89,24 @@ def test_list_with_pagination_handles_legacy_backend_array(monkeypatch):
     response = session_mod.ChatSessionViewSet().list(_request({"page": "1", "page_size": "20"}))
 
     assert response.data == [_session("v2")]
+
+
+def test_list_pagination_params_invalid_fallback_to_default(monkeypatch):
+    """非法分页参数（0、负数、非数字）回退默认值，并以整数透传给平台"""
+    api = MagicMock()
+    api.list_chat_session.return_value = {"data": [_session("v2")]}
+    monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
+    view = session_mod.ChatSessionViewSet()
+
+    # page=0、page_size=abc 均非法，应回退默认值
+    view.list(_request({"page": "0", "page_size": "abc"}))
+
+    api.list_chat_session.assert_called_once_with(
+        headers={"X-BKAIDEV-USER": "alice"},
+        params={
+            "session_type": view.session_type,
+            "protocol_version": AGUI_PROTOCOL_VERSION,
+            "page": session_mod.DEFAULT_SESSION_PAGE,
+            "page_size": session_mod.DEFAULT_SESSION_PAGE_SIZE,
+        },
+    )


### PR DESCRIPTION
## 背景

配合【小鲸】历史会话分页需求（前端见 `707f7c95 feat: 小鲸历史会话支持分页`），Agent 侧会话列表接口原先调用平台接口后仅做协议版本过滤、返回数组，需透传分页参数并保持分页响应结构。

## 改动内容

- `ChatSessionViewSet.list` 透传 `page`、`page_size` 到平台 `list_chat_session` 接口
- 固定透传 `protocol_version=AGUI_PROTOCOL_VERSION`，由平台侧按协议版本过滤，分页 count 准确
- 响应保留分页结构；仅对旧后端返回数组的情况做协议版本过滤
- 新增 `DEFAULT_SESSION_PAGE`、`DEFAULT_SESSION_PAGE_SIZE` 常量，消除魔法数字
- 新增 `_parse_positive_int`：分页参数统一转 int 并校验 `>=1`，非法值回退默认值，消除字符串/整数类型不一致

## 接口协议

前端调用 Agent 侧会话列表接口：

```http
GET /session/?page=1&page_size=20
```

- `page`：可选，默认 `1`，最小值 `1`
- `page_size`：可选，默认 `20`，最小值 `1`
- `session_type`、`protocol_version` 由 Agent 内部自动补充，前端无需传递

响应 `data`：

```json
{"page": 1, "num_pages": 3, "count": 52, "results": [...]}
```

前端列表使用 `results`，分页总数使用 `count`，总页数使用 `num_pages`。

## 测试

`tests/views/test_session_view.py` 覆盖：

- 无分页参数时返回旧版数组（兼容旧前端）
- 显式分页参数时透传并返回分页结构
- 旧后端返回数组时的兼容处理
- 非法分页参数（`0`、负数、非数字）回退默认值

Made with [Cursor](https://cursor.com)