### PR TITLE
feat: 模型选择器对齐后端结构 --story=136352793

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -11,7 +11,7 @@
     <ChatContainer
       v-model:cite="cite"
       v-model:render-mode="chatMode"
-      v-model:selected-model-id="selectedModelId"
+      v-model:selected-model="selectedModel"
       v-model:selected-shortcut="selectedShortcut"
       :enable-selection="false"
       :messages="messages"
@@ -196,8 +196,8 @@
   const cite = shallowRef('');
   const userInput = shallowRef<string | TagSchema>('');
   const selectedShortcut = deepRef<null | Shortcut>(null);
-  // 模型选择器：默认选中首个模型
-  const selectedModelId = shallowRef<string>(MOCK_MODELS[0].id);
+  // 模型选择器：默认选中首个模型（值为 llm_name）
+  const selectedModel = shallowRef<string>(MOCK_MODELS[0].llm_name);
   const handleModelChange = (model: IModelOption) => {
     console.log('model change:', model);
   };

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -44,53 +44,53 @@ import {
   t,
 } from '../src';
 
-// 模型图标示例：演示「图片地址（string）」形态；组件形态见下方直接用 AIBluekingIcon
+// 模型图标示例：图标为图片地址（string），贴合后端返回的 icon 字段
 const DEEPSEEK_ICON =
   "data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='7' fill='%234a6cf7'/%3E%3C/svg%3E";
 
-// 模型选择器 mock 数据：icon 同时演示「Vue 组件」与「图片地址」两种形态，capabilities 演示三种语义色
+// 生成贴合后端结构的模型 mock，补齐公共字段，聚焦 property（能力标签由其派生）与 description
+const createMockModel = (id: number, llmName: string, extra: Partial<IModelOption> = {}): IModelOption => ({
+  id,
+  llm_code: llmName,
+  llm_name: llmName,
+  llm_type: 'chat.completion',
+  max_token_size: 4096,
+  space_auth_mode: 'PUBLIC',
+  user_auth_mode: 'PUBLIC',
+  base_model: 'hunyuan',
+  icon: DEEPSEEK_ICON,
+  tag_names: [],
+  property: {},
+  ...extra,
+});
+
+// 模型选择器 mock 数据：property 派生能力标签（图生文/深度思考/快速思考），description 作为选项 hover 提示
 export const MOCK_MODELS: IModelOption[] = [
-  {
-    id: 'hunyuan-turbos',
-    name: 'hunyuan-turbos',
-    icon: AIBluekingIcon,
-    capabilities: [
-      { text: '图生文', theme: 'warning' },
-      { text: '深度思考', theme: 'primary' },
-    ],
-  },
-  {
-    id: 'hy3-hunyuan',
-    name: 'Hy3 hunyuan',
-    icon: AIBluekingIcon,
-    capabilities: [
-      { text: '图生文', theme: 'warning' },
-      { text: '快速思考', theme: 'success' },
-    ],
-  },
-  {
-    id: 'deepseek-r1',
-    name: 'Deepseek - R1',
-    icon: DEEPSEEK_ICON,
-    capabilities: [{ text: '深度思考', theme: 'primary' }],
-  },
-  {
-    id: 'deepseek-v3',
-    name: 'Deepseek - V3',
-    icon: DEEPSEEK_ICON,
-    capabilities: [{ text: '快速思考', theme: 'success' }],
-  },
-  {
-    id: 'gpt-4o',
-    name: 'GPT-4o',
-    icon: DEEPSEEK_ICON,
-  },
-  {
-    id: 'legacy-model',
-    name: 'Legacy Model（已停用）',
-    icon: DEEPSEEK_ICON,
+  createMockModel(1, 'hunyuan-turbos', {
+    description: '混元 turbos 模型，支持视觉理解与深度思考',
+    property: { max_model_len: 32000, support_thinking: true, support_vision: true },
+  }),
+  createMockModel(2, 'Hy3 hunyuan', {
+    description: '混元 Hy3 模型，支持视觉理解与快速思考',
+    property: { max_model_len: 32000, support_thinking_quick: true, support_vision: true },
+  }),
+  createMockModel(3, 'Deepseek - R1', {
+    base_model: 'deepseek',
+    description: 'DeepSeek R1 推理模型，支持深度思考',
+    property: { max_model_len: 64000, support_thinking: true },
+  }),
+  createMockModel(4, 'Deepseek - V3', {
+    base_model: 'deepseek',
+    description: 'DeepSeek V3 通用模型，支持快速思考',
+    property: { max_model_len: 64000, support_thinking_quick: true },
+  }),
+  createMockModel(5, 'GPT-4o', {
+    base_model: 'openai',
+    description: 'GPT-4o 通用对话模型',
+  }),
+  createMockModel(6, 'Legacy Model（已停用）', {
     disabled: true,
-  },
+  }),
 ];
 
 export const MOCK_SHORTCUTS = [

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -391,7 +391,7 @@ vi.mock('../chat-input/chat-input.vue', () => ({
       shortcuts: Array,
       skills: Array,
       models: Array,
-      selectedModelId: String,
+      selectedModel: String,
       supportUpload: Boolean,
       cite: String,
       shortcutId: String,
@@ -401,7 +401,14 @@ vi.mock('../chat-input/chat-input.vue', () => ({
       onUpload: Function,
       tippyOptions: Object,
     },
-    emits: ['update:modelValue', 'update:cite', 'update:selectedModelId', 'selectShortcut', 'deleteShortcut', 'modelChange'],
+    emits: [
+      'update:modelValue',
+      'update:cite',
+      'update:selectedModel',
+      'selectShortcut',
+      'deleteShortcut',
+      'modelChange',
+    ],
     setup(_, { slots }) {
       return () => h('div', { class: 'mock-chat-input' }, [slots.top?.(), slots.interrupt?.()]);
     },
@@ -813,20 +820,20 @@ describe('ChatContainer', () => {
       expect(ci.props('skills')).toEqual(skills);
     });
 
-    it('应该将 models 与 selectedModelId 透传给 ChatInput', () => {
-      const models = [{ id: 'gpt-4', name: 'GPT-4' }];
+    it('应该将 models 与 selectedModel 透传给 ChatInput', () => {
+      const models = [{ id: 1, llm_name: 'GPT-4' }];
 
       wrapper = mount(ChatContainer, {
-        props: { ...defaultProps, models, selectedModelId: 'gpt-4' },
+        props: { ...defaultProps, models, selectedModel: 'GPT-4' },
       });
 
       const ci = wrapper.findComponent({ name: 'ChatInput' });
       expect(ci.props('models')).toEqual(models);
-      expect(ci.props('selectedModelId')).toBe('gpt-4');
+      expect(ci.props('selectedModel')).toBe('GPT-4');
     });
 
     it('ChatInput 触发 modelChange 时应向上冒泡', async () => {
-      const models = [{ id: 'gpt-4', name: 'GPT-4' }];
+      const models = [{ id: 1, llm_name: 'GPT-4' }];
 
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, models },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -231,7 +231,7 @@
           <template v-else>
             <ChatInput
               v-model:cite="cite"
-              v-model:selected-model-id="selectedModelId"
+              v-model:selected-model="selectedModel"
               :message-status="inputStatus"
               :model-value="modelValue"
               :models="models"
@@ -442,8 +442,8 @@
     required: false,
     default: '',
   });
-  // 当前选中的模型 id，透传给 ChatInput 的模型选择器（v-model:selectedModelId）
-  const selectedModelId = defineModel<string>('selectedModelId', {
+  // 当前选中的模型（值为 llm_name），透传给 ChatInput 的模型选择器（v-model:selectedModel）
+  const selectedModel = defineModel<string>('selectedModel', {
     required: false,
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -80,11 +80,11 @@
         <template #before-send>
           <slot
             name="model-selector"
-            v-bind="{ models, selectedModel: selectedModelId }"
+            v-bind="{ models, selectedModel }"
           >
             <ModelSelector
               v-if="models?.length"
-              v-model="selectedModelId"
+              v-model="selectedModel"
               class="chat-input-model-selector"
               :models="models"
               :tippy-options="tippyOptions"
@@ -142,8 +142,8 @@
     required: false,
     default: '',
   });
-  // 当前选中的模型 id（v-model:selectedModelId）
-  const selectedModelId = defineModel<string>('selectedModelId', {
+  // 当前选中的模型（值为 llm_name，v-model:selectedModel）
+  const selectedModel = defineModel<string>('selectedModel', {
     required: false,
   });
   const maxHeight = shallowRef(200);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/capabilities.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/capabilities.ts
@@ -24,6 +24,24 @@
  * IN THE SOFTWARE.
  */
 
-export { default as ModelSelector } from './model-selector.vue';
-export type { IModelCapability, IModelOption, IModelProperty, ModelCapabilityTheme } from './types';
-export { useModelSelector } from './use-model-selector';
+import { t } from '../../../lang/lang';
+
+import type { IModelCapability, IModelOption, IModelProperty, ModelCapabilityTheme } from './types';
+
+/** property 能力开关 → 展示标签的映射定义（数组顺序即标签展示顺序） */
+const CAPABILITY_DEFS: {
+  key: keyof IModelProperty;
+  label: () => string;
+  theme: ModelCapabilityTheme;
+}[] = [
+  { key: 'support_thinking', label: () => t('深度思考'), theme: 'primary' },
+  { key: 'support_thinking_quick', label: () => t('快速思考'), theme: 'success' },
+  { key: 'support_vision', label: () => t('图生文'), theme: 'warning' },
+];
+
+/** 根据模型 property 派生能力标签列表（仅保留已开启的能力，文案走 i18n） */
+export const resolveModelCapabilities = (model: IModelOption): IModelCapability[] =>
+  CAPABILITY_DEFS.filter(def => model.property?.[def.key]).map(def => ({
+    text: def.label(),
+    theme: def.theme,
+  }));

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-panel.vue
@@ -24,10 +24,11 @@
         :key="model.id"
         class="ai-model-selector-panel-option"
         :class="{
-          'is-selected': model.id === selectedId,
+          'is-selected': model.llm_name === selectedName,
           'is-active': index === activeIndex,
           'is-disabled': model.disabled,
         }"
+        :title="model.description"
         @click="handleSelect(model)"
       >
         <span
@@ -35,27 +36,22 @@
           class="ai-model-selector-panel-option-icon"
         >
           <img
-            v-if="typeof model.icon === 'string'"
             alt=""
             :src="model.icon"
-          />
-          <component
-            :is="model.icon"
-            v-else
           />
         </span>
         <span
           class="ai-model-selector-panel-option-name"
-          :title="model.name"
+          :title="model.llm_name"
         >
-          {{ model.name }}
+          {{ model.llm_name }}
         </span>
         <span
-          v-if="model.capabilities?.length"
+          v-if="capabilityMap.get(model.llm_name)?.length"
           class="ai-model-selector-panel-option-tags"
         >
           <span
-            v-for="(capability, capabilityIndex) in model.capabilities"
+            v-for="(capability, capabilityIndex) in capabilityMap.get(model.llm_name)"
             :key="capabilityIndex"
             class="ai-model-capability-tag"
             :class="`is-${capability.theme || 'default'}`"
@@ -80,24 +76,32 @@
 </template>
 
 <script setup lang="ts">
-  import { nextTick, shallowRef, useTemplateRef, watch } from 'vue';
+  import { computed, nextTick, shallowRef, useTemplateRef, watch } from 'vue';
 
   import { Input as BkInput, Exception } from 'bkui-vue';
 
   import { useMenuKeydown } from '../../../composables/use-menu-keydown';
   import { SearchIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
+  import { resolveModelCapabilities } from './capabilities';
 
-  import type { IModelOption } from './types';
+  import type { IModelCapability, IModelOption } from './types';
 
   const props = defineProps<{
     /** 待展示的模型列表（已按关键字过滤） */
     models: IModelOption[];
     /** 搜索框占位文案 */
     searchPlaceholder?: string;
-    /** 当前选中模型 id */
-    selectedId?: string;
+    /** 当前选中模型的 llm_name */
+    selectedName?: string;
   }>();
+
+  /** 预计算每个模型的能力标签，避免模板内重复派生（键为 llm_name） */
+  const capabilityMap = computed(() => {
+    const map = new Map<string, IModelCapability[]>();
+    props.models.forEach(model => map.set(model.llm_name, resolveModelCapabilities(model)));
+    return map;
+  });
   const emit = defineEmits<{
     (e: 'select', model: IModelOption): void;
   }>();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-trigger.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-trigger.vue
@@ -8,17 +8,12 @@
       class="ai-model-selector-trigger-icon"
     >
       <img
-        v-if="typeof model.icon === 'string'"
         alt=""
         :src="model.icon"
       />
-      <component
-        :is="model.icon"
-        v-else
-      />
     </span>
     <span class="ai-model-selector-trigger-name">
-      {{ model?.name || placeholder }}
+      {{ model?.llm_name || placeholder }}
     </span>
     <ArrowLeftIcon class="ai-model-selector-trigger-arrow" />
   </div>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.spec.ts
@@ -79,10 +79,23 @@ vi.mock('vue-tippy', () => ({
   }),
 }));
 
+// 构造贴合后端结构的模型选项，补齐必填字段
+const createModel = (id: number, llmName: string, extra: Partial<IModelOption> = {}): IModelOption => ({
+  id,
+  llm_code: llmName,
+  llm_name: llmName,
+  llm_type: 'chat.completion',
+  max_token_size: 4096,
+  property: {},
+  space_auth_mode: 'PUBLIC',
+  user_auth_mode: 'PUBLIC',
+  ...extra,
+});
+
 const mockModels: IModelOption[] = [
-  { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-  { id: 'claude', name: 'Claude 3', disabled: true },
-  { id: 'deepseek', name: 'DeepSeek' },
+  createModel(1, 'GPT-4', { property: { support_thinking: true } }),
+  createModel(2, 'Claude 3', { disabled: true }),
+  createModel(3, 'DeepSeek'),
 ];
 
 describe('ModelSelector', () => {
@@ -111,7 +124,7 @@ describe('ModelSelector', () => {
       wrapper = mount(ModelSelector, {
         props: {
           models: mockModels,
-          modelValue: 'gpt-4',
+          modelValue: 'GPT-4',
         },
       });
 
@@ -140,8 +153,8 @@ describe('ModelSelector', () => {
       const options = wrapper.findAll('.ai-model-selector-panel-option');
       await options[2].trigger('click');
 
-      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['deepseek']);
-      expect(wrapper.emitted('change')?.[0]).toEqual([{ id: 'deepseek', name: 'DeepSeek' }]);
+      expect(wrapper.emitted('update:modelValue')?.[0]).toEqual(['DeepSeek']);
+      expect(wrapper.emitted('change')?.[0]).toEqual([mockModels[2]]);
     });
 
     it('禁用项点击时不应触发 change', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.vue
@@ -8,7 +8,7 @@
     <ModelSelectorTrigger
       :disabled="disabled"
       :expanded="isExpanded"
-      :model="selectedModel"
+      :model="currentModel"
       :placeholder="placeholder"
     />
     <template #content>
@@ -17,7 +17,7 @@
         v-model:keyword="keyword"
         :models="filteredModels"
         :search-placeholder="searchPlaceholder"
-        :selected-id="selectedId"
+        :selected-name="selectedModel"
         @select="handleSelect"
       />
     </template>
@@ -61,16 +61,16 @@
   const emit = defineEmits<{
     (e: 'change', model: IModelOption): void;
   }>();
-  /** 当前选中的模型 id（v-model） */
-  const selectedId = defineModel<string>();
+  /** 当前选中的模型（值为 llm_name，v-model） */
+  const selectedModel = defineModel<string>();
 
   const tippyRef = useTemplateRef<InstanceType<typeof Tippy>>('tippyRef');
   const panelRef = useTemplateRef<InstanceType<typeof ModelSelectorPanel>>('panelRef');
   const isExpanded = shallowRef(false);
 
-  const { keyword, filteredModels, selectedModel, resetKeyword } = useModelSelector({
+  const { keyword, filteredModels, currentModel, resetKeyword } = useModelSelector({
     models: toRef(props, 'models'),
-    selectedId,
+    selectedModel,
   });
 
   const innerTippyProps = computed(
@@ -101,7 +101,7 @@
   };
 
   const handleSelect = (model: IModelOption) => {
-    selectedId.value = model.id;
+    selectedModel.value = model.llm_name;
     emit('change', model);
     tippyRef.value?.hide?.();
   };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/types.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/types.ts
@@ -24,28 +24,66 @@
  * IN THE SOFTWARE.
  */
 
-import type { Component } from 'vue';
-
-/** 模型能力标签，如「图生文」「深度思考」「快速思考」 */
+/** 模型能力标签，如「图生文」「深度思考」「快速思考」（由组件依据 property 派生，走内置 i18n） */
 export interface IModelCapability {
-  /** 标签文案（由调用方提供，不走内置 i18n） */
+  /** 标签文案 */
   text: string;
   /** 语义主题，决定标签配色，缺省为 default */
   theme?: ModelCapabilityTheme;
 }
 
-/** 模型选项 */
+/** 模型选项（贴合后端模型接口结构） */
 export interface IModelOption {
-  /** 能力标签列表 */
-  capabilities?: IModelCapability[];
-  /** 是否禁用，禁用项不可选中 */
+  /** 基础模型标识，如 deepseek */
+  base_model?: string;
+  /** 模型描述，作为选项 hover 的 title 提示 */
+  description?: string;
+  /** 是否禁用（前端扩展字段，后端无此字段时默认不禁用） */
   disabled?: boolean;
-  /** 模型图标：图片地址（string）或 Vue 组件 / VNode（由调用方按品牌提供） */
-  icon?: Component | string;
-  /** 模型唯一标识，作为选中值 */
-  id: string;
-  /** 模型展示名 */
-  name: string;
+  /** 模型图标地址 */
+  icon?: string;
+  /** 模型主键 id */
+  id: number;
+  /** 模型编码 */
+  llm_code: string;
+  /** 模型展示名，同时作为选中值（v-model:selectedModel） */
+  llm_name: string;
+  /** 模型类型，如 chat.completion */
+  llm_type: string;
+  /** 最大 token 数 */
+  max_token_size: number;
+  /** 模型能力属性，用于派生能力标签 */
+  property: IModelProperty;
+  /** 空间维度鉴权模式，如 APPLY */
+  space_auth_mode: string;
+  /** 标签名列表 */
+  tag_names?: string[];
+  /** 用户维度鉴权模式，如 PUBLIC */
+  user_auth_mode: string;
+}
+
+/** 模型属性（后端 property 字段），描述模型支持的能力开关与运行参数 */
+export interface IModelProperty {
+  /** 智能体类型，如 openai */
+  agent_type?: string;
+  /** 是否为默认模型 */
+  default?: boolean;
+  /** 是否自建部署 */
+  is_self_host?: boolean;
+  /** 模型最大上下文长度 */
+  max_model_len?: number;
+  /** 是否支持摘要 */
+  support_summary?: boolean;
+  /** 是否支持深度思考 */
+  support_thinking?: boolean;
+  /** 是否支持快速思考 */
+  support_thinking_quick?: boolean;
+  /** 是否支持工具调用 */
+  support_tools?: boolean;
+  /** 是否支持图生文（视觉） */
+  support_vision?: boolean;
+  /** 是否支持上下文窗口 */
+  support_window?: boolean;
 }
 
 /** 模型能力标签的语义主题，决定标签配色（与设计稿语义色一一对应） */

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.spec.ts
@@ -31,24 +31,32 @@ import { describe, expect, it } from 'vitest';
 
 import { useModelSelector } from './use-model-selector';
 
-import type { IModelOption } from './types';
+import type { IModelOption, IModelProperty } from './types';
 
-const models: IModelOption[] = [
-  { id: 'gpt-4', name: 'GPT-4' },
-  { id: 'claude', name: 'Claude 3' },
-  { id: 'deepseek', name: 'DeepSeek' },
-];
+// 构造贴合后端结构的模型选项，补齐必填字段，便于用例聚焦 llm_name 逻辑
+const createModel = (id: number, llmName: string, property: IModelProperty = {}): IModelOption => ({
+  id,
+  llm_code: llmName,
+  llm_name: llmName,
+  llm_type: 'chat.completion',
+  max_token_size: 4096,
+  property,
+  space_auth_mode: 'PUBLIC',
+  user_auth_mode: 'PUBLIC',
+});
+
+const models: IModelOption[] = [createModel(1, 'GPT-4'), createModel(2, 'Claude 3'), createModel(3, 'DeepSeek')];
 
 describe('useModelSelector', () => {
   it('关键字为空时应返回完整模型列表', async () => {
     let result: ReturnType<typeof useModelSelector> | undefined;
-    const selectedId = ref<string | undefined>('gpt-4');
+    const selectedModel = ref<string | undefined>('GPT-4');
 
     const Host = defineComponent({
       setup() {
         result = useModelSelector({
           models: computed(() => models),
-          selectedId,
+          selectedModel,
         });
         return () => h('div');
       },
@@ -63,13 +71,13 @@ describe('useModelSelector', () => {
 
   it('应按模型名过滤列表（不区分大小写）', async () => {
     let result: ReturnType<typeof useModelSelector> | undefined;
-    const selectedId = ref<string | undefined>();
+    const selectedModel = ref<string | undefined>();
 
     const Host = defineComponent({
       setup() {
         result = useModelSelector({
           models: computed(() => models),
-          selectedId,
+          selectedModel,
         });
         return () => h('div');
       },
@@ -78,22 +86,22 @@ describe('useModelSelector', () => {
     const wrapper = mount(Host);
     await nextTick();
 
-    result!.keyword.value = 'claude';
+    result?.keyword.value = 'claude';
     await nextTick();
-    expect(result?.filteredModels.value).toEqual([{ id: 'claude', name: 'Claude 3' }]);
+    expect(result?.filteredModels.value).toEqual([models[1]]);
 
     wrapper.unmount();
   });
 
-  it('应根据 selectedId 解析当前选中模型', async () => {
+  it('应根据 selectedModel 解析当前选中模型', async () => {
     let result: ReturnType<typeof useModelSelector> | undefined;
-    const selectedId = ref<string | undefined>('deepseek');
+    const selectedModel = ref<string | undefined>('DeepSeek');
 
     const Host = defineComponent({
       setup() {
         result = useModelSelector({
           models: computed(() => models),
-          selectedId,
+          selectedModel,
         });
         return () => h('div');
       },
@@ -102,19 +110,19 @@ describe('useModelSelector', () => {
     const wrapper = mount(Host);
     await nextTick();
 
-    expect(result?.selectedModel.value).toEqual({ id: 'deepseek', name: 'DeepSeek' });
+    expect(result?.currentModel.value).toEqual(models[2]);
     wrapper.unmount();
   });
 
   it('resetKeyword 应清空搜索关键字', async () => {
     let result: ReturnType<typeof useModelSelector> | undefined;
-    const selectedId = ref<string | undefined>();
+    const selectedModel = ref<string | undefined>();
 
     const Host = defineComponent({
       setup() {
         result = useModelSelector({
           models: computed(() => models),
-          selectedId,
+          selectedModel,
         });
         return () => h('div');
       },
@@ -123,7 +131,7 @@ describe('useModelSelector', () => {
     const wrapper = mount(Host);
     await nextTick();
 
-    result!.keyword.value = 'gpt';
+    result?.keyword.value = 'gpt';
     await nextTick();
     result?.resetKeyword();
     await nextTick();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.ts
@@ -35,10 +35,10 @@ import type { IModelOption } from './types';
 export const useModelSelector = (params: {
   /** 模型列表 */
   models: ComputedRef<IModelOption[]> | Ref<IModelOption[]>;
-  /** 当前选中模型 id */
-  selectedId: Ref<string | undefined>;
+  /** 当前选中模型（值为 llm_name） */
+  selectedModel: Ref<string | undefined>;
 }) => {
-  /** 搜索关键字（仅按模型名做包含匹配） */
+  /** 搜索关键字（仅按模型展示名 llm_name 做包含匹配） */
   const keyword = shallowRef('');
 
   /** 按关键字过滤后的模型列表 */
@@ -47,12 +47,12 @@ export const useModelSelector = (params: {
     if (!kw) {
       return params.models.value;
     }
-    return params.models.value.filter(model => model.name.toLowerCase().includes(kw));
+    return params.models.value.filter(model => model.llm_name.toLowerCase().includes(kw));
   });
 
   /** 当前选中的模型对象 */
-  const selectedModel = computed<IModelOption | undefined>(() =>
-    params.models.value.find(model => model.id === params.selectedId.value),
+  const currentModel = computed<IModelOption | undefined>(() =>
+    params.models.value.find(model => model.llm_name === params.selectedModel.value),
   );
 
   /** 重置搜索关键字 */
@@ -63,7 +63,7 @@ export const useModelSelector = (params: {
   return {
     keyword,
     filteredModels,
-    selectedModel,
+    currentModel,
     resetKeyword,
   };
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/index.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/index.ts
@@ -36,7 +36,7 @@ import ContentRender from './chat-content/content-render/content-render.vue';
 import ChatInput from './chat-input/chat-input.vue';
 import { ModelSelector } from './chat-input/model-selector';
 export * from './chat-content';
-export type { IModelCapability, IModelOption, ModelCapabilityTheme } from './chat-input/model-selector';
+export type { IModelCapability, IModelOption, IModelProperty, ModelCapabilityTheme } from './chat-input/model-selector';
 import MessageContainer from './chat-message/message-container/message-container.vue';
 import MessageRender from './chat-message/message-render/message-render.vue';
 import ExecutionSummary from './execution-summary/execution-summary.vue';

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -52,6 +52,8 @@ export const lang = {
   返回内容: 'Return Content',
   编辑: 'Edit',
   深度思考: 'Deep Thinking',
+  快速思考: 'Quick Thinking',
+  图生文: 'Image to Text',
   '图片加载中...': 'Loading image...',
   图片加载失败: 'Failed to load image',
   思考中: 'Thinking...',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -38,12 +38,12 @@ sinceVersion: 1.0.0
   const inputUpload = ref('');
   const inputSlot = ref('');
   const inputModel = ref('');
-  const selectedModelId = ref('gpt-4');
+  const selectedModelId = ref('GPT-4');
 
   const models = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3', capabilities: [{ text: '快速思考', theme: 'success' }] },
-    { id: 'deepseek', name: 'DeepSeek' },
+    { id: 1, llm_name: 'GPT-4', property: { support_thinking: true } },
+    { id: 2, llm_name: 'Claude 3', property: { support_thinking_quick: true } },
+    { id: 3, llm_name: 'DeepSeek', property: { support_vision: true } },
   ];
 
   const handleModelChange = (model) => {
@@ -704,13 +704,13 @@ const handleSendMessage = async (
 
 ## 模型选择
 
-传入 `models` 后，会在发送按钮左侧展示 [ModelSelector](/components/input/model-selector)。选中值通过 `v-model:selected-model-id` 双向绑定，`@model-change` 可获取完整模型对象。
+传入 `models` 后，会在发送按钮左侧展示 [ModelSelector](/components/input/model-selector)。选中值（模型的 `llm_name`）通过 `v-model:selected-model` 双向绑定，`@model-change` 可获取完整模型对象。能力标签由组件依据 `property` 自动派生。
 
 ```vue
 <template>
   <ChatInput
     v-model="inputValue"
-    v-model:selected-model-id="selectedModelId"
+    v-model:selected-model="selectedModel"
     :message-status="messageStatus"
     :models="models"
     :on-send-message="handleSendMessage"
@@ -723,15 +723,16 @@ const handleSendMessage = async (
   import { ChatInput, MessageStatus, type IModelOption, type TagSchema } from '@blueking/chat-x';
 
   const inputValue = ref('');
-  const selectedModelId = ref('gpt-4');
+  // 选中值为 llm_name
+  const selectedModel = ref('GPT-4');
   const messageStatus = ref(MessageStatus.Complete);
   const models: IModelOption[] = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3' },
+    { id: 1, llm_name: 'GPT-4', property: { support_thinking: true } },
+    { id: 2, llm_name: 'Claude 3', property: {} },
   ];
 
   const handleSendMessage = async (content: string, docSchema: TagSchema) => {
-    /* 发送时可读取 selectedModelId.value */
+    /* 发送时可读取 selectedModel.value */
   };
 
   const handleModelChange = (model: IModelOption) => {
@@ -743,7 +744,7 @@ const handleSendMessage = async (
 <div class="demo">
   <ChatInputComp
     v-model="inputModel"
-    v-model:selected-model-id="selectedModelId"
+    v-model:selected-model="selectedModelId"
     message-status="complete"
     :models="models"
     :on-send-message="handleSendMessage"
@@ -797,7 +798,7 @@ const handleSendMessage = async (
 | 属性名             | 类型                                                                       | 默认值   | 必填 | 说明                                                    |
 | ------------------ | -------------------------------------------------------------------------- | -------- | ---- | ------------------------------------------------------- |
 | modelValue         | `string \| TagSchema`                                                      | -        | ✅   | 编辑器的值，支持 `v-model`                              |
-| selectedModelId    | `string`                                                                   | -        | -    | 当前选中的模型 id，支持 `v-model:selected-model-id`     |
+| selectedModel      | `string`                                                                   | -        | -    | 当前选中模型的 `llm_name`，支持 `v-model:selected-model` |
 | messageStatus      | `MessageStatus`                                                            | -        | -    | 消息状态，控制按钮；输入为空时内部强制 `disabled`       |
 | cite               | `string`                                                                   | `''`     | -    | 引用内容，支持 `v-model:cite`，不为空时显示引用区       |
 | skills             | `ISkillListItem[]`                                                         | `[]`     | -    | Skill 列表，输入 `/` 触发，选中后插入 Skill 标签        |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/model-selector.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/model-selector.md
@@ -19,11 +19,11 @@ sinceVersion: 1.0.0
   import { ref } from 'vue'
   import ModelSelectorComp from '../../../src/components/chat-input/model-selector/model-selector.vue'
 
-  const selectedModelId = ref('gpt-4')
+  const selectedModel = ref('GPT-4')
   const models = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3', capabilities: [{ text: '快速思考', theme: 'success' }] },
-    { id: 'deepseek', name: 'DeepSeek', capabilities: [{ text: '图生文', theme: 'warning' }] },
+    { id: 1, llm_name: 'GPT-4', description: 'GPT-4 通用模型', property: { support_thinking: true } },
+    { id: 2, llm_name: 'Claude 3', property: { support_thinking_quick: true } },
+    { id: 3, llm_name: 'DeepSeek', property: { support_vision: true } },
   ]
 
   const handleModelChange = (model) => {
@@ -55,10 +55,12 @@ ModelSelector（Tippy 容器，theme: ai-model-selector）
 
 ## 基础用法
 
+选中值为模型的 `llm_name`；能力标签由组件依据 `property`（`support_thinking` / `support_thinking_quick` / `support_vision`）自动派生，无需调用方传入。
+
 ```vue
 <template>
   <ModelSelector
-    v-model="selectedModelId"
+    v-model="selectedModel"
     :models="models"
     @change="handleModelChange"
   />
@@ -68,10 +70,24 @@ ModelSelector（Tippy 容器，theme: ai-model-selector）
   import { ref } from 'vue';
   import { ModelSelector, type IModelOption } from '@blueking/chat-x';
 
-  const selectedModelId = ref('gpt-4');
+  // 选中值为 llm_name
+  const selectedModel = ref('DeepSeek-V4-Pro-Online-32k');
   const models: IModelOption[] = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3' },
+    {
+      id: 119,
+      llm_code: 'DeepSeek-V4-Pro-Online-32k',
+      llm_name: 'DeepSeek-V4-Pro-Online-32k',
+      llm_type: 'chat.completion',
+      space_auth_mode: 'APPLY',
+      user_auth_mode: 'PUBLIC',
+      max_token_size: 4096,
+      icon: 'https://example.com/deepseek.png',
+      description: 'DeepSeek-V4-Pro 旗舰版本，支持超长上下文与复杂任务处理',
+      base_model: 'deepseek',
+      tag_names: [],
+      // support_thinking → 深度思考、support_vision → 图生文
+      property: { support_thinking: true, support_vision: true, max_model_len: 32000 },
+    },
   ];
 
   const handleModelChange = (model: IModelOption) => {
@@ -82,7 +98,7 @@ ModelSelector（Tippy 容器，theme: ai-model-selector）
 
 <div class="demo">
   <ModelSelectorComp
-    v-model="selectedModelId"
+    v-model="selectedModel"
     :models="models"
     @change="handleModelChange"
   />
@@ -102,9 +118,9 @@ ModelSelector（Tippy 容器，theme: ai-model-selector）
 
 ### v-model
 
-| 属性名 | 类型     | 说明               |
-| ------ | -------- | ------------------ |
-| —      | `string` | 当前选中的模型 id |
+| 属性名 | 类型     | 说明                          |
+| ------ | -------- | ----------------------------- |
+| —      | `string` | 当前选中模型的 `llm_name` 值 |
 
 ### Events
 
@@ -115,31 +131,56 @@ ModelSelector（Tippy 容器，theme: ai-model-selector）
 ## 类型定义
 
 ```typescript
-import type { IModelCapability, IModelOption, ModelCapabilityTheme } from '@blueking/chat-x';
+import type { IModelCapability, IModelOption, IModelProperty, ModelCapabilityTheme } from '@blueking/chat-x';
 
 type ModelCapabilityTheme = 'default' | 'primary' | 'success' | 'warning';
 
+// 能力标签由组件依据 property 派生（文案走内置 i18n）
 interface IModelCapability {
   theme?: ModelCapabilityTheme;
   text: string;
 }
 
+// 模型能力属性，决定派生出的能力标签
+interface IModelProperty {
+  agent_type?: string;
+  default?: boolean;
+  is_self_host?: boolean;
+  max_model_len?: number;
+  support_summary?: boolean;
+  support_thinking?: boolean; // → 深度思考
+  support_thinking_quick?: boolean; // → 快速思考
+  support_tools?: boolean;
+  support_vision?: boolean; // → 图生文
+  support_window?: boolean;
+}
+
+// 模型选项，贴合后端模型接口结构
 interface IModelOption {
-  capabilities?: IModelCapability[];
-  disabled?: boolean;
-  icon?: Component | string;
-  id: string;
-  name: string;
+  base_model?: string;
+  description?: string; // 选项 hover 的 title 提示
+  disabled?: boolean; // 前端扩展字段，禁用项不可选中
+  icon?: string;
+  id: number;
+  llm_code: string;
+  llm_name: string; // 展示名，同时作为选中值
+  llm_type: string;
+  max_token_size: number;
+  property: IModelProperty;
+  space_auth_mode: string;
+  tag_names?: string[];
+  user_auth_mode: string;
 }
 ```
 
 ## 注意事项
 
 1. `models` 为空或 `disabled` 为 `true` 时，下拉不会展开。
-2. 能力标签文案由调用方提供，不走内置 i18n。
-3. 展开面板后会自动聚焦搜索框；列表支持键盘上下选择与 Enter 确认（复用 `useMenuKeydown`）。
+2. 选中值为模型的 `llm_name`；能力标签由组件依据 `property` 的 `support_thinking` / `support_thinking_quick` / `support_vision` 派生，文案走内置 i18n。
+3. `description` 会作为选项 hover 的 `title` 提示展示。
+4. 展开面板后会自动聚焦搜索框；列表支持键盘上下选择与 Enter 确认（复用 `useMenuKeydown`）。
 
 ## 关联组件
 
 - [ChatInput](/components/input/chat-input)：传入 `models` 后默认在发送按钮左侧渲染本组件，也可通过 `#model-selector` 插槽完全自定义。
-- [ChatContainer](/components/setup/chat-container)：透传 `models` 与 `v-model:selected-model-id`，并向上 emit `modelChange`。
+- [ChatContainer](/components/setup/chat-container)：透传 `models` 与 `v-model:selected-model`，并向上 emit `modelChange`。

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -6,7 +6,7 @@ domain: setup
 description: 完整对话容器，组合消息列表、输入区、模型选择、快捷指令、执行摘要、分享选择和自定义 Tab。
 aiSummary: >
   完整对话容器，组合消息列表、输入区、模型选择、快捷指令、执行摘要、分享选择和自定义 Tab。
-  透传 models / selectedModelId；支持 welcomeTitle 与 #welcome。
+  透传 models / selectedModel；支持 welcomeTitle 与 #welcome。
   源码位置：src/components/chat-container/chat-container.vue。
 relatedComponents:
   - slug: message-container
@@ -14,7 +14,7 @@ relatedComponents:
   - slug: chat-input
     relation: 对话输入与快捷指令入口
   - slug: model-selector
-    relation: 透传 models / selectedModelId，在输入区展示模型选择器
+    relation: 透传 models / selectedModel，在输入区展示模型选择器
   - slug: shortcut-render
     relation: 快捷指令表单浮层
   - slug: execution-summary
@@ -31,11 +31,11 @@ sinceVersion: 1.0.0
 
   const inputBasic = ref('');
   const inputModel = ref('');
-  const selectedModelId = ref('gpt-4');
+  const selectedModelId = ref('GPT-4');
   const models = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3', capabilities: [{ text: '快速思考', theme: 'success' }] },
-    { id: 'deepseek', name: 'DeepSeek', capabilities: [{ text: '图生文', theme: 'warning' }] },
+    { id: 1, llm_name: 'GPT-4', property: { support_thinking: true } },
+    { id: 2, llm_name: 'Claude 3', property: { support_thinking_quick: true } },
+    { id: 3, llm_name: 'DeepSeek', property: { support_vision: true } },
   ];
   const messagesBasic = ref([
     {
@@ -242,7 +242,7 @@ sinceVersion: 1.0.0
 - **待审批发送阻塞**：存在 `AIDevToolApproval` 且为 `pending` / `draft` 时，输入区上方提示，并通过 `ChatInput.sendDisabledTip` 禁止发送
 - **用户问题中断**：待回答 `UserQuestion` 时挂载 `UserQuestionCard`；结构化作答走 `onInterruptResume`，输入框直接发送走 `onSendMessage`（第三参数带 skip `payload` 与 `interrupt`），且不自动清空输入框
 - **执行摘要 / 侧栏全屏 / 自定义 Tab**：侧栏展示工具调用与 FlowAgent 记录，支持搜索定位；Tab 栏可全屏；`useCustomTabProvider` 支持动态 Tab
-- **模型选择**：透传 `models`、`v-model:selectedModelId` 与 `@modelChange` 至 `ChatInput`，传入 `models` 后在发送按钮左侧展示 [ModelSelector](/components/input/model-selector)
+- **模型选择**：透传 `models`、`v-model:selectedModel` 与 `@modelChange` 至 `ChatInput`，传入 `models` 后在发送按钮左侧展示 [ModelSelector](/components/input/model-selector)
 - **分享模式 / 渲染模式**：内置多选分享；`renderMode` 经 Provider 下传。`Share` 态开放侧栏只读查看，隐藏底部输入与「重试 / 跳过」等交互
 - **字号主题**：`size` 为 `small`（默认 12px）/ `normal`（14px）；根节点 `data-ai-size`，浮层同步 `document.body.dataset.aiSize`
 - **空状态欢迎页**：无消息时展示 Banner、`welcomeTitle`（默认「你好，我是小鲸」）与 `openingRemark`
@@ -268,7 +268,7 @@ ai-chat-container（:data-ai-size="size"）
         │   └── #welcome（默认：Banner + welcomeTitle + openingRemark；自定义则整块替换）
         ├── SelectionFooter（分享模式）
         ├── ShortcutRender（有快捷指令时）
-        └── ChatInput（透传 models / selectedModelId；interrupt 槽展示 UserQuestionCard / InputInfoAlert）
+        └── ChatInput（透传 models / selectedModel；interrupt 槽展示 UserQuestionCard / InputInfoAlert）
 ```
 
 ## 基础用法
@@ -919,13 +919,13 @@ ai-chat-container（:data-ai-size="size"）
 
 ## 模型选择
 
-`ChatContainer` 将 `models`、`v-model:selected-model-id` 与 `@model-change` 透传至内部 [ChatInput](/components/input/chat-input)。传入 `models` 后，发送按钮左侧展示 [ModelSelector](/components/input/model-selector)；发送时可读取当前 `selectedModelId`。
+`ChatContainer` 将 `models`、`v-model:selected-model` 与 `@model-change` 透传至内部 [ChatInput](/components/input/chat-input)。传入 `models` 后，发送按钮左侧展示 [ModelSelector](/components/input/model-selector)；选中值为模型的 `llm_name`，发送时可读取当前 `selectedModel`。
 
 ```vue
 <template>
   <ChatContainer
     v-model="inputValue"
-    v-model:selected-model-id="selectedModelId"
+    v-model:selected-model="selectedModel"
     :messages="messages"
     message-status="complete"
     :models="models"
@@ -939,16 +939,17 @@ ai-chat-container（:data-ai-size="size"）
   import { ChatContainer, type IModelOption, type Message, type TagSchema } from '@blueking/chat-x';
 
   const inputValue = ref('');
-  const selectedModelId = ref('gpt-4');
+  // 选中值为 llm_name
+  const selectedModel = ref('GPT-4');
   const messages = ref<Message[]>([]);
   const models: IModelOption[] = [
-    { id: 'gpt-4', name: 'GPT-4', capabilities: [{ text: '深度思考', theme: 'primary' }] },
-    { id: 'claude', name: 'Claude 3', capabilities: [{ text: '快速思考', theme: 'success' }] },
-    { id: 'deepseek', name: 'DeepSeek', capabilities: [{ text: '图生文', theme: 'warning' }] },
+    { id: 1, llm_name: 'GPT-4', property: { support_thinking: true } },
+    { id: 2, llm_name: 'Claude 3', property: { support_thinking_quick: true } },
+    { id: 3, llm_name: 'DeepSeek', property: { support_vision: true } },
   ];
 
   const handleSendMessage = async (content: string, docSchema: TagSchema) => {
-    // 发送时可读取 selectedModelId.value
+    // 发送时可读取 selectedModel.value
   };
   const handleModelChange = (model: IModelOption) => {
     console.log('切换模型:', model);
@@ -962,7 +963,7 @@ ai-chat-container（:data-ai-size="size"）
   <div style="height: 480px; border: 1px solid #eaebf0; border-radius: 8px; overflow: hidden;">
     <ChatContainerComp
       v-model="inputModel"
-      v-model:selected-model-id="selectedModelId"
+      v-model:selected-model="selectedModelId"
       :messages="messagesBasic"
       message-status="complete"
       :models="models"
@@ -1042,7 +1043,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | selectedShortcut | `Shortcut \| null`    | 当前选中的快捷指令                                                                                                                                |
 | cite             | `string`              | 引用内容                                                                                                                                          |
 | renderMode       | `RenderMode`          | 渲染模式（默认 `Chat`）。`Share` 开放侧栏只读查看并隐藏底部输入与交互操作；`Test` 隐藏分享按钮                                                    |
-| selectedModelId  | `string`              | 当前选中的模型 id，透传至 ChatInput 的 ModelSelector                                                                                              |
+| selectedModel    | `string`              | 当前选中模型的 `llm_name`，透传至 ChatInput 的 ModelSelector                                                                                      |
 
 ### Events
 
@@ -1145,13 +1146,26 @@ interface CustomTab<T = Record<string, unknown>> {
   data?: T & { messageUid?: string; component?: Component; props?: Record<string, unknown> };
 }
 
-// 模型选项（透传至 ChatInput / ModelSelector）
+// 模型选项（透传至 ChatInput / ModelSelector，贴合后端接口结构；能力标签由 property 派生）
 interface IModelOption {
-  id: string;
-  name: string;
-  icon?: Component | string;
-  disabled?: boolean;
-  capabilities?: { text: string; theme?: 'default' | 'primary' | 'success' | 'warning' }[];
+  id: number;
+  llm_code: string;
+  llm_name: string; // 展示名，同时作为选中值
+  llm_type: string;
+  space_auth_mode: string;
+  user_auth_mode: string;
+  max_token_size: number;
+  property: {
+    support_thinking?: boolean; // → 深度思考
+    support_thinking_quick?: boolean; // → 快速思考
+    support_vision?: boolean; // → 图生文
+    [key: string]: unknown;
+  };
+  icon?: string;
+  description?: string;
+  base_model?: string;
+  tag_names?: string[];
+  disabled?: boolean; // 前端扩展字段
 }
 
 // 快捷指令
@@ -1166,7 +1180,7 @@ interface Shortcut {
 
 - [MessageContainer](/components/setup/message-container) — 消息列表区域
 - [ChatInput](/components/input/chat-input) — 输入与快捷指令
-- [ModelSelector](/components/input/model-selector) — 模型选择器（透传 `models` / `selectedModelId`）
+- [ModelSelector](/components/input/model-selector) — 模型选择器（透传 `models` / `selectedModel`）
 - [ShortcutRender](/components/input/shortcut-render) — 快捷指令表单
 - [ExecutionSummary](/components/agent/execution-summary) — 执行摘要侧栏
 - [SelectionFooter](/components/input/selection-footer) — 多选操作栏


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】ModelSelector 对齐后端模型数据结构（1070093903136352793）

ModelSelector 初版使用前端自定义 `id`/`name`/`capabilities`，与后端模型接口不一致，消费方需二次映射。

## 改动
- `IModelOption` 对齐后端字段（`llm_name`/`llm_code`/`property`/`icon` 等）
- `v-model:selectedModelId` → `v-model:selectedModel`（值为 `llm_name`）
- 能力标签由 `property`（`support_thinking` / `support_thinking_quick` / `support_vision`）派生，文案走 i18n
- 图标仅支持图片地址；同步 playground mock、单测与 wiki

## 影响面
- **破坏性变更**：消费方需按新 `IModelOption` 传 `models`，并将 `selectedModelId` 迁移为 `selectedModel`
- 组件：ModelSelector、ChatInput、ChatContainer

## 测试
- [ ] 模型列表按后端结构直接渲染
- [ ] 选中值绑定 `llm_name`，切换正常
- [ ] property 能力标签展示正确
- [ ] 单测通过

Made with [Cursor](https://cursor.com)