### PR TITLE
feat: 检查模型质量 --story=135734842

### DIFF
--- a/src/agent/aidev_agent/config.py
+++ b/src/agent/aidev_agent/config.py
@@ -153,6 +153,10 @@ BKAI_TOOL_TEAM_ENABLED = env.bool("BKAI_TOOL_TEAM_ENABLED", True)
 BKAI_TOOL_TASK_ENABLED = env.bool("BKAI_TOOL_TASK_ENABLED", True)
 # BKAI 子智能体配置
 BKAI_A2A_SESSION_TEMPORARY = env.bool("BKAI_A2A_SESSION_TEMPORARY", False)
+# LLM 重试策略: "sdk" 由 aidev 自主控制重试, "llm_gw" 由模型网关 Retry-After 头控制重试
+LLM_RETRY_STRATEGY = env.str("LLM_RETRY_STRATEGY", "llm_gw")
+# 质量判断模型配置（用于 quality_gate 判断模型是否完成任务）
+JUDGMENT_LLM_MODEL = env.str("JUDGMENT_LLM_MODEL", "aidev-chat-fast")
 # end: 配置
 
 

--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -693,6 +693,8 @@ class LangGraphAgent:
         )
 
     async def _handle_on_chat_model_end_event(self, event: Any) -> AsyncGenerator[BaseEvent, None]:
+        if not self.front_end_display:
+            return
         # ChatModelEnd CustomEvent：把"模型这一轮的完整输出快照"分发给 DB 侧。
         # SSE 侧 AidevAGUIAgent.run() 通过 skip_encode_custom 跳过编码（不进入 SSE 输出）。
         # 顺序：在消息收尾事件（ToolCallEnd/TextMessageEnd）之后发出，确保 DB 侧拿到的是收尾后的完整态。

--- a/src/agent/aidev_agent/core/graphs/react/graph.py
+++ b/src/agent/aidev_agent/core/graphs/react/graph.py
@@ -91,13 +91,13 @@ logger = logging.getLogger(__name__)
 
 
 def _resolve_task_state_schema(schemas: List[type]) -> type:
-    """Resolve state schema by merging multiple TypedDict schemas.
+    """通过合并多个 TypedDict schemas 来解析状态 schema。
 
     Args:
-        schemas: List of TypedDict schemas to merge
+        schemas: 要合并的 TypedDict schemas 列表
 
     Returns:
-        A new TypedDict class with all fields from input schemas
+        包含所有输入 schemas 字段的新 TypedDict 类
     """
     all_annotations = {}
     for schema in schemas:
@@ -145,6 +145,7 @@ class ReActAgentBuilder:
         self._llm: BaseChatModel | None = None
         self._knowledge_llm: BaseChatModel | None = None
         self._non_thinking_llm: BaseChatModel | None = None
+        self._fast_llm: BaseChatModel | None = None
         self._support_vision: bool = False
         self._llm_token_limit: int = 28000
         # 对话设置
@@ -517,6 +518,8 @@ class ReActAgentBuilder:
         if options.non_thinking_llm is not None:
             self._non_thinking_llm = options.non_thinking_llm
             self._knowledge_llm = options.non_thinking_llm
+        if options.fast_llm is not None:
+            self._fast_llm = options.fast_llm
         if options.knowledge_llm is not None:
             self._knowledge_llm = options.knowledge_llm
         if options.extra_tools is not None:
@@ -641,6 +644,7 @@ class ReActAgentBuilder:
         *,
         llm: BaseChatModel,
         non_thinking_llm: BaseChatModel,
+        judge_llm: BaseChatModel | None,
         tools: List[BaseTool],
     ):
         """创建模型节点。
@@ -651,6 +655,7 @@ class ReActAgentBuilder:
         Args:
             llm: 语言模型
             non_thinking_llm: 非深度思考模型
+            judge_llm: 判断用 LLM（quality_gate 任务完成度判断）；None 时 fail-open
             tools: 工具列表
 
         Returns:
@@ -697,6 +702,7 @@ class ReActAgentBuilder:
         model_node = std_make_model_node(
             llm=llm,
             non_thinking_llm=non_thinking_llm,
+            judge_llm=judge_llm,
             tools=tools,
             node_options=node_options,
         )
@@ -1052,6 +1058,10 @@ class ReActAgentBuilder:
             raise ValueError("ReActAgentBuilder 构建失败：缺少 llm，请先调用 set_llm(...) 或 set_bkai_options(...)")
         callbacks = list(self._callbacks or [])
         non_thinking_llm = self._non_thinking_llm or self._llm
+        # 判断 LLM：仅使用显式配置的 fast_llm；未配置时为 None（fail-open）。
+        # 不回退到 non_thinking_llm/llm——判断模型是独立的轻量模型，
+        # 回退到主模型会导致每次正常响应多一次主模型调用。
+        judge_llm = self._fast_llm
 
         self._prepare_agent_options()
 
@@ -1118,6 +1128,7 @@ class ReActAgentBuilder:
         model_node = self._prepare_agent_model_node(
             llm=self._llm,
             non_thinking_llm=non_thinking_llm,
+            judge_llm=judge_llm,
             tools=tools,
         )
 

--- a/src/agent/aidev_agent/core/nodes/model/__init__.py
+++ b/src/agent/aidev_agent/core/nodes/model/__init__.py
@@ -1,15 +1,26 @@
 # -*- coding: utf-8 -*-
-"""Model node package.
+"""模型节点包。
 
-This package groups the model node implementation (`build_model_node`) and its
-strongly-coupled context processing utilities (previously under
-`aidev_agent.core.nodes.context_processor`).
+本包组织了模型节点实现（`build_model_node`）及其
+强耦合的上下文处理工具（前身在 `aidev_agent.core.nodes.context_processor` 下）。
 """
 
 from .basic_middleware import get_beijing_now
 from .context_assembly import ContextAssembly
 from .node import ModelState, build_model_node
-from .pydantic_models import ModelNodeSettings
+from .pydantic_models import (
+    RETRYABLE_EXCEPTIONS,
+    ModelChainConfig,
+    ModelNodeSettings,
+    RecoveryException,
+    RecoveryNudgeError,
+    RecoveryPrefillError,
+    RecoveryRetryableException,
+    RecoveryRetryError,
+    RetryableRateLimitError,
+    TruncationError,
+)
+from .quality_gate import QualityGate
 from .token_compression import (
     ChatHistoryCompressionMiddleware,
     CompressionState,
@@ -19,6 +30,8 @@ from .token_compression import (
     ToolOutputLengthCompressionMiddleware,
     ToolOutputTokenCompressionMiddleware,
 )
+from .tool_call_repair import ParsedToolCall, parse_standalone_plain_text_tool_call_blocks
+from .utils import promote_plain_text_tool_call_message, should_promote_message
 
 __all__ = [
     "ChatHistoryCompressionMiddleware",
@@ -26,11 +39,25 @@ __all__ = [
     "ContextAssembly",
     "KnowledgeCompressionMiddleware",
     "KnowledgeCompressor",
+    "ModelChainConfig",
     "ModelState",
     "ModelNodeSettings",
+    "ParsedToolCall",
+    "QualityGate",
+    "RecoveryException",
+    "RecoveryNudgeError",
+    "RecoveryPrefillError",
+    "RecoveryRetryError",
+    "RecoveryRetryableException",
+    "RETRYABLE_EXCEPTIONS",
+    "RetryableRateLimitError",
     "ToolOutputCompressor",
     "ToolOutputLengthCompressionMiddleware",
     "ToolOutputTokenCompressionMiddleware",
+    "TruncationError",
     "build_model_node",
     "get_beijing_now",
+    "parse_standalone_plain_text_tool_call_blocks",
+    "promote_plain_text_tool_call_message",
+    "should_promote_message",
 ]

--- a/src/agent/aidev_agent/core/nodes/model/__init__.py
+++ b/src/agent/aidev_agent/core/nodes/model/__init__.py
@@ -10,7 +10,6 @@ from .context_assembly import ContextAssembly
 from .node import ModelState, build_model_node
 from .pydantic_models import (
     RETRYABLE_EXCEPTIONS,
-    ModelChainConfig,
     ModelNodeSettings,
     RecoveryException,
     RecoveryNudgeError,
@@ -39,7 +38,6 @@ __all__ = [
     "ContextAssembly",
     "KnowledgeCompressionMiddleware",
     "KnowledgeCompressor",
-    "ModelChainConfig",
     "ModelState",
     "ModelNodeSettings",
     "ParsedToolCall",

--- a/src/agent/aidev_agent/core/nodes/model/model_chain.py
+++ b/src/agent/aidev_agent/core/nodes/model/model_chain.py
@@ -1,0 +1,281 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueKing - AIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage
+from langchain_core.runnables import Runnable, RunnableLambda
+from langchain_core.tools import BaseTool
+from openai import RateLimitError
+from tenacity import RetryError
+
+from aidev_agent.config import settings
+from aidev_agent.packages.langchain_core.output_parsers import StructuredOutputToToolMessageParser
+
+from .pydantic_models import (
+    RETRYABLE_EXCEPTIONS,
+    ProcessorContext,
+    RetryableRateLimitError,
+)
+from .quality_gate import QualityGate
+from .utils import promote_plain_text_tool_call_message
+
+logger = logging.getLogger(__name__)
+
+
+def _promote_message(message: AnyMessage, allowed_tool_names: set[str]) -> AnyMessage:
+    """尝试将消息中的纯文本工具调用提升为原生 tool_calls。"""
+    if not isinstance(message, AIMessage):
+        return message
+    return promote_plain_text_tool_call_message(message, allowed_tool_names)
+
+
+def _extract_query_text_and_images(query: Any) -> tuple[Any, list[dict[str, Any]]]:
+    """从 query 中提取文本和图片（OpenAI 风格内容列表）。"""
+
+    if not isinstance(query, list):
+        return query, []
+
+    text_parts: list[str] = []
+    image_contents: list[dict[str, Any]] = []
+    for item in query:
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        if item_type == "text":
+            text = item.get("text")
+            if isinstance(text, str):
+                text_parts.append(text)
+        elif item_type == "image_url":
+            image_contents.append(item)
+
+    return "\n".join(text_parts), image_contents
+
+
+def _attach_images_to_last_human_message(messages: list[BaseMessage], image_contents: list[dict[str, Any]]) -> None:
+    """将图片内容挂载到最后一条 HumanMessage，避免丢失多模态输入。"""
+
+    if not image_contents:
+        return
+
+    for idx in range(len(messages) - 1, -1, -1):
+        if not isinstance(messages[idx], HumanMessage):
+            continue
+
+        human_message = messages[idx]
+        rendered_text = human_message.content if isinstance(human_message.content, str) else ""
+        multimodal_content: list[dict[str, Any]] = []
+        if rendered_text:
+            multimodal_content.append({"type": "text", "text": rendered_text})
+        multimodal_content.extend(image_contents)
+        messages[idx] = human_message.model_copy(update={"content": multimodal_content})
+        return
+
+
+def _build_effective_chain(
+    *,
+    llm: BaseChatModel,
+    tools: list[BaseTool],
+    use_structured_response: bool,
+    enable_parallel_tool_calls: bool,
+    use_tool_call_promotion: bool,
+    max_tokens_override: int | None = None,
+) -> Runnable:
+    """从原始 LLM 构建可执行的 chain。
+
+    根据模式标志绑定工具、结构化响应解析器、promotion 等，返回
+    可直接调用的 Runnable。
+
+    构建顺序：
+    1. max_tokens 前置（消除两分支重复 bind）
+    2. 无工具时直接返回 llm——StructuredOutputToToolMessageParser 的唯一
+       作用是将 JSON 输出解析为 tool_calls，无工具时无意义
+    3. structured / 非 structured 分支构建 chain
+    4. promotion 统一加在末尾（两个分支一致）
+    """
+    # 1. max_tokens 前置
+    if max_tokens_override:
+        llm = llm.bind(max_tokens=max_tokens_override)
+
+    # 2. 无工具 → 直接返回 llm
+    #    StructuredOutputToToolMessageParser 的作用是把 JSON 输出解析为
+    #    tool_calls；没有工具时 parser 无意义，无论 use_structured_response
+    #    取值如何都应直接返回 llm。
+    if not tools:
+        return llm
+
+    # 3. 构建 chain（tools 非空）
+    if use_structured_response:
+        chain = llm | StructuredOutputToToolMessageParser(
+            llm=llm,
+            enable_parallel_tool_calls=enable_parallel_tool_calls,
+        )
+    else:
+        chain = llm.bind_tools(tools)
+
+    # 4. promotion（两个分支统一加；无工具时已在上方提前返回）
+    if use_tool_call_promotion:
+        allowed_tool_names = {t.name for t in tools}
+        chain = chain | RunnableLambda(lambda msg, _names=allowed_tool_names: _promote_message(msg, _names))
+    return chain
+
+
+def _exhaustion_fallback(ctx: ProcessorContext) -> ProcessorContext:
+    """当所有重试耗尽时返回最后响应。"""
+    return ctx
+
+
+def _build_model_chain(
+    *,
+    llm,
+    context_assembly,
+    model_chain_config,
+    quality_gate: QualityGate,
+    use_structured_response: bool,
+    enable_parallel_tool_calls: bool,
+    use_tool_call_promotion: bool,
+) -> Runnable:
+    """构建共享的 LCEL 模型链。
+
+    将原 _run_recovery_loop / _arun_recovery_loop 的 while 循环逻辑
+    替换为 LCEL 管道：RunnableLambda 步骤 → RunnableRetry → RunnableWithFallbacks。
+
+    Args:
+        llm: 语言模型
+        context_assembly: 上下文装配器
+        model_chain_config: 模型链配置（max_empty_retries 等）
+        quality_gate: 质量门禁实例（评估响应并决定恢复路由）
+        use_structured_response: 是否使用结构化响应模式
+        enable_parallel_tool_calls: 是否启用并行工具调用
+        use_tool_call_promotion: 是否启用工具调用提升
+
+    Returns:
+        Runnable，支持 .invoke() 和 .ainvoke()
+    """
+
+    # ------------------------------------------------------------------
+    # 内部函数：消息渲染（链头，D-07/D-08/D-09）
+    # ------------------------------------------------------------------
+    def _render_messages(ctx: ProcessorContext) -> ProcessorContext:
+        """渲染 prompt 模板为消息列表，填入 ctx.messages (D-07/D-08)。
+
+        复用入口 ctx（不构造临时 ProcessorContext——D-08）。原地变更
+        ctx.messages 并返回同一对象，使重试边界重新执行时消息保留。
+        """
+        chat_prompt_template = context_assembly.get_chat_prompt_template(ctx)
+        context_variables = context_assembly.get_chat_prompt_variables(ctx)
+        image_contents: list[dict[str, Any]] = []
+        query, image_contents = _extract_query_text_and_images(context_variables.get("query"))
+        if image_contents:
+            context_variables = {**context_variables, "query": query}
+        prompt_value = chat_prompt_template.invoke(context_variables, config=ctx.config)
+        messages: list[BaseMessage] = prompt_value.to_messages()
+        _attach_images_to_last_human_message(messages, image_contents)
+        ctx.messages = messages  # 原地变更 ctx，返回同一对象
+        return ctx
+
+    # ------------------------------------------------------------------
+    # 内部函数：LLM 调用步骤
+    # ------------------------------------------------------------------
+    def _call_llm(ctx: ProcessorContext) -> ProcessorContext:
+        """从原始 LLM 构建 chain 并调用，处理 RateLimitError。"""
+        tools = context_assembly.get_choice_tools(ctx)
+        effective_llm = _build_effective_chain(
+            llm=llm,
+            tools=tools,
+            use_structured_response=use_structured_response,
+            enable_parallel_tool_calls=enable_parallel_tool_calls,
+            use_tool_call_promotion=use_tool_call_promotion,
+            max_tokens_override=ctx.model_chain_state.max_tokens_override,
+        )
+        try:
+            response = effective_llm.invoke(ctx.messages, config=ctx.config)
+        except RateLimitError:
+            if settings.LLM_RETRY_STRATEGY != "sdk":
+                raise
+            ctx.model_chain_state.empty_content_retries += 1
+            logger.warning(
+                "Rate limit error, waiting 60s before retry (%d/%d)",
+                ctx.model_chain_state.empty_content_retries,
+                ctx.model_chain_state.max_empty_retries,
+            )
+            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_empty_retries:
+                raise
+            time.sleep(60)
+            raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
+        ctx.response = response
+        return ctx
+
+    async def _acall_llm(ctx: ProcessorContext) -> ProcessorContext:
+        """从原始 LLM 异步构建 chain 并调用，处理 RateLimitError。"""
+        tools = context_assembly.get_choice_tools(ctx)
+        effective_llm = _build_effective_chain(
+            llm=llm,
+            tools=tools,
+            use_structured_response=use_structured_response,
+            enable_parallel_tool_calls=enable_parallel_tool_calls,
+            use_tool_call_promotion=use_tool_call_promotion,
+            max_tokens_override=ctx.model_chain_state.max_tokens_override,
+        )
+        try:
+            response = await effective_llm.ainvoke(ctx.messages, config=ctx.config)
+        except RateLimitError:
+            if settings.LLM_RETRY_STRATEGY != "sdk":
+                raise
+            ctx.model_chain_state.empty_content_retries += 1
+            logger.warning(
+                "Rate limit error, waiting 60s before retry (%d/%d)",
+                ctx.model_chain_state.empty_content_retries,
+                ctx.model_chain_state.max_empty_retries,
+            )
+            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_empty_retries:
+                raise
+            await asyncio.sleep(60)
+            raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
+        ctx.response = response
+        return ctx
+
+    # ------------------------------------------------------------------
+    # 链组合：_render_messages（仅一次）| model_chain（含重试 + 回退）
+    # ------------------------------------------------------------------
+    # _render_messages 不参与重试——消息渲染是幂等的、只应跑一次，
+    # 重试时只需重建 model_chain（llm | capture | quality）。
+    # with_fallbacks 也只包裹 model_chain——耗尽时返回最后响应。
+    model_chain = RunnableLambda(_call_llm, _acall_llm) | RunnableLambda(quality_gate)
+    # 用重试包装 — 捕获所有 RETRYABLE_EXCEPTIONS
+    retryable_model_chain = model_chain.with_retry(
+        retry_if_exception_type=RETRYABLE_EXCEPTIONS,
+        stop_after_attempt=model_chain_config.max_empty_retries + 1,
+        wait_exponential_jitter=True,
+        exponential_jitter_params={"initial": 0.001},  # 最小化 — 实际等待在 Lambda 中
+    )
+
+    # _exhaustion_fallback 是模块级函数（无闭包依赖）
+
+    model_chain = RunnableLambda(_render_messages) | retryable_model_chain.with_fallbacks(
+        [RunnableLambda(_exhaustion_fallback)],
+        exceptions_to_handle=(RetryError,),
+    )
+
+    return model_chain

--- a/src/agent/aidev_agent/core/nodes/model/model_chain.py
+++ b/src/agent/aidev_agent/core/nodes/model/model_chain.py
@@ -93,14 +93,13 @@ def _attach_images_to_last_human_message(messages: list[BaseMessage], image_cont
         return
 
 
-def _build_effective_chain(
+def build_llm_with_tools(
     *,
     llm: BaseChatModel,
     tools: list[BaseTool],
     use_structured_response: bool,
     enable_parallel_tool_calls: bool,
     use_tool_call_promotion: bool,
-    max_tokens_override: int | None = None,
 ) -> Runnable:
     """从原始 LLM 构建可执行的 chain。
 
@@ -108,24 +107,26 @@ def _build_effective_chain(
     可直接调用的 Runnable。
 
     构建顺序：
-    1. max_tokens 前置（消除两分支重复 bind）
-    2. 无工具时直接返回 llm——StructuredOutputToToolMessageParser 的唯一
+    1. 无工具时直接返回 llm——StructuredOutputToToolMessageParser 的唯一
        作用是将 JSON 输出解析为 tool_calls，无工具时无意义
-    3. structured / 非 structured 分支构建 chain
-    4. promotion 统一加在末尾（两个分支一致）
-    """
-    # 1. max_tokens 前置
-    if max_tokens_override:
-        llm = llm.bind(max_tokens=max_tokens_override)
+    2. structured / 非 structured 分支构建 chain
+    3. promotion 统一加在末尾（两个分支一致）
 
-    # 2. 无工具 → 直接返回 llm
+    注意：max_tokens 不在此处绑定。``llm.bind(max_tokens=...)`` 返回的
+    ``RunnableBinding`` 在后续 ``bind_tools`` 时会通过 ``__getattr__``
+    代理到底层 ChatModel，绕开 ``RunnableBinding.bind`` 的 kwargs 合并，
+    导致 max_tokens 丢失。max_tokens 改由调用方在 ``invoke`` / ``ainvoke``
+    时按 ``max_tokens_override`` 传入（利用 ``RunnableBinding.invoke`` 的
+    ``{**self.kwargs, **kwargs}`` 合并语义）。
+    """
+    # 1. 无工具 → 直接返回 llm
     #    StructuredOutputToToolMessageParser 的作用是把 JSON 输出解析为
     #    tool_calls；没有工具时 parser 无意义，无论 use_structured_response
     #    取值如何都应直接返回 llm。
     if not tools:
         return llm
 
-    # 3. 构建 chain（tools 非空）
+    # 2. 构建 chain（tools 非空）
     if use_structured_response:
         chain = llm | StructuredOutputToToolMessageParser(
             llm=llm,
@@ -134,7 +135,7 @@ def _build_effective_chain(
     else:
         chain = llm.bind_tools(tools)
 
-    # 4. promotion（两个分支统一加；无工具时已在上方提前返回）
+    # 3. promotion（两个分支统一加；无工具时已在上方提前返回）
     if use_tool_call_promotion:
         allowed_tool_names = {t.name for t in tools}
         chain = chain | RunnableLambda(lambda msg, _names=allowed_tool_names: _promote_message(msg, _names))
@@ -150,7 +151,7 @@ def _build_model_chain(
     *,
     llm,
     context_assembly,
-    model_chain_config,
+    max_retries: int,
     quality_gate: QualityGate,
     use_structured_response: bool,
     enable_parallel_tool_calls: bool,
@@ -164,7 +165,7 @@ def _build_model_chain(
     Args:
         llm: 语言模型
         context_assembly: 上下文装配器
-        model_chain_config: 模型链配置（max_empty_retries 等）
+        max_retries: 模型调用失败或返回无效消息时的最大重试次数
         quality_gate: 质量门禁实例（评估响应并决定恢复路由）
         use_structured_response: 是否使用结构化响应模式
         enable_parallel_tool_calls: 是否启用并行工具调用
@@ -175,7 +176,7 @@ def _build_model_chain(
     """
 
     # ------------------------------------------------------------------
-    # 内部函数：消息渲染（链头，D-07/D-08/D-09）
+    # 内部函数：消息渲染
     # ------------------------------------------------------------------
     def _render_messages(ctx: ProcessorContext) -> ProcessorContext:
         """渲染 prompt 模板为消息列表，填入 ctx.messages (D-07/D-08)。
@@ -201,16 +202,20 @@ def _build_model_chain(
     def _call_llm(ctx: ProcessorContext) -> ProcessorContext:
         """从原始 LLM 构建 chain 并调用，处理 RateLimitError。"""
         tools = context_assembly.get_choice_tools(ctx)
-        effective_llm = _build_effective_chain(
+        llm_with_tools = build_llm_with_tools(
             llm=llm,
             tools=tools,
             use_structured_response=use_structured_response,
             enable_parallel_tool_calls=enable_parallel_tool_calls,
             use_tool_call_promotion=use_tool_call_promotion,
-            max_tokens_override=ctx.model_chain_state.max_tokens_override,
         )
+        # max_tokens 在 invoke 时传入，避免 bind(max_tokens) 与 bind_tools
+        # 组合时 max_tokens 被 RunnableBinding.__getattr__ 代理丢弃。
+        invoke_kwargs: dict[str, Any] = {}
+        if ctx.model_chain_state.max_tokens_override:
+            invoke_kwargs["max_tokens"] = ctx.model_chain_state.max_tokens_override
         try:
-            response = effective_llm.invoke(ctx.messages, config=ctx.config)
+            response = llm_with_tools.invoke(ctx.messages, config=ctx.config, **invoke_kwargs)
         except RateLimitError:
             if settings.LLM_RETRY_STRATEGY != "sdk":
                 raise
@@ -218,9 +223,9 @@ def _build_model_chain(
             logger.warning(
                 "Rate limit error, waiting 60s before retry (%d/%d)",
                 ctx.model_chain_state.empty_content_retries,
-                ctx.model_chain_state.max_empty_retries,
+                ctx.model_chain_state.max_retries,
             )
-            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_empty_retries:
+            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_retries:
                 raise
             time.sleep(60)
             raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
@@ -230,16 +235,20 @@ def _build_model_chain(
     async def _acall_llm(ctx: ProcessorContext) -> ProcessorContext:
         """从原始 LLM 异步构建 chain 并调用，处理 RateLimitError。"""
         tools = context_assembly.get_choice_tools(ctx)
-        effective_llm = _build_effective_chain(
+        llm_with_tools = build_llm_with_tools(
             llm=llm,
             tools=tools,
             use_structured_response=use_structured_response,
             enable_parallel_tool_calls=enable_parallel_tool_calls,
             use_tool_call_promotion=use_tool_call_promotion,
-            max_tokens_override=ctx.model_chain_state.max_tokens_override,
         )
+        # max_tokens 在 invoke 时传入，避免 bind(max_tokens) 与 bind_tools
+        # 组合时 max_tokens 被 RunnableBinding.__getattr__ 代理丢弃。
+        invoke_kwargs: dict[str, Any] = {}
+        if ctx.model_chain_state.max_tokens_override:
+            invoke_kwargs["max_tokens"] = ctx.model_chain_state.max_tokens_override
         try:
-            response = await effective_llm.ainvoke(ctx.messages, config=ctx.config)
+            response = await llm_with_tools.ainvoke(ctx.messages, config=ctx.config, **invoke_kwargs)
         except RateLimitError:
             if settings.LLM_RETRY_STRATEGY != "sdk":
                 raise
@@ -247,9 +256,9 @@ def _build_model_chain(
             logger.warning(
                 "Rate limit error, waiting 60s before retry (%d/%d)",
                 ctx.model_chain_state.empty_content_retries,
-                ctx.model_chain_state.max_empty_retries,
+                ctx.model_chain_state.max_retries,
             )
-            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_empty_retries:
+            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_retries:
                 raise
             await asyncio.sleep(60)
             raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
@@ -266,7 +275,7 @@ def _build_model_chain(
     # 用重试包装 — 捕获所有 RETRYABLE_EXCEPTIONS
     retryable_model_chain = model_chain.with_retry(
         retry_if_exception_type=RETRYABLE_EXCEPTIONS,
-        stop_after_attempt=model_chain_config.max_empty_retries + 1,
+        stop_after_attempt=max_retries + 1,
         wait_exponential_jitter=True,
         exponential_jitter_params={"initial": 0.001},  # 最小化 — 实际等待在 Lambda 中
     )

--- a/src/agent/aidev_agent/core/nodes/model/node.py
+++ b/src/agent/aidev_agent/core/nodes/model/node.py
@@ -107,10 +107,9 @@ def build_model_node(
 
     use_structured_response = node_options.use_structured_response
     enable_parallel_tool_calls = node_options.enable_parallel_tool_calls
-    model_chain_config = node_options.model_chain_config
     quality_gate = QualityGate(
         judge_llm=judge_llm,
-        enable_judgment_llm=model_chain_config.enable_judgment_llm,
+        enable_judge_response=node_options.enable_judge_response,
     )
 
     # 在内部构建 ContextAssembly，并手动加载所有必需的中间件
@@ -195,7 +194,7 @@ def build_model_node(
     model_chain = _build_model_chain(
         llm=llm,
         context_assembly=context_assembly,
-        model_chain_config=model_chain_config,
+        max_retries=node_options.max_model_retries,
         quality_gate=quality_gate,
         use_structured_response=use_structured_response,
         enable_parallel_tool_calls=enable_parallel_tool_calls,
@@ -215,10 +214,7 @@ def build_model_node(
             store=store,
             llm=llm,
             model_chain_state=ModelChainState(
-                max_empty_retries=model_chain_config.max_empty_retries,
-                max_thinking_prefill_retries=model_chain_config.max_thinking_prefill_retries,
-                max_truncation_retries=model_chain_config.max_truncation_retries,
-                max_truncated_tool_call_retries=model_chain_config.max_truncated_tool_call_retries,
+                max_retries=node_options.max_model_retries,
             ),
             messages=[],
             response=None,
@@ -241,10 +237,7 @@ def build_model_node(
             store=store,
             llm=llm,
             model_chain_state=ModelChainState(
-                max_empty_retries=model_chain_config.max_empty_retries,
-                max_thinking_prefill_retries=model_chain_config.max_thinking_prefill_retries,
-                max_truncation_retries=model_chain_config.max_truncation_retries,
-                max_truncated_tool_call_retries=model_chain_config.max_truncated_tool_call_retries,
+                max_retries=node_options.max_model_retries,
             ),
             messages=[],
             response=None,

--- a/src/agent/aidev_agent/core/nodes/model/node.py
+++ b/src/agent/aidev_agent/core/nodes/model/node.py
@@ -22,15 +22,13 @@ import logging
 from typing import Annotated, Any, Dict, List
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage
-from langchain_core.runnables import Runnable, RunnableConfig, RunnableLambda
+from langchain_core.messages import AnyMessage
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph._internal._runnable import RunnableCallable
 from langgraph.graph.message import add_messages
 from langgraph.store.base import BaseStore
 from typing_extensions import Required, TypedDict
-
-from aidev_agent.packages.langchain_core.output_parsers import StructuredOutputToToolMessageParser
 
 from .basic_middleware import (
     BaseVariablesMiddleware,
@@ -39,6 +37,7 @@ from .basic_middleware import (
     SpecialVariablesPostMiddleware,
 )
 from .context_assembly import ContextAssembly
+from .model_chain import _build_model_chain
 from .prompt_middleware import (
     BeijingTimeMiddleware,
     DecisionSystemMiddleware,
@@ -48,7 +47,8 @@ from .prompt_middleware import (
     RoleDefinitionMiddleware,
     StructuredChatFormatMiddleware,
 )
-from .pydantic_models import ModelNodeSettings, ProcessorContext
+from .pydantic_models import ModelChainState, ModelNodeSettings, ProcessorContext
+from .quality_gate import QualityGate
 from .token_compression import (
     ChatHistoryCompressionMiddleware,
     KnowledgeCompressionMiddleware,
@@ -59,59 +59,6 @@ from .token_compression import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-class InvalidModelMessageError(Exception):
-    """模型返回了无效 message（content 和 tool_calls 均为空）时抛出。"""
-
-
-def _is_invalid_message(message: AnyMessage) -> bool:
-    """
-    判断模型返回的 message 是否无效。
-
-    无效条件（任一满足即无效）:
-    1. message 不是 AIMessage 类型
-    2. message.content 为空且 message.tool_calls 为空
-
-    Args:
-        message: LangChain 的 message 对象
-
-    Returns:
-        bool: True 表示无效，需要重试；False 表示有效
-    """
-
-    # 条件 1: 不是 AIMessage
-    if not isinstance(message, AIMessage):
-        return True
-
-    # 条件 2: content 和 tool_calls 都为空
-    has_content = False
-    has_tool_calls = False
-
-    # 检查 content
-    if message.content:
-        # 多模态内容，只要 list 长度大于 0 就认为有内容
-        # 返回有问题不会解析出 list，所以只要 list 存在且非空就是有效的
-        has_content = (isinstance(message.content, str) and message.content.strip() != "") or (
-            isinstance(message.content, list) and len(message.content) > 0
-        )
-
-    # 检查 tool_calls
-    if message.tool_calls:
-        has_tool_calls = len(message.tool_calls) > 0
-
-    return not has_content and not has_tool_calls
-
-
-def _validate_model_message(message: AnyMessage) -> AnyMessage:
-    """校验模型返回的 message，无效时抛出 InvalidModelMessageError 触发 with_retry 重试。"""
-    if _is_invalid_message(message):
-        raise InvalidModelMessageError(
-            f"Model returned invalid message: "
-            f"content={repr(message.content)[:100]}, "
-            f"tool_calls={len(message.tool_calls) if hasattr(message, 'tool_calls') else 'N/A'}"
-        )
-    return message
 
 
 class ModelState(TypedDict, total=False):
@@ -126,146 +73,28 @@ class ModelState(TypedDict, total=False):
     messages: Required[Annotated[list[AnyMessage], add_messages]]
 
 
-def _extract_query_text_and_images(query: Any) -> tuple[Any, list[dict[str, Any]]]:
-    """从 query 中提取文本和图片（OpenAI-style content list）。"""
-
-    if not isinstance(query, list):
-        return query, []
-
-    text_parts: list[str] = []
-    image_contents: list[dict[str, Any]] = []
-    for item in query:
-        if not isinstance(item, dict):
-            continue
-        item_type = item.get("type")
-        if item_type == "text":
-            text = item.get("text")
-            if isinstance(text, str):
-                text_parts.append(text)
-        elif item_type == "image_url":
-            image_contents.append(item)
-
-    return "\n".join(text_parts), image_contents
-
-
-def _attach_images_to_last_human_message(messages: list[BaseMessage], image_contents: list[dict[str, Any]]) -> None:
-    """将图片内容挂载到最后一条 HumanMessage，避免丢失多模态输入。"""
-
-    if not image_contents:
-        return
-
-    for idx in range(len(messages) - 1, -1, -1):
-        if not isinstance(messages[idx], HumanMessage):
-            continue
-
-        human_message = messages[idx]
-        rendered_text = human_message.content if isinstance(human_message.content, str) else ""
-        multimodal_content: list[dict[str, Any]] = []
-        if rendered_text:
-            multimodal_content.append({"type": "text", "text": rendered_text})
-        multimodal_content.extend(image_contents)
-        messages[idx] = human_message.model_copy(update={"content": multimodal_content})
-        return
-
-
-def _prepare_model_chain(
-    *,
-    llm: BaseChatModel,
-    context_assembly: ContextAssembly,
-    use_structured_response: bool,
-    enable_parallel_tool_calls: bool,
-    max_retries: int,
-    state: ModelState,
-    config: RunnableConfig,
-    store: BaseStore,
-) -> tuple[Runnable, list[BaseMessage]]:
-    """
-    准备模型推理所需的 LLM chain 和渲染后的 messages。
-
-    抽取 model_node 和 amodel_node 的公共逻辑，包括：
-    - 获取工具列表
-    - 获取 prompt 模板
-    - 准备上下文变量
-    - 渲染 prompt -> messages
-    - 构建 LLM chain（含校验和重试）
-
-    Args:
-        llm: 语言模型
-        context_assembly: 上下文组件实例
-        use_structured_response: 是否使用结构化输出模式
-        enable_parallel_tool_calls: 是否启用并行工具调用
-        max_retries: 最大重试次数
-        state: 状态字典
-        config: Runnable 配置
-        store: LangGraph Store
-
-    Returns:
-        tuple: (llm_chain, messages)
-            - llm_chain: LLM chain（含校验模块和 with_retry）
-            - messages: 渲染后的消息列表（可观测点）
-    """
-
-    # 创建共享的 ProcessorContext（整个 node 执行过程中复用）
-    ctx = ProcessorContext(
-        state=state,
-        config=config,
-        store=store,
-        llm=llm,
-    )
-
-    # 使用 ContextAssembly 获取工具
-    tools = context_assembly.get_choice_tools(ctx)
-    # 使用 ContextAssembly 选择 prompt 模板（会设置 ctx.chat_prompt_template）
-    chat_prompt_template = context_assembly.get_chat_prompt_template(ctx)
-    # 使用 ContextAssembly 准备上下文变量
-    context_variables = context_assembly.get_chat_prompt_variables(ctx)
-    image_contents: list[dict[str, Any]] = []
-    query, image_contents = _extract_query_text_and_images(context_variables.get("query"))
-    if image_contents:
-        context_variables = {**context_variables, "query": query}
-
-    # 渲染 prompt -> messages（可观测点）
-    prompt_value = chat_prompt_template.invoke(context_variables, config=config)
-    messages: list[BaseMessage] = prompt_value.to_messages()
-    _attach_images_to_last_human_message(messages, image_contents)
-
-    # 根据模式构建不同的 llm_chain（不含 prompt）
-    if use_structured_response:
-        # 创建结构化输出解析器（用于 use_structured_response 模式）
-        # 传递 llm 以支持 DeepSeek R1 等模型的特殊处理
-        # 注意：不传递 tools，工具存在性校验由 ToolNode 负责
-        tool_message_parser = StructuredOutputToToolMessageParser(
-            llm=llm,
-            enable_parallel_tool_calls=enable_parallel_tool_calls,
-        )
-        # 结构化输出模式：llm 输出经过 parser 转换为带 tool_calls 的 AIMessage
-        llm_chain: Runnable = llm | tool_message_parser
-        # 添加工具描述到上下文变量
-    else:
-        # 原生工具调用模式：使用 bind_tools 绑定工具
-        llm_chain = llm.bind_tools(tools) if tools else llm
-
-    # 在 chain 末尾添加校验模块，无效消息抛异常触发 with_retry 重试
-    llm_chain = (llm_chain | RunnableLambda(_validate_model_message)).with_retry(
-        retry_if_exception_type=(InvalidModelMessageError,),
-        stop_after_attempt=max_retries,
-    )
-
-    return llm_chain, messages
+# ---------------------------------------------------------------------------
+# build_model_node
+# ---------------------------------------------------------------------------
 
 
 def build_model_node(
     *,
     llm: BaseChatModel,
     non_thinking_llm: BaseChatModel = None,
+    judge_llm: BaseChatModel | None = None,
     tools: List[BaseTool],
     node_options: ModelNodeSettings | None = None,
 ) -> RunnableCallable:
     """创建标准 QA 场景的模型节点。
 
+    模型节点内部包含 recovery 循环，处理模型响应异常（空内容、纯思考、截断等），
+    无需在 graph 层添加额外的 recovery 节点。
+
     Args:
         llm: 语言模型
         non_thinking_llm: 辅助模型
+        judge_llm: 判断用 LLM（用于 quality_gate 评估任务完成度）；None 时 fail-open
         tools: 工具列表（全量工具，内部会根据 state 决策筛选）
         node_options: 模型节点选项（可选，不传则使用默认值）
 
@@ -278,8 +107,11 @@ def build_model_node(
 
     use_structured_response = node_options.use_structured_response
     enable_parallel_tool_calls = node_options.enable_parallel_tool_calls
-
-    # NOTE: `chat_prompt_templates` is kept for backwards compatibility but is no longer used.
+    model_chain_config = node_options.model_chain_config
+    quality_gate = QualityGate(
+        judge_llm=judge_llm,
+        enable_judgment_llm=model_chain_config.enable_judgment_llm,
+    )
 
     # 在内部构建 ContextAssembly，并手动加载所有必需的中间件
     context_assembly = ContextAssembly(tools=tools)
@@ -324,6 +156,7 @@ def build_model_node(
     tool_output_compressor = ToolOutputCompressor(
         non_thinking_llm, compressor_type=node_options.tool_output_compressor_type
     )
+    # 基于 Token 超限的工具输出压缩
     context_assembly.add_middleware(
         "variable",
         ToolOutputLengthCompressionMiddleware(
@@ -331,7 +164,7 @@ def build_model_node(
             tool_output_compressor_func=tool_output_compressor,
         ),
     )
-    # 基于 Token 超限的工具输出压缩
+    # 工具压缩后重新渲染agent_scratchpad
     context_assembly.add_middleware(
         "variable",
         ToolOutputTokenCompressionMiddleware(
@@ -340,7 +173,6 @@ def build_model_node(
             token_margin=node_options.token_margin,
         ),
     )
-    # 工具压缩后重新渲染agent_scratchpad
     context_assembly.add_middleware(
         "variable",
         SpecialVariablesPostMiddleware(use_structured_response=use_structured_response),
@@ -349,7 +181,6 @@ def build_model_node(
         "variable",
         DeepSeekR1VariablesMiddleware(use_deepseek_r1_models_process=node_options.use_deepseek_r1_models_process),
     )
-
     context_assembly.add_middleware(
         "variable",
         ChatHistoryCompressionMiddleware(
@@ -357,10 +188,19 @@ def build_model_node(
             token_margin=node_options.token_margin,
         ),
     )
-
-    # Extension: allow graph layer to inject additional tool middlewares
     for m in getattr(node_options, "extra_tool_middlewares", []) or []:
         context_assembly.add_middleware("tool", m)
+
+    # 在闭包作用域中一次性构建共享的 LCEL 模型链。
+    model_chain = _build_model_chain(
+        llm=llm,
+        context_assembly=context_assembly,
+        model_chain_config=model_chain_config,
+        quality_gate=quality_gate,
+        use_structured_response=use_structured_response,
+        enable_parallel_tool_calls=enable_parallel_tool_calls,
+        use_tool_call_promotion=node_options.use_tool_call_promotion,
+    )
 
     def model_node(
         state: ModelState,
@@ -368,36 +208,25 @@ def build_model_node(
         *,
         store: BaseStore,
     ) -> Dict[str, Any]:
-        """
-        同步模型推理节点。
-
-        - 根据 state 中的 decision 选择合适的 ReAct Prompt
-        - 支持两种模式：
-          - use_structured_response=True: 使用结构化输出 + tool_message_parser
-          - use_structured_response=False: 使用原生 function calling (bind_tools)
-
-        Args:
-            state: 类型安全的状态字典
-            config: Runnable 配置
-            store: LangGraph Store
-
-        Returns:
-            包含 messages 的字典
-        """
-        llm_chain, messages = _prepare_model_chain(
-            llm=llm,
-            context_assembly=context_assembly,
-            use_structured_response=use_structured_response,
-            enable_parallel_tool_calls=enable_parallel_tool_calls,
-            max_retries=node_options.max_model_retries,
+        """同步模型推理节点（含内部恢复循环）。"""
+        ctx = ProcessorContext(
             state=state,
             config=config,
             store=store,
+            llm=llm,
+            model_chain_state=ModelChainState(
+                max_empty_retries=model_chain_config.max_empty_retries,
+                max_thinking_prefill_retries=model_chain_config.max_thinking_prefill_retries,
+                max_truncation_retries=model_chain_config.max_truncation_retries,
+                max_truncated_tool_call_retries=model_chain_config.max_truncated_tool_call_retries,
+            ),
+            messages=[],
+            response=None,
         )
-
-        response = llm_chain.invoke(messages, config=config)
-
-        return {"messages": [response]}
+        # 断言链运行时必填字段（中间件路径不校验）
+        assert ctx.config is not None and ctx.state is not None
+        final_ctx = model_chain.invoke(ctx)
+        return {"messages": [final_ctx.response]}
 
     async def amodel_node(
         state: ModelState,
@@ -405,35 +234,24 @@ def build_model_node(
         *,
         store: BaseStore,
     ) -> Dict[str, Any]:
-        """
-        异步模型推理节点。
-
-        - 根据 state 中的 decision 选择合适的 ReAct Prompt
-        - 支持两种模式：
-          - use_structured_response=True: 使用结构化输出 + tool_message_parser
-          - use_structured_response=False: 使用原生 function calling (bind_tools)
-
-        Args:
-            state: 类型安全的状态字典
-            config: Runnable 配置
-            store: LangGraph Store
-
-        Returns:
-            包含 messages 的字典
-        """
-        llm_chain, messages = _prepare_model_chain(
-            llm=llm,
-            context_assembly=context_assembly,
-            use_structured_response=use_structured_response,
-            enable_parallel_tool_calls=enable_parallel_tool_calls,
-            max_retries=node_options.max_model_retries,
+        """异步模型推理节点（含内部恢复循环）。"""
+        ctx = ProcessorContext(
             state=state,
             config=config,
             store=store,
+            llm=llm,
+            model_chain_state=ModelChainState(
+                max_empty_retries=model_chain_config.max_empty_retries,
+                max_thinking_prefill_retries=model_chain_config.max_thinking_prefill_retries,
+                max_truncation_retries=model_chain_config.max_truncation_retries,
+                max_truncated_tool_call_retries=model_chain_config.max_truncated_tool_call_retries,
+            ),
+            messages=[],
+            response=None,
         )
-
-        response = await llm_chain.ainvoke(messages, config=config)
-
-        return {"messages": [response]}
+        # 断言链运行时必填字段（中间件路径不校验）
+        assert ctx.config is not None and ctx.state is not None
+        final_ctx = await model_chain.ainvoke(ctx)
+        return {"messages": [final_ctx.response]}
 
     return RunnableCallable(model_node, amodel_node, trace=True)

--- a/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
+++ b/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
@@ -68,11 +68,11 @@ class ModelChainState:
     truncated_tool_call_retries: int = 0
     max_tokens_override: int | None = None  # D-10
 
-    # 从 ModelChainConfig 注入的恢复上限。
-    max_empty_retries: int = 3
-    max_thinking_prefill_retries: int = 2
-    max_truncation_retries: int = 3
-    max_truncated_tool_call_retries: int = 3
+    # 所有恢复类型的统一上限（从 ModelNodeSettings.max_model_retries 注入）。
+    # 4 个分类计数器（empty_content_retries / thinking_prefill_retries /
+    # length_continue_retries / truncated_tool_call_retries）仍保留用于
+    # 日志和路由判断，但上限统一为 max_retries。
+    max_retries: int = 10
 
 
 @dataclass
@@ -118,34 +118,6 @@ class Middleware(Protocol):
 DEFAULT_ENABLE_PARALLEL_TOOL_CALLS: bool = True
 
 
-class ModelChainConfig(BaseModel):
-    """模型链的不可变配置。
-
-    控制当模型返回异常响应（空内容、纯思考、截断等）时的重试行为。
-    """
-
-    max_empty_retries: int = Field(
-        default=3,
-        description="空内容响应的最大重试次数",
-    )
-    max_thinking_prefill_retries: int = Field(
-        default=2,
-        description="纯思考响应（无文本输出）的 prefill 重试次数",
-    )
-    max_truncation_retries: int = Field(
-        default=3,
-        description="文本截断的最大重试次数",
-    )
-    max_truncated_tool_call_retries: int = Field(
-        default=3,
-        description="工具调用截断的最大重试次数",
-    )
-    enable_judgment_llm: bool = Field(
-        default=True,
-        description="是否在内容响应上调用判断 LLM 评估任务完成度。关闭可省去每次正常响应的额外 LLM 调用",
-    )
-
-
 class ModelNodeSettings(BaseModel):
     """Settings for `build_model_node`.
 
@@ -177,10 +149,9 @@ class ModelNodeSettings(BaseModel):
         default=True,
         description="是否启用纯文本工具调用提升（将文本中的工具调用格式解析为原生 tool_calls）",
     )
-
-    model_chain_config: ModelChainConfig = Field(
-        default_factory=ModelChainConfig,
-        description="模型链配置（空内容、纯思考、截断等异常场景的重试行为）",
+    enable_judge_response: bool = Field(
+        default=True,
+        description="是否启用任务完成度评估。关闭后 has_content 分支直接返回 NORMAL_COMPLETION，省去每次正常响应的额外判断 LLM 调用",
     )
 
     # ---------------------------------------------------------------------

--- a/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
+++ b/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Dict, List, Literal, Optional, Protocol
 
 from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
@@ -53,6 +54,28 @@ class PromptSlots:
 
 
 @dataclass
+class ModelChainState:
+    """模型节点恢复循环的每次调用恢复计数器。
+
+    跟踪多层恢复链的重试计数和回退数据，
+    处理模型响应异常（空内容、仅思考响应、截断等）。
+    """
+
+    empty_content_retries: int = 0
+    thinking_prefill_retries: int = 0
+    post_tool_empty_retried: bool = False
+    length_continue_retries: int = 0
+    truncated_tool_call_retries: int = 0
+    max_tokens_override: int | None = None  # D-10
+
+    # 从 ModelChainConfig 注入的恢复上限。
+    max_empty_retries: int = 3
+    max_thinking_prefill_retries: int = 2
+    max_truncation_retries: int = 3
+    max_truncated_tool_call_retries: int = 3
+
+
+@dataclass
 class ProcessorContext:
     """中间件共享上下文。
 
@@ -77,6 +100,10 @@ class ProcessorContext:
     metadata: Dict[str, Any] = field(default_factory=dict)
     # 跨 ReAct 周期的缓存（由 ContextAssembly 注入，用于存储消息切割缓存、压缩状态等）
     assembly_cache: Optional[Dict[str, Any]] = None
+    # 注意：max_tokens_override 不在此处——它在 ModelChainState 上
+    messages: List[BaseMessage] = field(default_factory=list)
+    model_chain_state: Optional[ModelChainState] = None
+    response: Optional[AIMessage | AnyMessage] = None
 
 
 class Middleware(Protocol):
@@ -89,6 +116,34 @@ class Middleware(Protocol):
 
 
 DEFAULT_ENABLE_PARALLEL_TOOL_CALLS: bool = True
+
+
+class ModelChainConfig(BaseModel):
+    """模型链的不可变配置。
+
+    控制当模型返回异常响应（空内容、纯思考、截断等）时的重试行为。
+    """
+
+    max_empty_retries: int = Field(
+        default=3,
+        description="空内容响应的最大重试次数",
+    )
+    max_thinking_prefill_retries: int = Field(
+        default=2,
+        description="纯思考响应（无文本输出）的 prefill 重试次数",
+    )
+    max_truncation_retries: int = Field(
+        default=3,
+        description="文本截断的最大重试次数",
+    )
+    max_truncated_tool_call_retries: int = Field(
+        default=3,
+        description="工具调用截断的最大重试次数",
+    )
+    enable_judgment_llm: bool = Field(
+        default=True,
+        description="是否在内容响应上调用判断 LLM 评估任务完成度。关闭可省去每次正常响应的额外 LLM 调用",
+    )
 
 
 class ModelNodeSettings(BaseModel):
@@ -112,6 +167,20 @@ class ModelNodeSettings(BaseModel):
     max_model_retries: int = Field(
         default=10,
         description="模型调用失败或返回无效消息时的最大重试次数。默认为 10。可通过环境变量 MODEL_MAX_RETRIES 配置。",
+    )
+
+    # ---------------------------------------------------------------------
+    # Stability / recovery settings
+    # ---------------------------------------------------------------------
+
+    use_tool_call_promotion: bool = Field(
+        default=True,
+        description="是否启用纯文本工具调用提升（将文本中的工具调用格式解析为原生 tool_calls）",
+    )
+
+    model_chain_config: ModelChainConfig = Field(
+        default_factory=ModelChainConfig,
+        description="模型链配置（空内容、纯思考、截断等异常场景的重试行为）",
     )
 
     # ---------------------------------------------------------------------
@@ -178,3 +247,49 @@ class ModelNodeSettings(BaseModel):
         description="(internal) Extra tool pipeline middlewares injected by graph layer.",
         exclude=True,
     )
+
+
+# =============================================================================
+# Recovery Exceptions（从 recovery_exceptions.py 迁移而来 — D-14）
+# =============================================================================
+
+
+class RecoveryException(Exception):
+    """所有恢复触发异常的基类。"""
+
+    def __init__(self, response: AIMessage, message: str = ""):
+        self.response = response
+        super().__init__(message or self.__class__.__name__)
+
+
+class RecoveryRetryableException(RecoveryException):
+    """可重试异常的中间基类（被 RunnableRetry 捕获）。"""
+
+
+class RecoveryNudgeError(RecoveryRetryableException):
+    """工具后空响应 — 发送提示并重试。"""
+
+
+class RecoveryPrefillError(RecoveryRetryableException):
+    """仅思考响应 — 追加 prefill 并重试。"""
+
+
+class TruncationError(RecoveryRetryableException):
+    """截断响应 — 继续或重建 chain 并重试。"""
+
+
+class RecoveryRetryError(RecoveryRetryableException):
+    """空内容 — 简单重试。"""
+
+
+class RetryableRateLimitError(RecoveryRetryableException):
+    """429 限流 — 睡眠后重试。"""
+
+
+RETRYABLE_EXCEPTIONS: tuple[type[RecoveryRetryableException], ...] = (
+    RecoveryNudgeError,
+    RecoveryPrefillError,
+    TruncationError,
+    RecoveryRetryError,
+    RetryableRateLimitError,
+)

--- a/src/agent/aidev_agent/core/nodes/model/quality_gate.py
+++ b/src/agent/aidev_agent/core/nodes/model/quality_gate.py
@@ -1,0 +1,435 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, SystemMessage
+
+from aidev_agent.packages.langgraph.streaming.utils import conditional_dispatch_custom_event
+
+from .pydantic_models import (
+    ProcessorContext,
+    RecoveryNudgeError,
+    RecoveryPrefillError,
+    RecoveryRetryError,
+    TruncationError,
+)
+from .utils import (
+    detect_thinking_exhaustion,
+    extract_text_from_content,
+    has_content_after_think_block,
+    has_inline_thinking,
+    has_prior_tool_results,
+    is_truncated,
+    strip_think_blocks,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# 质量门禁常量
+# ---------------------------------------------------------------------------
+
+RECOVERY_NUDGE_PROMPT = (
+    "You just executed tool calls but returned an empty response. "
+    "Please process the tool results above and continue with the task."
+)
+
+TRUNCATION_CONTINUE_PROMPT = (
+    "Your previous response was truncated. Continue exactly where you left off. Do not restart or repeat prior text."
+)
+
+THINKING_EXHAUSTED_MESSAGE = (
+    "Model used all output tokens on reasoning with none left for the response. "
+    "Try increasing max_tokens or lowering reasoning effort."
+)
+
+
+# ---------------------------------------------------------------------------
+# 响应路由枚举
+# ---------------------------------------------------------------------------
+
+
+class ResponseRoute(enum.Enum):
+    """模型响应质量评估后的路由决策。
+
+    每个枚举成员表示一条明确的后继处理路径，供恢复循环使用。
+    """
+
+    # 正常路径
+    NORMAL_COMPLETION = "normal_completion"  # 有内容，无工具调用 → 结束对话
+    TOOL_EXECUTION = "tool_execution"  # 有工具调用 → 进入工具执行
+
+    # 恢复路径
+    RECOVERY_NUDGE = "recovery_nudge"  # 工具后空响应 → 发送提示
+    RECOVERY_PREFILL = "recovery_prefill"  # 仅思考响应 → 追加 prefill
+    RECOVERY_TRUNCATION = "recovery_truncation"  # 截断响应 → 继续生成
+    RECOVERY_RETRY = "recovery_retry"  # 空内容 → 简单重试
+
+
+# ---------------------------------------------------------------------------
+# 质量门禁（可子类化以定制判断逻辑）
+# ---------------------------------------------------------------------------
+
+
+class QualityGate:
+    """模型响应质量门禁。
+
+    评估模型响应并决定后续路由（正常完成 / 工具执行 / 各种恢复路径）。
+    作为可调用对象（``__call__``）接入 model_chain LCEL 管道。
+
+    可子类化以定制任务完成度判断逻辑——重写以下方法/属性即可，无需重写
+    整个路由/恢复流程：
+
+    - ``judgment_sys_prompt``：判断系统提示词
+    - ``_judge_task_completion``：调用判断 LLM 评估完成度
+    - ``_judge_response_completion``：提取输入/输出并调用判断
+    - ``_extract_last_human_input``：提取最后一条用户输入
+    """
+
+    # 判断系统提示词——类属性，子类可重写
+    judgment_sys_prompt: str = """你是一个任务完成度判断器。我会给你以下信息：
+1. 用户的最后一条输入
+2. 智能助手的最后一条输出
+
+你需要判断智能助手的输出是否实际完成了用户输入中要求的任务，以便于放行用户继续提问
+完成任务的情况如下：
+1. 输出详细的报告，回答了用户的问题，或者完成了用户的任务
+2. 要求用户补充相关信息，澄清问题等回复
+3. 明确指出不能完成用户任务，例如：根据已有知识不能回答问题
+4. 其他你认为完成任务了的情况
+
+判断规则：
+- 如果助手的输出明确回答了用户的问题或完成了用户要求的任务，判断为"已完成"
+- 如果助手的输出明显未完成用户任务（如答非所问、拒绝回答、输出不完整、仅重复用户输入等），判断为"未完成"
+- 如果无法确定助手是否完成了任务，判断为"不确定"
+
+请只返回以下三个词中的一个，不要返回任何其他内容：
+- 已完成
+- 未完成
+- 不确定"""
+
+    def __init__(
+        self,
+        *,
+        judge_llm: BaseChatModel | None = None,
+        enable_judgment_llm: bool = True,
+    ) -> None:
+        """初始化质量门禁。
+
+        Args:
+            judge_llm: 判断用 LLM 实例。构造一次并复用（避免每次响应重建）。
+                为 None 时 fail-open（跳过判断，视为已完成）。
+            enable_judgment_llm: 是否在内容响应上调用判断 LLM。关闭后
+                ``has_content`` 分支直接返回 ``NORMAL_COMPLETION``，省去
+                每次正常响应的额外 LLM 调用。
+        """
+        self.judge_llm = judge_llm
+        self.enable_judgment_llm = enable_judgment_llm
+
+    # ------------------------------------------------------------------
+    # 任务完成度判断（SRE3-6-35B-A3B-nothinking judge，fail-open 语义）
+    # ------------------------------------------------------------------
+
+    def _extract_last_human_input(self, messages: list[BaseMessage]) -> str | None:
+        """从消息列表中逆向提取最后一条 HumanMessage 的文本。"""
+        for msg in reversed(messages):
+            if isinstance(msg, HumanMessage):
+                return extract_text_from_content(msg.content)
+        return None
+
+    def _judge_task_completion(
+        self,
+        judgment_llm,
+        last_user_input: str,
+        last_model_output: str,
+        *,
+        enable_custom_event: bool = True,
+    ) -> bool:
+        """调用判断模型评估任务是否完成。fail-open：无法确定未完成则返回 True。
+
+        Args:
+            judgment_llm: 用于判断的 LLM 实例
+            last_user_input: 最后一条用户输入文本
+            last_model_output: 最后一条模型输出文本（已剔除 think 块）
+            enable_custom_event: 是否派发 custom_event（用于 SSE 流期间
+                切换 ``front_end_display``，避免判断 LLM 的流式输出写入 DB
+                或显示给前端）。
+
+        Returns:
+            True 表示任务已完成（或无法确定未完成），False 表示明确未完成
+        """
+        if not judgment_llm or not last_user_input or not last_model_output:
+            return True  # fail-open
+
+        usr_prompt = (
+            f"用户最后一条输入：\n```\n{last_user_input}\n```\n\n"
+            f"智能助手最后一条输出：\n```\n{last_model_output}\n```\n\n"
+            f"请判断智能助手是否完成了用户的任务。"
+        )
+        messages = [
+            SystemMessage(content=self.judgment_sys_prompt),
+            HumanMessage(content=usr_prompt),
+        ]
+        # 判断 LLM 调用期间关闭前端显示/DB 写入，避免判断输出污染会话流。
+        # 使用 try/finally 确保异常路径下也恢复 front_end_display=True。
+        conditional_dispatch_custom_event(
+            "custom_event",
+            {"front_end_display": False},
+            enable_custom_event=enable_custom_event,
+        )
+        try:
+            resp = judgment_llm.invoke(messages)
+            result = (resp.content or "").strip()
+            # fail-open：只有明确"未完成"才返回 False
+            return "未完成" not in result
+        except Exception:
+            logger.warning("judgment LLM call failed, fail-open", exc_info=True)
+            return True
+        finally:
+            conditional_dispatch_custom_event(
+                "custom_event",
+                {"front_end_display": True},
+                enable_custom_event=enable_custom_event,
+            )
+
+    def _judge_response_completion(
+        self,
+        response: AnyMessage,
+        working_messages: list[BaseMessage],
+        *,
+        enable_custom_event: bool = True,
+    ) -> bool:
+        """提取最后用户输入和模型输出，调用判断 LLM。fail-open 语义。
+
+        Args:
+            enable_custom_event: 是否派发 custom_event（透传给 _judge_task_completion）。
+
+        Returns:
+            True 表示任务已完成（或无法确定未完成），False 表示明确未完成
+        """
+        if self.judge_llm is None:
+            return True  # fail-open：未配置判断 LLM，跳过判断
+        last_user_input = self._extract_last_human_input(working_messages)
+        last_model_output = extract_text_from_content(response.content)
+        if last_model_output:
+            last_model_output = strip_think_blocks(last_model_output)
+        return self._judge_task_completion(
+            self.judge_llm,
+            last_user_input,
+            last_model_output,
+            enable_custom_event=enable_custom_event,
+        )
+
+    # ------------------------------------------------------------------
+    # 响应校验
+    # ------------------------------------------------------------------
+
+    def validate_response(self, ctx: ProcessorContext) -> ResponseRoute:
+        """评估模型响应质量并确定后继路由。
+
+        返回一个 ``ResponseRoute`` 枚举成员，表示模型节点应采取的下一步操作。
+
+        路由决策顺序（由高到低优先级）：
+        1. 有工具调用 → TOOL_EXECUTION
+        2. 有有效内容 → NORMAL_COMPLETION（若启用判断 LLM，需先通过完成度判断）
+        3. 工具后空响应 → RECOVERY_NUDGE
+        4. 仅思考响应 → RECOVERY_PREFILL
+        5. 截断响应 → RECOVERY_TRUNCATION
+        6. 空内容 → RECOVERY_RETRY
+        7. 恢复选项耗尽 → NORMAL_COMPLETION
+        """
+        response = ctx.response
+        recovery = ctx.model_chain_state
+        working_messages = ctx.messages
+
+        # 1. 截断的工具调用 → 需要重建 chain 并重试。
+        #    必须在通用 tool_calls 检查之前处理，否则截断的工具调用会被误判为正常工具执行。
+        if (
+            response.tool_calls
+            and is_truncated(response)
+            and recovery.truncated_tool_call_retries < recovery.max_truncated_tool_call_retries
+        ):
+            logger.info(
+                "Recovery: truncated tool call (retry %d/%d)",
+                recovery.truncated_tool_call_retries + 1,
+                recovery.max_truncated_tool_call_retries,
+            )
+            return ResponseRoute.RECOVERY_TRUNCATION
+
+        # 2. 有工具调用 → 正常工具执行路径。
+        if response.tool_calls:
+            return ResponseRoute.TOOL_EXECUTION
+
+        # 3. 有有效内容 → 正常完成。
+        #    参照 hermes-agent 的 map_finish_reason(None) → "stop" 行为：
+        #    如果模型输出有 content 但没有 finish_reason，仍然视为正常完成。
+        content = response.content or ""
+        has_content = (isinstance(content, str) and has_content_after_think_block(content)) or (
+            isinstance(content, list) and len(content) > 0
+        )
+        if has_content:
+            if self.enable_judgment_llm and not self._judge_response_completion(
+                response,
+                working_messages,
+                enable_custom_event=ctx.metadata.get("enable_custom_event", True),
+            ):
+                return ResponseRoute.RECOVERY_RETRY
+            return ResponseRoute.NORMAL_COMPLETION
+
+        # 从这里开始：消息没有可用内容。
+
+        # 4. 工具后提示。
+        if (
+            has_prior_tool_results(working_messages)
+            and not recovery.post_tool_empty_retried
+            and not (isinstance(content, str) and has_inline_thinking(content))
+        ):
+            logger.info("Recovery: post-tool empty response, sending nudge")
+            return ResponseRoute.RECOVERY_NUDGE
+
+        # 5. 仅思考：有推理内容但无文本输出。
+        has_reasoning = bool(getattr(response, "reasoning_content", None))
+        if (
+            has_reasoning
+            or (
+                isinstance(content, str) and has_inline_thinking(content) and not has_content_after_think_block(content)
+            )
+        ) and recovery.thinking_prefill_retries < recovery.max_thinking_prefill_retries:
+            logger.info(
+                "Recovery: thinking-only response (prefill retry %d/%d)",
+                recovery.thinking_prefill_retries + 1,
+                recovery.max_thinking_prefill_retries,
+            )
+            return ResponseRoute.RECOVERY_PREFILL
+
+        # 6. 截断：finish_reason == "length"。
+        if is_truncated(response) and recovery.length_continue_retries < recovery.max_truncation_retries:
+            logger.info(
+                "Recovery: truncated response (retry %d/%d)",
+                recovery.length_continue_retries + 1,
+                recovery.max_truncation_retries,
+            )
+            return ResponseRoute.RECOVERY_TRUNCATION
+
+        # 7. 空内容重试。
+        if recovery.empty_content_retries < recovery.max_empty_retries:
+            logger.info(
+                "Recovery: empty content (retry %d/%d)",
+                recovery.empty_content_retries + 1,
+                recovery.max_empty_retries,
+            )
+            return ResponseRoute.RECOVERY_RETRY
+
+        # 8. 终端：已耗尽所有恢复选项。
+        logger.warning("Recovery: all recovery options exhausted, ending")
+        return ResponseRoute.NORMAL_COMPLETION
+
+    # ------------------------------------------------------------------
+    # 质量门禁执行（ctx 进 ctx 出，供 model_chain LCEL 管道使用）
+    # ------------------------------------------------------------------
+
+    def __call__(self, ctx: ProcessorContext) -> ProcessorContext:
+        """评估模型响应质量并决定后续路由。
+
+        根据 validate_response 的返回结果应用恢复操作并抛出对应异常，
+        或正常返回以终止循环。
+        """
+        response = ctx.response
+
+        # 非 AIMessage 直接结束
+        if not isinstance(response, AIMessage):
+            return ctx
+
+        route = self.validate_response(ctx)
+
+        # 终端路由：正常返回，不抛异常
+        if route == ResponseRoute.NORMAL_COMPLETION:
+            return ctx
+        if route == ResponseRoute.TOOL_EXECUTION:
+            return ctx
+
+        # 工具后空响应 → 发送提示
+        if route == ResponseRoute.RECOVERY_NUDGE:
+            ctx.messages.append(AIMessage(content="(empty)"))
+            ctx.messages.append(HumanMessage(content=RECOVERY_NUDGE_PROMPT))
+            ctx.model_chain_state.post_tool_empty_retried = True
+            raise RecoveryNudgeError(response)
+
+        # 仅思考响应 → 追加 prefill
+        if route == ResponseRoute.RECOVERY_PREFILL:
+            ctx.messages.append(
+                AIMessage(
+                    content=response.content or "",
+                    response_metadata={"finish_reason": "incomplete"},
+                )
+            )
+            ctx.model_chain_state.thinking_prefill_retries += 1
+            raise RecoveryPrefillError(response)
+
+        # 截断响应 → 继续或重建 chain
+        if route == ResponseRoute.RECOVERY_TRUNCATION:
+            content = response.content or ""
+
+            # 思考预算耗尽
+            if isinstance(content, str) and detect_thinking_exhaustion(content):
+                logger.warning("Recovery: thinking-budget exhaustion detected")
+                ctx.response = AIMessage(content=THINKING_EXHAUSTED_MESSAGE)
+                return ctx
+
+            # 工具调用截断：设置 max_tokens_override，下次 _call_llm 会使用增强的 max_tokens
+            if response.tool_calls:
+                ctx.model_chain_state.truncated_tool_call_retries += 1
+                multiplier = min(ctx.model_chain_state.truncated_tool_call_retries + 1, 3)
+                boosted_max_tokens = min(32768, multiplier * 8192)
+                logger.info(
+                    "Recovery: truncated tool call (retry %d/%d), boosting max_tokens to %d",
+                    ctx.model_chain_state.truncated_tool_call_retries,
+                    ctx.model_chain_state.max_truncated_tool_call_retries,
+                    boosted_max_tokens,
+                )
+                ctx.model_chain_state.max_tokens_override = boosted_max_tokens
+            else:
+                # 仅文本截断：追加临时内容 + 续行提示
+                ctx.model_chain_state.length_continue_retries += 1
+                ctx.messages.append(
+                    AIMessage(
+                        content=content,
+                        response_metadata={"finish_reason": "incomplete"},
+                    )
+                )
+                ctx.messages.append(HumanMessage(content=TRUNCATION_CONTINUE_PROMPT))
+
+            raise TruncationError(response)
+
+        # 空内容重试
+        if route == ResponseRoute.RECOVERY_RETRY:
+            ctx.model_chain_state.empty_content_retries += 1
+            logger.info(
+                "Recovery retry: empty_content_retries=%d/%d",
+                ctx.model_chain_state.empty_content_retries,
+                ctx.model_chain_state.max_empty_retries,
+            )
+            raise RecoveryRetryError(response)
+
+        # 兜底：终止
+        return ctx

--- a/src/agent/aidev_agent/core/nodes/model/quality_gate.py
+++ b/src/agent/aidev_agent/core/nodes/model/quality_gate.py
@@ -109,7 +109,8 @@ class QualityGate:
     # 判断系统提示词——类属性，子类可重写
     judgment_sys_prompt: str = """你是一个任务完成度判断器。我会给你以下信息：
 1. 用户的最后一条输入
-2. 智能助手的最后一条输出
+2. 智能助手回答过程中调用的工具及其参数（如有）
+3. 智能助手的最后一条输出
 
 你需要判断智能助手的输出是否实际完成了用户输入中要求的任务，以便于放行用户继续提问
 完成任务的情况如下：
@@ -132,19 +133,19 @@ class QualityGate:
         self,
         *,
         judge_llm: BaseChatModel | None = None,
-        enable_judgment_llm: bool = True,
+        enable_judge_response: bool = True,
     ) -> None:
         """初始化质量门禁。
 
         Args:
             judge_llm: 判断用 LLM 实例。构造一次并复用（避免每次响应重建）。
                 为 None 时 fail-open（跳过判断，视为已完成）。
-            enable_judgment_llm: 是否在内容响应上调用判断 LLM。关闭后
+            enable_judge_response: 是否启用任务完成度评估。关闭后
                 ``has_content`` 分支直接返回 ``NORMAL_COMPLETION``，省去
-                每次正常响应的额外 LLM 调用。
+                每次正常响应的额外判断 LLM 调用。
         """
         self.judge_llm = judge_llm
-        self.enable_judgment_llm = enable_judgment_llm
+        self.enable_judge_response = enable_judge_response
 
     # ------------------------------------------------------------------
     # 任务完成度判断（SRE3-6-35B-A3B-nothinking judge，fail-open 语义）
@@ -157,12 +158,40 @@ class QualityGate:
                 return extract_text_from_content(msg.content)
         return None
 
+    def _extract_tool_calls_since_last_human(self, messages: list[BaseMessage]) -> list[dict]:
+        """从消息列表中提取最后一次 HumanMessage 之后发生的工具调用信息。
+
+        只提取工具名称和参数，不包含工具返回结果。
+        从最后一条 HumanMessage 开始向后扫描，收集之后所有 AIMessage 中的 tool_calls。
+
+        Returns:
+            工具调用列表，每个元素为 ``{"name": str, "args": dict}``
+        """
+        # 找到最后一条 HumanMessage 的索引
+        last_human_idx = -1
+        for i in range(len(messages) - 1, -1, -1):
+            if isinstance(messages[i], HumanMessage):
+                last_human_idx = i
+                break
+
+        if last_human_idx == -1:
+            return []
+
+        # 从 HumanMessage 之后开始收集所有 AIMessage 中的 tool_calls
+        tool_calls: list[dict] = []
+        for msg in messages[last_human_idx + 1 :]:
+            if isinstance(msg, AIMessage) and msg.tool_calls:
+                for tc in msg.tool_calls:
+                    tool_calls.append({"name": tc.get("name", ""), "args": tc.get("args", {})})
+        return tool_calls
+
     def _judge_task_completion(
         self,
         judgment_llm,
         last_user_input: str,
         last_model_output: str,
         *,
+        tool_calls: list[dict] | None = None,
         enable_custom_event: bool = True,
     ) -> bool:
         """调用判断模型评估任务是否完成。fail-open：无法确定未完成则返回 True。
@@ -171,6 +200,8 @@ class QualityGate:
             judgment_llm: 用于判断的 LLM 实例
             last_user_input: 最后一条用户输入文本
             last_model_output: 最后一条模型输出文本（已剔除 think 块）
+            tool_calls: 最后一次用户提问到 AI 回答期间调用的工具及参数列表，
+                每个元素为 ``{"name": str, "args": dict}``，不包含工具结果
             enable_custom_event: 是否派发 custom_event（用于 SSE 流期间
                 切换 ``front_end_display``，避免判断 LLM 的流式输出写入 DB
                 或显示给前端）。
@@ -181,8 +212,17 @@ class QualityGate:
         if not judgment_llm or not last_user_input or not last_model_output:
             return True  # fail-open
 
+        # 构建工具调用信息文本
+        tool_calls_text = ""
+        if tool_calls:
+            tool_lines = []
+            for tc in tool_calls:
+                tool_lines.append(f"- {tc['name']}({tc['args']})")
+            tool_calls_text = "调用的工具及参数：\n" + "\n".join(tool_lines) + "\n\n"
+
         usr_prompt = (
             f"用户最后一条输入：\n```\n{last_user_input}\n```\n\n"
+            f"{tool_calls_text}"
             f"智能助手最后一条输出：\n```\n{last_model_output}\n```\n\n"
             f"请判断智能助手是否完成了用户的任务。"
         )
@@ -219,7 +259,7 @@ class QualityGate:
         *,
         enable_custom_event: bool = True,
     ) -> bool:
-        """提取最后用户输入和模型输出，调用判断 LLM。fail-open 语义。
+        """提取最后用户输入、工具调用信息和模型输出，调用判断 LLM。fail-open 语义。
 
         Args:
             enable_custom_event: 是否派发 custom_event（透传给 _judge_task_completion）。
@@ -233,10 +273,12 @@ class QualityGate:
         last_model_output = extract_text_from_content(response.content)
         if last_model_output:
             last_model_output = strip_think_blocks(last_model_output)
+        tool_calls = self._extract_tool_calls_since_last_human(working_messages)
         return self._judge_task_completion(
             self.judge_llm,
             last_user_input,
             last_model_output,
+            tool_calls=tool_calls,
             enable_custom_event=enable_custom_event,
         )
 
@@ -267,12 +309,12 @@ class QualityGate:
         if (
             response.tool_calls
             and is_truncated(response)
-            and recovery.truncated_tool_call_retries < recovery.max_truncated_tool_call_retries
+            and recovery.truncated_tool_call_retries < recovery.max_retries
         ):
             logger.info(
                 "Recovery: truncated tool call (retry %d/%d)",
                 recovery.truncated_tool_call_retries + 1,
-                recovery.max_truncated_tool_call_retries,
+                recovery.max_retries,
             )
             return ResponseRoute.RECOVERY_TRUNCATION
 
@@ -288,7 +330,7 @@ class QualityGate:
             isinstance(content, list) and len(content) > 0
         )
         if has_content:
-            if self.enable_judgment_llm and not self._judge_response_completion(
+            if self.enable_judge_response and not self._judge_response_completion(
                 response,
                 working_messages,
                 enable_custom_event=ctx.metadata.get("enable_custom_event", True),
@@ -314,29 +356,29 @@ class QualityGate:
             or (
                 isinstance(content, str) and has_inline_thinking(content) and not has_content_after_think_block(content)
             )
-        ) and recovery.thinking_prefill_retries < recovery.max_thinking_prefill_retries:
+        ) and recovery.thinking_prefill_retries < recovery.max_retries:
             logger.info(
                 "Recovery: thinking-only response (prefill retry %d/%d)",
                 recovery.thinking_prefill_retries + 1,
-                recovery.max_thinking_prefill_retries,
+                recovery.max_retries,
             )
             return ResponseRoute.RECOVERY_PREFILL
 
         # 6. 截断：finish_reason == "length"。
-        if is_truncated(response) and recovery.length_continue_retries < recovery.max_truncation_retries:
+        if is_truncated(response) and recovery.length_continue_retries < recovery.max_retries:
             logger.info(
                 "Recovery: truncated response (retry %d/%d)",
                 recovery.length_continue_retries + 1,
-                recovery.max_truncation_retries,
+                recovery.max_retries,
             )
             return ResponseRoute.RECOVERY_TRUNCATION
 
         # 7. 空内容重试。
-        if recovery.empty_content_retries < recovery.max_empty_retries:
+        if recovery.empty_content_retries < recovery.max_retries:
             logger.info(
                 "Recovery: empty content (retry %d/%d)",
                 recovery.empty_content_retries + 1,
-                recovery.max_empty_retries,
+                recovery.max_retries,
             )
             return ResponseRoute.RECOVERY_RETRY
 
@@ -404,7 +446,7 @@ class QualityGate:
                 logger.info(
                     "Recovery: truncated tool call (retry %d/%d), boosting max_tokens to %d",
                     ctx.model_chain_state.truncated_tool_call_retries,
-                    ctx.model_chain_state.max_truncated_tool_call_retries,
+                    ctx.model_chain_state.max_retries,
                     boosted_max_tokens,
                 )
                 ctx.model_chain_state.max_tokens_override = boosted_max_tokens
@@ -427,7 +469,7 @@ class QualityGate:
             logger.info(
                 "Recovery retry: empty_content_retries=%d/%d",
                 ctx.model_chain_state.empty_content_retries,
-                ctx.model_chain_state.max_empty_retries,
+                ctx.model_chain_state.max_retries,
             )
             raise RecoveryRetryError(response)
 

--- a/src/agent/aidev_agent/core/nodes/model/tool_call_repair.py
+++ b/src/agent/aidev_agent/core/nodes/model/tool_call_repair.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueKing - AIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Tool name pattern: alphanumeric, underscore, hyphen
+_TOOL_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
+# XML-ish function name pattern
+_XML_FUNC_NAME_RE = re.compile(r"[A-Za-z0-9_.:\-]{1,120}")
+# XML-ish parameter name pattern
+_XML_PARAM_NAME_RE = re.compile(r"[A-Za-z0-9_.:\-]{1,120}")
+
+
+@dataclass
+class ParsedToolCall:
+    """Represents a single tool call parsed from plain text."""
+
+    name: str
+    arguments: dict
+
+
+def parse_standalone_plain_text_tool_call_blocks(
+    text: str,
+    allowed_tool_names: set[str],
+) -> list[ParsedToolCall] | None:
+    """Parse plain-text tool call blocks, returning a list only if ALL text is consumed.
+
+    Tries three parser formats at each position (bracket, harmony, XML-ish).
+    If any portion of the text cannot be parsed as a valid tool call, returns None
+    (all-or-nothing semantics). Tool names must match ``allowed_tool_names``
+    case-insensitively.
+
+    Args:
+        text: The full text to parse.
+        allowed_tool_names: Set of valid tool names (case-insensitive matching).
+
+    Returns:
+        A list of ParsedToolCall if all text is consumed as valid tool calls,
+        or None if any portion fails.
+    """
+    if not text or not text.strip():
+        return None
+
+    # Build a case-insensitive lookup: lowered_name -> canonical_name
+    name_lookup: dict[str, str] = {n.lower(): n for n in allowed_tool_names}
+
+    results: list[ParsedToolCall] = []
+    cursor = 0
+    length = len(text)
+
+    while cursor < length:
+        # Skip leading whitespace / newlines between blocks
+        while cursor < length and text[cursor] in (" ", "\t", "\n", "\r"):
+            cursor += 1
+        if cursor >= length:
+            break
+
+        # Try each parser in order
+        parsed, new_cursor = _try_bracket_format(text, cursor, name_lookup)
+        if parsed is not None:
+            results.append(parsed)
+            cursor = new_cursor
+            continue
+
+        parsed, new_cursor = _try_harmony_format(text, cursor, name_lookup)
+        if parsed is not None:
+            results.append(parsed)
+            cursor = new_cursor
+            continue
+
+        parsed, new_cursor = _try_xml_format(text, cursor, name_lookup)
+        if parsed is not None:
+            results.append(parsed)
+            cursor = new_cursor
+            continue
+
+        # No parser matched — not all text is tool calls
+        return None
+
+    if not results:
+        return None
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Bracket Format Parser
+# ---------------------------------------------------------------------------
+
+
+def _try_bracket_format(
+    text: str,
+    cursor: int,
+    name_lookup: dict[str, str],
+) -> tuple[ParsedToolCall | None, int]:
+    """Try parsing a bracket-format tool call at *cursor*.
+
+    Patterns::
+
+        [tool:name]{"arg": "val"}
+        [name]\\n{"arg": "val"}
+
+    With optional closing markers: ``[END_TOOL_REQUEST]`` or ``[/name]``.
+    """
+    if cursor >= len(text) or text[cursor] != "[":
+        return None, cursor
+
+    # --- Parse header ---
+    # Check for [tool:name] variant
+    tool_prefix_match = re.match(r"\[tool:", text[cursor:])
+    if tool_prefix_match:
+        name_start = cursor + len("[tool:")
+        m = _TOOL_NAME_RE.match(text, name_start)
+        if not m or m.end() >= len(text) or text[m.end()] != "]":
+            return None, cursor
+        name = m.group()
+        pos = m.end() + 1  # skip ']'
+        # No line break required after [tool:name]
+    else:
+        # Plain [name] variant
+        m = _TOOL_NAME_RE.match(text, cursor + 1)
+        if not m or m.end() >= len(text) or text[m.end()] != "]":
+            return None, cursor
+        name = m.group()
+        pos = m.end() + 1  # skip ']'
+        # Require a line break after ]
+        if pos < len(text) and text[pos] == "\n":
+            pos += 1
+        elif pos < len(text) and text[pos] == "\r":
+            pos += 1
+            if pos < len(text) and text[pos] == "\n":
+                pos += 1
+        else:
+            # No line break after plain [name] — not a bracket format
+            return None, cursor
+
+    # Validate name against allowed
+    canonical = name_lookup.get(name.lower())
+    if canonical is None:
+        return None, cursor
+
+    # --- Find JSON object ---
+    json_obj, pos = _extract_json_object(text, pos)
+    if json_obj is None:
+        return None, cursor
+
+    # --- Optional closing markers ---
+    saved_pos = pos
+    pos = _skip_whitespace(text, pos)
+
+    # Try [END_TOOL_REQUEST]
+    if text[pos:].startswith("[END_TOOL_REQUEST]"):
+        pos += len("[END_TOOL_REQUEST]")
+        pos = _skip_whitespace(text, pos)
+    # Try [/name]
+    elif text[pos:].startswith(f"[/{name}]"):
+        pos += len(f"[/{name}]")
+        pos = _skip_whitespace(text, pos)
+    else:
+        pos = saved_pos
+
+    return ParsedToolCall(name=canonical, arguments=json_obj), pos
+
+
+# ---------------------------------------------------------------------------
+# Harmony Format Parser
+# ---------------------------------------------------------------------------
+
+
+def _try_harmony_format(
+    text: str,
+    cursor: int,
+    name_lookup: dict[str, str],
+) -> tuple[ParsedToolCall | None, int]:
+    """Try parsing a harmony-format tool call at *cursor*.
+
+    Pattern::
+
+        [<|channel|>]commentary|analysis|final to=tool_name code [<|message|>]
+        {"arg": "val"}
+
+    With optional ``<|call|>`` closing marker.
+    """
+    pos = cursor
+
+    # Optional opening '[' bracket
+    if pos < len(text) and text[pos] == "[":
+        pos += 1
+
+    # Optional <|channel|> prefix
+    if text[pos:].startswith("<|channel|>"):
+        pos += len("<|channel|>")
+        # Skip optional closing ']' after channel marker
+        if pos < len(text) and text[pos] == "]":
+            pos += 1
+
+    # Channel keyword: commentary, analysis, or final
+    for kw in ("commentary", "analysis", "final"):
+        if text[pos:].startswith(kw):
+            pos += len(kw)
+            break
+    else:
+        return None, cursor
+
+    # Skip whitespace
+    pos = _skip_whitespace(text, pos)
+
+    # to=tool_name
+    if not text[pos:].startswith("to="):
+        return None, cursor
+    pos += len("to=")
+
+    m = _TOOL_NAME_RE.match(text, pos)
+    if not m:
+        return None, cursor
+    name = m.group()
+    pos = m.end()
+
+    # Validate name
+    canonical = name_lookup.get(name.lower())
+    if canonical is None:
+        return None, cursor
+
+    # Skip whitespace
+    pos = _skip_whitespace(text, pos)
+
+    # "code" keyword
+    if not text[pos:].startswith("code"):
+        return None, cursor
+    pos += len("code")
+
+    # Skip whitespace
+    pos = _skip_whitespace(text, pos)
+
+    # Optional [<|message|>] or <|message|> marker
+    if text[pos:].startswith("[<|message|>]"):
+        pos += len("[<|message|>]")
+    elif text[pos:].startswith("<|message|>"):
+        pos += len("<|message|>")
+
+    # Skip whitespace/newlines
+    pos = _skip_whitespace(text, pos)
+
+    # --- Find JSON object ---
+    json_obj, pos = _extract_json_object(text, pos)
+    if json_obj is None:
+        return None, cursor
+
+    # --- Optional <|call|> closing ---
+    saved_pos = pos
+    pos = _skip_whitespace(text, pos)
+    if text[pos:].startswith("<|call|>"):
+        pos += len("<|call|>")
+    else:
+        pos = saved_pos
+
+    return ParsedToolCall(name=canonical, arguments=json_obj), pos
+
+
+# ---------------------------------------------------------------------------
+# XML-ish Format Parser
+# ---------------------------------------------------------------------------
+
+
+def _try_xml_format(
+    text: str,
+    cursor: int,
+    name_lookup: dict[str, str],
+) -> tuple[ParsedToolCall | None, int]:
+    """Try parsing an XML-ish format tool call at *cursor*.
+
+    Pattern::
+
+        <function=tool_name>
+          <parameter=key>value</parameter>
+        </function>
+    """
+    pos = cursor
+
+    # Opening: <function=name>
+    if not text[pos:].startswith("<function="):
+        return None, cursor
+    pos += len("<function=")
+
+    m = _XML_FUNC_NAME_RE.match(text, pos)
+    if not m or pos + len(m.group()) >= len(text) or text[pos + len(m.group())] != ">":
+        return None, cursor
+    name = m.group()
+    pos += len(m.group()) + 1  # skip '>'
+
+    # Validate name
+    canonical = name_lookup.get(name.lower())
+    if canonical is None:
+        return None, cursor
+
+    # Parse parameters
+    args: dict = {}
+    while pos < len(text):
+        # Skip whitespace
+        pos = _skip_whitespace(text, pos)
+
+        # Check for closing </function>
+        if text[pos:].startswith("</function>"):
+            pos += len("</function>")
+            return ParsedToolCall(name=canonical, arguments=args), pos
+
+        # Check for <parameter=key>
+        if not text[pos:].startswith("<parameter="):
+            # Unknown content — fail
+            return None, cursor
+        pos += len("<parameter=")
+
+        pm = _XML_PARAM_NAME_RE.match(text, pos)
+        if not pm or pos + len(pm.group()) >= len(text) or text[pos + len(pm.group())] != ">":
+            return None, cursor
+        param_name = pm.group()
+        pos += len(pm.group()) + 1  # skip '>'
+
+        # Read raw value until </parameter> (case-insensitive close)
+        close_tag = "</parameter>"
+        close_idx = text.lower().find(close_tag.lower(), pos)
+        if close_idx == -1:
+            return None, cursor
+
+        value = text[pos:close_idx]
+        # Strip leading/trailing line breaks from parameter values
+        value = value.strip("\n\r")
+        # Try to parse as JSON for type consistency with bracket/harmony formats
+        try:
+            parsed_value = json.loads(value)
+            if isinstance(parsed_value, (dict, list, int, float, bool)):
+                args[param_name] = parsed_value
+            else:
+                args[param_name] = value
+        except (json.JSONDecodeError, ValueError):
+            args[param_name] = value
+        pos = close_idx + len(close_tag)
+
+    # Reached end without </function>
+    return None, cursor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _skip_whitespace(text: str, pos: int) -> int:
+    """Advance *pos* past whitespace characters."""
+    while pos < len(text) and text[pos] in (" ", "\t", "\n", "\r"):
+        pos += 1
+    return pos
+
+
+def _extract_json_object(text: str, pos: int) -> tuple[dict | None, int]:
+    """Extract a JSON object ``{...}`` starting at *pos* using balanced brace counting.
+
+    Returns (parsed_dict, new_pos) or (None, pos) on failure.
+    """
+    # Skip whitespace before JSON
+    while pos < len(text) and text[pos] in (" ", "\t", "\n", "\r"):
+        pos += 1
+
+    if pos >= len(text) or text[pos] != "{":
+        return None, pos
+
+    start = pos
+    depth = 0
+    in_string = False
+    escape_next = False
+
+    while pos < len(text):
+        ch = text[pos]
+        if escape_next:
+            escape_next = False
+            pos += 1
+            continue
+        if ch == "\\":
+            if in_string:
+                escape_next = True
+            pos += 1
+            continue
+        if ch == '"':
+            in_string = not in_string
+            pos += 1
+            continue
+        if in_string:
+            pos += 1
+            continue
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                pos += 1
+                json_str = text[start:pos]
+                try:
+                    obj = json.loads(json_str)
+                    if isinstance(obj, dict):
+                        return obj, pos
+                except json.JSONDecodeError:
+                    pass
+                return None, start
+        pos += 1
+
+    return None, start

--- a/src/agent/aidev_agent/core/nodes/model/utils.py
+++ b/src/agent/aidev_agent/core/nodes/model/utils.py
@@ -82,8 +82,18 @@ def is_truncated(message: AIMessage) -> bool:
 
 
 def has_prior_tool_results(messages: list[BaseMessage]) -> bool:
-    """如果最近消息中有 ToolMessage 条目，返回 ``True``。"""
-    for msg in reversed(messages[:-1]):
+    """如果从消息列表末尾向前扫描时遇到 ToolMessage，返回 ``True``。
+
+    遍历完整的 ``messages`` 列表（不排除最后一条）——因为 ``ctx.response``
+    是独立字段（``ctx.response = response``），不会追加到 ``ctx.messages``。
+    在 ReAct 循环工具执行后，``ctx.messages`` 末尾正是 ToolMessage（工具结果），
+    必须将其纳入扫描，否则会误判为"无前置工具结果"。
+
+    扫描语义：从末尾向前逐条检查，遇到 ToolMessage 立即返回 True；
+    遇到 HumanMessage 则 break（认为已回到新一轮用户输入，不再向前追溯）；
+    遇到 AIMessage 继续向前扫描。
+    """
+    for msg in reversed(messages):
         if isinstance(msg, ToolMessage):
             return True
         if isinstance(msg, HumanMessage):

--- a/src/agent/aidev_agent/core/nodes/model/utils.py
+++ b/src/agent/aidev_agent/core/nodes/model/utils.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueKing - AIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import Any
+
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, ToolMessage
+
+from .tool_call_repair import parse_standalone_plain_text_tool_call_blocks
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# 思考块与截断辅助函数
+# ---------------------------------------------------------------------------
+
+# 匹配完整的 think/thinking/reasoning 块，支持多行内容。
+_THINK_BLOCK_RE = re.compile(
+    r"<(think|thinking|reasoning)>.*?</\1>",
+    re.DOTALL | re.IGNORECASE,
+)
+
+_THINK_OPEN_TAG_RE = re.compile(
+    r"<(?:think|thinking|reasoning)>",
+    re.IGNORECASE,
+)
+
+
+def strip_think_blocks(content: str) -> str:
+    """从内容中移除 ``<think>...</think>``、``<thinking>...</thinking>`` 和
+    ``<reasoning>...</reasoning>`` 标签块。
+    """
+    return _THINK_BLOCK_RE.sub("", content).strip()
+
+
+def has_inline_thinking(content: str) -> bool:
+    """如果内容包含开启的推理/思考标签，返回 ``True``。"""
+    return bool(_THINK_OPEN_TAG_RE.search(content))
+
+
+def has_content_after_think_block(content: str) -> bool:
+    """如果内容在 think 块外有非空文本，返回 ``True``。"""
+    if not content:
+        return False
+    stripped = strip_think_blocks(content)
+    return bool(stripped)
+
+
+def detect_thinking_exhaustion(content: str) -> bool:
+    """如果内容有 think 标签但剔除后无内容，返回 ``True``。
+
+    这表明模型将所有输出 token 用于推理。
+    """
+    if not content:
+        return False
+    return has_inline_thinking(content) and not has_content_after_think_block(content)
+
+
+def is_truncated(message: AIMessage) -> bool:
+    """如果消息被截断（finish_reason == ``"length"``），返回 ``True``。"""
+    finish_reason = message.response_metadata.get("finish_reason", "")
+    return finish_reason == "length"
+
+
+def has_prior_tool_results(messages: list[BaseMessage]) -> bool:
+    """如果最近消息中有 ToolMessage 条目，返回 ``True``。"""
+    for msg in reversed(messages[:-1]):
+        if isinstance(msg, ToolMessage):
+            return True
+        if isinstance(msg, HumanMessage):
+            break
+    return False
+
+
+# ---------------------------------------------------------------------------
+# 纯文本工具调用提升
+# ---------------------------------------------------------------------------
+
+
+def extract_text_from_content(content: Any) -> str | None:
+    """从消息内容中提取文本，同时处理字符串和列表格式。
+
+    参数：
+        content: 普通字符串或内容块列表。
+
+    返回：
+        去除首尾空白后的文本内容；如果没有文本则返回 None。
+    """
+    if isinstance(content, str):
+        text = content.strip()
+        return text if text else None
+
+    if isinstance(content, list):
+        text_parts: list[str] = []
+        for block in content:
+            if isinstance(block, dict) and block.get("type") == "text":
+                block_text = block.get("text", "")
+                if isinstance(block_text, str):
+                    text_parts.append(block_text)
+        joined = "".join(text_parts).strip()
+        return joined if joined else None
+
+    return None
+
+
+def should_promote_message(message: AIMessage, allowed_tool_names: set[str]) -> bool:
+    """判断纯文本工具调用是否应提升为原生 tool_calls。
+
+    参数：
+        message: 待评估的 AI 消息。
+        allowed_tool_names: 有效工具名称集合，用于大小写不敏感匹配。
+
+    返回：
+        如果消息看起来包含应提升的纯文本工具调用，则返回 True；否则 False。
+    """
+    if not allowed_tool_names:
+        return False
+
+    if not isinstance(message, AIMessage):
+        return False
+
+    # 仅在消息有文本内容但没有原生 tool_calls 时提升。
+    if message.tool_calls:
+        return False
+
+    text = extract_text_from_content(message.content)
+    if not text:
+        return False
+
+    # 仅在停止原因表明未使用工具时提升。当模型已经打算使用工具时，
+    # 通常会将 finish_reason 设为 "tool_calls" 或类似值；这种情况下无需提升。
+    finish_reason = ""
+    if message.response_metadata:
+        finish_reason = str(message.response_metadata.get("finish_reason", "")).lower()
+    return finish_reason not in ("tool_calls", "tool_call", "function_call")
+
+
+def promote_plain_text_tool_call_message(
+    message: AIMessage,
+    allowed_tool_names: set[str],
+) -> AIMessage:
+    """尝试将 *message* 中的纯文本工具调用提升为原生 ``tool_calls``。
+
+    如果提升成功，返回一个新的 ``AIMessage``，其中：
+    - ``content`` 保留原始内容。
+    - ``tool_calls`` 填充解析出的工具调用。
+    - ``response_metadata`` 更新为包含 ``promoted_from_plain_text: True``。
+
+    如果提升失败（或不适用），则原样返回 *message*。
+
+    参数：
+        message: 可能需要提升的 AI 消息。
+        allowed_tool_names: 用于匹配的有效工具名称集合。
+
+    返回：
+        包含已提升 tool_calls 的新 AIMessage，或原始消息。
+    """
+    if not should_promote_message(message, allowed_tool_names):
+        return message
+
+    text = extract_text_from_content(message.content)
+    if text is None:
+        return message
+
+    parsed = parse_standalone_plain_text_tool_call_blocks(text, allowed_tool_names)
+    if parsed is None:
+        logger.debug("promote: no plain-text tool calls found in message")
+        return message
+
+    # 构建 tool_calls 列表。
+    tool_calls: list[dict[str, Any]] = []
+    for p in parsed:
+        tool_calls.append(
+            {
+                "name": p.name,
+                "args": p.arguments,
+                "id": f"call_{uuid.uuid4().hex[:24]}",
+            }
+        )
+
+    # 保留原始内容；字符串保持字符串，列表内容块保持列表。
+    content = message.content
+
+    # 标记 response_metadata，便于下游识别提升来源。
+    new_metadata = {**(message.response_metadata or {}), "promoted_from_plain_text": True}
+
+    new_message = AIMessage(
+        content=content,
+        tool_calls=tool_calls,
+        response_metadata=new_metadata,
+        id=message.id,
+    )
+
+    logger.info(
+        "promote: promoted %d plain-text tool call(s) to native format",
+        len(tool_calls),
+    )
+    return new_message

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -338,6 +338,10 @@ class AgentExecutorKwargs(BaseModel):
         default=None, description="用于知识检索的模型（BaseChatModel；未设置时通常与 llm 相同）"
     )
     non_thinking_llm: Optional[Any] = Field(default=None, description="非深度思考模型（BaseChatModel 或 str）")
+    fast_llm: Optional[Any] = Field(
+        default=None,
+        description="快速/轻量模型（BaseChatModel），用于 quality_gate 判断 LLM 等辅助任务；未设置时回退到 non_thinking_llm",
+    )
 
     # 模型上下文配置（由上层从 AgentConfig 转换而来，控制 LLM 推理行为）
     model_context_options: Optional[ModelContextSettings] = Field(

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -99,6 +99,9 @@ class ChatCompletionAgent(BaseModel):
     种子实例不可执行（``execute()`` 假设非空）。"""
     chat_model_non_thinking: BaseChatModel | None = None
     """非思考模型；由 :meth:`ChatAgentBuilder.build_chat_model_non_thinking` 填充。"""
+    chat_model_fast: BaseChatModel | None = None
+    """快速/轻量模型；由 :meth:`ChatAgentBuilder.build_chat_model_fast` 填充。
+    用于 quality_gate 判断 LLM 等辅助任务。"""
     non_thinking_llm: str | None = Field(default=None, deprecated="使用 chat_model_non_thinking 替代")
     chat_history: list[ChatPrompt] | None = None
     files: list[dict] = Field(default_factory=list)
@@ -166,6 +169,7 @@ class ChatCompletionAgent(BaseModel):
         # 构建 chat_model 和 chat_model_non_thinking
         self.chat_model = builder.build_chat_model()
         self.chat_model_non_thinking = builder.build_chat_model_non_thinking()
+        self.chat_model_fast = builder.build_chat_model_fast()
         # 构建需要依赖resource_manager的资源
         self.resource_manager = ctx.resource_manager
         self.skills = builder.build_skills()
@@ -308,7 +312,7 @@ class ChatCompletionAgent(BaseModel):
         }
 
         header_value = json.dumps(attrs, ensure_ascii=True)
-        for model in (self.chat_model, self.chat_model_non_thinking):
+        for model in (self.chat_model, self.chat_model_non_thinking, self.chat_model_fast):
             if model is None or not hasattr(model, "default_headers"):
                 continue
             if model.default_headers is None:
@@ -968,6 +972,7 @@ class ChatCompletionAgent(BaseModel):
         return self.agent_cls.get_agent_executor(
             llm=self.chat_model,
             non_thinking_llm=self.chat_model_non_thinking or self.chat_model,
+            fast_llm=self.chat_model_fast,
             extra_tools=self.tools,
             chat_history=messages[:-1],
             tool_execution_interval=self.TOOL_EXECUTION_INTERVAL,
@@ -1136,6 +1141,9 @@ class ChatAgentBuilder:
         if self.ctx.session_code:
             kwargs["session_code"] = self.ctx.session_code
 
+        if settings.LLM_RETRY_STRATEGY == "sdk":
+            kwargs["max_retries"] = 0
+
         return ChatModel.get_setup_instance(**kwargs)
 
     def build_chat_model_non_thinking(self) -> BaseChatModel | None:
@@ -1150,6 +1158,35 @@ class ChatAgentBuilder:
         chat = self.ctx.chat or ChatBuildExtras()
         if chat.auth_headers:
             kwargs["auth_headers"] = chat.auth_headers
+
+        if settings.LLM_RETRY_STRATEGY == "sdk":
+            kwargs["max_retries"] = 0
+
+        return ChatModel.get_setup_instance(**kwargs)
+
+    def build_chat_model_fast(self) -> BaseChatModel | None:
+        """构建快速/轻量模型（用于 quality_gate 判断 LLM 等辅助任务）。
+
+        当前从环境变量 ``settings.JUDGMENT_LLM_MODEL`` 读取模型名（默认
+        ``SRE3-6-35B-A3B-nothinking``）。待配置平台改造完成后，改为从
+        ``agent_config.fast_llm`` 读取（与 ``build_chat_model_non_thinking``
+        读 ``agent_config.non_thinking_llm`` 对称）。
+        """
+        model_name = settings.JUDGMENT_LLM_MODEL
+        base_url = settings.LLM_GW_ENDPOINT
+        if not model_name or not base_url:
+            return None
+        kwargs: dict[str, Any] = {
+            "model": model_name,
+            "base_url": base_url,
+        }
+        chat = self.ctx.chat or ChatBuildExtras()
+        if chat.auth_headers:
+            kwargs["auth_headers"] = chat.auth_headers
+
+        if settings.LLM_RETRY_STRATEGY == "sdk":
+            kwargs["max_retries"] = 0
+
         return ChatModel.get_setup_instance(**kwargs)
 
     def build_chat_history(self, session_context_data: List[dict]) -> List[ChatPrompt]:

--- a/src/agent/tests/api/test_bk_agent.py
+++ b/src/agent/tests/api/test_bk_agent.py
@@ -1,9 +1,29 @@
 # -*- coding: utf-8 -*-
-"""BkAgentApi 客户端单元测试。"""
+"""BkAgentApi 客户端单元测试."""
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 from aidev_agent.api.bk_agent import BkAgentApi, Client
+
+
+@pytest.fixture
+def configured_api_url_tmpl(monkeypatch):
+    """设置 BK_API_URL_TMPL 模板并重算 APIGW_URL_FORMAT。
+
+    测试环境未配置 BK_API_URL_TMPL（为 None），导致 APIGW_URL_FORMAT
+    退化为 "None/{stage}"，get_endpoint 的 api_name 参数被忽略。
+    本 fixture 提供一个含 {api_name} 的真实模板，使 get_endpoint 正常工作。
+    """
+    tmpl = "http://{api_name}.test.com"
+    monkeypatch.setattr("aidev_agent.api.constants.settings.BK_API_URL_TMPL", tmpl)
+    monkeypatch.setattr(
+        "aidev_agent.api.constants.APIGW_URL_FORMAT",
+        "{}/{{stage}}".format(tmpl),
+    )
+    # bk_agent.py / utils.py 已 import APIGW_URL_FORMAT，需同步 patch
+    monkeypatch.setattr("aidev_agent.api.bk_agent.APIGW_URL_FORMAT", "{}/{{stage}}".format(tmpl))
+    monkeypatch.setattr("aidev_agent.api.utils.APIGW_URL_FORMAT", "{}/{{stage}}".format(tmpl))
 
 
 class TestClientOperations:
@@ -45,7 +65,7 @@ class TestBkAgentApiGetClient:
         mock_get_client.assert_called_once()
 
     @patch("aidev_agent.api.bk_agent._get_client_by_settings")
-    def test_get_client_endpoint_contains_bp_prefix(self, mock_get_client: MagicMock) -> None:
+    def test_get_client_endpoint_contains_bp_prefix(self, mock_get_client: MagicMock, configured_api_url_tmpl) -> None:
         """get_client(agent_code='my_agent') 的 endpoint 包含 bp-my_agent。"""
         mock_client = MagicMock(spec=Client)
         mock_get_client.return_value = mock_client
@@ -160,7 +180,9 @@ class TestBkAgentApiValidateEndpoint:
         assert call_kwargs.kwargs["endpoint"] == "http://host/bp-test/"
 
     @patch("aidev_agent.api.bk_agent._get_client_by_settings")
-    def test_validate_endpoint_with_empty_endpoint_noop(self, mock_get_client: MagicMock) -> None:
+    def test_validate_endpoint_with_empty_endpoint_noop(
+        self, mock_get_client: MagicMock, configured_api_url_tmpl
+    ) -> None:
         """validate_endpoint=True 但 endpoint 为空时，不触发校验，正常自动构建。"""
         mock_client = MagicMock(spec=Client)
         mock_get_client.return_value = mock_client

--- a/src/agent/tests/core/graphs/test_react.py
+++ b/src/agent/tests/core/graphs/test_react.py
@@ -486,7 +486,7 @@ class TestReActAgentBuilder:
 
         captured_tools = {}
 
-        def _fake_make_model_node(*, llm, non_thinking_llm, tools, node_options):
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
             captured_tools["tools"] = tools
             return MagicMock()
 
@@ -522,7 +522,7 @@ class TestReActAgentBuilder:
 
         captured_tools = {}
 
-        def _fake_make_model_node(*, llm, non_thinking_llm, tools, node_options):
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
             captured_tools["tools"] = tools
             return MagicMock()
 
@@ -596,7 +596,7 @@ class TestReActAgentBuilder:
 
         captured_node_options = {}
 
-        def _fake_make_model_node(*, llm, non_thinking_llm, tools, node_options):
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
             captured_node_options["opts"] = node_options
             return MagicMock()
 
@@ -1171,7 +1171,7 @@ class TestReActAgentBuilder:
 
         captured = {}
 
-        def _fake_make_model_node(*, llm, non_thinking_llm, tools, node_options):
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
             captured["non_thinking_llm"] = non_thinking_llm
             return MagicMock()
 

--- a/src/agent/tests/core/nodes/model/test_model_chain.py
+++ b/src/agent/tests/core/nodes/model/test_model_chain.py
@@ -16,21 +16,23 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 import httpx
 import pytest
-from aidev_agent.core.nodes.model.model_chain import _build_effective_chain, _build_model_chain
+from aidev_agent.core.nodes.model.model_chain import _build_model_chain, build_llm_with_tools
 from aidev_agent.core.nodes.model.pydantic_models import (
-    ModelChainConfig,
     ModelChainState,
     ProcessorContext,
 )
 from aidev_agent.core.nodes.model.quality_gate import QualityGate
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
-from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSequence
-from langchain_core.tools import BaseTool
+from langchain_core.runnables import RunnableBinding, RunnableConfig, RunnableLambda, RunnableSequence
+from langchain_core.tools import BaseTool, StructuredTool
+from langchain_openai import ChatOpenAI
 from openai import RateLimitError
+from pydantic import PrivateAttr
 
 # ---------------------------------------------------------------------------
 # 辅助函数
@@ -97,14 +99,13 @@ class TestModelChain:
     def test_normal_completion_first_try(self, mock_context_assembly):
         """测试正常完成：LLM 返回有效内容 → 不重试，直接返回"""
         mock_llm = _make_response_queue_llm([AIMessage(content="Hello, world!")])
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
 
         chain = _build_model_chain(
             llm=mock_llm,
             context_assembly=mock_context_assembly,
-            model_chain_config=model_chain_config,
-            quality_gate=QualityGate(enable_judgment_llm=False),
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
             use_structured_response=False,
             enable_parallel_tool_calls=False,
             use_tool_call_promotion=False,
@@ -115,15 +116,13 @@ class TestModelChain:
             config=RunnableConfig(),
             store=Mock(),
             messages=[],
-            model_chain_state=ModelChainState(max_empty_retries=3),
+            model_chain_state=ModelChainState(max_retries=3),
             response=None,
         )
 
         result = chain.invoke(initial_ctx)
         assert result.response.content == "Hello, world!"
         assert mock_llm._invoke_count[0] == 1
-
-    def test_empty_then_success_after_retry(self, mock_context_assembly):
         """测试空内容重试后成功：首次空 → retry → 第二次有内容"""
         mock_llm = _make_response_queue_llm(
             [
@@ -131,15 +130,14 @@ class TestModelChain:
                 AIMessage(content="重试后成功"),
             ]
         )
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         # plan 04 后 _render_messages 是链头，覆盖 ctx.messages——设置渲染输出
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
 
         chain = _build_model_chain(
             llm=mock_llm,
             context_assembly=mock_context_assembly,
-            model_chain_config=model_chain_config,
-            quality_gate=QualityGate(enable_judgment_llm=False),
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
             use_structured_response=False,
             enable_parallel_tool_calls=False,
             use_tool_call_promotion=False,
@@ -150,7 +148,7 @@ class TestModelChain:
             config=RunnableConfig(),
             store=Mock(),
             messages=[],
-            model_chain_state=ModelChainState(max_empty_retries=3),
+            model_chain_state=ModelChainState(max_retries=3),
             response=None,
         )
 
@@ -168,14 +166,13 @@ class TestModelChain:
                 AIMessage(content="", tool_calls=[]),
             ]
         )
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
 
         chain = _build_model_chain(
             llm=mock_llm,
             context_assembly=mock_context_assembly,
-            model_chain_config=model_chain_config,
-            quality_gate=QualityGate(enable_judgment_llm=False),
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
             use_structured_response=False,
             enable_parallel_tool_calls=False,
             use_tool_call_promotion=False,
@@ -186,7 +183,7 @@ class TestModelChain:
             config=RunnableConfig(),
             store=Mock(),
             messages=[],
-            model_chain_state=ModelChainState(max_empty_retries=3),
+            model_chain_state=ModelChainState(max_retries=3),
             response=None,
         )
 
@@ -208,7 +205,6 @@ class TestModelChain:
         mock_llm.bind_tools = Mock(return_value=mock_llm)
         mock_llm._invoke_count = invoke_counter
 
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
 
         with (
@@ -218,8 +214,8 @@ class TestModelChain:
             chain = _build_model_chain(
                 llm=mock_llm,
                 context_assembly=mock_context_assembly,
-                model_chain_config=model_chain_config,
-                quality_gate=QualityGate(enable_judgment_llm=False),
+                max_retries=3,
+                quality_gate=QualityGate(enable_judge_response=False),
                 use_structured_response=False,
                 enable_parallel_tool_calls=False,
                 use_tool_call_promotion=False,
@@ -230,7 +226,7 @@ class TestModelChain:
                 config=RunnableConfig(),
                 store=Mock(),
                 messages=[],
-                model_chain_state=ModelChainState(max_empty_retries=3),
+                model_chain_state=ModelChainState(max_retries=3),
                 response=None,
             )
 
@@ -245,14 +241,13 @@ class TestModelChain:
                 AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "1"}]),
             ]
         )
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
 
         chain = _build_model_chain(
             llm=mock_llm,
             context_assembly=mock_context_assembly,
-            model_chain_config=model_chain_config,
-            quality_gate=QualityGate(enable_judgment_llm=False),
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
             use_structured_response=False,
             enable_parallel_tool_calls=False,
             use_tool_call_promotion=False,
@@ -263,7 +258,7 @@ class TestModelChain:
             config=RunnableConfig(),
             store=Mock(),
             messages=[],
-            model_chain_state=ModelChainState(max_empty_retries=3),
+            model_chain_state=ModelChainState(max_retries=3),
             response=None,
         )
 
@@ -281,14 +276,13 @@ class TestModelChain:
                 AIMessage(content="处理完成"),
             ]
         )
-        model_chain_config = ModelChainConfig(max_empty_retries=3)
         self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test"), tool_msg])
 
         chain = _build_model_chain(
             llm=mock_llm,
             context_assembly=mock_context_assembly,
-            model_chain_config=model_chain_config,
-            quality_gate=QualityGate(enable_judgment_llm=False),
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
             use_structured_response=False,
             enable_parallel_tool_calls=False,
             use_tool_call_promotion=False,
@@ -299,17 +293,21 @@ class TestModelChain:
             config=RunnableConfig(),
             store=Mock(),
             messages=[],
-            model_chain_state=ModelChainState(max_empty_retries=3),
+            model_chain_state=ModelChainState(max_retries=3),
             response=None,
         )
 
         result = chain.invoke(initial_ctx)
         assert result.response.content == "处理完成"
+        # post_tool_empty_retried 仅由 RECOVERY_NUDGE 分支置 True（quality_gate.py:375）。
+        # 若 has_prior_tool_results 误排末尾 ToolMessage，会走 RECOVERY_RETRY，
+        # 此标志保持 False，断言失败——从而捕获路由错误。
+        assert result.model_chain_state.post_tool_empty_retried is True
         assert mock_llm._invoke_count[0] == 2
 
 
 # ---------------------------------------------------------------------------
-# _build_effective_chain 单元测试（D-09~D-12 重构 + promotion bug 修复）
+# build_llm_with_tools 单元测试（D-09~D-12 重构 + promotion bug 修复）
 # ---------------------------------------------------------------------------
 
 
@@ -317,7 +315,6 @@ def _make_chainable_llm():
     """创建支持 | 运算符和 bind/bind_tools 的 mock LLM。
 
     bind/bind_tools 均返回自身（RunnableLambda），使 chain 可拼接。
-    记录 bind 调用参数以便断言 max_tokens 是否前置。
     """
     llm = RunnableLambda(lambda x, **kw: AIMessage(content="ok"))
     llm.bind_tools = Mock(return_value=llm)
@@ -332,8 +329,138 @@ def _make_mock_tool(name: str = "search") -> BaseTool:
     return t
 
 
-class TestBuildEffectiveChain:
-    """测试 _build_effective_chain 的 4 步结构（D-09~D-12）。"""
+# ---------------------------------------------------------------------------
+# max_tokens / tools 回归测试辅助函数
+# ---------------------------------------------------------------------------
+
+
+def _make_real_llm() -> ChatOpenAI:
+    """构造一个真实 ChatOpenAI 实例（不打网络，只用于 bind/bind_tools 检查）。"""
+    return ChatOpenAI(model="gpt-4o-mini", api_key="sk-test-no-network")
+
+
+def _make_real_tool() -> StructuredTool:
+    """构造一个真实的 StructuredTool，避免 mock。"""
+
+    def _search(q: str) -> str:
+        """search tool."""
+        return f"result for {q}"
+
+    return StructuredTool.from_function(_search, name="search")
+
+
+def _collect_binding_kwargs(runnable: Any) -> dict[str, Any]:
+    """从 Runnable / RunnableBinding / RunnableSequence 中收集 binding kwargs。
+
+    - RunnableBinding：返回自身 kwargs + 递归 bound
+    - RunnableSequence：合并所有 step 的 binding kwargs
+    """
+    merged: dict[str, Any] = {}
+
+    steps = getattr(runnable, "steps", None)
+    if steps is not None:
+        for step in steps:
+            merged.update(_collect_binding_kwargs(step))
+        return merged
+
+    if isinstance(runnable, RunnableBinding):
+        merged.update(runnable.kwargs)
+        merged.update(_collect_binding_kwargs(runnable.bound))
+        return merged
+
+    return merged
+
+
+def _make_openai_response_dict() -> dict[str, Any]:
+    """构造一个合法的 OpenAI chat completion 响应 dict。
+
+    结构需被 ``_create_chat_result`` 接受：含 ``choices``，每个 choice 含
+    ``message``（role + content）和 ``finish_reason``。
+    """
+    return {
+        "id": "chatcmpl-test",
+        "model": "gpt-4o-mini",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "done"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+    }
+
+
+class CapturingChatOpenAI(ChatOpenAI):
+    """继承 ChatOpenAI，注入 mock client 捕获 create 调用的 payload。
+
+    不打网络：同步路径走 ``self.client.with_raw_response.create(**payload).parse()``，
+    异步路径走 ``await self.async_client.with_raw_response.create(**payload).parse()``。
+    两条路径的 payload 都被捕获到 ``_captured_payloads``，用于断言 max_tokens 与
+    tools 是否同时到达底层 API 调用。
+    """
+
+    _captured_payloads: list = PrivateAttr(default_factory=list)
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self._captured_payloads = []
+        response_dict = _make_openai_response_dict()
+
+        self.client = Mock(spec=["with_raw_response", "create"])
+        self.client.with_raw_response = Mock(spec=["create"])
+
+        self.root_client = Mock(spec=["chat", "responses"])
+        self.root_client.chat = Mock(spec=["completions"])
+        self.root_client.chat.completions = self.client
+        self.root_client.responses = Mock(spec=["with_raw_response"])
+        self.root_client.responses.with_raw_response = Mock(spec=["create", "parse"])
+
+        self.async_client = Mock(spec=["with_raw_response", "create"])
+        self.async_client.with_raw_response = Mock(spec=["create"])
+
+        self.root_async_client = Mock(spec=["chat", "responses"])
+        self.root_async_client.chat = Mock(spec=["completions"])
+        self.root_async_client.chat.completions = self.async_client
+        self.root_async_client.responses = Mock(spec=["with_raw_response"])
+        self.root_async_client.responses.with_raw_response = Mock(spec=["create", "parse"])
+
+        def _capture_sync(**payload: Any) -> Any:
+            self._captured_payloads.append(payload)
+            return Mock(parse=Mock(return_value=response_dict))
+
+        async def _capture_async(**payload: Any) -> Any:
+            self._captured_payloads.append(payload)
+            return Mock(parse=Mock(return_value=response_dict))
+
+        self.client.with_raw_response.create = _capture_sync
+        self.async_client.with_raw_response.create = _capture_async
+
+
+def _make_context_assembly_with_tools(tools: list[StructuredTool]) -> Mock:
+    """构造 mock ContextAssembly，返回指定 tools 与单条 HumanMessage。"""
+    ca = Mock()
+    ca.get_choice_tools = Mock(return_value=tools)
+    ca.get_chat_prompt_variables = Mock(return_value={})
+    ca.get_chat_prompt_template = Mock(
+        return_value=Mock(invoke=Mock(return_value=Mock(to_messages=Mock(return_value=[HumanMessage(content="hi")]))))
+    )
+    return ca
+
+
+def _make_ctx_with_override(max_tokens_override: int | None) -> ProcessorContext:
+    return ProcessorContext(
+        state={"messages": []},
+        config=RunnableConfig(),
+        store=Mock(),
+        messages=[],
+        model_chain_state=ModelChainState(max_retries=3, max_tokens_override=max_tokens_override),
+        response=None,
+    )
+
+
+class TestBuildLlmWithTools:
+    """测试 build_llm_with_tools 的结构（D-09~D-12）。"""
 
     @pytest.mark.parametrize(
         "use_structured_response,expected_steps",
@@ -349,7 +476,7 @@ class TestBuildEffectiveChain:
         tools = [_make_mock_tool("search")]
         with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
             mock_parser_cls.return_value = RunnableLambda(lambda x: x)
-            chain = _build_effective_chain(
+            chain = build_llm_with_tools(
                 llm=llm,
                 tools=tools,
                 use_structured_response=use_structured_response,
@@ -372,7 +499,7 @@ class TestBuildEffectiveChain:
         tools = [_make_mock_tool("search")]
         with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
             mock_parser_cls.return_value = RunnableLambda(lambda x: x)
-            chain = _build_effective_chain(
+            chain = build_llm_with_tools(
                 llm=llm,
                 tools=tools,
                 use_structured_response=use_structured_response,
@@ -399,7 +526,7 @@ class TestBuildEffectiveChain:
         输出解析为 tool_calls），直接返回 llm。
         """
         llm = _make_chainable_llm()
-        chain = _build_effective_chain(
+        chain = build_llm_with_tools(
             llm=llm,
             tools=[],
             use_structured_response=use_structured_response,
@@ -408,42 +535,218 @@ class TestBuildEffectiveChain:
         )
         assert chain is llm
 
-    @pytest.mark.parametrize(
-        "use_structured_response",
-        [False, True],
-    )
-    def test_max_tokens_override_binds_llm(self, use_structured_response):
-        """max_tokens_override=16384 → llm 被 bind(max_tokens=16384)（两分支均生效）。"""
-        llm = _make_chainable_llm()
-        tools = [_make_mock_tool("search")]
-        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
-            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
-            _build_effective_chain(
-                llm=llm,
-                tools=tools,
-                use_structured_response=use_structured_response,
-                enable_parallel_tool_calls=False,
-                use_tool_call_promotion=False,
-                max_tokens_override=16384,
-            )
-        llm.bind.assert_called_once_with(max_tokens=16384)
 
-    @pytest.mark.parametrize(
-        "use_structured_response",
-        [False, True],
+# ---------------------------------------------------------------------------
+# max_tokens / tools 回归测试
+# ---------------------------------------------------------------------------
+# 背景：``llm.bind(max_tokens=...)`` 返回 ``RunnableBinding``，再对它调用
+# ``.bind_tools()`` 会经 ``RunnableBinding.__getattr__`` 代理到底层 ChatModel 的
+# ``bind_tools``，而 ``bind_tools`` 内部 ``super().bind(tools=...)`` 在底层
+# ChatModel 上创建全新的 ``RunnableBinding``，kwargs 只有 tools，max_tokens 被丢弃。
+#
+# 修复：``build_llm_with_tools`` 不再绑定 max_tokens，改由 ``_call_llm`` /
+# ``_acall_llm`` 在 ``invoke`` / ``ainvoke`` 时按 ``max_tokens_override`` 传入，
+# 利用 ``RunnableBinding.invoke`` 的 ``{**self.kwargs, **kwargs}`` 合并语义确保
+# max_tokens 与 tools 同时到达底层 API 调用。
+
+
+class TestMaxTokensNotLostInBindToolsBranch:
+    """build_llm_with_tools 不绑定 max_tokens，改在 invoke 时传。"""
+
+    @pytest.mark.xfail(
+        reason="RunnableBinding.bind_tools 经 __getattr__ 代理到底层 ChatModel，"
+        "绕开 RunnableBinding.bind 的 kwargs 合并；新设计在 invoke 时传 max_tokens 规避"
     )
-    def test_no_max_tokens_when_override_none(self, use_structured_response):
-        """max_tokens_override=None → llm 不被 bind(max_tokens=...)。"""
-        llm = _make_chainable_llm()
-        tools = [_make_mock_tool("search")]
-        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
-            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
-            _build_effective_chain(
-                llm=llm,
-                tools=tools,
-                use_structured_response=use_structured_response,
-                enable_parallel_tool_calls=False,
-                use_tool_call_promotion=False,
-                max_tokens_override=None,
-            )
-        llm.bind.assert_not_called()
+    def test_max_tokens_lost_when_bind_before_bind_tools(self):
+        """``llm.bind(max_tokens=...).bind_tools([...])`` 会丢失 max_tokens。
+
+        ``RunnableBinding`` 未重写 ``bind_tools``，属性查找经 ``__getattr__``
+        代理到底层 ChatModel 的 ``bind_tools``；``bind_tools`` 内部
+        ``super().bind(tools=...)`` 在底层 ChatModel 上创建全新 binding，
+        原 binding 的 max_tokens 被丢弃。
+        """
+        llm = _make_real_llm()
+        bound_with_max = llm.bind(max_tokens=16384)
+        chain = bound_with_max.bind_tools([_make_real_tool()])
+
+        kwargs = _collect_binding_kwargs(chain)
+        assert "tools" in kwargs, "tools 应被绑定"
+        assert "max_tokens" in kwargs, (
+            f"max_tokens 被丢失！实际 kwargs keys: {sorted(kwargs.keys())}。"
+            "RunnableBinding.bind_tools 不会合并已有 kwargs。"
+        )
+        assert kwargs["max_tokens"] == 16384
+
+    def test_llm_with_tools_does_not_bind_max_tokens_non_structured(self):
+        """build_llm_with_tools 在非 structured 分支不绑定 max_tokens。
+
+        新设计移除了 ``llm.bind(max_tokens=...)`` 调用，bind_tools 分支的
+        binding kwargs 只含 tools，不含 max_tokens。invoke-time 传参由
+        ``TestCallLlmInvokeTimePayload`` 验证。
+        """
+        llm = _make_real_llm()
+        tool = _make_real_tool()
+        chain = build_llm_with_tools(
+            llm=llm,
+            tools=[tool],
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+        kwargs = _collect_binding_kwargs(chain)
+        assert "tools" in kwargs, "tools 应被绑定"
+        assert "max_tokens" not in kwargs, "build_llm_with_tools 不应绑定 max_tokens"
+
+    def test_bind_tools_then_bind_preserves_both(self):
+        """``llm.bind_tools(tools).bind(max_tokens=...)`` 两者都在。
+
+        ``RunnableBinding.bind`` 被 ``@override`` 重写，内部
+        ``kwargs={**self.kwargs, **kwargs}`` 合并；而 ``bind_tools`` 经
+        ``__getattr__`` 代理到底层（绕开合并）。顺序决定结果：
+        - ``bind(max_tokens)`` → ``bind_tools(tools)``：丢失 max_tokens
+        - ``bind_tools(tools)`` → ``bind(max_tokens)``：两者都在
+        """
+        llm = _make_real_llm()
+        tool = _make_real_tool()
+        chain = llm.bind_tools([tool]).bind(max_tokens=16384)
+
+        kwargs = _collect_binding_kwargs(chain)
+        assert "tools" in kwargs, f"tools 不应丢失！kwargs keys: {sorted(kwargs.keys())}"
+        assert "max_tokens" in kwargs, f"max_tokens 应保留！kwargs keys: {sorted(kwargs.keys())}"
+        assert kwargs["max_tokens"] == 16384
+
+    def test_llm_with_tools_does_not_bind_max_tokens_structured(self):
+        """structured 分支同样不绑定 max_tokens。"""
+        llm = _make_real_llm()
+        tool = _make_real_tool()
+        chain = build_llm_with_tools(
+            llm=llm,
+            tools=[tool],
+            use_structured_response=True,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+        kwargs = _collect_binding_kwargs(chain)
+        assert "max_tokens" not in kwargs, "structured 分支也不应绑定 max_tokens"
+
+
+class TestCallLlmInvokeTimePayload:
+    """验证 _call_llm / _acall_llm 在 invoke / ainvoke 时传入 max_tokens。
+
+    通过继承 ``ChatOpenAI`` 注入 mock client，跑完整的 ``_build_model_chain``
+    链路。底层 ``client.create`` 收到的 payload 应同时含 ``max_tokens`` 与
+    ``tools``——这证明 ``RunnableBinding.invoke`` 的 ``{**self.kwargs, **kwargs}``
+    合并语义把 invoke-time max_tokens 与 binding 的 tools 正确合并到底层 API 调用。
+    """
+
+    def test_sync_call_llm_passes_max_tokens_and_tools(self):
+        """_call_llm：max_tokens_override 设置时，client.create payload 同时含 max_tokens 与 tools。"""
+        llm = CapturingChatOpenAI(model="gpt-4o-mini", api_key="sk-test-no-network")
+        tool = _make_real_tool()
+        ca = _make_context_assembly_with_tools([tool])
+
+        chain = _build_model_chain(
+            llm=llm,
+            context_assembly=ca,
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        ctx = _make_ctx_with_override(max_tokens_override=16384)
+        chain.invoke(ctx)
+
+        assert len(llm._captured_payloads) == 1, f"应只调用一次 client.create，实际 {len(llm._captured_payloads)}"
+        payload = llm._captured_payloads[0]
+        # langchain_openai 的 ChatOpenAI._get_request_payload 会把 max_tokens
+        # 标准化为 max_completion_tokens（OpenAI 2024-09 起的字段名）
+        assert payload.get("max_completion_tokens") == 16384, (
+            f"max_completion_tokens 应为 16384，实际 payload: {payload.get('max_completion_tokens')}"
+        )
+        assert "tools" in payload, "payload 应含 tools"
+        assert len(payload["tools"]) == 1, f"tools 应有 1 个，实际 {len(payload['tools'])}"
+        assert payload["tools"][0]["function"]["name"] == "search", f"tool name 应为 search，实际 {payload['tools'][0]}"
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_passes_max_tokens_and_tools(self):
+        """_acall_llm：max_tokens_override 设置时，async_client.create payload 同时含 max_tokens 与 tools。"""
+        llm = CapturingChatOpenAI(model="gpt-4o-mini", api_key="sk-test-no-network")
+        tool = _make_real_tool()
+        ca = _make_context_assembly_with_tools([tool])
+
+        chain = _build_model_chain(
+            llm=llm,
+            context_assembly=ca,
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        ctx = _make_ctx_with_override(max_tokens_override=24576)
+        await chain.ainvoke(ctx)
+
+        assert len(llm._captured_payloads) == 1, f"应只调用一次 async_client.create，实际 {len(llm._captured_payloads)}"
+        payload = llm._captured_payloads[0]
+        assert payload.get("max_completion_tokens") == 24576, (
+            f"max_completion_tokens 应为 24576，实际 payload: {payload.get('max_completion_tokens')}"
+        )
+        assert "tools" in payload, "payload 应含 tools"
+        assert len(payload["tools"]) == 1, f"tools 应有 1 个，实际 {len(payload['tools'])}"
+        assert payload["tools"][0]["function"]["name"] == "search", f"tool name 应为 search，实际 {payload['tools'][0]}"
+
+    def test_sync_call_llm_no_max_tokens_when_override_none(self):
+        """_call_llm：max_tokens_override=None 时，payload 不含 max_tokens，但仍含 tools。"""
+        llm = CapturingChatOpenAI(model="gpt-4o-mini", api_key="sk-test-no-network")
+        tool = _make_real_tool()
+        ca = _make_context_assembly_with_tools([tool])
+
+        chain = _build_model_chain(
+            llm=llm,
+            context_assembly=ca,
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        ctx = _make_ctx_with_override(max_tokens_override=None)
+        chain.invoke(ctx)
+
+        assert len(llm._captured_payloads) == 1
+        payload = llm._captured_payloads[0]
+        assert "max_tokens" not in payload and "max_completion_tokens" not in payload, (
+            f"max_tokens_override=None 时不应传 max_tokens，实际 payload keys: {sorted(payload.keys())}"
+        )
+        assert "tools" in payload, "tools 应始终被绑定"
+
+    @pytest.mark.asyncio
+    async def test_async_call_llm_no_max_tokens_when_override_none(self):
+        """_acall_llm：max_tokens_override=None 时，payload 不含 max_tokens，但仍含 tools。"""
+        llm = CapturingChatOpenAI(model="gpt-4o-mini", api_key="sk-test-no-network")
+        tool = _make_real_tool()
+        ca = _make_context_assembly_with_tools([tool])
+
+        chain = _build_model_chain(
+            llm=llm,
+            context_assembly=ca,
+            max_retries=3,
+            quality_gate=QualityGate(enable_judge_response=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        ctx = _make_ctx_with_override(max_tokens_override=None)
+        await chain.ainvoke(ctx)
+
+        assert len(llm._captured_payloads) == 1
+        payload = llm._captured_payloads[0]
+        assert "max_tokens" not in payload and "max_completion_tokens" not in payload, (
+            f"max_tokens_override=None 时不应传 max_tokens，实际 payload keys: {sorted(payload.keys())}"
+        )
+        assert "tools" in payload, "tools 应始终被绑定"

--- a/src/agent/tests/core/nodes/model/test_model_chain.py
+++ b/src/agent/tests/core/nodes/model/test_model_chain.py
@@ -1,0 +1,449 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueKing - AIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+"""
+
+from unittest.mock import Mock, patch
+
+import httpx
+import pytest
+from aidev_agent.core.nodes.model.model_chain import _build_effective_chain, _build_model_chain
+from aidev_agent.core.nodes.model.pydantic_models import (
+    ModelChainConfig,
+    ModelChainState,
+    ProcessorContext,
+)
+from aidev_agent.core.nodes.model.quality_gate import QualityGate
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig, RunnableLambda, RunnableSequence
+from langchain_core.tools import BaseTool
+from openai import RateLimitError
+
+# ---------------------------------------------------------------------------
+# 辅助函数
+# ---------------------------------------------------------------------------
+
+
+def _make_rate_limit_error() -> RateLimitError:
+    """创建一个 mock RateLimitError，需要提供 httpx.Response"""
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    response = httpx.Response(429, request=request)
+    return RateLimitError("rate limited", response=response, body=None)
+
+
+def _make_response_queue_llm(responses):
+    """创建按顺序返回响应的 mock LLM（同步版本，独立测试使用）。
+
+    每个测试构建独立的 mock LLM，用于 _build_model_chain 的 .invoke() 调用。
+    """
+    queue = list(responses)
+    invoke_counter = [0]
+
+    def invoke_fn(input, config=None, **kwargs):
+        invoke_counter[0] += 1
+        return queue.pop(0) if queue else AIMessage(content="")
+
+    llm = RunnableLambda(invoke_fn)
+    llm.bind_tools = Mock(return_value=llm)
+    llm._invoke_count = invoke_counter
+    return llm
+
+
+# ---------------------------------------------------------------------------
+# 测试类
+# ---------------------------------------------------------------------------
+
+
+class TestModelChain:
+    """测试 _build_model_chain 生成的 LCEL 链（独立于 build_model_node）"""
+
+    @pytest.fixture
+    def mock_context_assembly(self):
+        """Mock ContextAssembly。
+
+        _render_messages 现在是链头（plan 04），会调用
+        get_chat_prompt_template(ctx).invoke(vars, config).to_messages()
+        覆盖 ctx.messages。此 fixture 默认让该链返回空列表；测试可通过
+        设置 ca.get_chat_prompt_template().invoke().to_messages.return_value
+        覆盖期望的消息（plan 04 后 _render_messages 主动渲染而非透传入口 messages）。
+        """
+        ca = Mock()
+        ca.get_choice_tools = Mock(return_value=[])
+        ca.get_chat_prompt_variables = Mock(return_value={})
+        # 默认让 _render_messages 渲染出空消息列表
+        ca.get_chat_prompt_template = Mock(
+            return_value=Mock(invoke=Mock(return_value=Mock(to_messages=Mock(return_value=[]))))
+        )
+        return ca
+
+    @staticmethod
+    def _set_rendered_messages(ca: Mock, messages: list):
+        """让 _render_messages（链头）渲染出指定 messages 列表。"""
+        ca.get_chat_prompt_template().invoke().to_messages.return_value = messages
+
+    def test_normal_completion_first_try(self, mock_context_assembly):
+        """测试正常完成：LLM 返回有效内容 → 不重试，直接返回"""
+        mock_llm = _make_response_queue_llm([AIMessage(content="Hello, world!")])
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        chain = _build_model_chain(
+            llm=mock_llm,
+            context_assembly=mock_context_assembly,
+            model_chain_config=model_chain_config,
+            quality_gate=QualityGate(enable_judgment_llm=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        initial_ctx = ProcessorContext(
+            state={"messages": []},
+            config=RunnableConfig(),
+            store=Mock(),
+            messages=[],
+            model_chain_state=ModelChainState(max_empty_retries=3),
+            response=None,
+        )
+
+        result = chain.invoke(initial_ctx)
+        assert result.response.content == "Hello, world!"
+        assert mock_llm._invoke_count[0] == 1
+
+    def test_empty_then_success_after_retry(self, mock_context_assembly):
+        """测试空内容重试后成功：首次空 → retry → 第二次有内容"""
+        mock_llm = _make_response_queue_llm(
+            [
+                AIMessage(content="", tool_calls=[]),  # 空 → RecoveryRetryError
+                AIMessage(content="重试后成功"),
+            ]
+        )
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        # plan 04 后 _render_messages 是链头，覆盖 ctx.messages——设置渲染输出
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        chain = _build_model_chain(
+            llm=mock_llm,
+            context_assembly=mock_context_assembly,
+            model_chain_config=model_chain_config,
+            quality_gate=QualityGate(enable_judgment_llm=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        initial_ctx = ProcessorContext(
+            state={"messages": []},
+            config=RunnableConfig(),
+            store=Mock(),
+            messages=[],
+            model_chain_state=ModelChainState(max_empty_retries=3),
+            response=None,
+        )
+
+        result = chain.invoke(initial_ctx)
+        assert result.response.content == "重试后成功"
+        assert mock_llm._invoke_count[0] == 2
+
+    def test_all_retries_exhausted_returns_last(self, mock_context_assembly):
+        """测试重试耗尽：全部空内容 → 返回最后一个空响应，不抛异常"""
+        mock_llm = _make_response_queue_llm(
+            [
+                AIMessage(content="", tool_calls=[]),
+                AIMessage(content="", tool_calls=[]),
+                AIMessage(content="", tool_calls=[]),
+                AIMessage(content="", tool_calls=[]),
+            ]
+        )
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        chain = _build_model_chain(
+            llm=mock_llm,
+            context_assembly=mock_context_assembly,
+            model_chain_config=model_chain_config,
+            quality_gate=QualityGate(enable_judgment_llm=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        initial_ctx = ProcessorContext(
+            state={"messages": []},
+            config=RunnableConfig(),
+            store=Mock(),
+            messages=[],
+            model_chain_state=ModelChainState(max_empty_retries=3),
+            response=None,
+        )
+
+        result = chain.invoke(initial_ctx)
+        assert result.response.content == ""
+        assert mock_llm._invoke_count[0] == 4
+
+    def test_rate_limit_error_retried(self, mock_context_assembly):
+        """测试 RateLimitError 被捕获 → sleep → 重试 → 成功"""
+        invoke_counter = [0]
+
+        def invoke_fn(input, config=None, **kwargs):
+            invoke_counter[0] += 1
+            if invoke_counter[0] == 1:
+                raise _make_rate_limit_error()
+            return AIMessage(content="限流后重试成功")
+
+        mock_llm = RunnableLambda(invoke_fn)
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        mock_llm._invoke_count = invoke_counter
+
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        with (
+            patch("aidev_agent.core.nodes.model.model_chain.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("time.sleep", return_value=None),
+        ):
+            chain = _build_model_chain(
+                llm=mock_llm,
+                context_assembly=mock_context_assembly,
+                model_chain_config=model_chain_config,
+                quality_gate=QualityGate(enable_judgment_llm=False),
+                use_structured_response=False,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=False,
+            )
+
+            initial_ctx = ProcessorContext(
+                state={"messages": []},
+                config=RunnableConfig(),
+                store=Mock(),
+                messages=[],
+                model_chain_state=ModelChainState(max_empty_retries=3),
+                response=None,
+            )
+
+            result = chain.invoke(initial_ctx)
+            assert result.response.content == "限流后重试成功"
+            assert invoke_counter[0] == 2
+
+    def test_tool_calls_passthrough(self, mock_context_assembly):
+        """测试工具调用：返回 TOOL_EXECUTION → 不重试，原样返回"""
+        mock_llm = _make_response_queue_llm(
+            [
+                AIMessage(content="", tool_calls=[{"name": "search", "args": {"q": "test"}, "id": "1"}]),
+            ]
+        )
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        chain = _build_model_chain(
+            llm=mock_llm,
+            context_assembly=mock_context_assembly,
+            model_chain_config=model_chain_config,
+            quality_gate=QualityGate(enable_judgment_llm=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        initial_ctx = ProcessorContext(
+            state={"messages": []},
+            config=RunnableConfig(),
+            store=Mock(),
+            messages=[],
+            model_chain_state=ModelChainState(max_empty_retries=3),
+            response=None,
+        )
+
+        result = chain.invoke(initial_ctx)
+        assert len(result.response.tool_calls) == 1
+        assert result.response.tool_calls[0]["name"] == "search"
+        assert mock_llm._invoke_count[0] == 1
+
+    def test_post_tool_nudge_retried(self, mock_context_assembly):
+        """测试工具后空响应 → RECOVERY_NUDGE → 重试成功"""
+        tool_msg = ToolMessage(content="工具结果", tool_call_id="1")
+        mock_llm = _make_response_queue_llm(
+            [
+                AIMessage(content="", tool_calls=[]),  # 工具后空 → nudge
+                AIMessage(content="处理完成"),
+            ]
+        )
+        model_chain_config = ModelChainConfig(max_empty_retries=3)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test"), tool_msg])
+
+        chain = _build_model_chain(
+            llm=mock_llm,
+            context_assembly=mock_context_assembly,
+            model_chain_config=model_chain_config,
+            quality_gate=QualityGate(enable_judgment_llm=False),
+            use_structured_response=False,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=False,
+        )
+
+        initial_ctx = ProcessorContext(
+            state={"messages": []},
+            config=RunnableConfig(),
+            store=Mock(),
+            messages=[],
+            model_chain_state=ModelChainState(max_empty_retries=3),
+            response=None,
+        )
+
+        result = chain.invoke(initial_ctx)
+        assert result.response.content == "处理完成"
+        assert mock_llm._invoke_count[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_effective_chain 单元测试（D-09~D-12 重构 + promotion bug 修复）
+# ---------------------------------------------------------------------------
+
+
+def _make_chainable_llm():
+    """创建支持 | 运算符和 bind/bind_tools 的 mock LLM。
+
+    bind/bind_tools 均返回自身（RunnableLambda），使 chain 可拼接。
+    记录 bind 调用参数以便断言 max_tokens 是否前置。
+    """
+    llm = RunnableLambda(lambda x, **kw: AIMessage(content="ok"))
+    llm.bind_tools = Mock(return_value=llm)
+    llm.bind = Mock(return_value=llm)
+    return llm
+
+
+def _make_mock_tool(name: str = "search") -> BaseTool:
+    """创建带 name 属性的 mock BaseTool。"""
+    t = Mock(spec=BaseTool)
+    t.name = name
+    return t
+
+
+class TestBuildEffectiveChain:
+    """测试 _build_effective_chain 的 4 步结构（D-09~D-12）。"""
+
+    @pytest.mark.parametrize(
+        "use_structured_response,expected_steps",
+        [(False, 2), (True, 3)],
+    )
+    def test_promotion_applied_when_enabled_and_tools_nonempty(self, use_structured_response, expected_steps):
+        """tools 非空 + use_tool_call_promotion=True → chain 末尾含 promotion（两分支统一）
+
+        use_structured_response=True 是 bug 修复——旧代码 structured 分支无 promotion
+        （旧代码 structured 分支 steps=2，重构后 steps=3，末尾多一个 promotion）。
+        """
+        llm = _make_chainable_llm()
+        tools = [_make_mock_tool("search")]
+        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
+            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
+            chain = _build_effective_chain(
+                llm=llm,
+                tools=tools,
+                use_structured_response=use_structured_response,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=True,
+            )
+        # chain 应为 RunnableSequence，末尾步骤是 promotion 的 RunnableLambda
+        assert isinstance(chain, RunnableSequence)
+        assert len(chain.steps) == expected_steps
+        last_step = chain.steps[-1]
+        assert isinstance(last_step, RunnableLambda)
+
+    @pytest.mark.parametrize(
+        "use_structured_response",
+        [False, True],
+    )
+    def test_no_promotion_when_disabled(self, use_structured_response):
+        """use_tool_call_promotion=False → 两分支均不追加 promotion。"""
+        llm = _make_chainable_llm()
+        tools = [_make_mock_tool("search")]
+        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
+            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
+            chain = _build_effective_chain(
+                llm=llm,
+                tools=tools,
+                use_structured_response=use_structured_response,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=False,
+            )
+        if use_structured_response:
+            # structured 无 promotion → llm | parser（2 步）
+            assert isinstance(chain, RunnableSequence)
+            assert len(chain.steps) == 2
+        else:
+            # 非 structured 无 promotion → 直接返回 llm.bind_tools()（即 llm，非 Sequence）
+            assert chain is llm
+
+    @pytest.mark.parametrize(
+        "use_structured_response",
+        [False, True],
+    )
+    def test_empty_tools_returns_llm_directly(self, use_structured_response):
+        """tools=[] → 提前返回 llm，不追加 promotion，不挂 parser。
+
+        无论 use_structured_response 取值如何，无工具时
+        StructuredOutputToToolMessageParser 无意义（其作用是把 JSON
+        输出解析为 tool_calls），直接返回 llm。
+        """
+        llm = _make_chainable_llm()
+        chain = _build_effective_chain(
+            llm=llm,
+            tools=[],
+            use_structured_response=use_structured_response,
+            enable_parallel_tool_calls=False,
+            use_tool_call_promotion=True,
+        )
+        assert chain is llm
+
+    @pytest.mark.parametrize(
+        "use_structured_response",
+        [False, True],
+    )
+    def test_max_tokens_override_binds_llm(self, use_structured_response):
+        """max_tokens_override=16384 → llm 被 bind(max_tokens=16384)（两分支均生效）。"""
+        llm = _make_chainable_llm()
+        tools = [_make_mock_tool("search")]
+        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
+            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
+            _build_effective_chain(
+                llm=llm,
+                tools=tools,
+                use_structured_response=use_structured_response,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=False,
+                max_tokens_override=16384,
+            )
+        llm.bind.assert_called_once_with(max_tokens=16384)
+
+    @pytest.mark.parametrize(
+        "use_structured_response",
+        [False, True],
+    )
+    def test_no_max_tokens_when_override_none(self, use_structured_response):
+        """max_tokens_override=None → llm 不被 bind(max_tokens=...)。"""
+        llm = _make_chainable_llm()
+        tools = [_make_mock_tool("search")]
+        with patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_cls:
+            mock_parser_cls.return_value = RunnableLambda(lambda x: x)
+            _build_effective_chain(
+                llm=llm,
+                tools=tools,
+                use_structured_response=use_structured_response,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=False,
+                max_tokens_override=None,
+            )
+        llm.bind.assert_not_called()

--- a/src/agent/tests/core/nodes/model/test_quality_gate.py
+++ b/src/agent/tests/core/nodes/model/test_quality_gate.py
@@ -11,10 +11,11 @@ from aidev_agent.core.nodes.model.quality_gate import (
 from aidev_agent.core.nodes.model.utils import (
     detect_thinking_exhaustion,
     has_content_after_think_block,
+    has_prior_tool_results,
     is_truncated,
     strip_think_blocks,
 )
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig
 
 # ---------------------------------------------------------------------------
@@ -63,6 +64,23 @@ class TestHelperFunctions:
         msg2 = AIMessage(content="x", response_metadata={"finish_reason": "stop"})
         assert is_truncated(msg2) is False
 
+    @pytest.mark.parametrize(
+        "messages, expected",
+        [
+            ([ToolMessage(content="r", tool_call_id="1")], True),
+            ([HumanMessage(content="hi"), ToolMessage(content="r", tool_call_id="1")], True),
+            ([HumanMessage(content="hi")], False),
+            ([], False),
+            (
+                [AIMessage(content="ai"), HumanMessage(content="hi"), ToolMessage(content="r", tool_call_id="1")],
+                True,
+            ),
+            ([ToolMessage(content="r", tool_call_id="1"), HumanMessage(content="hi")], False),
+        ],
+    )
+    def test_has_prior_tool_results(self, messages, expected):
+        assert has_prior_tool_results(messages) is expected
+
 
 # ---------------------------------------------------------------------------
 # 测试任务完成度判断（SRE3-6-35B-A3B-nothinking judge）
@@ -101,7 +119,7 @@ class TestTaskJudgment:
     def test_judge_routes_by_completion(self, judge_response, expect_route):
         mock_llm = Mock()
         mock_llm.invoke.return_value = AIMessage(content=judge_response)
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         response = AIMessage(content="这是回答")
         messages = [HumanMessage(content="用户问题")]
         ctx = _make_ctx(response, messages)
@@ -111,7 +129,7 @@ class TestTaskJudgment:
     def test_judge_fail_open_on_exception(self):
         mock_llm = Mock()
         mock_llm.invoke.side_effect = RuntimeError("timeout")
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         route = gate.validate_response(ctx)
@@ -119,7 +137,7 @@ class TestTaskJudgment:
 
     def test_judge_fail_open_when_no_judge_llm(self):
         """judge_llm=None → fail-open（跳过判断，视为已完成）。"""
-        gate = QualityGate(judge_llm=None, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=None, enable_judge_response=True)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         route = gate.validate_response(ctx)
@@ -137,7 +155,7 @@ class TestTaskJudgment:
     def test_judge_think_block_stripped(self):
         mock_llm = Mock()
         mock_llm.invoke.return_value = AIMessage(content="已完成")
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         think_content = "<think>admiration</think>visible answer"
         response = AIMessage(content=think_content)
         ctx = _make_ctx(response)
@@ -149,13 +167,13 @@ class TestTaskJudgment:
         assert "visible answer" in human_msg.content
 
 
-class TestEnableJudgmentLlmSwitch:
-    """测试 enable_judgment_llm 开关。"""
+class TestEnableJudgeResponseSwitch:
+    """测试 enable_judge_response 开关。"""
 
     def test_disabled_skips_judgment(self):
-        """enable_judgment_llm=False → 有内容直接 NORMAL_COMPLETION，不调用 judgment LLM。"""
+        """enable_judge_response=False → 有内容直接 NORMAL_COMPLETION，不调用 judgment LLM。"""
         mock_llm = Mock()
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=False)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=False)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         route = gate.validate_response(ctx)
@@ -163,10 +181,10 @@ class TestEnableJudgmentLlmSwitch:
         mock_llm.invoke.assert_not_called()
 
     def test_enabled_invokes_judgment(self):
-        """enable_judgment_llm=True + judge_llm 已配置 → 有内容时调用 judgment LLM。"""
+        """enable_judge_response=True + judge_llm 已配置 → 有内容时调用 judgment LLM。"""
         mock_llm = Mock()
         mock_llm.invoke.return_value = AIMessage(content="已完成")
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         route = gate.validate_response(ctx)
@@ -182,7 +200,7 @@ class TestFrontEndDisplayEvents:
         """invoke 前派发 front_end_display=False，invoke 后派发 front_end_display=True。"""
         mock_llm = Mock()
         mock_llm.invoke.return_value = AIMessage(content="已完成")
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         gate.validate_response(ctx)
@@ -199,7 +217,7 @@ class TestFrontEndDisplayEvents:
         """invoke 抛异常时，finally 仍恢复 front_end_display=True（fail-open）。"""
         mock_llm = Mock()
         mock_llm.invoke.side_effect = RuntimeError("timeout")
-        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
         response = AIMessage(content="回答")
         ctx = _make_ctx(response)
         route = gate.validate_response(ctx)

--- a/src/agent/tests/core/nodes/model/test_quality_gate.py
+++ b/src/agent/tests/core/nodes/model/test_quality_gate.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import Mock, patch
+
+import pytest
+from aidev_agent.core.nodes.model.pydantic_models import ModelChainState, ProcessorContext
+from aidev_agent.core.nodes.model.quality_gate import (
+    QualityGate,
+    ResponseRoute,
+)
+from aidev_agent.core.nodes.model.utils import (
+    detect_thinking_exhaustion,
+    has_content_after_think_block,
+    is_truncated,
+    strip_think_blocks,
+)
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.runnables import RunnableConfig
+
+# ---------------------------------------------------------------------------
+# 测试恢复状态
+# ---------------------------------------------------------------------------
+
+
+class TestModelChainState:
+    def test_max_tokens_override_default(self):
+        rs = ModelChainState()
+        assert rs.max_tokens_override is None
+
+    def test_max_tokens_override_set(self):
+        rs = ModelChainState(max_tokens_override=16384)
+        assert rs.max_tokens_override == 16384
+
+
+# ---------------------------------------------------------------------------
+# 测试辅助函数
+# ---------------------------------------------------------------------------
+
+
+class TestHelperFunctions:
+    @pytest.mark.parametrize(
+        "content, expected",
+        [
+            ("<think>content</think>", ""),
+            ("<thinking>deep</thinking>", ""),
+            ("<reasoning>logic</reasoning>", ""),
+        ],
+    )
+    def test_strip_think_blocks(self, content, expected):
+        assert strip_think_blocks(content) == expected
+
+    def test_has_content_after_think_block(self):
+        assert has_content_after_think_block("<think>x</think>visible") is True
+        assert has_content_after_think_block("<think>x</think>") is False
+
+    def test_detect_thinking_exhaustion(self):
+        assert detect_thinking_exhaustion("<think>lots of thought</think>") is True
+        assert detect_thinking_exhaustion("<think>thought</think>answer") is False
+
+    def test_is_truncated(self):
+        msg = AIMessage(content="x", response_metadata={"finish_reason": "length"})
+        assert is_truncated(msg) is True
+        msg2 = AIMessage(content="x", response_metadata={"finish_reason": "stop"})
+        assert is_truncated(msg2) is False
+
+
+# ---------------------------------------------------------------------------
+# 测试任务完成度判断（SRE3-6-35B-A3B-nothinking judge）
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(response, messages=None):
+    """构造测试用 ProcessorContext。
+
+    默认关闭 enable_custom_event——测试不在 LangChain run 上下文中，
+    dispatch_custom_event 会因无 parent run id 抛 RuntimeError。
+    """
+    if messages is None:
+        messages = [HumanMessage(content="问题")]
+    return ProcessorContext(
+        state={"messages": messages},
+        config=RunnableConfig(),
+        messages=messages,
+        model_chain_state=ModelChainState(),
+        response=response,
+        metadata={"enable_custom_event": False},
+    )
+
+
+class TestTaskJudgment:
+    """测试 SRE3-6-35B-A3B-nothinking 任务完成度判断。"""
+
+    @pytest.mark.parametrize(
+        "judge_response, expect_route",
+        [
+            ("已完成", ResponseRoute.NORMAL_COMPLETION),
+            ("不确定", ResponseRoute.NORMAL_COMPLETION),
+            ("未完成", ResponseRoute.RECOVERY_RETRY),
+        ],
+    )
+    def test_judge_routes_by_completion(self, judge_response, expect_route):
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = AIMessage(content=judge_response)
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        response = AIMessage(content="这是回答")
+        messages = [HumanMessage(content="用户问题")]
+        ctx = _make_ctx(response, messages)
+        route = gate.validate_response(ctx)
+        assert route == expect_route
+
+    def test_judge_fail_open_on_exception(self):
+        mock_llm = Mock()
+        mock_llm.invoke.side_effect = RuntimeError("timeout")
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        route = gate.validate_response(ctx)
+        assert route == ResponseRoute.NORMAL_COMPLETION
+
+    def test_judge_fail_open_when_no_judge_llm(self):
+        """judge_llm=None → fail-open（跳过判断，视为已完成）。"""
+        gate = QualityGate(judge_llm=None, enable_judgment_llm=True)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        route = gate.validate_response(ctx)
+        assert route == ResponseRoute.NORMAL_COMPLETION
+
+    def test_extract_last_human_input(self):
+        gate = QualityGate()
+        messages = [
+            HumanMessage(content="第一个问题"),
+            AIMessage(content="第一个回答"),
+            HumanMessage(content="第二个问题"),
+        ]
+        assert gate._extract_last_human_input(messages) == "第二个问题"
+
+    def test_judge_think_block_stripped(self):
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = AIMessage(content="已完成")
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        think_content = "<think>admiration</think>visible answer"
+        response = AIMessage(content=think_content)
+        ctx = _make_ctx(response)
+        gate.validate_response(ctx)
+        # 验证传给判断 LLM 的 HumanMessage 不含 think 块
+        call_args = mock_llm.invoke.call_args[0][0]
+        human_msg = next(m for m in call_args if isinstance(m, HumanMessage))
+        assert "admiration" not in human_msg.content
+        assert "visible answer" in human_msg.content
+
+
+class TestEnableJudgmentLlmSwitch:
+    """测试 enable_judgment_llm 开关。"""
+
+    def test_disabled_skips_judgment(self):
+        """enable_judgment_llm=False → 有内容直接 NORMAL_COMPLETION，不调用 judgment LLM。"""
+        mock_llm = Mock()
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=False)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        route = gate.validate_response(ctx)
+        assert route == ResponseRoute.NORMAL_COMPLETION
+        mock_llm.invoke.assert_not_called()
+
+    def test_enabled_invokes_judgment(self):
+        """enable_judgment_llm=True + judge_llm 已配置 → 有内容时调用 judgment LLM。"""
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = AIMessage(content="已完成")
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        route = gate.validate_response(ctx)
+        assert route == ResponseRoute.NORMAL_COMPLETION
+        mock_llm.invoke.assert_called_once()
+
+
+class TestFrontEndDisplayEvents:
+    """测试判断 LLM 调用前后的 front_end_display 事件派发。"""
+
+    @patch("aidev_agent.core.nodes.model.quality_gate.conditional_dispatch_custom_event")
+    def test_events_dispatched_around_invoke(self, mock_dispatch):
+        """invoke 前派发 front_end_display=False，invoke 后派发 front_end_display=True。"""
+        mock_llm = Mock()
+        mock_llm.invoke.return_value = AIMessage(content="已完成")
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        gate.validate_response(ctx)
+
+        # 应该派发 2 次：False（关闭前端显示）→ True（恢复）
+        assert mock_dispatch.call_count == 2
+        first_call = mock_dispatch.call_args_list[0]
+        second_call = mock_dispatch.call_args_list[1]
+        assert first_call.args == ("custom_event", {"front_end_display": False})
+        assert second_call.args == ("custom_event", {"front_end_display": True})
+
+    @patch("aidev_agent.core.nodes.model.quality_gate.conditional_dispatch_custom_event")
+    def test_front_end_display_restored_on_exception(self, mock_dispatch):
+        """invoke 抛异常时，finally 仍恢复 front_end_display=True（fail-open）。"""
+        mock_llm = Mock()
+        mock_llm.invoke.side_effect = RuntimeError("timeout")
+        gate = QualityGate(judge_llm=mock_llm, enable_judgment_llm=True)
+        response = AIMessage(content="回答")
+        ctx = _make_ctx(response)
+        route = gate.validate_response(ctx)
+
+        assert route == ResponseRoute.NORMAL_COMPLETION  # fail-open
+        # 仍应派发 2 次：False → True（finally 恢复）
+        assert mock_dispatch.call_count == 2
+        assert mock_dispatch.call_args_list[-1].args == ("custom_event", {"front_end_display": True})

--- a/src/agent/tests/core/nodes/model/test_tool_call_repair.py
+++ b/src/agent/tests/core/nodes/model/test_tool_call_repair.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+
+from aidev_agent.core.nodes.model.tool_call_repair import (
+    parse_standalone_plain_text_tool_call_blocks,
+)
+from aidev_agent.core.nodes.model.utils import (
+    extract_text_from_content,
+    promote_plain_text_tool_call_message,
+    should_promote_message,
+)
+from langchain_core.messages import AIMessage
+
+# ---------------------------------------------------------------------------
+# TestParseBracketFormat
+# ---------------------------------------------------------------------------
+
+
+class TestParseBracketFormat:
+    def test_bracket_format_simple(self):
+        text = '[read_file]\n{"file_path": "/app/main.py"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app/main.py"}
+
+    def test_bracket_tool_prefix(self):
+        text = '[tool:read_file]{"file_path": "/app/main.py"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app/main.py"}
+
+    def test_bracket_with_closing_marker(self):
+        text = '[read_file]\n{"file_path": "/app"}\n[/read_file]'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].arguments == {"file_path": "/app"}
+
+    def test_bracket_unknown_tool(self):
+        text = '[unknown_tool]\n{"arg": "val"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is None
+
+    def test_bracket_mixed_content(self):
+        text = 'some text [read_file]\n{"file_path": "/app"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# TestParseHarmonyFormat
+# ---------------------------------------------------------------------------
+
+
+class TestParseHarmonyFormat:
+    def test_harmony_simple(self):
+        text = 'commentary to=read_file code\n{"file_path": "/app"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app"}
+
+    def test_harmony_with_channel(self):
+        text = '<|channel|>analysis to=read_file code<|message|>\n{"file_path": "/app"}'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app"}
+
+    def test_harmony_with_call_marker(self):
+        text = 'commentary to=read_file code\n{"file_path": "/app"}\n<|call|>'
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app"}
+
+
+# ---------------------------------------------------------------------------
+# TestParseXmlFormat
+# ---------------------------------------------------------------------------
+
+
+class TestParseXmlFormat:
+    def test_xml_simple(self):
+        text = "<function=read_file><parameter=file_path>/app/main.py</parameter></function>"
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"read_file"})
+        assert result is not None
+        assert len(result) == 1
+        assert result[0].name == "read_file"
+        assert result[0].arguments == {"file_path": "/app/main.py"}
+
+    def test_xml_multiple_params(self):
+        text = (
+            "<function=write_file>"
+            "<parameter=file_path>/app/main.py</parameter>"
+            "<parameter=content>hello</parameter>"
+            "</function>"
+        )
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"write_file"})
+        assert result is not None
+        assert result[0].arguments == {"file_path": "/app/main.py", "content": "hello"}
+
+    def test_xml_no_whitespace_between_params(self):
+        """Regression: no infinite loop when parameters have no whitespace between them."""
+        text = "<function=f><parameter=a></parameter><parameter=b></parameter></function>"
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"f"})
+        assert result is not None
+        assert result[0].arguments == {"a": "", "b": ""}
+
+    def test_xml_typed_values(self):
+        """XML parameters that look like JSON should be parsed as typed values."""
+        text = "<function=f><parameter=count>42</parameter><parameter=name>test</parameter></function>"
+        result = parse_standalone_plain_text_tool_call_blocks(text, {"f"})
+        assert result is not None
+        assert result[0].arguments["count"] == 42
+        assert result[0].arguments["name"] == "test"
+
+
+# ---------------------------------------------------------------------------
+# TestPromoteMessage
+# ---------------------------------------------------------------------------
+
+
+class TestPromoteMessage:
+    def test_should_promote_text_only(self):
+        msg = AIMessage(content="hello")
+        assert should_promote_message(msg, {"read_file"}) is True
+
+    def test_should_not_promote_with_tool_calls(self):
+        msg = AIMessage(content="hello", tool_calls=[{"name": "x", "args": {}, "id": "1"}])
+        assert should_promote_message(msg, {"read_file"}) is False
+
+    def test_should_not_promote_empty_tools(self):
+        msg = AIMessage(content="hello")
+        assert should_promote_message(msg, set()) is False
+
+    def test_promote_success(self):
+        text = '[read_file]\n{"file_path": "/app"}'
+        msg = AIMessage(content=text)
+        result = promote_plain_text_tool_call_message(msg, {"read_file"})
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "read_file"
+
+    def test_promote_failure(self):
+        msg = AIMessage(content="some mixed text here")
+        result = promote_plain_text_tool_call_message(msg, {"read_file"})
+        assert result is msg
+
+    def test_promote_changes_metadata(self):
+        text = '[read_file]\n{"file_path": "/app"}'
+        msg = AIMessage(content=text)
+        result = promote_plain_text_tool_call_message(msg, {"read_file"})
+        assert result.response_metadata.get("promoted_from_plain_text") is True
+
+    def test_promote_preserves_list_content(self):
+        """WR-04: promotion preserves non-text content blocks."""
+        text = '[read_file]\n{"file_path": "/app"}'
+        content_list = [{"type": "text", "text": text}, {"type": "image_url", "url": "http://example.com/img"}]
+        msg = AIMessage(content=content_list)
+        result = promote_plain_text_tool_call_message(msg, {"read_file"})
+        assert len(result.tool_calls) == 1
+        # Original list content is preserved
+        assert isinstance(result.content, list)
+        assert len(result.content) == 2
+
+
+# ---------------------------------------------------------------------------
+# TestExtractTextFromContent (WR-05)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTextFromContent:
+    def test_string_content(self):
+        assert extract_text_from_content("hello world") == "hello world"
+
+    def test_string_content_stripped(self):
+        assert extract_text_from_content("  hello  ") == "hello"
+
+    def test_empty_string_returns_none(self):
+        assert extract_text_from_content("") is None
+
+    def test_whitespace_only_returns_none(self):
+        assert extract_text_from_content("   \n\t  ") is None
+
+    def test_list_of_dicts_with_text(self):
+        content = [{"type": "text", "text": "hello"}, {"type": "text", "text": " world"}]
+        assert extract_text_from_content(content) == "hello world"
+
+    def test_list_of_dicts_mixed_types(self):
+        """Only text blocks are extracted; image_url and other types are skipped."""
+        content = [
+            {"type": "text", "text": "look at this:"},
+            {"type": "image_url", "url": "http://example.com/img"},
+            {"type": "text", "text": " nice"},
+        ]
+        assert extract_text_from_content(content) == "look at this: nice"
+
+    def test_list_of_dicts_no_text_blocks(self):
+        content = [{"type": "image_url", "url": "http://example.com/img"}]
+        assert extract_text_from_content(content) is None
+
+    def test_list_of_dicts_empty_text(self):
+        content = [{"type": "text", "text": ""}, {"type": "text", "text": "   "}]
+        assert extract_text_from_content(content) is None
+
+    def test_non_string_non_list_returns_none(self):
+        assert extract_text_from_content(42) is None
+        assert extract_text_from_content(None) is None

--- a/src/agent/tests/core/nodes/model/test_utils.py
+++ b/src/agent/tests/core/nodes/model/test_utils.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""TDD tests for aidev_agent.core.nodes.model.utils (CR #1 extraction).
+
+These tests verify that the 7 helper functions + 2 regex constants were
+correctly migrated to utils.py and remain behaviorally identical.
+"""
+
+from aidev_agent.core.nodes.model.utils import (
+    detect_thinking_exhaustion,
+    has_content_after_think_block,
+    has_inline_thinking,
+    has_prior_tool_results,
+    is_truncated,
+    promote_plain_text_tool_call_message,
+    strip_think_blocks,
+)
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+
+class TestUtilsImports:
+    """Verify all 7 functions are importable from utils."""
+
+    def test_strip_think_blocks_importable(self):
+        assert callable(strip_think_blocks)
+
+    def test_has_inline_thinking_importable(self):
+        assert callable(has_inline_thinking)
+
+    def test_has_content_after_think_block_importable(self):
+        assert callable(has_content_after_think_block)
+
+    def test_detect_thinking_exhaustion_importable(self):
+        assert callable(detect_thinking_exhaustion)
+
+    def test_is_truncated_importable(self):
+        assert callable(is_truncated)
+
+    def test_has_prior_tool_results_importable(self):
+        assert callable(has_prior_tool_results)
+
+    def test_promote_plain_text_tool_call_message_importable(self):
+        assert callable(promote_plain_text_tool_call_message)
+
+
+class TestUtilsBehavior:
+    """Verify migrated functions behave identically."""
+
+    def test_strip_think_blocks_removes_block(self):
+        assert strip_think_blocks("<think>x</think>") == ""
+
+    def test_has_content_after_think_block_true(self):
+        assert has_content_after_think_block("<think>x</think>visible") is True
+
+    def test_has_content_after_think_block_false(self):
+        assert has_content_after_think_block("<think>x</think>") is False
+
+    def test_detect_thinking_exhaustion_true(self):
+        assert detect_thinking_exhaustion("<think>lots</think>") is True
+
+    def test_detect_thinking_exhaustion_false(self):
+        assert detect_thinking_exhaustion("<think>lots</think>answer") is False
+
+    def test_is_truncated_length(self):
+        msg = AIMessage(content="x", response_metadata={"finish_reason": "length"})
+        assert is_truncated(msg) is True
+
+    def test_is_truncated_stop(self):
+        msg = AIMessage(content="x", response_metadata={"finish_reason": "stop"})
+        assert is_truncated(msg) is False
+
+    def test_has_prior_tool_results_true(self):
+        msgs = [HumanMessage(content="q"), ToolMessage(content="r", tool_call_id="1"), AIMessage(content="a")]
+        assert has_prior_tool_results(msgs) is True
+
+    def test_has_prior_tool_results_false(self):
+        msgs = [HumanMessage(content="q"), AIMessage(content="a")]
+        assert has_prior_tool_results(msgs) is False
+
+    def test_promote_plain_text_tool_call_message(self):
+        msg = AIMessage(content='[read_file]\n{"file_path": "/app"}')
+        result = promote_plain_text_tool_call_message(msg, {"read_file"})
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0]["name"] == "read_file"

--- a/src/agent/tests/core/nodes/test_model.py
+++ b/src/agent/tests/core/nodes/test_model.py
@@ -18,14 +18,17 @@ to the current version of the project delivered to anyone in the future.
 
 from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
 import pytest
-from aidev_agent.core.nodes.model import ModelNodeSettings, ModelState, build_model_node
-from aidev_agent.core.nodes.model.node import InvalidModelMessageError, _is_invalid_message
+from aidev_agent.core.nodes.model import ModelChainConfig, ModelNodeSettings, ModelState, build_model_node
+from aidev_agent.core.nodes.model.pydantic_models import ModelChainState, ProcessorContext
+from aidev_agent.core.nodes.model.quality_gate import QualityGate, ResponseRoute
 from aidev_agent.enums import Decision
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 from langchain_core.runnables import RunnableConfig, RunnableLambda
 from langchain_core.tools import tool
 from langgraph._internal._runnable import RunnableCallable
+from openai import RateLimitError
 
 
 class TestModelState:
@@ -41,7 +44,7 @@ class TestModelState:
 def _make_mock_llm(invoke_return=None, ainvoke_return=None):
     """创建支持 Runnable 链式操作的 mock LLM。
 
-    使用 RunnableLambda 包装 mock 函数，确保 | 运算符和 with_retry 正常工作。
+    用 RunnableLambda 包装 mock 函数，确保 | 运算符正常工作。
     """
     invoke_fn = Mock(return_value=invoke_return or AIMessage(content="Mocked response"))
     ainvoke_fn = AsyncMock(return_value=ainvoke_return or AIMessage(content="Mocked async response"))
@@ -142,15 +145,15 @@ class TestBuildModelNode:
             p_vars.assert_called_once()
             mock_llm.bind_tools.assert_called_once()
 
-    def test_model_node_sync_with_structured_response(self, mock_llm, mock_store, mock_prompt_setup):
+    def test_model_node_sync_with_structured_response(self, mock_llm, sample_tools, mock_store, mock_prompt_setup):
         """测试同步模型节点（structured_response 模式）"""
         mock_template, variables = mock_prompt_setup
 
         with (
-            patch("aidev_agent.core.nodes.model.node.StructuredOutputToToolMessageParser") as mock_parser_class,
+            patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_class,
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools",
-                return_value=[],
+                return_value=sample_tools,
             ) as p_tools,
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template",
@@ -167,7 +170,7 @@ class TestBuildModelNode:
 
             node = build_model_node(
                 llm=mock_llm,
-                tools=[],
+                tools=sample_tools,
                 node_options=ModelNodeSettings(use_structured_response=True),
             )
 
@@ -234,15 +237,17 @@ class TestBuildModelNode:
             p_vars.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_model_node_async_with_structured_response(self, mock_llm, mock_store, mock_prompt_setup):
+    async def test_model_node_async_with_structured_response(
+        self, mock_llm, sample_tools, mock_store, mock_prompt_setup
+    ):
         """测试异步模型节点（structured_response 模式）"""
         mock_template, variables = mock_prompt_setup
 
         with (
-            patch("aidev_agent.core.nodes.model.node.StructuredOutputToToolMessageParser") as mock_parser_class,
+            patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_class,
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools",
-                return_value=[],
+                return_value=sample_tools,
             ) as p_tools,
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template",
@@ -258,7 +263,7 @@ class TestBuildModelNode:
 
             node = build_model_node(
                 llm=mock_llm,
-                tools=[],
+                tools=sample_tools,
                 node_options=ModelNodeSettings(use_structured_response=True),
             )
 
@@ -318,15 +323,15 @@ class TestBuildModelNode:
             p_template.assert_called_once()
             p_vars.assert_called_once()
 
-    def test_model_node_with_parallel_tool_calls_enabled(self, mock_llm, mock_store, mock_prompt_setup):
+    def test_model_node_with_parallel_tool_calls_enabled(self, mock_llm, sample_tools, mock_store, mock_prompt_setup):
         """测试启用并行工具调用"""
         mock_template, variables = mock_prompt_setup
 
         with (
-            patch("aidev_agent.core.nodes.model.node.StructuredOutputToToolMessageParser") as mock_parser_class,
+            patch("aidev_agent.core.nodes.model.model_chain.StructuredOutputToToolMessageParser") as mock_parser_class,
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools",
-                return_value=[],
+                return_value=sample_tools,
             ),
             patch(
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template",
@@ -342,7 +347,7 @@ class TestBuildModelNode:
 
             node = build_model_node(
                 llm=mock_llm,
-                tools=[],
+                tools=sample_tools,
                 node_options=ModelNodeSettings(use_structured_response=True),
             )
 
@@ -467,81 +472,11 @@ class TestBuildModelNode:
         assert rendered_messages[-1].content[1] == image_item
 
 
-class TestIsInvalidMessage:
-    """测试 _is_invalid_message 函数"""
-
-    def test_empty_content_empty_tool_calls(self):
-        # 测试空 content + 空 tool_calls → True
-        message = AIMessage(content="", tool_calls=[])
-        assert _is_invalid_message(message) is True
-        # 测试有 content + 空 tool_calls → False
-        message = AIMessage(content="Hello, world!", tool_calls=[])
-        assert _is_invalid_message(message) is False
-        # 测试空 content + 有 tool_calls → False
-        message = AIMessage(
-            content="",
-            tool_calls=[{"name": "search", "args": {"query": "test"}, "id": "1"}],
-        )
-        assert _is_invalid_message(message) is False
-        # 测试非 AIMessage → True
-        message = HumanMessage(content="Hello")
-        assert _is_invalid_message(message) is True
-        # 测试多模态 content 包含文本 → False
-        message = AIMessage(
-            content=[
-                {"type": "text", "text": "Hello"},
-                {"type": "image_url", "image_url": {"url": "http://example.com/image.jpg"}},
-            ],
-            tool_calls=[],
-        )
-        assert _is_invalid_message(message) is False
-        # 测试多模态 content 不包含文本但有图片 → False（非空 list 即为有效）
-        # 修复：返回有问题不会解析出 list，所以只要 list 存在且非空就是有效的
-        message = AIMessage(
-            content=[
-                {"type": "image_url", "image_url": {"url": "http://example.com/image.jpg"}},
-            ],
-            tool_calls=[],
-        )
-        assert _is_invalid_message(message) is False
-        # 测试 content 仅包含空白字符 → True
-        message = AIMessage(content="   \n\t  ", tool_calls=[])
-        assert _is_invalid_message(message) is True
-        # 测试 content 包含前后空白但最终有文本 → False
-        message = AIMessage(content="  Hello, world!  ", tool_calls=[])
-        assert _is_invalid_message(message) is False
-        # 测试多模态 content 文本部分仅包含空白但有图片 → False（非空 list 即为有效）
-        # 修复：返回有问题不会解析出 list，所以只要 list 存在且非空就是有效的
-        message = AIMessage(
-            content=[
-                {"type": "text", "text": "   "},
-                {"type": "image_url", "image_url": {"url": "http://example.com/image.jpg"}},
-            ],
-            tool_calls=[],
-        )
-        assert _is_invalid_message(message) is False
-        # 测试空 tool_calls 列表 → 依赖 content 判断
-        message = AIMessage(content="Some content", tool_calls=[])
-        assert _is_invalid_message(message) is False
-        # 测试多模态 content 为空列表 → True（无有效内容）
-        message = AIMessage(content=[], tool_calls=[])
-        assert _is_invalid_message(message) is True
-        # 测试多个 tool_calls → False
-        message = AIMessage(
-            content="",
-            tool_calls=[
-                {"name": "search", "args": {"query": "test"}, "id": "1"},
-                {"name": "calculator", "args": {"expression": "1+1"}, "id": "2"},
-            ],
-        )
-        assert _is_invalid_message(message) is False
-
-
 def _make_response_queue_llm(responses, aresponses=None):
     """创建按顺序返回响应的 mock LLM，支持 Runnable 链操作。
 
     Args:
-        responses: 同步响应列表，按 pop(0) 顺序消费
+        responses: 同步响应列表，按 pop(0) 顺序消耗
         aresponses: 异步响应列表，如不提供则复用 responses
     """
     queue = list(responses)
@@ -564,8 +499,8 @@ def _make_response_queue_llm(responses, aresponses=None):
     return llm
 
 
-class TestModelNodeRetry:
-    """测试 model_node 重试逻辑（with_retry + InvalidModelMessageError）"""
+class TestModelNodeRecoveryLoop:
+    """测试 model_node 内部 recovery 循环逻辑"""
 
     @pytest.fixture
     def mock_store(self):
@@ -597,11 +532,7 @@ class TestModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -611,12 +542,12 @@ class TestModelNodeRetry:
             assert result["messages"][0].content == "Success response"
             assert mock_llm._invoke_count[0] == 1
 
-    def test_first_failure_second_success(self, mock_store, mock_prompt_setup):
-        """测试首次失败（无效消息），第二次成功 → 重试 1 次"""
+    def test_empty_then_success(self, mock_store, mock_prompt_setup):
+        """测试首次返回空内容，第二次成功 → recovery 循环重试"""
         mock_llm = _make_response_queue_llm(
             [
-                AIMessage(content="", tool_calls=[]),  # 无效
-                AIMessage(content="Success after retry"),  # 有效
+                AIMessage(content="", tool_calls=[]),  # 空 → recovery_retry
+                AIMessage(content="Success after retry"),
             ]
         )
         mock_template, variables = mock_prompt_setup
@@ -630,11 +561,7 @@ class TestModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -644,8 +571,8 @@ class TestModelNodeRetry:
             assert result["messages"][0].content == "Success after retry"
             assert mock_llm._invoke_count[0] == 2
 
-    def test_multiple_failures_then_success(self, mock_store, mock_prompt_setup):
-        """测试多次失败，最终成功 → 重试多次"""
+    def test_multiple_empty_then_success(self, mock_store, mock_prompt_setup):
+        """测试多次空内容，最终成功 → recovery 循环多次重试"""
         mock_llm = _make_response_queue_llm(
             [
                 AIMessage(content="", tool_calls=[]),
@@ -664,11 +591,7 @@ class TestModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -678,10 +601,15 @@ class TestModelNodeRetry:
             assert result["messages"][0].content == "Success after 2 retries"
             assert mock_llm._invoke_count[0] == 3
 
-    def test_all_failures_raise_after_retries_exhausted(self, mock_store, mock_prompt_setup):
-        """测试全部失败（一直返回无效消息）→ 重试耗尽后抛出异常"""
+    def test_all_empty_exhausted_returns_last(self, mock_store, mock_prompt_setup):
+        """测试全部返回空内容 → 重试耗尽后返回最后一个空响应（不抛异常）
+
+        max_empty_retries=3 表示允许 3 次重试（共 4 次调用）：
+        调用1→空(retry1)→调用2→空(retry2)→调用3→空(retry3)→调用4→空(exhausted→end)
+        """
         mock_llm = _make_response_queue_llm(
             [
+                AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
@@ -701,22 +629,20 @@ class TestModelNodeRetry:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
+                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
 
-            with pytest.raises(InvalidModelMessageError):
-                node.invoke(state, config=config, store=mock_store)
+            result = node.invoke(state, config=config, store=mock_store)
 
-            assert mock_llm._invoke_count[0] == 3
+            # recovery 循环耗尽后返回最后一个空响应，不抛异常
+            assert result["messages"][0].content == ""
+            assert mock_llm._invoke_count[0] == 4
 
     def test_exception_not_retried(self, mock_store, mock_prompt_setup):
-        """测试调用抛出普通异常 → 不重试，直接抛出
-
-        with_retry 只配置了重试 InvalidModelMessageError，其他异常直接抛出。
-        """
+        """测试调用抛出普通异常 → 不重试，直接抛出"""
         invoke_counter = [0]
 
         def invoke_fn(input, config=None, **kwargs):
@@ -737,11 +663,7 @@ class TestModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -749,7 +671,6 @@ class TestModelNodeRetry:
             with pytest.raises(Exception, match="Model invocation failed"):
                 node.invoke(state, config=config, store=mock_store)
 
-            # 普通异常不会触发重试，只调用一次
             assert mock_llm._invoke_count[0] == 1
 
     def test_retry_with_tool_calls_eventually_valid(self, mock_store, mock_prompt_setup):
@@ -774,11 +695,7 @@ class TestModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -789,9 +706,63 @@ class TestModelNodeRetry:
             assert result["messages"][0].tool_calls[0]["name"] == "search"
             assert mock_llm._invoke_count[0] == 2
 
+    def test_truncated_tool_call_rebuilds_chain(self, mock_store, mock_prompt_setup):
+        """测试截断的工具调用触发 chain 重建（max_tokens 提升）
 
-class TestAModelNodeRetry:
-    """测试 amodel_node 异步重试逻辑（with_retry + InvalidModelMessageError）"""
+        第一次调用返回截断的 tool_call 响应（finish_reason="length"），
+        触发 RECOVERY_TRUNCATION → 工具调用截断分支 → 重建 chain 并重试。
+        验证：LLM 被调用两次，最终成功。
+        """
+        mock_template, variables = mock_prompt_setup
+
+        mock_llm = _make_response_queue_llm(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "search", "args": {"query": "test"}, "id": "1"}],
+                    response_metadata={"finish_reason": "length"},
+                ),
+                AIMessage(content="chain 重建后成功"),
+            ]
+        )
+        # 为 mock LLM 添加 .bind() 支持，因为截断恢复路径会调用 .bind(max_tokens=...)
+        mock_llm.bind = Mock(return_value=mock_llm)
+
+        with (
+            patch("aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools", return_value=[]),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template",
+                return_value=mock_template,
+            ),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables",
+                return_value=variables,
+            ),
+        ):
+            node = build_model_node(
+                llm=mock_llm,
+                tools=[],
+                node_options=ModelNodeSettings(
+                    model_chain_config=ModelChainConfig(
+                        max_empty_retries=3,
+                        max_truncated_tool_call_retries=3,
+                    )
+                ),
+            )
+
+            state: ModelState = {"messages": [HumanMessage(content="test")]}
+            config = RunnableConfig()
+
+            result = node.invoke(state, config=config, store=mock_store)
+
+            # 验证最终成功返回
+            assert result["messages"][0].content == "chain 重建后成功"
+            # 验证 LLM 被调用了两次（初始 + 重建 chain 后重试）
+            assert mock_llm._invoke_count[0] == 2
+
+
+class TestAModelNodeRecoveryLoop:
+    """测试 amodel_node 异步 recovery 循环逻辑"""
 
     @pytest.fixture
     def mock_store(self):
@@ -824,11 +795,7 @@ class TestAModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -839,8 +806,8 @@ class TestAModelNodeRetry:
             assert mock_llm._ainvoke_count[0] == 1
 
     @pytest.mark.asyncio
-    async def test_first_failure_second_success(self, mock_store, mock_prompt_setup):
-        """测试首次失败（无效消息），第二次成功 → 重试 1 次"""
+    async def test_empty_then_success(self, mock_store, mock_prompt_setup):
+        """测试首次返回空内容，第二次成功 → recovery 循环重试"""
         mock_llm = _make_response_queue_llm(
             [
                 AIMessage(content="", tool_calls=[]),
@@ -858,11 +825,7 @@ class TestAModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -873,8 +836,8 @@ class TestAModelNodeRetry:
             assert mock_llm._ainvoke_count[0] == 2
 
     @pytest.mark.asyncio
-    async def test_multiple_failures_then_success(self, mock_store, mock_prompt_setup):
-        """测试多次失败，最终成功 → 重试多次"""
+    async def test_multiple_empty_then_success(self, mock_store, mock_prompt_setup):
+        """测试多次空内容，最终成功 → recovery 循环多次重试"""
         mock_llm = _make_response_queue_llm(
             [
                 AIMessage(content="", tool_calls=[]),
@@ -893,11 +856,7 @@ class TestAModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -908,10 +867,15 @@ class TestAModelNodeRetry:
             assert mock_llm._ainvoke_count[0] == 3
 
     @pytest.mark.asyncio
-    async def test_all_failures_raise_after_retries_exhausted(self, mock_store, mock_prompt_setup):
-        """测试全部失败（一直返回无效消息）→ 重试耗尽后抛出异常"""
+    async def test_all_empty_exhausted_returns_last(self, mock_store, mock_prompt_setup):
+        """测试全部返回空内容 → 重试耗尽后返回最后一个空响应（不抛异常）
+
+        max_empty_retries=3 表示允许 3 次重试（共 4 次调用）：
+        调用1→空(retry1)→调用2→空(retry2)→调用3→空(retry3)→调用4→空(exhausted→end)
+        """
         mock_llm = _make_response_queue_llm(
             [
+                AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
                 AIMessage(content="", tool_calls=[]),
@@ -931,23 +895,20 @@ class TestAModelNodeRetry:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
+                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
 
-            with pytest.raises(InvalidModelMessageError):
-                await node.ainvoke(state, config=config, store=mock_store)
+            result = await node.ainvoke(state, config=config, store=mock_store)
 
-            assert mock_llm._ainvoke_count[0] == 3
+            assert result["messages"][0].content == ""
+            assert mock_llm._ainvoke_count[0] == 4
 
     @pytest.mark.asyncio
     async def test_exception_not_retried(self, mock_store, mock_prompt_setup):
-        """测试调用抛出普通异常 → 不重试，直接抛出
-
-        with_retry 只配置了重试 InvalidModelMessageError，其他异常直接抛出。
-        """
+        """测试调用抛出普通异常 → 不重试，直接抛出"""
         ainvoke_counter = [0]
 
         async def ainvoke_fn(input, config=None, **kwargs):
@@ -968,11 +929,7 @@ class TestAModelNodeRetry:
                 "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
             ),
         ):
-            node = build_model_node(
-                llm=mock_llm,
-                tools=[],
-                node_options=ModelNodeSettings(max_model_retries=3),
-            )
+            node = build_model_node(llm=mock_llm, tools=[])
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
             config = RunnableConfig()
@@ -980,5 +937,286 @@ class TestAModelNodeRetry:
             with pytest.raises(Exception, match="Model invocation failed"):
                 await node.ainvoke(state, config=config, store=mock_store)
 
-            # 普通异常不会触发重试，只调用一次
             assert mock_llm._ainvoke_count[0] == 1
+
+
+def _make_ctx(response, messages=None, model_chain_state=None):
+    """构造测试用 ProcessorContext。"""
+    if messages is None:
+        messages = []
+    if model_chain_state is None:
+        model_chain_state = ModelChainState()
+    return ProcessorContext(
+        state={"messages": messages},
+        config=RunnableConfig(),
+        messages=messages,
+        model_chain_state=model_chain_state,
+        response=response,
+    )
+
+
+class TestValidateResponse:
+    """测试 validate_response 函数"""
+
+    def _make_gate(self, *, enable_judgment_llm: bool = False) -> QualityGate:
+        """构造测试用 QualityGate。默认关闭 judgment LLM 避免 test 触发真实 LLM 构造。"""
+        return QualityGate(enable_judgment_llm=enable_judgment_llm)
+
+    def test_tool_calls_returns_pv_node(self):
+        msg = AIMessage(content="", tool_calls=[{"name": "x", "args": {}, "id": "1"}])
+        ctx = _make_ctx(msg)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.TOOL_EXECUTION
+
+    def test_content_returns_end(self):
+        msg = AIMessage(content="hello")
+        ctx = _make_ctx(msg)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.NORMAL_COMPLETION
+
+    @pytest.mark.parametrize(
+        "content",
+        [
+            [{"type": "text", "text": "hello"}],
+            [{"type": "image_url", "image_url": {"url": "http://example.com"}}],
+        ],
+    )
+    def test_list_content_returns_end(self, content):
+        msg = AIMessage(content=content)
+        ctx = _make_ctx(msg)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.NORMAL_COMPLETION
+
+    def test_content_no_finish_reason_returns_normal_completion(self):
+        """测试有 content + 无 tool_calls + 无 finish_reason → 正常完成
+
+        参照 hermes-agent 的 map_finish_reason(None) → "stop" 行为：
+        当模型输出有内容但没有 finish_reason 时，视为正常完成。
+        """
+        msg = AIMessage(content="hello")
+        assert not msg.response_metadata.get("finish_reason")
+        ctx = _make_ctx(msg)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.NORMAL_COMPLETION
+
+    def test_empty_after_tools_nudge(self):
+        tool_msg = ToolMessage(content="result", tool_call_id="1")
+        msg = AIMessage(content="")
+        ctx = _make_ctx(msg, [tool_msg, msg])
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.RECOVERY_NUDGE
+
+    def test_thinking_only_prefill(self):
+        msg = AIMessage(content="<think>reasoning</think>", reasoning_content="deep thought")
+        ctx = _make_ctx(msg)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.RECOVERY_PREFILL
+
+    def test_truncated_response(self):
+        msg = AIMessage(content="", response_metadata={"finish_reason": "length"})
+        ctx = _make_ctx(msg, model_chain_state=ModelChainState(post_tool_empty_retried=True))
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.RECOVERY_TRUNCATION
+
+    def test_empty_retry(self):
+        msg = AIMessage(content="")
+        ctx = _make_ctx(msg, model_chain_state=ModelChainState(post_tool_empty_retried=True))
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.RECOVERY_RETRY
+
+    def test_exhausted_retries_returns_end(self):
+        msg = AIMessage(content="")
+        rs = ModelChainState(
+            empty_content_retries=3,
+            post_tool_empty_retried=True,
+            thinking_prefill_retries=2,
+            length_continue_retries=3,
+        )
+        ctx = _make_ctx(msg, model_chain_state=rs)
+        result = self._make_gate().validate_response(ctx)
+        assert result == ResponseRoute.NORMAL_COMPLETION
+
+
+class TestModelNodeRateLimit:
+    """测试 model_node 对 RateLimitError 的捕获和重试逻辑"""
+
+    @staticmethod
+    def _make_rate_limit_error() -> RateLimitError:
+        """创建一个 mock RateLimitError，需要提供 httpx.Response"""
+        request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+        response = httpx.Response(429, request=request)
+        return RateLimitError("rate limited", response=response, body=None)
+
+    @pytest.fixture
+    def mock_store(self):
+        """Mock BaseStore"""
+        return Mock()
+
+    @pytest.fixture
+    def mock_prompt_setup(self):
+        """Mock prompt template 和 variables"""
+        mock_template = Mock()
+        prompt_value = Mock()
+        prompt_value.to_messages.return_value = [HumanMessage(content="test")]
+        mock_template.invoke = Mock(return_value=prompt_value)
+
+        variables = {"input": "test", "chat_history": [], "agent_scratchpad": []}
+        return mock_template, variables
+
+    def test_rate_limit_error_retried(self, mock_store, mock_prompt_setup):
+        """测试 RateLimitError 后被重试并成功
+
+        模拟 1 次 RateLimitError → 重试 → 成功返回，验证调用次数为 2。
+        """
+        invoke_counter = [0]
+
+        def invoke_fn(input, config=None, **kwargs):
+            invoke_counter[0] += 1
+            if invoke_counter[0] == 1:
+                raise self._make_rate_limit_error()
+            return AIMessage(content="Success after rate limit")
+
+        mock_llm = RunnableLambda(invoke_fn)
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        mock_llm._invoke_count = invoke_counter
+        mock_template, variables = mock_prompt_setup
+
+        with (
+            patch("aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools", return_value=[]),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template", return_value=mock_template
+            ),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
+            ),
+            patch("aidev_agent.config.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("time.sleep", return_value=None),  # 跳过实际等待
+        ):
+            node = build_model_node(llm=mock_llm, tools=[])
+
+            state: ModelState = {"messages": [HumanMessage(content="test")]}
+            config = RunnableConfig()
+
+            result = node.invoke(state, config=config, store=mock_store)
+
+            assert result["messages"][0].content == "Success after rate limit"
+            assert invoke_counter[0] == 2
+
+    def test_rate_limit_error_exhausted(self, mock_store, mock_prompt_setup):
+        """测试 RateLimitError 连续发生 → 重试耗尽后抛出异常
+
+        max_empty_retries=3 意味着允许 3 次重试（共 4 次调用），
+        第 4 次 RateLimitError 时不再重试，直接抛出。
+        """
+        invoke_counter = [0]
+
+        def invoke_fn(input, config=None, **kwargs):
+            invoke_counter[0] += 1
+            raise self._make_rate_limit_error()
+
+        mock_llm = RunnableLambda(invoke_fn)
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        mock_llm._invoke_count = invoke_counter
+        mock_template, variables = mock_prompt_setup
+
+        with (
+            patch("aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools", return_value=[]),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template", return_value=mock_template
+            ),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
+            ),
+            patch("aidev_agent.config.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("time.sleep", return_value=None),
+        ):
+            node = build_model_node(
+                llm=mock_llm,
+                tools=[],
+                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+            )
+
+            state: ModelState = {"messages": [HumanMessage(content="test")]}
+            config = RunnableConfig()
+
+            with pytest.raises(RateLimitError):
+                node.invoke(state, config=config, store=mock_store)
+
+            # 第 1 次 invoke + 3 次重试 = 4 次调用，第 4 次触发耗尽抛出
+            assert invoke_counter[0] == 4
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_async_retried(self, mock_store, mock_prompt_setup):
+        """测试异步 RateLimitError 后被重试并成功"""
+        ainvoke_counter = [0]
+
+        async def ainvoke_fn(input, config=None, **kwargs):
+            ainvoke_counter[0] += 1
+            if ainvoke_counter[0] == 1:
+                raise self._make_rate_limit_error()
+            return AIMessage(content="Success after rate limit")
+
+        mock_llm = RunnableLambda(lambda x, **kw: AIMessage(content=""), afunc=ainvoke_fn)
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        mock_llm._ainvoke_count = ainvoke_counter
+        mock_template, variables = mock_prompt_setup
+
+        with (
+            patch("aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools", return_value=[]),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template", return_value=mock_template
+            ),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
+            ),
+            patch("aidev_agent.config.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("asyncio.sleep", AsyncMock(return_value=None)),
+        ):
+            node = build_model_node(llm=mock_llm, tools=[])
+
+            state: ModelState = {"messages": [HumanMessage(content="test")]}
+            config = RunnableConfig()
+
+            result = await node.ainvoke(state, config=config, store=mock_store)
+
+            assert result["messages"][0].content == "Success after rate limit"
+            assert ainvoke_counter[0] == 2
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_async_exhausted(self, mock_store, mock_prompt_setup):
+        """测试异步 RateLimitError 连续发生 → 重试耗尽后抛出异常"""
+        ainvoke_counter = [0]
+
+        async def ainvoke_fn(input, config=None, **kwargs):
+            ainvoke_counter[0] += 1
+            raise self._make_rate_limit_error()
+
+        mock_llm = RunnableLambda(lambda x, **kw: AIMessage(content=""), afunc=ainvoke_fn)
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        mock_llm._ainvoke_count = ainvoke_counter
+        mock_template, variables = mock_prompt_setup
+
+        with (
+            patch("aidev_agent.core.nodes.model.node.ContextAssembly.get_choice_tools", return_value=[]),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_template", return_value=mock_template
+            ),
+            patch(
+                "aidev_agent.core.nodes.model.node.ContextAssembly.get_chat_prompt_variables", return_value=variables
+            ),
+            patch("aidev_agent.config.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("asyncio.sleep", AsyncMock(return_value=None)),
+        ):
+            node = build_model_node(
+                llm=mock_llm,
+                tools=[],
+                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+            )
+
+            state: ModelState = {"messages": [HumanMessage(content="test")]}
+            config = RunnableConfig()
+
+            with pytest.raises(RateLimitError):
+                await node.ainvoke(state, config=config, store=mock_store)
+
+            assert ainvoke_counter[0] == 4

--- a/src/agent/tests/core/nodes/test_model.py
+++ b/src/agent/tests/core/nodes/test_model.py
@@ -20,7 +20,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
-from aidev_agent.core.nodes.model import ModelChainConfig, ModelNodeSettings, ModelState, build_model_node
+from aidev_agent.core.nodes.model import ModelNodeSettings, ModelState, build_model_node
 from aidev_agent.core.nodes.model.pydantic_models import ModelChainState, ProcessorContext
 from aidev_agent.core.nodes.model.quality_gate import QualityGate, ResponseRoute
 from aidev_agent.enums import Decision
@@ -604,7 +604,7 @@ class TestModelNodeRecoveryLoop:
     def test_all_empty_exhausted_returns_last(self, mock_store, mock_prompt_setup):
         """测试全部返回空内容 → 重试耗尽后返回最后一个空响应（不抛异常）
 
-        max_empty_retries=3 表示允许 3 次重试（共 4 次调用）：
+        max_model_retries=3 表示允许 3 次重试（共 4 次调用）：
         调用1→空(retry1)→调用2→空(retry2)→调用3→空(retry3)→调用4→空(exhausted→end)
         """
         mock_llm = _make_response_queue_llm(
@@ -629,7 +629,7 @@ class TestModelNodeRecoveryLoop:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+                node_options=ModelNodeSettings(max_model_retries=3),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
@@ -742,12 +742,7 @@ class TestModelNodeRecoveryLoop:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(
-                    model_chain_config=ModelChainConfig(
-                        max_empty_retries=3,
-                        max_truncated_tool_call_retries=3,
-                    )
-                ),
+                node_options=ModelNodeSettings(max_model_retries=3),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
@@ -870,7 +865,7 @@ class TestAModelNodeRecoveryLoop:
     async def test_all_empty_exhausted_returns_last(self, mock_store, mock_prompt_setup):
         """测试全部返回空内容 → 重试耗尽后返回最后一个空响应（不抛异常）
 
-        max_empty_retries=3 表示允许 3 次重试（共 4 次调用）：
+        max_model_retries=3 表示允许 3 次重试（共 4 次调用）：
         调用1→空(retry1)→调用2→空(retry2)→调用3→空(retry3)→调用4→空(exhausted→end)
         """
         mock_llm = _make_response_queue_llm(
@@ -895,7 +890,7 @@ class TestAModelNodeRecoveryLoop:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+                node_options=ModelNodeSettings(max_model_retries=3),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
@@ -958,9 +953,9 @@ def _make_ctx(response, messages=None, model_chain_state=None):
 class TestValidateResponse:
     """测试 validate_response 函数"""
 
-    def _make_gate(self, *, enable_judgment_llm: bool = False) -> QualityGate:
-        """构造测试用 QualityGate。默认关闭 judgment LLM 避免 test 触发真实 LLM 构造。"""
-        return QualityGate(enable_judgment_llm=enable_judgment_llm)
+    def _make_gate(self, *, enable_judge_response: bool = False) -> QualityGate:
+        """构造测试用 QualityGate。默认关闭判断 LLM 避免 test 触发真实 LLM 构造。"""
+        return QualityGate(enable_judge_response=enable_judge_response)
 
     def test_tool_calls_returns_pv_node(self):
         msg = AIMessage(content="", tool_calls=[{"name": "x", "args": {}, "id": "1"}])
@@ -1002,7 +997,9 @@ class TestValidateResponse:
     def test_empty_after_tools_nudge(self):
         tool_msg = ToolMessage(content="result", tool_call_id="1")
         msg = AIMessage(content="")
-        ctx = _make_ctx(msg, [tool_msg, msg])
+        # ctx.response 是独立字段，不在 ctx.messages 中；工具执行后 messages
+        # 末尾正是 ToolMessage，符合实际运行时语义。
+        ctx = _make_ctx(msg, [tool_msg])
         result = self._make_gate().validate_response(ctx)
         assert result == ResponseRoute.RECOVERY_NUDGE
 
@@ -1031,6 +1028,7 @@ class TestValidateResponse:
             post_tool_empty_retried=True,
             thinking_prefill_retries=2,
             length_continue_retries=3,
+            max_retries=2,
         )
         ctx = _make_ctx(msg, model_chain_state=rs)
         result = self._make_gate().validate_response(ctx)
@@ -1105,7 +1103,7 @@ class TestModelNodeRateLimit:
     def test_rate_limit_error_exhausted(self, mock_store, mock_prompt_setup):
         """测试 RateLimitError 连续发生 → 重试耗尽后抛出异常
 
-        max_empty_retries=3 意味着允许 3 次重试（共 4 次调用），
+        max_model_retries=3 意味着允许 3 次重试（共 4 次调用），
         第 4 次 RateLimitError 时不再重试，直接抛出。
         """
         invoke_counter = [0]
@@ -1133,7 +1131,7 @@ class TestModelNodeRateLimit:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+                node_options=ModelNodeSettings(max_model_retries=3),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}
@@ -1210,7 +1208,7 @@ class TestModelNodeRateLimit:
             node = build_model_node(
                 llm=mock_llm,
                 tools=[],
-                node_options=ModelNodeSettings(model_chain_config=ModelChainConfig(max_empty_retries=3)),
+                node_options=ModelNodeSettings(max_model_retries=3),
             )
 
             state: ModelState = {"messages": [HumanMessage(content="test")]}

--- a/src/agent/tests/core/nodes/test_model_skill.py
+++ b/src/agent/tests/core/nodes/test_model_skill.py
@@ -197,7 +197,7 @@ class TestReActBuilderSkillsIntegration:
 
         captured = {}
 
-        def _fake_make_model_node(*, llm, non_thinking_llm, tools, node_options):
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
             captured["tools"] = tools
             captured["node_options"] = node_options
             return MagicMock()


### PR DESCRIPTION
1. 添加了 model_chain 文件， 新建了 build_model_chain 现在的标准链为：
_render_messages | ((llm | tool | use_tool_call_promotion ) | quality_gate ).with_retry
2. 迁移 is_invalid_message 到 quilty_gate 中 (is_invalid_message 主要是无内容且无工具调用)
3. 迁移 _prepare_model_chain 到 model_chain 中
4. 构造了模型返回质量门禁，以便于提升模型质量
- 检查是否是 AIMessage，处置：非 AIMessage 直接结束
- 检查工具调用是否被截断，处置：被截断时提高 token 预算
- 检查是否有工具调用，处置：有工具调用时放行
- 检查有效内容是否完成了任务，处置：未完成任务时重试，完成任务时放行
- 最近有 ToolMessage 调用，处置：空请求轻推
- 仅思考没有内容，处置：重试
- 返回原因是 length (超 token 截断)， 处置：被截断时提高 token 预算