### PR TITLE
feat: 支持智能体模板本地一键调试 --story=1070093903136413328

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # 导入子目录中的 Makefile 文件
 ROOT_DIR?=$(shell git rev-parse --show-toplevel)
+TEMPLATE_PROJECT_DIR := template/{{cookiecutter.project_name}}
 
 .PHONY: ALL
 ALL: init-project
@@ -95,6 +96,11 @@ release_versions:
 sync_template_sdk_versions:
 	@echo "Syncing template SDK versions from repository packages..."
 	@uv run python scripts/update_versions.py --sync-template-sdk-versions
+
+.PHONY: dev
+dev:
+	uv run --no-sync python scripts/template_debug.py --env-file "$(env_file)"
+	$(MAKE) -C '$(TEMPLATE_PROJECT_DIR)' dev
 
 # Catch-all rule to prevent Make from complaining about unknown targets
 %:

--- a/readme.md
+++ b/readme.md
@@ -71,7 +71,7 @@
 make dev
 ```
 
-> `make dev` 会把 `aidev_agent`、`aidev_bkplugin` 源码软链到模板目录，自动执行 `migrate`、`createcachetable`，并根据 `.env` 中的 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动本地服务。
+> `make dev` 会把 `aidev_agent`、`aidev_bkplugin` 源码软链到模板目录，自动安装模板依赖，执行 `migrate`、`createcachetable`，并根据 `.env` 中的 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动本地服务。
 > `.env` 请优先到 bkaidev 平台进入对应智能体，通过「下载源码」获取完整工程；源码包中已包含该智能体对应的 `.env` 文件。
 > 默认使用 `template/{{cookiecutter.project_name}}/.env`；也可以执行 `make dev env_file=/path/to/.env`，先复制指定环境文件再启动。
 > 首次运行前请按模板说明完成本地域名 hosts 映射。

--- a/readme.md
+++ b/readme.md
@@ -66,15 +66,14 @@
    - [企业微信机器人开发指南](./src/plugins/aidev_wxbot/readme.md)
 
 ### 模板项目本地开发（快捷方式）
-可参考 `template/{{cookiecutter.project_name}}/Makefile` 使用一键启动命令：
+在仓库根目录使用一键启动命令：
 ```bash
-cd template/{{cookiecutter.project_name}}
 make dev
 ```
 
-> `make dev` 会自动执行 `migrate`、`createcachetable` 并启动本地服务（`0.0.0.0:5000`）。
+> `make dev` 会把 `aidev_agent`、`aidev_bkplugin` 源码软链到模板目录，自动执行 `migrate`、`createcachetable`，并根据 `.env` 中的 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动本地服务。
 > `.env` 请优先到 bkaidev 平台进入对应智能体，通过「下载源码」获取完整工程；源码包中已包含该智能体对应的 `.env` 文件。
-> 下载后请将源码包中的 `.env` 放到本地模板项目根目录（`template/{{cookiecutter.project_name}}/.env`）再执行 `make dev`。
+> 默认使用 `template/{{cookiecutter.project_name}}/.env`；也可以执行 `make dev env_file=/path/to/.env`，先复制指定环境文件再启动。
 > 首次运行前请按模板说明完成本地域名 hosts 映射。
 
 ### 前端开发

--- a/scripts/template_debug.py
+++ b/scripts/template_debug.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Prepare the repository's cookiecutter project for local source debugging."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+TEMPLATE_PROJECT = REPOSITORY_ROOT / "template" / "{{cookiecutter.project_name}}"
+SOURCE_LINKS = {
+    "aidev_agent": REPOSITORY_ROOT / "src" / "agent" / "aidev_agent",
+    "aidev_bkplugin": REPOSITORY_ROOT / "src" / "plugins" / "aidev_bkplugin" / "aidev_bkplugin",
+}
+
+
+def ensure_source_link(name: str, source: Path) -> None:
+    destination = TEMPLATE_PROJECT / name
+    if not source.is_dir():
+        raise RuntimeError(f"source package does not exist: {source}")
+
+    if os.path.lexists(destination):
+        if not destination.is_symlink():
+            raise RuntimeError(f"refusing to replace non-symlink path: {destination}")
+
+        current_source = (destination.parent / os.readlink(destination)).resolve()
+        if current_source != source.resolve():
+            print(f"Replacing source link: {destination} -> {os.readlink(destination)}")
+            destination.unlink()
+        else:
+            print(f"Source link already exists: {destination} -> {os.readlink(destination)}")
+            return
+
+    relative_source = os.path.relpath(source, start=destination.parent)
+    destination.symlink_to(relative_source, target_is_directory=True)
+    print(f"Created source link: {destination} -> {relative_source}")
+
+
+def prepare_env_file(env_file: str) -> None:
+    destination = TEMPLATE_PROJECT / ".env"
+    if not env_file:
+        if not destination.is_file():
+            raise RuntimeError(f"environment file not found: {destination}; pass env_file=/path/to/.env")
+        print(f"Using existing environment file: {destination}")
+        return
+
+    source = Path(env_file).expanduser().resolve()
+    if not source.is_file():
+        raise RuntimeError(f"environment file does not exist: {source}")
+    if destination.is_file() and destination.resolve() == source:
+        print(f"Using existing environment file: {destination}")
+        return
+
+    shutil.copy2(source, destination)
+    print(f"Copied environment file to: {destination}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--env-file",
+        default="",
+        help="optional .env file to copy into the template project; defaults to its existing .env",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        prepare_env_file(args.env_file)
+        for name, source in SOURCE_LINKS.items():
+            ensure_source_link(name, source)
+    except (OSError, RuntimeError) as error:
+        print(f"Template debug preparation failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/template/{{cookiecutter.project_name}}/Makefile
+++ b/template/{{cookiecutter.project_name}}/Makefile
@@ -51,7 +51,7 @@ lint:
 
 # 一键启动：加载 .env、初始化数据库，并在 local.${BKPAAS_BK_DOMAIN}:8000 启动本地服务
 .PHONY: dev
-dev:
+dev: uv-install
 	@set -eu; \
 	if [ ! -f ./.env ]; then \
 		echo "Missing .env. Put it in $(CURDIR)/.env or run root make dev env_file=/path/to/.env" >&2; \

--- a/template/{{cookiecutter.project_name}}/Makefile
+++ b/template/{{cookiecutter.project_name}}/Makefile
@@ -36,7 +36,7 @@ clean:
 	find . -name ".cache" | xargs rm -rf
 	rm -rf ./dist
 	rm -rf .venv
-	uv clean
+	uv clean --force
 
 .git/hooks/pre-commit: ${ROOT_DIR}/.pre-commit-config.yaml
 	uv run pre-commit install -t pre-commit

--- a/template/{{cookiecutter.project_name}}/Makefile
+++ b/template/{{cookiecutter.project_name}}/Makefile
@@ -49,11 +49,19 @@ clean:
 lint:
 	uv run pre-commit run -a --hook-stage commit
 
-# 一键启动：migrate + createcachetable 后启动本地服务（需已配置 .env 与 hosts）
+# 一键启动：加载 .env、初始化数据库，并在 local.${BKPAAS_BK_DOMAIN}:8000 启动本地服务
 .PHONY: dev
 dev:
-	set -e; \
+	@set -eu; \
+	if [ ! -f ./.env ]; then \
+		echo "Missing .env. Put it in $(CURDIR)/.env or run root make dev env_file=/path/to/.env" >&2; \
+		exit 1; \
+	fi; \
+	set -a; \
 	. ./.env; \
+	set +a; \
+	dev_host="local.$${BKPAAS_BK_DOMAIN:?Missing BKPAAS_BK_DOMAIN in .env}"; \
+	echo "Starting template service at http://$$dev_host:8000"; \
 	uv run --no-sync python bin/manage.py migrate; \
 	uv run --no-sync python bin/manage.py createcachetable; \
-	uv run --no-sync python bin/manage.py runserver 0.0.0.0:5000
+	uv run --no-sync python bin/manage.py runserver "$$dev_host:8000"

--- a/template/{{cookiecutter.project_name}}/readme.md
+++ b/template/{{cookiecutter.project_name}}/readme.md
@@ -41,7 +41,7 @@ cp ./support-files/env.template .env
 make dev
 ```
 
-`make dev` 会加载 `.env`、初始化数据库和缓存表，并根据 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动服务。也可以手动执行：
+`make dev` 会安装模板依赖、加载 `.env`、初始化数据库和缓存表，并根据 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动服务。也可以手动执行：
 
 ```shell
 source .env

--- a/template/{{cookiecutter.project_name}}/readme.md
+++ b/template/{{cookiecutter.project_name}}/readme.md
@@ -38,6 +38,12 @@ cp ./support-files/env.template .env
 然后，执行以下脚本启动本地服务，即可开始测试：
 
 ```shell
+make dev
+```
+
+`make dev` 会加载 `.env`、初始化数据库和缓存表，并根据 `BKPAAS_BK_DOMAIN` 以 `local.<BKPAAS_BK_DOMAIN>:8000` 启动服务。也可以手动执行：
+
+```shell
 source .env
 source .venv/bin/activate
 python bin/manage.py migrate

--- a/template/{{cookiecutter.project_name}}/uv.lock
+++ b/template/{{cookiecutter.project_name}}/uv.lock
@@ -51,7 +51,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aidev-agent", extras = ["opentelemetry"], specifier = "==2.2.0" },
-    { name = "aidev-ai-blueking", specifier = "==2.2.0b11" },
+    { name = "aidev-ai-blueking", specifier = "==2.2.1b5" },
     { name = "aidev-bkplugin", specifier = "==2.2.0" },
     { name = "aidev-wxbot", specifier = "==2.2.0" },
     { name = "bk-plugin-framework", specifier = "==2.3.15" },
@@ -134,15 +134,15 @@ opentelemetry = [
 
 [[package]]
 name = "aidev-ai-blueking"
-version = "2.2.0b11"
+version = "2.2.1b5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aidev-agent" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/90/b7257150a1e64320a4bbc62c66824b02ec5f3e73383eb9378345a57282cd/aidev_ai_blueking-2.2.0b11.tar.gz", hash = "sha256:aa337ac32f0c6db707c4f8b4e6ef7c51e74abc0d60ae8151f923fb9dcacd5559", size = 3934881, upload-time = "2026-07-08T02:57:48.584Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/cc/9a1ecd72af63fdf3e22fccc8886cef1e7f965140bb1b8227b9a612d5bc9a/aidev_ai_blueking-2.2.1b5.tar.gz", hash = "sha256:c6b91f8f6f8666a4a30947bb3e1c6458d738923fced6c8bf46182391a2a55bf1", size = 3939101, upload-time = "2026-07-16T12:17:26.773Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/66/6ad2e05078959083d9c0b961f28ee9471c3bfbd74d36d5a5eb745fd3508a/aidev_ai_blueking-2.2.0b11-py3-none-any.whl", hash = "sha256:a61bf7bc9ba127a2ae6b471837651e13a01e25dce0deaafcb57dd7a4a006a47a", size = 3986501, upload-time = "2026-07-08T02:57:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/ca/21efa695a0fdc27b167d40baada2a20db7ed32d7fb5bb87f0a9c63016a38/aidev_ai_blueking-2.2.1b5-py3-none-any.whl", hash = "sha256:818f121113b7271cd43ca8f15d157ebc49f0988f62d64cf577f45bf99fd5203d", size = 3991068, upload-time = "2026-07-16T12:17:25.248Z" },
 ]
 
 [[package]]

--- a/template/{{cookiecutter.project_name}}/uv.lock
+++ b/template/{{cookiecutter.project_name}}/uv.lock
@@ -51,7 +51,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aidev-agent", extras = ["opentelemetry"], specifier = "==2.2.0" },
-    { name = "aidev-ai-blueking", specifier = "==2.2.1b5" },
+    { name = "aidev-ai-blueking", specifier = "==2.2.0b11" },
     { name = "aidev-bkplugin", specifier = "==2.2.0" },
     { name = "aidev-wxbot", specifier = "==2.2.0" },
     { name = "bk-plugin-framework", specifier = "==2.3.15" },
@@ -134,15 +134,15 @@ opentelemetry = [
 
 [[package]]
 name = "aidev-ai-blueking"
-version = "2.2.1b5"
+version = "2.2.0b11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aidev-agent" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/cc/9a1ecd72af63fdf3e22fccc8886cef1e7f965140bb1b8227b9a612d5bc9a/aidev_ai_blueking-2.2.1b5.tar.gz", hash = "sha256:c6b91f8f6f8666a4a30947bb3e1c6458d738923fced6c8bf46182391a2a55bf1", size = 3939101, upload-time = "2026-07-16T12:17:26.773Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/90/b7257150a1e64320a4bbc62c66824b02ec5f3e73383eb9378345a57282cd/aidev_ai_blueking-2.2.0b11.tar.gz", hash = "sha256:aa337ac32f0c6db707c4f8b4e6ef7c51e74abc0d60ae8151f923fb9dcacd5559", size = 3934881, upload-time = "2026-07-08T02:57:48.584Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/ca/21efa695a0fdc27b167d40baada2a20db7ed32d7fb5bb87f0a9c63016a38/aidev_ai_blueking-2.2.1b5-py3-none-any.whl", hash = "sha256:818f121113b7271cd43ca8f15d157ebc49f0988f62d64cf577f45bf99fd5203d", size = 3991068, upload-time = "2026-07-16T12:17:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/66/6ad2e05078959083d9c0b961f28ee9471c3bfbd74d36d5a5eb745fd3508a/aidev_ai_blueking-2.2.0b11-py3-none-any.whl", hash = "sha256:a61bf7bc9ba127a2ae6b471837651e13a01e25dce0deaafcb57dd7a4a006a47a", size = 3986501, upload-time = "2026-07-08T02:57:46.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

仓库内调试 cookiecutter 智能体模板时，需要手工准备本地源码依赖、环境配置和 Django 初始化命令，启动步骤较分散。

## 原因

模板项目默认使用已发布的 Python 包，无法直接加载当前仓库中的 Agent 与插件源码；现有快捷命令也没有覆盖源码链接和环境文件准备。

## 改动内容

- 在仓库根目录增加 `make dev`，准备调试环境后透传到模板项目。
- 默认复用模板目录已有的 `.env`，并支持通过 `env_file` 复制指定环境文件。
- 幂等创建 `aidev_agent`、`aidev_bkplugin` 源码软链，拒绝覆盖同名真实文件或目录。
- 模板启动前自动执行增量依赖安装，避免全新克隆因缺少 Django 等依赖而失败。
- 模板启动时加载并导出 `.env`，依次执行 `migrate`、`createcachetable` 和 `runserver`。
- 模板清理目标使用 `uv clean --force`，确保清理缓存时忽略占用检查。
- 本地域名从 `BKPAAS_BK_DOMAIN` 生成，服务固定使用 8000 端口。
- 更新根目录与模板项目的本地调试文档。

## 收益

开发者可以在仓库根目录通过一个命令调试模板，并确保运行时直接加载当前源码。

## 测试验证

- 本次文件范围 pre-commit：通过。
- `git diff --check`：通过。
- `make -n dev`：确认根入口正确透传，模板命令顺序与参数符合预期。
- 重复执行准备脚本：默认和显式 `env_file` 均通过，源码软链保持幂等。
- Python 导入检查：两个包均从模板目录的源码软链加载。
- 全新临时 uv 环境安装：成功解析 209 个包、安装 184 个包，并确认可导入 Django 4.2.29。
- `make -n clean`：确认模板清理流程使用 `uv clean --force`。
- 完整仓库 pre-commit：被上游基线中本次改动范围外的既有 Ruff 和语法错误阻塞。
