### PR TITLE
feat: bkplugin 支持智能体模型热更新（llm 列表接口 + chat_completion llm 热切换）

### DIFF
--- a/src/agent/aidev_agent/api/bk_aidev.py
+++ b/src/agent/aidev_agent/api/bk_aidev.py
@@ -196,6 +196,14 @@ class OpenApiGroup(OperationGroup):
         path="/openapi/aidev/resource/v1/agent/{agent_code}/",
     )
 
+    # 应用态模型列表：供已发布智能体入口（如小鲸）拉取空间可用模型，配合 chat_completion 的 llm 字段实现模型热切换
+    list_app_v1_llms = bind_property(
+        Operation,
+        name="list_app_v1_llms",
+        method="GET",
+        path="/openapi/aidev/app/v1/llms/",
+    )
+
     create_tool_approval = bind_property(
         Operation,
         name="create_tool_approval",

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/openapi/urls.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/openapi/urls.py
@@ -15,6 +15,7 @@ from aidev_bkplugin.openapi.views import (
     OpenapiChatCompletionViewSet,
     OpenapiChatSessionContentViewSet,
     OpenapiChatSessionViewSet,
+    OpenapiLLMViewSet,
     OpenapiUserOperationViewSet,
 )
 
@@ -25,6 +26,7 @@ _router.register("session", OpenapiChatSessionViewSet, "session")
 _router.register("session_content", OpenapiChatSessionContentViewSet, "session_content")
 _router.register("agent", OpenapiAgentInfoViewSet, "agent_info")
 _router.register("user_operation", OpenapiUserOperationViewSet, "user_operation")
+_router.register("llm", OpenapiLLMViewSet, "openapi_llm")
 
 
 urlpatterns = [

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/openapi/views.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/openapi/views.py
@@ -14,6 +14,7 @@ from aidev_bkplugin.services.agent_helpers import AgentHelper
 from aidev_bkplugin.views.agent import AgentInfoViewSet
 from aidev_bkplugin.views.base import PluginViewSet
 from aidev_bkplugin.views.chat import ChatCompletionViewSet
+from aidev_bkplugin.views.llm import LLMViewSet
 from aidev_bkplugin.views.session import ChatSessionContentViewSet, ChatSessionViewSet
 from aidev_bkplugin.views.user_operation import UserOperationViewSet
 
@@ -85,4 +86,10 @@ class OpenapiAgentInfoViewSet(OpenapiPluginViewSet, AgentInfoViewSet):
 
 
 class OpenapiUserOperationViewSet(OpenapiPluginViewSet, UserOperationViewSet):
+    pass
+
+
+class OpenapiLLMViewSet(OpenapiPluginViewSet, LLMViewSet):
+    """应用态 LLM 列表接口：供小鲸等已发布智能体入口拉取空间可用模型。"""
+
     pass

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/serializers/chat_completion.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/serializers/chat_completion.py
@@ -21,6 +21,7 @@ from rest_framework import serializers
 
 from aidev_bkplugin.services.agent_execution import build_execute_kwargs
 from aidev_bkplugin.services.agent_config import AgentConfigFetcher
+from aidev_bkplugin.services.llm import LLMService
 
 
 class ChatPromptContentField(serializers.Field):
@@ -67,6 +68,11 @@ class ChatCompletionRequestSerializer(serializers.Serializer):
     session_code = serializers.CharField(required=False, allow_blank=True, default="")
     thread_id = serializers.CharField(required=False, allow_blank=True, default="")
 
+    # 模型热更新：覆盖智能体原配置的 chat_model / non_thinking_llm，需在当前空间可用模型列表内
+    llm = serializers.CharField(
+        required=False, allow_blank=True, default="", help_text="热切换模型 llm_code，需在当前空间可用模型列表内"
+    )
+
     # 流程智能体
     task_id = serializers.CharField(required=False, allow_blank=True, default="")
     flow_start_params = serializers.DictField(required=False, default=dict)
@@ -104,5 +110,10 @@ class ChatCompletionRequestSerializer(serializers.Serializer):
         if not thread_id and not attrs.get("session_code"):
             thread_id = str(uuid.uuid4())
         attrs["thread_id"] = thread_id
+
+        # llm 热切换授权校验：非空时校验是否在当前空间可用模型列表内，避免越权切换到未授权模型
+        llm = attrs.get("llm", "")
+        if llm and not LLMService.is_llm_accessible(username=username, llm_code=llm):
+            raise serializers.ValidationError({"llm": f"模型 {llm} 不在当前空间可用模型列表内"})
 
         return attrs

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/serializers/llm.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/serializers/llm.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+"""LLM 列表接口入参 serializer。"""
+
+from rest_framework import serializers
+
+
+class LLMListRequestSerializer(serializers.Serializer):
+    """LLM 列表查询入参，透传给平台应用态 ``app/v1/llms`` 网关接口。"""
+
+    llm_type = serializers.CharField(
+        required=False, allow_blank=True, default="", help_text="模型类型，不传时平台默认 chat.completion"
+    )
+    supports = serializers.CharField(
+        required=False, allow_blank=True, default="", help_text="模型能力过滤，逗号分隔，如 tools,vision"
+    )
+    fuzzy = serializers.CharField(
+        required=False, allow_blank=True, default="", help_text="模糊搜索关键词，按 llm_name/description/base_model 匹配"
+    )

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
@@ -12,7 +12,7 @@ from logging import getLogger
 
 from aidev_agent.enums import AgentBuildType, PromptRole, SessionsStatus
 from aidev_agent.packages.resource_manager.agent import AgentResourceManager
-from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.pydantic_models import AgentConfig, ChatPrompt
 from aidev_agent.services.agent import AgentInstanceFactory, ChatCompletionAgent
 from aidev_agent.services.common_agent import common_agent_factory
 from aidev_agent.services.event_handlers import AGUISessionWriter
@@ -22,6 +22,26 @@ from .agent_helpers import AgentHelper
 from .agent_session import SessionManager
 
 logger = getLogger(__name__)
+
+
+class LLMOverrideResourceManager(AgentResourceManager):
+    """带 llm 热切换覆盖的 resource manager。
+
+    在 ``get_agent_config`` 装配 ``AgentConfig`` 后，用传入的 ``llm`` 覆盖 ``chat_model`` /
+    ``non_thinking_llm``，实现已发布智能体在聊天时动态切换模型，无需重新发布智能体。
+    ``llm`` 为空时不覆盖，行为与 ``AgentResourceManager`` 完全一致。
+    """
+
+    def __init__(self, username: str = "", llm: str = ""):
+        super().__init__(username=username)
+        self.llm = llm or ""
+
+    def get_agent_config(self, agent_code: str, version: str | None = None, **kwargs) -> AgentConfig:
+        config = super().get_agent_config(agent_code, version=version, **kwargs)
+        if self.llm:
+            config.chat_model = self.llm
+            config.non_thinking_llm = self.llm
+        return config
 
 
 class AgentBuilder:
@@ -37,11 +57,14 @@ class AgentBuilder:
         agent_code: str | None = None,
         session_manager: SessionManager | None = None,
         turn_id: str = "",
+        llm: str = "",
     ):
         self.username = username
         self.agent_code = agent_code or settings.APP_CODE
         self.session_manager = session_manager or SessionManager(username=username, agent_code=agent_code)
         self.turn_id = turn_id
+        # 模型热更新：非空时覆盖 agent 配置的 chat_model / non_thinking_llm
+        self.llm = llm or ""
 
     def by_session_code(
         self,
@@ -131,7 +154,9 @@ class AgentBuilder:
         event_handler = AGUISessionWriter(
             session_code=session_code, client=AgentHelper.get_client(), username=self.username, turn_id=self.turn_id
         )
-        resource_manager = AgentResourceManager(username=self.username) if self.username else None
+        resource_manager = (
+            LLMOverrideResourceManager(username=self.username, llm=self.llm) if self.username else None
+        )
         return AgentInstanceFactory.build_agent(
             build_type=AgentBuildType.SESSION,
             session_code=session_code,

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/llm.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/llm.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""LLM 服务：调平台应用态 ``app/v1/llms`` 网关接口，拉取当前空间可用模型列表。
+
+供小鲸等已发布智能体入口在聊天时拉取可选模型，配合 ``chat_completion`` 的 ``llm`` 字段
+实现智能体模型热更新；同时提供 ``llm`` 空间授权校验能力。
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from typing import Any
+
+from aidev_agent.packages.resource_manager import resource_manager
+
+logger = getLogger(__name__)
+
+
+class LLMService:
+    """调平台应用态 llm 列表网关接口。
+
+    平台接口走 ``AppBaseView`` 应用态鉴权（app_code + app_secret），用户权限过滤通过
+    ``X-BKAIDEV-USER`` header 透传；空间解析由平台按 app_code 兜底完成。
+    """
+
+    @staticmethod
+    def list_llms(
+        username: str = "",
+        llm_type: str = "",
+        supports: str = "",
+        fuzzy: str = "",
+    ) -> list[dict[str, Any]]:
+        """拉取当前空间可用 LLM 列表。
+
+        Args:
+            username: 用户名，透传给平台做用户权限过滤；为空时平台仅返回公开 + 空间授权模型。
+            llm_type: 模型类型过滤，不传时平台默认 chat.completion。
+            supports: 模型能力过滤，逗号分隔（如 ``"tools,vision"``）。
+            fuzzy: 模糊搜索关键词。
+
+        Returns:
+            平台返回的模型精简列表（llm_code/llm_name/llm_type/icon/...）。
+        """
+        client = resource_manager().get_client()
+        params: dict[str, Any] = {}
+        if llm_type:
+            params["llm_type"] = llm_type
+        if supports:
+            # 逗号分隔透传，平台 AppLLMListRequest.normalize_supports 会 split 成 List[str]
+            params["supports"] = supports
+        if fuzzy:
+            params["fuzzy"] = fuzzy
+        headers = {"X-BKAIDEV-USER": username} if username else {}
+        result = client.api.list_app_v1_llms(params=params, headers=headers)
+        return result.get("data", []) or []
+
+    @staticmethod
+    def is_llm_accessible(username: str = "", llm_code: str = "") -> bool:
+        """校验 ``llm_code`` 是否在当前空间可用模型列表内。
+
+        用于 ``chat_completion`` 收到 ``llm`` 字段时做空间授权校验，避免越权切换到未授权模型。
+        ``llm_code`` 为空时视为不覆盖（沿用智能体原配置），直接放行。
+        """
+        if not llm_code:
+            return True
+        llms = LLMService.list_llms(username=username)
+        return any(llm.get("llm_code") == llm_code for llm in llms)

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/urls.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/urls.py
@@ -7,6 +7,7 @@ from .views.agent import AgentInfoViewSet
 from .views.chat import ChatCompletionViewSet
 from .views.chat_group import ChatGroupViewSet
 from .views.flow_agent import FlowAgentViewSet
+from .views.llm import LLMViewSet
 from .views.session import (
     ChatSessionContentFeedbackViewSet,
     ChatSessionContentViewSet,
@@ -25,6 +26,7 @@ _router.register("session_feedback", ChatSessionContentFeedbackViewSet, "chat_se
 _router.register("chat_group", ChatGroupViewSet, "chat_group")
 _router.register("share", ChatSessionShareView, "share")
 _router.register("user_operation", UserOperationViewSet, "user_operation")
+_router.register("llm", LLMViewSet, "llm")
 
 
 urlpatterns = [

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -110,6 +110,7 @@ class ChatCompletionViewSet(PluginViewSet):
                     execute_kwargs=execute_kwargs,
                     turn_id=turn_id,
                     channel_type=self.channel_type,
+                    llm=data.get("llm", ""),
                 )
 
             # 走到这里 thread_id 必为空（上面已 return）；由 serializer 中的 uuid 兜底规则可推出
@@ -119,7 +120,9 @@ class ChatCompletionViewSet(PluginViewSet):
             turn_id = self._save_user_input(session_code, username, _input, turn_id)
             if hasattr(execute_kwargs, "turn_id"):
                 execute_kwargs.turn_id = turn_id
-            agent_instance = AgentBuilder(username=request.user.username, turn_id=turn_id).by_session_code(
+            agent_instance = AgentBuilder(
+                username=request.user.username, turn_id=turn_id, llm=data.get("llm", "")
+            ).by_session_code(
                 session_code,
                 version=execute_kwargs.version,
                 channel_type=self.channel_type,
@@ -183,11 +186,12 @@ class ChatCompletionViewSet(PluginViewSet):
         execute_kwargs: ExecuteKwargs,
         turn_id: str,
         channel_type: str,
+        llm: str = "",
     ):
         """
         通过 thread_id 自动管理会话，使用 chat_history 初始化，自动保存到 session
         """
-        builder = AgentBuilder(username=username, turn_id=turn_id)
+        builder = AgentBuilder(username=username, turn_id=turn_id, llm=llm)
         agent_instance, session_code = builder.by_thread_id_with_chat_history(
             thread_id=thread_id,
             chat_history=chat_history,

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/llm.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/llm.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""LLM 列表视图：供小鲸等已发布智能体入口拉取当前空间可用模型。
+
+应用态入口（apigw）：``OpenapiLLMViewSet``（见 ``openapi/views.py``）。
+用户态入口（应用域名直连）：本模块 ``LLMViewSet``。
+两者复用同一 ``list_llms`` 逻辑，差异仅在鉴权 Mixin。
+"""
+
+from rest_framework.decorators import action
+from rest_framework.views import Response
+
+from aidev_bkplugin.serializers.llm import LLMListRequestSerializer
+from aidev_bkplugin.services.llm import LLMService
+from aidev_bkplugin.views.base import PluginViewSet
+
+
+class LLMViewSet(PluginViewSet):
+    @action(detail=False, methods=["GET"], url_path="list", url_name="list")
+    def list_llms(self, request):
+        """获取当前空间可用 LLM 列表，用于聊天时动态切换模型（智能体模型热更新）。"""
+        username = self.get_username()
+        slz = LLMListRequestSerializer(data=request.query_params)
+        slz.is_valid(raise_exception=True)
+        data = slz.validated_data
+        llms = LLMService.list_llms(
+            username=username,
+            llm_type=data.get("llm_type", ""),
+            supports=data.get("supports", ""),
+            fuzzy=data.get("fuzzy", ""),
+        )
+        return Response(data=llms)

--- a/src/plugins/aidev_bkplugin/tests/conftest.py
+++ b/src/plugins/aidev_bkplugin/tests/conftest.py
@@ -18,3 +18,15 @@ if _SRC_AGENT.is_dir() and str(_SRC_AGENT) not in sys.path:
 # 卸掉可能已被 wheel 版预加载的 aidev_agent，让后续 import 走源码。
 for _mod in [name for name in list(sys.modules) if name == "aidev_agent" or name.startswith("aidev_agent.")]:
     sys.modules.pop(_mod, None)
+
+# bk_plugin_framework 是蓝鲸内部包，本地测试环境可能未安装；
+# 注入轻量 mock 让 aidev_bkplugin.views.base 的 import 不报错（inject_user_token 装饰器透传）。
+import types
+
+_bk_pf = types.ModuleType("bk_plugin_framework")
+_bk_pf_kit = types.ModuleType("bk_plugin_framework.kit")
+_bk_pf_kit_dec = types.ModuleType("bk_plugin_framework.kit.decorators")
+_bk_pf_kit_dec.inject_user_token = lambda *a, **k: (lambda f: f)
+sys.modules.setdefault("bk_plugin_framework", _bk_pf)
+sys.modules.setdefault("bk_plugin_framework.kit", _bk_pf_kit)
+sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_pf_kit_dec)

--- a/src/plugins/aidev_bkplugin/tests/services/agent/test_builder.py
+++ b/src/plugins/aidev_bkplugin/tests/services/agent/test_builder.py
@@ -75,9 +75,9 @@ def test_by_thread_id_skips_save_when_save_content_false():
     sm.save_content.assert_not_called()
 
 
-def test_by_session_code_passes_user_resource_manager():
+def test_by_session_code_passes_llm_override_resource_manager():
     from aidev_agent.packages.resource_manager.agent import AgentResourceManager
-    from aidev_bkplugin.services.agent_builder import AgentBuilder
+    from aidev_bkplugin.services.agent_builder import AgentBuilder, LLMOverrideResourceManager
 
     build_p, factory_p, client_p = _patch_factories()
     with build_p as mock_build, factory_p as mock_factory, client_p:
@@ -86,5 +86,47 @@ def test_by_session_code_passes_user_resource_manager():
         AgentBuilder(username="alice").by_session_code("sc-1")
 
     rm = mock_build.call_args.kwargs["resource_manager"]
+    assert isinstance(rm, LLMOverrideResourceManager)
     assert isinstance(rm, AgentResourceManager)
     assert rm.username == "alice"
+    assert rm.llm == ""
+
+
+def test_by_session_code_attaches_llm_to_resource_manager():
+    from aidev_bkplugin.services.agent_builder import AgentBuilder, LLMOverrideResourceManager
+
+    build_p, factory_p, client_p = _patch_factories()
+    with build_p as mock_build, factory_p as mock_factory, client_p:
+        mock_factory.return_value = MagicMock()
+        mock_build.return_value = MagicMock()
+        AgentBuilder(username="alice", llm="gpt-4").by_session_code("sc-1")
+
+    rm = mock_build.call_args.kwargs["resource_manager"]
+    assert isinstance(rm, LLMOverrideResourceManager)
+    assert rm.llm == "gpt-4"
+
+
+def test_llm_override_resource_manager_overrides_chat_model_when_llm_set():
+    from aidev_agent.packages.resource_manager.agent import AgentResourceManager
+    from aidev_bkplugin.services.agent_builder import LLMOverrideResourceManager
+
+    config = MagicMock(name="agent_config")
+    with patch.object(AgentResourceManager, "get_agent_config", return_value=config):
+        rm = LLMOverrideResourceManager(username="alice", llm="gpt-4")
+        result = rm.get_agent_config("x")
+    assert result is config
+    assert config.chat_model == "gpt-4"
+    assert config.non_thinking_llm == "gpt-4"
+
+
+def test_llm_override_resource_manager_keeps_original_when_llm_empty():
+    from aidev_agent.packages.resource_manager.agent import AgentResourceManager
+    from aidev_bkplugin.services.agent_builder import LLMOverrideResourceManager
+
+    config = MagicMock(name="agent_config")
+    config.chat_model = "orig"
+    config.non_thinking_llm = "orig"
+    with patch.object(AgentResourceManager, "get_agent_config", return_value=config):
+        LLMOverrideResourceManager(username="alice", llm="").get_agent_config("x")
+    assert config.chat_model == "orig"
+    assert config.non_thinking_llm == "orig"

--- a/src/plugins/aidev_bkplugin/tests/services/test_llm.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_llm.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""LLMService 单测：调平台 app/v1/llms 网关接口 + llm 空间授权校验。"""
+
+from unittest.mock import patch
+
+
+class TestLLMServiceListLLMs:
+    """list_llms 透传查询参数并抽取 data。"""
+
+    def test_calls_platform_api_with_params_and_user_header(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        with patch("aidev_bkplugin.services.llm.resource_manager") as rm:
+            client = rm.return_value.get_client.return_value
+            client.api.list_app_v1_llms.return_value = {"data": [{"llm_code": "gpt-4"}]}
+            result = LLMService.list_llms(
+                username="alice", llm_type="chat.completion", supports="tools,vision", fuzzy="gpt"
+            )
+
+        assert result == [{"llm_code": "gpt-4"}]
+        client.api.list_app_v1_llms.assert_called_once_with(
+            params={"llm_type": "chat.completion", "supports": "tools,vision", "fuzzy": "gpt"},
+            headers={"X-BKAIDEV-USER": "alice"},
+        )
+
+    def test_omits_empty_params_and_header_when_username_blank(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        with patch("aidev_bkplugin.services.llm.resource_manager") as rm:
+            client = rm.return_value.get_client.return_value
+            client.api.list_app_v1_llms.return_value = {"data": []}
+            LLMService.list_llms(username="")
+
+        client.api.list_app_v1_llms.assert_called_once_with(params={}, headers={})
+
+    def test_returns_empty_list_when_data_missing(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        with patch("aidev_bkplugin.services.llm.resource_manager") as rm:
+            client = rm.return_value.get_client.return_value
+            client.api.list_app_v1_llms.return_value = {}
+            assert LLMService.list_llms(username="alice") == []
+
+
+class TestLLMServiceAccessible:
+    """is_llm_accessible：llm_code 为空放行；非空时按空间可用列表校验。"""
+
+    def test_blank_llm_code_passes(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        assert LLMService.is_llm_accessible(username="alice", llm_code="") is True
+
+    def test_llm_in_list_returns_true(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        with patch.object(LLMService, "list_llms", return_value=[{"llm_code": "gpt-4"}, {"llm_code": "claude"}]):
+            assert LLMService.is_llm_accessible(username="alice", llm_code="gpt-4") is True
+
+    def test_llm_not_in_list_returns_false(self):
+        from aidev_bkplugin.services.llm import LLMService
+
+        with patch.object(LLMService, "list_llms", return_value=[{"llm_code": "gpt-4"}]):
+            assert LLMService.is_llm_accessible(username="alice", llm_code="unknown") is False

--- a/src/plugins/aidev_bkplugin/tests/settings.py
+++ b/src/plugins/aidev_bkplugin/tests/settings.py
@@ -27,7 +27,9 @@ CACHES = {
 INSTALLED_APPS = [
     "django.contrib.contenttypes",
     "django.contrib.auth",
-    # 不注册 aidev_bkplugin，避免 apps.py 在测试启动时加载 OTel/grpc 等运行时副作用模块
+    # 注册 aidev_bkplugin 让 models.Checkpoint/Write 获得 app_label；用轻量 BkpluginTestConfig
+    # 避免 apps.py ready() 的 OTel/httpx/远程 AgentConfigFetcher 副作用
+    "tests.test_apps.BkpluginTestConfig",
 ]
 
 MIDDLEWARE: list = []

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+"""测试专用轻量 AppConfig：注册 ``aidev_bkplugin`` 让 ``models.Checkpoint/Write`` 获得 app_label，
+但**不重写** ``ready()``，避免 ``aidev_bkplugin/apps.py`` 的 OTel / httpx / bkoauth 等运行时副作用
+在测试启动时加载（含远程 ``AgentConfigFetcher.get_info`` 调用）。
+
+仅在 ``tests.settings.INSTALLED_APPS`` 中引用，不影响生产部署。
+"""
+
+from django.apps import AppConfig
+
+
+class BkpluginTestConfig(AppConfig):
+    name = "aidev_bkplugin"
+    default_auto_field = "django.db.models.BigAutoField"

--- a/src/plugins/aidev_bkplugin/tests/views/test_chat_completion_serializer.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_chat_completion_serializer.py
@@ -192,3 +192,34 @@ class TestChatCompletionRequestSerializerThreadIdFallback:
     def test_thread_id_not_generated_when_session_code_present(self):
         data = self._validated({"session_code": "s-1"})
         assert data["thread_id"] == ""
+
+
+class TestChatCompletionRequestSerializerLLMHotSwap:
+    """llm 热切换字段：默认空串放行；非空时走 LLMService.is_llm_accessible 空间授权校验。"""
+
+    @pytest.fixture(autouse=True)
+    def _stub_llm_accessible(self):
+        with patch("aidev_bkplugin.serializers.chat_completion.LLMService") as m:
+            m.is_llm_accessible.return_value = True
+            yield m
+
+    def _validated(self, payload: dict, username: str = "u") -> dict:
+        s = ChatCompletionRequestSerializer(data=payload, context={"username": username})
+        s.is_valid(raise_exception=True)
+        return s.validated_data
+
+    def test_llm_defaults_to_empty_and_passes(self):
+        data = self._validated({"input": "hi"})
+        assert data["llm"] == ""
+
+    def test_accessible_llm_passes_through(self, _stub_llm_accessible):
+        _stub_llm_accessible.is_llm_accessible.return_value = True
+        data = self._validated({"input": "hi", "llm": "gpt-4"}, username="alice")
+        assert data["llm"] == "gpt-4"
+        _stub_llm_accessible.is_llm_accessible.assert_called_once_with(username="alice", llm_code="gpt-4")
+
+    def test_inaccessible_llm_rejected(self, _stub_llm_accessible):
+        _stub_llm_accessible.is_llm_accessible.return_value = False
+        s = ChatCompletionRequestSerializer(data={"input": "hi", "llm": "gpt-4"}, context={"username": "u"})
+        with pytest.raises(ValidationError):
+            s.is_valid(raise_exception=True)


### PR DESCRIPTION
## 背景
支持智能体模型热更新（story #136005006）：小鲸（aidev_bkplugin）chat 阶段动态切换 LLM。

## 改动
- SDK 客户端新增 `list_app_v1_llms`，调平台 openapi `app/v1/llms`
- 新增 `LLMViewSet` / `LLMService` / `LLMListRequestSerializer`，应用态 + 用户态双入口暴露 llm 列表
- `ChatCompletionRequestSerializer` 加 `llm` 字段，经 `LLMService.is_llm_accessible` 做空间授权校验
- `AgentBuilder` 经 `LLMOverrideResourceManager`（继承 `AgentResourceManager` 重写 `get_agent_config`）覆盖 `chat_model` / `non_thinking_llm`，view 全链路透传 llm
- 修复 bkplugin 单测环境：轻量 `BkpluginTestConfig` 注册 app 但不跑 `apps.py ready()` 副作用；conftest 注入 `bk_plugin_framework` mock

## 字段统一
热切换字段统一为 `llm`，与平台工作台 / 调试页保持一致。

## 关联
tapd: #136005006

Made with [Cursor](https://cursor.com)