### PR TITLE
feat: 文件产物异步获取下载预览链接 --story=136417365

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -16,6 +16,7 @@
       :messages="messages"
       :model-value="userInput"
       :on-agent-action="handleAgentAction"
+      :on-artifact-click="mockArtifactClick"
       :on-custom-tab-change="handleCustomTabChange"
       :on-interrupt-resume="handleInterruptResume"
       :on-send-message="handleSendMessage"
@@ -177,7 +178,7 @@
   import CustomTabContent from './custom-tab-content.vue';
   import { MOCK_INTERRUPT_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
-  import { MOCK_ARTIFACTS_MESSAGES, MOCK_PROMPTS, MOCK_RESOURCES } from './mock';
+  import { MOCK_ARTIFACTS_MESSAGES, MOCK_PROMPTS, MOCK_RESOURCES, mockArtifactClick } from './mock';
   import { uploadFileToSession } from './upload-file';
 
   import type { CustomTab, IAiSlashMenuItem, Shortcut, TagSchema } from '../src/types';

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -109,57 +109,78 @@ export const MOCK_SHORTCUTS = [
   },
 ] as Shortcut[];
 
-// AI 生成的文件产物（覆盖全部支持的 AIFileType 类型；最后一项无 url 用于验证「有 url 才显示下载」）
+// AI 生成的文件产物（流式阶段仅含元信息；download_url / preview_url 由 onArtifactClick 异步返回）
 export const MOCK_FILE_ARTIFACTS: AIFileInfo[] = [
   {
     name: '项目立项书.pdf',
     outputId: 'artifact-pdf',
-    previewUrl: 'https://example.com/preview/project.pdf',
     size: 245_760,
     type: AIFileType.Pdf,
-    url: 'https://example.com/download/project.pdf',
   },
   {
     name: '系统配置系统配置系统配置系统配置系统配置系统配置系统配置系统配置.md',
     outputId: 'artifact-markdown',
-    previewUrl: 'https://example.com/preview/config.md',
     size: 4_096,
     type: AIFileType.Markdown,
-    url: 'https://example.com/download/config.md',
   },
   {
     name: 'demo.json',
     outputId: 'artifact-json',
-    previewUrl: 'https://example.com/preview/demo.json',
     size: 1_280,
     type: AIFileType.Json,
-    url: 'https://example.com/download/demo.json',
   },
   {
     name: '自然风光.jpg',
     outputId: 'artifact-jpg',
-    previewUrl: 'https://example.com/preview/scenery.jpg',
     size: 1_048_576,
     type: AIFileType.Jpg,
-    url: 'https://example.com/download/scenery.jpg',
   },
   {
     name: 'dashboard_preview.html',
     outputId: 'artifact-html',
-    previewUrl: 'https://example.com/preview/dashboard.html',
     size: 8_192,
     type: AIFileType.Html,
-    url: 'https://example.com/download/dashboard.html',
   },
   {
     name: '会议纪要草稿.txt',
     outputId: 'artifact-txt',
-    previewUrl: 'https://example.com/preview/meeting.txt',
     size: 2_048,
     type: AIFileType.Txt,
-    url: '',
   },
 ];
+
+/** playground 模拟 onArtifactClick：按 outputId 异步返回 download_url / preview_url */
+export const MOCK_ARTIFACT_URL_MAP: Record<string, { download_url: string; preview_url: string }> = {
+  'artifact-pdf': {
+    download_url: 'https://example.com/download/project.pdf',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-markdown': {
+    download_url: 'https://example.com/download/config.md',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-json': {
+    download_url: 'https://example.com/download/demo.json',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-jpg': {
+    download_url: 'https://example.com/download/scenery.jpg',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-html': {
+    download_url: 'data:text/html,<h1>dashboard preview</h1><p>mock html artifact</p>',
+    preview_url: 'https://example.com/preview/dashboard.html',
+  },
+  'artifact-txt': {
+    download_url: 'https://example.com/download/meeting.txt',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+};
+
+export const mockArtifactClick = async (file: AIFileInfo) => {
+  await new Promise(resolve => setTimeout(resolve, 1400));
+  return MOCK_ARTIFACT_URL_MAP[file.outputId] ?? {};
+};
 
 // 带文件产物的会话消息，用于 playground 调试 artifacts 展示
 export const MOCK_ARTIFACTS_MESSAGES = [

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/file.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/file.ts
@@ -38,12 +38,17 @@ export type AIFileInfo = {
   name: string;
   /* 输出ID */
   outputId: string;
-  /* 预览URL */
-  previewUrl: string;
   /* 文件大小 */
   size: number;
   /* 文件类型 */
   type: AIFileType;
-  /* 文件URL */
-  url: string;
 };
+
+/** 点击文件产物后异步获取的下载 / 预览地址（snake_case） */
+export type ArtifactUrlResult = {
+  download_url?: string;
+  preview_url?: string;
+};
+
+/** 异步获取文件产物下载 / 预览链接 */
+export type OnArtifactClick = (file: AIFileInfo) => Promise<ArtifactUrlResult>;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -330,6 +330,7 @@
   import MessageLoading from '../message-loading/message-loading.vue';
   import SelectionFooter from '../selection-footer/selection-footer.vue';
 
+  import type { OnArtifactClick } from '../../ag-ui/types/file';
   import type {
     AITippyProps,
     CustomBkFlowTabData,
@@ -354,6 +355,8 @@
       tab: CustomTab<Record<string, unknown>>,
       events: { removeCustomTab: typeof removeCustomTab },
     ) => undefined | VNode;
+    /** 点击文件产物时异步获取 download_url / preview_url；未传则隐藏下载、预览无数据 */
+    onArtifactClick?: OnArtifactClick;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onCustomTabChange?: (tab: CustomTab<CustomBkFlowTabData>) => Promise<any>;
     openingRemark?: string;
@@ -470,7 +473,7 @@
     useCustomTabProvider<CustomBkFlowTabData>({
       executionTabVisible: () => props.executionTabVisible,
       onTabChange: async tab => {
-        // 文件产物 Tab 数据自包含（previewUrl 已在 artifact 上），无需走异步拉取
+        // 文件产物 Tab 由 FileArtifactPanel 自行通过 onArtifactClick 异步取链，无需走自定义 Tab 拉取
         if (tab.name === FILE_ARTIFACT_TAB_NAME) {
           return;
         }
@@ -524,6 +527,7 @@
 
   // 文件卡片点击 → 命中文件并弹出/切换到固定的「文件产物」侧栏 Tab（排在执行情况之前，不可关闭）
   const { activeArtifactId, setActiveArtifactId } = useArtifactPreviewProvider({
+    getOnArtifactClick: () => props.onArtifactClick,
     onOpen: () => {
       addCustomTab({
         closable: false,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
@@ -24,9 +24,9 @@
  * IN THE SOFTWARE.
  */
 
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
-import { type VueWrapper, mount } from '@vue/test-utils';
+import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../../../../ag-ui/types/file';
@@ -37,7 +37,6 @@ import type { AIFileInfo } from '../../../../ag-ui/types/file';
 
 vi.mock('tippy.js/dist/tippy.css', () => ({}));
 
-// Mock vue-tippy directive
 vi.mock('vue-tippy', () => ({
   directive: {
     mounted: vi.fn(),
@@ -45,13 +44,30 @@ vi.mock('vue-tippy', () => ({
   },
 }));
 
+vi.mock('bkui-vue', () => ({
+  Loading: {
+    name: 'Loading',
+    template: '<span class="mock-loading" />',
+  },
+}));
+
 const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
   name: '运维操作指引文档.doc',
   outputId: 'output-1',
-  previewUrl: 'https://example.com/preview',
   size: 1024,
   type: AIFileType.Pdf,
-  url: 'https://example.com/download',
+  ...overrides,
+});
+
+const createPreviewContext = (overrides: Record<string, unknown> = {}) => ({
+  activeArtifactId: ref(''),
+  canResolveArtifactUrl: computed(() => true),
+  openPreview: vi.fn(),
+  resolveArtifactUrls: vi.fn().mockResolvedValue({
+    download_url: 'https://example.com/download',
+    preview_url: 'https://example.com/preview',
+  }),
+  setActiveArtifactId: vi.fn(),
   ...overrides,
 });
 
@@ -75,16 +91,25 @@ describe('ArtifactFileCard', () => {
       expect(wrapper.find('.ai-artifact-file-card-icon svg').exists()).toBe(true);
     });
 
-    it('有 url 时应该展示下载按钮', () => {
-      wrapper = mount(ArtifactFileCard, { props: { file: createFile() } });
+    it('有 onArtifactClick 上下文时应展示下载按钮', () => {
+      wrapper = mount(ArtifactFileCard, {
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: createPreviewContext() } },
+        props: { file: createFile() },
+      });
 
       expect(wrapper.find('.ai-artifact-file-card-download').exists()).toBe(true);
     });
 
-    it('无 url 时应该隐藏下载按钮', () => {
-      wrapper = mount(ArtifactFileCard, { props: { file: createFile({ url: '' }) } });
+    it('未传 onArtifactClick 且无 onDownload 时应隐藏下载按钮', () => {
+      wrapper = mount(ArtifactFileCard, { props: { file: createFile() } });
 
       expect(wrapper.find('.ai-artifact-file-card-download').exists()).toBe(false);
+    });
+
+    it('传入 onDownload 时应展示下载按钮', () => {
+      wrapper = mount(ArtifactFileCard, { props: { file: createFile(), onDownload: vi.fn() } });
+
+      expect(wrapper.find('.ai-artifact-file-card-download').exists()).toBe(true);
     });
 
     it('传入 onPreview 时卡片应带可点击态', () => {
@@ -100,9 +125,8 @@ describe('ArtifactFileCard', () => {
     });
 
     it('存在侧栏预览上下文时卡片应带可点击态', () => {
-      const artifactPreview = { activeArtifactId: ref(''), openPreview: vi.fn(), setActiveArtifactId: vi.fn() };
       wrapper = mount(ArtifactFileCard, {
-        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: artifactPreview } },
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: createPreviewContext() } },
         props: { file: createFile() },
       });
 
@@ -133,7 +157,7 @@ describe('ArtifactFileCard', () => {
 
     it('无 onPreview 时点击卡片应调用侧栏预览 openPreview 并透传定位信息', async () => {
       const openPreview = vi.fn();
-      const artifactPreview = { activeArtifactId: ref(''), openPreview, setActiveArtifactId: vi.fn() };
+      const artifactPreview = createPreviewContext({ openPreview });
       const file = createFile();
       wrapper = mount(ArtifactFileCard, {
         global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: artifactPreview } },
@@ -158,12 +182,20 @@ describe('ArtifactFileCard', () => {
       clickSpy.mockRestore();
     });
 
-    it('未传 onDownload 时点击下载应该触发默认下载', async () => {
+    it('有 onArtifactClick 时点击下载应异步取链并触发下载', async () => {
       const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
-      wrapper = mount(ArtifactFileCard, { props: { file: createFile() } });
+      const resolveArtifactUrls = vi.fn().mockResolvedValue({
+        download_url: 'https://example.com/download',
+      });
+      wrapper = mount(ArtifactFileCard, {
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: createPreviewContext({ resolveArtifactUrls }) } },
+        props: { file: createFile() },
+      });
 
       await wrapper.find('.ai-artifact-file-card-download').trigger('click');
+      await flushPromises();
 
+      expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
       expect(clickSpy).toHaveBeenCalledTimes(1);
       clickSpy.mockRestore();
     });
@@ -171,9 +203,13 @@ describe('ArtifactFileCard', () => {
     it('点击下载不应该冒泡触发 onPreview', async () => {
       const onPreview = vi.fn();
       const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
-      wrapper = mount(ArtifactFileCard, { props: { file: createFile(), onPreview } });
+      wrapper = mount(ArtifactFileCard, {
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: createPreviewContext() } },
+        props: { file: createFile(), onPreview },
+      });
 
       await wrapper.find('.ai-artifact-file-card-download').trigger('click');
+      await flushPromises();
 
       expect(onPreview).not.toHaveBeenCalled();
       clickSpy.mockRestore();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
@@ -23,23 +23,34 @@
         {{ file.name }}
       </span>
     </div>
-    <!-- 右侧：下载按钮（有下载地址时才展示） -->
+    <!-- 右侧：有异步取链能力或外部 onDownload 时展示下载按钮 -->
     <div
-      v-if="file.url"
+      v-if="showDownload"
       v-tippy="downloadTippy"
       class="ai-artifact-file-card-download"
+      :class="{ 'is-loading': downloadLoading }"
       @click.stop="handleDownload"
     >
-      <component :is="downloadIcon" />
+      <Loading
+        v-if="downloadLoading"
+        mode="spin"
+        size="mini"
+        theme="primary"
+      />
+      <component
+        :is="downloadIcon"
+        v-else
+      />
     </div>
   </div>
 </template>
 <script setup lang="ts">
-  import { cloneVNode, computed } from 'vue';
+  import { cloneVNode, computed, shallowRef } from 'vue';
 
+  import { Loading } from 'bkui-vue';
   import { directive as vTippy } from 'vue-tippy';
 
-  import { useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
+  import { triggerArtifactDownload, useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
   import { DownloadFileIcon } from '../../../../icons/file';
   import { t } from '../../../../lang/lang';
@@ -71,9 +82,14 @@
   // 有外部 onPreview 或处于可预览的侧栏上下文时，卡片可点击
   const clickable = computed(() => !!props.onPreview || !!artifactPreview);
 
+  // 未传 onArtifactClick 时隐藏下载；有外部 onDownload 或可异步取链时展示
+  const showDownload = computed(() => !!props.onDownload || !!artifactPreview?.canResolveArtifactUrl.value);
+
   // 图标为共享 VNode，克隆后再渲染，避免同类型多卡复用同一实例
   const fileIcon = computed(() => getFileIcon(props.file.type));
   const downloadIcon = computed(() => cloneVNode(DownloadFileIcon));
+
+  const downloadLoading = shallowRef(false);
 
   const downloadTippy = computed(() => ({
     content: t('下载'),
@@ -93,20 +109,26 @@
     });
   };
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
+    if (downloadLoading.value) {
+      return;
+    }
     if (props.onDownload) {
       props.onDownload(props.file);
       return;
     }
-    // 默认下载：使用 url 字段，通过临时 <a> 触发浏览器下载
-    const link = document.createElement('a');
-    link.href = props.file.url;
-    link.download = props.file.name;
-    link.target = '_blank';
-    link.rel = 'noopener';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    if (!artifactPreview?.canResolveArtifactUrl.value) {
+      return;
+    }
+    downloadLoading.value = true;
+    try {
+      const { download_url: downloadUrl } = await artifactPreview.resolveArtifactUrls(props.file);
+      if (downloadUrl) {
+        triggerArtifactDownload(downloadUrl, props.file.name);
+      }
+    } finally {
+      downloadLoading.value = false;
+    }
   };
 </script>
 <style lang="scss">
@@ -162,6 +184,8 @@
       flex-shrink: 0;
       align-items: center;
       justify-content: center;
+      width: 24px;
+      height: 24px;
       padding: 4px;
       margin-left: 4px;
       font-size: 16px;
@@ -172,6 +196,12 @@
       &:hover {
         color: #3a84ff;
         background-color: #f0f1f5;
+      }
+
+      &.is-loading {
+        display: inline-flex;
+        pointer-events: none;
+        cursor: default;
       }
 
       .ai-artifact-file-card:hover & {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
@@ -23,13 +23,13 @@
  * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  */
-import { defineComponent, h } from 'vue';
+import { computed, defineComponent, h, ref } from 'vue';
 
 import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../../../../ag-ui/types/file';
-import { buildArtifactId } from '../../../../composables/use-artifact-preview';
+import { ARTIFACT_PREVIEW_TOKEN, buildArtifactId } from '../../../../composables/use-artifact-preview';
 import FileArtifactPanel from './file-artifact-panel.vue';
 
 import type { SessionArtifact } from '../../../../composables/use-artifact-preview';
@@ -40,7 +40,6 @@ vi.mock('vue-tippy', () => ({
   directive: { mounted: vi.fn(), unmounted: vi.fn() },
 }));
 
-// 轻量 mock bkui-vue，避免引入完整组件库
 vi.mock('bkui-vue', () => ({
   Button: defineComponent({
     emits: ['click'],
@@ -61,6 +60,16 @@ vi.mock('bkui-vue', () => ({
           onInput: (e: Event) => emit('update:modelValue', (e.target as HTMLInputElement).value),
         }),
   }),
+  Loading: defineComponent({
+    setup: () => () => h('span', { class: 'mock-loading' }),
+  }),
+}));
+
+vi.mock('../../../message-loading/message-loading.vue', () => ({
+  default: defineComponent({
+    name: 'MessageLoading',
+    setup: () => () => h('div', { class: 'mock-message-loading' }),
+  }),
 }));
 
 const createArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifact => {
@@ -71,13 +80,29 @@ const createArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifa
     messageUid,
     name: '项目立项书.pdf',
     outputId,
-    previewUrl: 'https://example.com/preview.pdf',
     size: 1024,
     type: AIFileType.Pdf,
-    url: 'https://example.com/download.pdf',
     ...overrides,
   };
 };
+
+const createPreviewContext = (overrides: Record<string, unknown> = {}) => ({
+  activeArtifactId: ref(''),
+  canResolveArtifactUrl: computed(() => true),
+  openPreview: vi.fn(),
+  resolveArtifactUrls: vi.fn().mockResolvedValue({
+    download_url: 'https://example.com/download.pdf',
+    preview_url: 'https://example.com/preview.pdf',
+  }),
+  setActiveArtifactId: vi.fn(),
+  ...overrides,
+});
+
+const mountPanel = (props: { activeId: string; artifacts: SessionArtifact[] }, previewCtx?: unknown) =>
+  mount(FileArtifactPanel, {
+    global: previewCtx ? { provide: { [ARTIFACT_PREVIEW_TOKEN]: previewCtx } } : {},
+    props,
+  });
 
 describe('FileArtifactPanel', () => {
   let wrapper: VueWrapper;
@@ -95,7 +120,7 @@ describe('FileArtifactPanel', () => {
       createArtifact({ outputId: 'a', name: '文档.pdf' }),
       createArtifact({ outputId: 'b', name: '统计.xlsx' }),
     ];
-    wrapper = mount(FileArtifactPanel, { props: { activeId: '', artifacts } });
+    wrapper = mountPanel({ activeId: '', artifacts });
 
     expect(wrapper.findAll('.ai-artifact-file-card.is-list').length).toBe(2);
     expect(wrapper.find('.ai-file-artifact-panel-list-title').text()).toContain('2');
@@ -103,7 +128,7 @@ describe('FileArtifactPanel', () => {
 
   it('命中文件的列表项应带 is-active 态', () => {
     const artifacts = [createArtifact({ outputId: 'a' }), createArtifact({ outputId: 'b' })];
-    wrapper = mount(FileArtifactPanel, { props: { activeId: artifacts[1].artifactId, artifacts } });
+    wrapper = mountPanel({ activeId: artifacts[1].artifactId, artifacts });
 
     const items = wrapper.findAll('.ai-artifact-file-card.is-list');
     expect(items[0].classes()).not.toContain('is-active');
@@ -112,7 +137,7 @@ describe('FileArtifactPanel', () => {
 
   it('点击其它文件项应 emit select', async () => {
     const artifacts = [createArtifact({ outputId: 'a' }), createArtifact({ outputId: 'b' })];
-    wrapper = mount(FileArtifactPanel, { props: { activeId: artifacts[0].artifactId, artifacts } });
+    wrapper = mountPanel({ activeId: artifacts[0].artifactId, artifacts });
 
     await wrapper.findAll('.ai-artifact-file-card.is-list')[1].trigger('click');
 
@@ -124,7 +149,7 @@ describe('FileArtifactPanel', () => {
       createArtifact({ outputId: 'a', name: '运维文档.pdf' }),
       createArtifact({ outputId: 'b', name: '统计.xlsx' }),
     ];
-    wrapper = mount(FileArtifactPanel, { props: { activeId: '', artifacts } });
+    wrapper = mountPanel({ activeId: '', artifacts });
 
     await wrapper.find('.mock-input').setValue('统计');
 
@@ -133,28 +158,51 @@ describe('FileArtifactPanel', () => {
     expect(items[0].text()).toContain('统计');
   });
 
-  it('pdf 文件应使用 iframe src 展示 previewUrl，且不发起 fetch', async () => {
+  it('未传 onArtifactClick 时预览区应展示无数据', async () => {
+    const artifact = createArtifact();
+    wrapper = mountPanel({ activeId: artifact.artifactId, artifacts: [artifact] });
+    await flushPromises();
+
+    expect(wrapper.find('.ai-file-artifact-panel-preview-empty').exists()).toBe(true);
+    expect(wrapper.find('.ai-file-artifact-panel-preview-iframe').exists()).toBe(false);
+  });
+
+  it('pdf 文件应异步取链后用 iframe src 展示 preview_url', async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
-    const artifact = createArtifact({ previewUrl: 'https://example.com/x.pdf', type: AIFileType.Pdf });
-    wrapper = mount(FileArtifactPanel, { props: { activeId: artifact.artifactId, artifacts: [artifact] } });
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/download.pdf',
+      preview_url: 'https://example.com/x.pdf',
+    });
+    const artifact = createArtifact({ type: AIFileType.Pdf });
+    wrapper = mountPanel(
+      { activeId: artifact.artifactId, artifacts: [artifact] },
+      createPreviewContext({ resolveArtifactUrls }),
+    );
     await flushPromises();
 
     const iframe = wrapper.find('.ai-file-artifact-panel-preview-iframe');
     expect(iframe.attributes('src')).toBe('https://example.com/x.pdf');
     expect(fetchSpy).not.toHaveBeenCalled();
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
     vi.unstubAllGlobals();
   });
 
-  it('html 文件应拉取 file.url 并用 iframe srcdoc 渲染', async () => {
+  it('html 文件应使用 download_url 拉取并用 iframe srcdoc 渲染', async () => {
     const fetchSpy = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('<h1>hi</h1>') });
     vi.stubGlobal('fetch', fetchSpy);
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/page.html',
+      preview_url: 'https://example.com/preview.pdf',
+    });
     const artifact = createArtifact({
       name: 'page.html',
       type: AIFileType.Html,
-      url: 'https://example.com/page.html',
     });
-    wrapper = mount(FileArtifactPanel, { props: { activeId: artifact.artifactId, artifacts: [artifact] } });
+    wrapper = mountPanel(
+      { activeId: artifact.artifactId, artifacts: [artifact] },
+      createPreviewContext({ resolveArtifactUrls }),
+    );
     await flushPromises();
 
     expect(fetchSpy).toHaveBeenCalledWith('https://example.com/page.html', expect.any(Object));
@@ -164,18 +212,47 @@ describe('FileArtifactPanel', () => {
   });
 
   it('html 拉取失败应展示错误态', async () => {
-    const fetchSpy = vi.fn().mockRejectedValue(new Error('network'));
+    const fetchSpy = vi.fn().mockRejectedValue(new Error('EOF'));
     vi.stubGlobal('fetch', fetchSpy);
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/page.html',
+    });
     const artifact = createArtifact({ name: 'page.html', type: AIFileType.Html });
-    wrapper = mount(FileArtifactPanel, { props: { activeId: artifact.artifactId, artifacts: [artifact] } });
+    wrapper = mountPanel(
+      { activeId: artifact.artifactId, artifacts: [artifact] },
+      createPreviewContext({ resolveArtifactUrls }),
+    );
     await flushPromises();
 
     expect(wrapper.find('.ai-file-artifact-panel-preview-error').exists()).toBe(true);
     vi.unstubAllGlobals();
   });
 
+  it('异步取链过程中应展示 MessageLoading', async () => {
+    let resolveUrls: (value: { preview_url: string }) => void = () => {};
+    const resolveArtifactUrls = vi.fn(
+      () =>
+        new Promise<{ preview_url: string }>(resolve => {
+          resolveUrls = resolve;
+        }),
+    );
+    const artifact = createArtifact();
+    wrapper = mountPanel(
+      { activeId: artifact.artifactId, artifacts: [artifact] },
+      createPreviewContext({ resolveArtifactUrls }),
+    );
+
+    expect(wrapper.find('.mock-message-loading').exists()).toBe(true);
+
+    resolveUrls({ preview_url: 'https://example.com/x.pdf' });
+    await flushPromises();
+
+    expect(wrapper.find('.mock-message-loading').exists()).toBe(false);
+    expect(wrapper.find('.ai-file-artifact-panel-preview-iframe').exists()).toBe(true);
+  });
+
   it('无命中文件时应展示空态', () => {
-    wrapper = mount(FileArtifactPanel, { props: { activeId: 'not-exist', artifacts: [createArtifact()] } });
+    wrapper = mountPanel({ activeId: 'not-exist', artifacts: [createArtifact()] });
 
     expect(wrapper.find('.ai-file-artifact-panel-preview-empty').exists()).toBe(true);
   });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
@@ -45,45 +45,62 @@
             </span>
           </div>
           <span
-            v-if="activeArtifact.url"
+            v-if="canResolveArtifactUrl"
             class="ai-file-artifact-panel-preview-header-download"
+            :class="{ 'is-loading': downloadLoading }"
             @click="handleDownload(activeArtifact)"
           >
-            <component :is="getDownloadIcon()" />
+            <Loading
+              v-if="downloadLoading"
+              mode="spin"
+              size="mini"
+              theme="primary"
+            />
+            <component
+              :is="getDownloadIcon()"
+              v-else
+            />
           </span>
         </div>
         <div class="ai-file-artifact-panel-preview-body">
-          <!-- HTML：拉取 file.url 的 html 字符串后用 iframe srcdoc 渲染 -->
-          <template v-if="isHtml">
-            <div
-              v-if="htmlStatus === 'loading'"
-              class="ai-file-artifact-panel-preview-skeleton ai-skeleton-element"
-            />
-            <div
-              v-else-if="htmlStatus === 'error'"
-              class="ai-file-artifact-panel-preview-error"
+          <!-- 异步取链 / HTML 拉取中：统一 MessageLoading -->
+          <div
+            v-if="previewStatus === 'loading'"
+            class="ai-file-artifact-panel-preview-loading"
+          >
+            <MessageLoading />
+          </div>
+          <div
+            v-else-if="previewStatus === 'error'"
+            class="ai-file-artifact-panel-preview-error"
+          >
+            <span>{{ t('预览加载失败') }}</span>
+            <Button
+              size="small"
+              text
+              theme="primary"
+              @click="loadPreview"
             >
-              <span>{{ t('预览加载失败') }}</span>
-              <Button
-                size="small"
-                text
-                theme="primary"
-                @click="loadHtml"
-              >
-                {{ t('重试') }}
-              </Button>
-            </div>
-            <iframe
-              v-else
-              class="ai-file-artifact-panel-preview-iframe"
-              :srcdoc="htmlContent"
-            />
-          </template>
-          <!-- 其余类型：previewUrl 为后台转换好的 pdf，直接 iframe 展示 -->
+              {{ t('重试') }}
+            </Button>
+          </div>
+          <div
+            v-else-if="previewStatus === 'empty'"
+            class="ai-file-artifact-panel-preview-empty"
+          >
+            {{ t('暂无可预览的文件') }}
+          </div>
+          <!-- HTML：用 download_url 拉取 html 后 iframe srcdoc -->
+          <iframe
+            v-else-if="isHtml"
+            class="ai-file-artifact-panel-preview-iframe"
+            :srcdoc="htmlContent"
+          />
+          <!-- 其余类型：preview_url 为后台转换好的 pdf -->
           <iframe
             v-else
             class="ai-file-artifact-panel-preview-iframe"
-            :src="activeArtifact.previewUrl"
+            :src="previewUrl"
           />
         </div>
       </template>
@@ -99,12 +116,14 @@
 <script setup lang="ts">
   import { cloneVNode, computed, onBeforeUnmount, shallowRef, watch } from 'vue';
 
-  import { Button, Input } from 'bkui-vue';
+  import { Button, Input, Loading } from 'bkui-vue';
 
   import { AIFileType } from '../../../../ag-ui/types/file';
+  import { triggerArtifactDownload, useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
   import { DownloadFileIcon } from '../../../../icons/file';
   import { t } from '../../../../lang/lang';
+  import MessageLoading from '../../../message-loading/message-loading.vue';
   import ArtifactFileCard from './artifact-file-card.vue';
   import { getFileIcon } from './file-icon';
 
@@ -121,10 +140,21 @@
     (e: 'select', id: string): void;
   }>();
 
+  const artifactPreview = useArtifactPreviewConsumer();
+  const canResolveArtifactUrl = computed(() => !!artifactPreview?.canResolveArtifactUrl.value);
+
   // 下载图标为共享 VNode，每处渲染克隆一份，避免多处复用同一实例
   const getDownloadIcon = () => cloneVNode(DownloadFileIcon);
 
   const keyword = shallowRef('');
+  const downloadLoading = shallowRef(false);
+  const previewStatus = shallowRef<'empty' | 'error' | 'idle' | 'loading' | 'ready'>('idle');
+  const previewUrl = shallowRef('');
+  const htmlContent = shallowRef('');
+  // 记录当前进行中的请求，切换文件时中断旧请求，避免竞态覆盖
+  let htmlAbortController: AbortController | undefined;
+  // 用于丢弃过期的 URL 解析结果
+  let loadSeq = 0;
 
   const filteredArtifacts = computed(() => {
     const kw = keyword.value.trim().toLowerCase();
@@ -138,38 +168,69 @@
 
   const isHtml = computed(() => activeArtifact.value?.type === AIFileType.Html);
 
-  const htmlStatus = shallowRef<'error' | 'idle' | 'loading' | 'ready'>('idle');
-  const htmlContent = shallowRef('');
-  // 记录当前进行中的请求，切换文件时中断旧请求，避免竞态覆盖
-  let htmlAbortController: AbortController | undefined;
-
-  const loadHtml = async () => {
+  const loadPreview = async () => {
     const file = activeArtifact.value;
     if (!file) {
+      previewStatus.value = 'empty';
       return;
     }
+
+    // 未传 onArtifactClick：预览区展示无数据
+    if (!artifactPreview?.canResolveArtifactUrl.value) {
+      previewStatus.value = 'empty';
+      previewUrl.value = '';
+      htmlContent.value = '';
+      return;
+    }
+
+    const seq = ++loadSeq;
     htmlAbortController?.abort();
-    const controller = new AbortController();
-    htmlAbortController = controller;
-    htmlStatus.value = 'loading';
+    previewStatus.value = 'loading';
+    previewUrl.value = '';
     htmlContent.value = '';
+
     try {
-      const res = await fetch(file.url, { signal: controller.signal });
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status}`);
-      }
-      const text = await res.text();
-      // 请求返回时若已切换到其它文件则丢弃结果
-      if (controller.signal.aborted) {
+      const urls = await artifactPreview.resolveArtifactUrls(file);
+      if (seq !== loadSeq) {
         return;
       }
-      htmlContent.value = text;
-      htmlStatus.value = 'ready';
+
+      if (file.type === AIFileType.Html) {
+        const downloadUrl = urls.download_url;
+        if (!downloadUrl) {
+          previewStatus.value = 'empty';
+          return;
+        }
+        const controller = new AbortController();
+        htmlAbortController = controller;
+        const res = await fetch(downloadUrl, { signal: controller.signal });
+        if (!res.ok) {
+          throw new Error(`HTTP ${res.status}`);
+        }
+        const text = await res.text();
+        if (controller.signal.aborted || seq !== loadSeq) {
+          return;
+        }
+        htmlContent.value = text;
+        previewStatus.value = 'ready';
+        return;
+      }
+
+      if (!urls.preview_url) {
+        previewStatus.value = 'empty';
+        return;
+      }
+      previewUrl.value = urls.preview_url;
+      previewStatus.value = 'ready';
     } catch {
-      if (controller.signal.aborted) {
+      if (seq !== loadSeq) {
         return;
       }
-      htmlStatus.value = 'error';
+      // abort 不算失败
+      if (htmlAbortController?.signal.aborted) {
+        return;
+      }
+      previewStatus.value = 'error';
     }
   };
 
@@ -180,33 +241,33 @@
     emits('select', item.artifactId);
   };
 
-  const handleDownload = (file: SessionArtifact) => {
-    const link = document.createElement('a');
-    link.href = file.url;
-    link.download = file.name;
-    link.target = '_blank';
-    link.rel = 'noopener';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+  const handleDownload = async (file: SessionArtifact) => {
+    if (downloadLoading.value || !artifactPreview?.canResolveArtifactUrl.value) {
+      return;
+    }
+    downloadLoading.value = true;
+    try {
+      const { download_url: downloadUrl } = await artifactPreview.resolveArtifactUrls(file);
+      if (downloadUrl) {
+        triggerArtifactDownload(downloadUrl, file.name);
+      }
+    } finally {
+      downloadLoading.value = false;
+    }
   };
 
-  // 命中文件变化时：html 触发拉取，其余类型清空 html 缓存交给 iframe.src 直接渲染
+  // 命中文件变化时重新异步取链并加载预览
   watch(
     () => activeArtifact.value?.artifactId,
     () => {
-      if (isHtml.value) {
-        loadHtml();
-      } else {
-        htmlAbortController?.abort();
-        htmlStatus.value = 'idle';
-        htmlContent.value = '';
-      }
+      downloadLoading.value = false;
+      loadPreview();
     },
     { immediate: true },
   );
 
   onBeforeUnmount(() => {
+    loadSeq += 1;
     htmlAbortController?.abort();
   });
 </script>
@@ -295,6 +356,8 @@
           flex-shrink: 0;
           align-items: center;
           justify-content: center;
+          width: 24px;
+          height: 24px;
           padding: 4px;
           font-size: 16px;
           color: #969799;
@@ -304,6 +367,11 @@
             color: variables.$color-primary;
             cursor: pointer;
             background-color: #f5f7fa;
+          }
+
+          &.is-loading {
+            pointer-events: none;
+            cursor: default;
           }
         }
       }
@@ -320,10 +388,11 @@
         border: none;
       }
 
-      &-skeleton {
-        width: 100%;
+      &-loading {
+        display: flex;
+        align-items: center;
+        justify-content: center;
         height: 100%;
-        border-radius: 4px;
       }
 
       &-error {
@@ -340,6 +409,7 @@
         flex: 1;
         align-items: center;
         justify-content: center;
+        height: 100%;
         color: variables.$color-text-secondary;
       }
     }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.spec.ts
@@ -45,10 +45,8 @@ vi.mock('vue-tippy', () => ({
 const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
   name: 'file.pdf',
   outputId: 'output-1',
-  previewUrl: '',
   size: 1024,
   type: AIFileType.Pdf,
-  url: 'https://example.com/download',
   ...overrides,
 });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
@@ -1,3 +1,29 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
 import { defineComponent, h } from 'vue';
 
 import { mount } from '@vue/test-utils';
@@ -10,15 +36,13 @@ import {
   useArtifactPreviewProvider,
 } from './use-artifact-preview';
 
-import type { AIFileInfo } from '../ag-ui/types/file';
+import type { AIFileInfo, OnArtifactClick } from '../ag-ui/types/file';
 
 const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
   name: 'file.pdf',
   outputId: 'output-1',
-  previewUrl: 'https://example.com/preview.pdf',
   size: 1024,
   type: AIFileType.Pdf,
-  url: 'https://example.com/download',
   ...overrides,
 });
 
@@ -30,8 +54,11 @@ describe('use-artifact-preview', () => {
   });
 
   describe('Provider / Consumer', () => {
-    // 通过父子组件建立 provide/inject，父暴露 provider api、子暴露 consumer ctx
-    const setup = (onOpen = vi.fn()) => {
+    const setup = (options: {
+      getOnArtifactClick?: () => OnArtifactClick | undefined;
+      onOpen?: ReturnType<typeof vi.fn>;
+    } = {}) => {
+      const onOpen = options.onOpen ?? vi.fn();
       let providerApi: ReturnType<typeof useArtifactPreviewProvider> | undefined;
       let consumerCtx: ReturnType<typeof useArtifactPreviewConsumer>;
 
@@ -43,7 +70,10 @@ describe('use-artifact-preview', () => {
       });
       const Parent = defineComponent({
         setup() {
-          providerApi = useArtifactPreviewProvider({ onOpen });
+          providerApi = useArtifactPreviewProvider({
+            getOnArtifactClick: options.getOnArtifactClick,
+            onOpen,
+          });
           return () => h(Child);
         },
       });
@@ -68,6 +98,52 @@ describe('use-artifact-preview', () => {
       consumerCtx?.setActiveArtifactId('custom-id');
 
       expect(providerApi?.activeArtifactId.value).toBe('custom-id');
+    });
+
+    it('未传 onArtifactClick 时 canResolveArtifactUrl 应为 false', () => {
+      const { consumerCtx } = setup();
+
+      expect(consumerCtx?.canResolveArtifactUrl.value).toBe(false);
+    });
+
+    it('resolveArtifactUrls 应按 outputId 缓存结果且不重复请求', async () => {
+      const onArtifactClick = vi.fn().mockResolvedValue({
+        download_url: 'https://example.com/d',
+        preview_url: 'https://example.com/p',
+      });
+      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
+      const file = createFile({ outputId: 'cache-1' });
+
+      const first = await consumerCtx!.resolveArtifactUrls(file);
+      const second = await consumerCtx!.resolveArtifactUrls(file);
+
+      expect(first).toEqual({
+        download_url: 'https://example.com/d',
+        preview_url: 'https://example.com/p',
+      });
+      expect(second).toEqual(first);
+      expect(onArtifactClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('并发 resolveArtifactUrls 应复用同一进行中请求', async () => {
+      let resolveClick: (value: { download_url: string }) => void = () => {};
+      const onArtifactClick = vi.fn(
+        () =>
+          new Promise<{ download_url: string }>(resolve => {
+            resolveClick = resolve;
+          }),
+      );
+      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
+      const file = createFile({ outputId: 'inflight-1' });
+
+      const p1 = consumerCtx!.resolveArtifactUrls(file);
+      const p2 = consumerCtx!.resolveArtifactUrls(file);
+      resolveClick({ download_url: 'https://example.com/d' });
+      const [r1, r2] = await Promise.all([p1, p2]);
+
+      expect(r1).toEqual({ download_url: 'https://example.com/d' });
+      expect(r2).toEqual(r1);
+      expect(onArtifactClick).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
@@ -1,12 +1,47 @@
-import { type Ref, inject, provide, shallowRef } from 'vue';
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
 
-import type { AIFileInfo } from '../ag-ui/types/file';
+import { type ComputedRef, type Ref, computed, inject, provide, shallowRef } from 'vue';
+
+import type { AIFileInfo, ArtifactUrlResult, OnArtifactClick } from '../ag-ui/types/file';
 
 /** 文件产物预览 Provider/Consumer 通信 token */
 export const ARTIFACT_PREVIEW_TOKEN = Symbol('ARTIFACT_PREVIEW_TOKEN');
 
 /** 文件产物侧栏 Tab 的保留唯一标识（固定 Tab，不可关闭） */
 export const FILE_ARTIFACT_TAB_NAME = 'file-artifact';
+
+export type OpenArtifactPreviewPayload = {
+  /** 被点击的文件 */
+  file: AIFileInfo;
+  /** 文件在所属消息 artifacts 中的下标 */
+  index: number;
+  /** 所属 AssistantMessage 的 uid */
+  messageUid: string;
+};
 
 /**
  * 会话级文件产物：在 AIFileInfo 基础上补充命中所需的唯一 id 与所属消息。
@@ -18,20 +53,15 @@ export type SessionArtifact = AIFileInfo & {
   messageUid: string;
 };
 
-export type OpenArtifactPreviewPayload = {
-  /** 被点击的文件 */
-  file: AIFileInfo;
-  /** 文件在所属消息 artifacts 中的下标 */
-  index: number;
-  /** 所属 AssistantMessage 的 uid */
-  messageUid: string;
-};
-
 type ArtifactPreviewContext = {
   /** 当前命中的文件 id */
   activeArtifactId: Ref<string>;
+  /** 是否具备异步取链能力（有 onArtifactClick 时下载按钮可见） */
+  canResolveArtifactUrl: ComputedRef<boolean>;
   /** 由文件卡片触发：命中文件并弹出/切换到文件产物侧栏 */
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
+  /** 按 outputId 缓存并解析 download_url / preview_url */
+  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
   /** 直接设置命中文件 id（侧栏列表内切换用） */
   setActiveArtifactId: (id: string) => void;
 };
@@ -40,16 +70,36 @@ type ArtifactPreviewContext = {
 export const buildArtifactId = (messageUid: string, index: number, outputId: string) =>
   `${messageUid}#${index}#${outputId}`;
 
+/** 通过临时 <a> 触发浏览器下载 */
+export const triggerArtifactDownload = (url: string, fileName: string) => {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = fileName;
+  link.target = '_blank';
+  link.rel = 'noopener';
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+};
+
 /**
  * 文件产物预览 Provider（在 ChatContainer 内使用）。
- * 仅维护「命中文件」这一份数据状态；打开侧栏 Tab 的副作用由外部 onOpen 注入，
- * 避免 composable 直接依赖 useCustomTab，保持职责单一。
+ * 维护「命中文件」状态，并封装 onArtifactClick 的 URL 解析与按 outputId 缓存；
+ * 打开侧栏 Tab 的副作用由外部 onOpen 注入。
  */
 export const useArtifactPreviewProvider = (options: {
+  /** 读取业务侧异步取链回调（用 getter 保持对 props 变更敏感） */
+  getOnArtifactClick?: () => OnArtifactClick | undefined;
   /** 命中文件后触发：由容器负责 addCustomTab + 展开侧栏 + 选中 Tab */
   onOpen: (artifactId: string) => void;
 }) => {
   const activeArtifactId = shallowRef('');
+  // 已成功解析的 URL 缓存（key = outputId）
+  const urlCache = new Map<string, ArtifactUrlResult>();
+  // 进行中的请求，避免同文件并发重复打接口
+  const inflight = new Map<string, Promise<ArtifactUrlResult>>();
+
+  const canResolveArtifactUrl = computed(() => !!options.getOnArtifactClick?.());
 
   const setActiveArtifactId = (id: string) => {
     activeArtifactId.value = id;
@@ -61,15 +111,51 @@ export const useArtifactPreviewProvider = (options: {
     options.onOpen(id);
   };
 
+  const resolveArtifactUrls = async (file: AIFileInfo): Promise<ArtifactUrlResult> => {
+    const key = file.outputId;
+    const cached = urlCache.get(key);
+    if (cached) {
+      return cached;
+    }
+
+    const pending = inflight.get(key);
+    if (pending) {
+      return pending;
+    }
+
+    const onArtifactClick = options.getOnArtifactClick?.();
+    if (!onArtifactClick) {
+      return {};
+    }
+
+    const request = onArtifactClick(file)
+      .then(result => {
+        urlCache.set(key, result ?? {});
+        inflight.delete(key);
+        return urlCache.get(key)!;
+      })
+      .catch(error => {
+        inflight.delete(key);
+        throw error;
+      });
+
+    inflight.set(key, request);
+    return request;
+  };
+
   provide<ArtifactPreviewContext>(ARTIFACT_PREVIEW_TOKEN, {
     activeArtifactId,
+    canResolveArtifactUrl,
     openPreview,
+    resolveArtifactUrls,
     setActiveArtifactId,
   });
 
   return {
     activeArtifactId,
+    canResolveArtifactUrl,
     openPreview,
+    resolveArtifactUrls,
     setActiveArtifactId,
   };
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -69,10 +69,8 @@ const createAssistantMessage = (
 const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
   name: 'file.pdf',
   outputId: 'output-1',
-  previewUrl: 'https://example.com/preview.pdf',
   size: 1024,
   type: AIFileType.Pdf,
-  url: 'https://example.com/download.pdf',
   ...overrides,
 });
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/activity-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/activity-message.md
@@ -10,9 +10,15 @@ aiSummary: >
 relatedComponents:
   - slug: message-render
     relation: 由 MessageRender 在 role 为 activity 时创建
-  - slug: assistant-message
-    relation: 常与助手回复相邻，描述检索或执行背景
-sinceVersion: 1.0.0
+  - slug: flow-agent-content
+    relation: activityType 为 flow_agent 时渲染
+  - slug: knowledge-rag-content
+    relation: activityType 为 knowledge_rag 时渲染
+  - slug: reference-doc-content
+    relation: activityType 为 reference_document 时渲染
+  - slug: chat-container
+    relation: uid / onInterruptResume / 侧栏 Tab 与 ChatContainer 联动
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -49,17 +55,16 @@ sinceVersion: 1.0.0
 </script>
 
 # ActivityMessage 活动消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/activity-message/activity-message.vue`
 - **能力域**：消息系统
-- **能力说明**：按 activityType 分发 FlowAgent、知识召回、引用文档等活动内容。
+- **能力说明**：按 `activityType` 分发 FlowAgent、知识召回、引用文档等活动内容；未知类型不渲染。
 
+> **导出说明**：`ActivityMessage` **未**从 `@blueking/chat-x` 包入口导出（入口同名导出是 TS interface）。消费方请通过 `MessageRender` / `MessageContainer` 渲染 `role: 'activity'`。下文带 `*Comp` 的 demo 为文档站内部相对路径示例。
 
-
-> **能力域**：消息系统
-
-活动消息组件，用于展示 AI 的知识检索（Knowledge RAG）过程、参考文档引用列表和 FlowAgent 流程执行情况。通过 `activityType` 切换三种工作模式，点击标题栏可折叠/展开内容区域。
+活动消息组件，用于展示知识检索（Knowledge RAG）、参考文档引用与 FlowAgent 执行情况。通过 `activityType` 映射到对应子组件；点击标题栏可折叠/展开。
 
 组件会将父级传入消息上的 **`uid`** 以 **`message-uid`** 形式透传给各活动子组件（`FlowAgentContent` / `KnowledgeRagContent` / `ReferenceDocContent`），用于侧栏自定义 Tab、`addCustomTab` 的 `data.messageUid` 与主对话区「在对话中定位」联动（详见 [ChatContainer](/components/setup/chat-container)）。
 
@@ -69,45 +74,46 @@ sinceVersion: 1.0.0
 
 组件根据 `activityType` 的值决定渲染模式：
 
-| `activityType`    | 模式           | 标题文案                             | 图标             | 内容区                              |
-| ----------------- | -------------- | ------------------------------------ | ---------------- | ----------------------------------- |
-| `'knowledge_rag'` | 知识检索模式   | 检索中 / 检索完成（随 status 切换）  | Loading / 文档   | Markdown 检索摘要 + 引用列表        |
-| `'flow_agent'`    | FlowAgent 模式 | 执行情况: 成功 N / 失败 N / 执行中 N | Loading / 箭头   | 任务节点树 + 节点详情（自定义 Tab） |
-| 其他任意值        | 引用文档模式   | 引用 N 篇资料作为参考                | 文档图标（固定） | 引用文档列表                        |
+| `activityType`          | 模式           | 标题文案                             | 图标             | 内容区                              |
+| ----------------------- | -------------- | ------------------------------------ | ---------------- | ----------------------------------- |
+| `'knowledge_rag'`       | 知识检索模式   | 检索中 / 检索完成（随 status 切换）  | Loading / 文档   | Markdown 检索摘要 + 引用列表        |
+| `'flow_agent'`          | FlowAgent 模式 | 执行情况: 成功 N / 失败 N / 执行中 N | Loading / 箭头   | 任务节点树 + 节点详情（自定义 Tab） |
+| `'reference_document'`  | 引用文档模式   | 引用 N 篇资料作为参考                | 文档图标（固定） | 引用文档列表                        |
+| 其他未映射值            | —              | —                                    | —                | **不渲染**（`activityComponent` 为 falsy） |
 
-> **注意：** 只有值严格等于 `'knowledge_rag'` 才进入知识检索模式；严格等于 `'flow_agent'`（`MessageContentType.FlowAgent`）才进入 FlowAgent 模式；其他值均按引用文档模式处理。
+> **注意：** 源码仅映射上述三种 `MessageContentType`；`activityType` 缺失或未知时组件输出为空。
 
 ## 引用文档模式
 
-`activityType` 传入 `MessageContentType.ReferenceDocument`（`'reference_document'`）或任意非 `'knowledge_rag'` 的值，`content` 传入文档对象数组。
+`activityType` 必须为 `MessageContentType.ReferenceDocument`（`'reference_document'`），`content` 传入文档对象数组。
 
 标题自动显示文档数量，始终展示文档图标，`status` 不影响标题和图标。
 
 ```vue
+<!-- 消费方：经 MessageRender 渲染 -->
 <template>
-  <ActivityMessage
-    v-model:collapsed="collapsed"
-    :content="docs"
-    status="complete"
-    :activity-type="MessageContentType.ReferenceDocument"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue';
-  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
+  import { MessageRender, MessageContentType, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const collapsed = ref(false);
-
-  const docs = [
-    {
-      name: 'Vue 3 组合式 API 指南',
-      url: 'https://cn.vuejs.org/guide/extras/composition-api-faq.html',
-      originFile: 'composition-api.md',
-    },
-    { name: 'TypeScript 高级类型手册', url: 'https://www.typescriptlang.org/docs/', originFile: 'ts-advanced.pdf' },
-    { name: '蓝鲸前端开发规范 v2.0', url: 'https://example.com/bk-standard', originFile: 'bk-standard.docx' },
-  ];
+  const message = {
+    id: '2',
+    messageId: '2',
+    role: MessageRole.Activity,
+    activityType: MessageContentType.ReferenceDocument,
+    status: MessageStatus.Complete,
+    uid: 'activity-ref-1',
+    content: [
+      {
+        name: 'Vue 3 组合式 API 指南',
+        url: 'https://cn.vuejs.org/guide/extras/composition-api-faq.html',
+        originFile: 'composition-api.md',
+      },
+      { name: 'TypeScript 高级类型手册', url: 'https://www.typescriptlang.org/docs/', originFile: 'ts-advanced.pdf' },
+    ],
+  };
 </script>
 ```
 
@@ -135,28 +141,25 @@ sinceVersion: 1.0.0
 
 ```vue
 <template>
-  <ActivityMessage
-    v-model:collapsed="collapsed"
-    :content="ragContent"
-    :status="status"
-    :activity-type="MessageContentType.KnowledgeRag"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue';
-  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
+  import { MessageRender, MessageContentType, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const collapsed = ref(false);
-  const status = ref(MessageStatus.Complete);
-
-  const ragContent = {
-    // 检索摘要（支持 Markdown）
-    content: '根据知识库检索，Vue 3 引入了 Composition API...',
-    // 引用文档列表
-    referenceDocument: [
-      { name: '知识库文档：Composition API 详解', url: 'https://example.com/kb1', originFile: 'kb1.md' },
-    ],
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Activity,
+    activityType: MessageContentType.KnowledgeRag,
+    status: MessageStatus.Complete,
+    uid: 'activity-rag-1',
+    content: {
+      content: '根据知识库检索，Vue 3 引入了 Composition API...',
+      referenceDocument: [
+        { name: '知识库文档：Composition API 详解', url: 'https://example.com/kb1', originFile: 'kb1.md' },
+      ],
+    },
   };
 </script>
 ```
@@ -221,24 +224,20 @@ sinceVersion: 1.0.0
 
 通过 `v-model:collapsed` 控制内容区的折叠状态，点击整个标题栏均可切换。默认为 `false`（展开）。
 
+文档站内部示例（相对路径引入组件本体）可通过 `v-model:collapsed` 控制；消费方一般不直接绑定，折叠状态由活动子组件内部管理。
+
 ```vue
-<template>
-  <!-- 默认展开 -->
-  <ActivityMessage
-    v-model:collapsed="collapsed"
-    :content="docs"
-    status="complete"
-    activity-type="reference_document"
-  />
-</template>
+<!-- 文档站内部示例 -->
+<ActivityMessageComp
+  v-model:collapsed="collapsed"
+  :content="docs"
+  status="complete"
+  activity-type="reference_document"
+/>
+```
 
-<script setup lang="ts">
-  import { ref } from 'vue';
-  import { ActivityMessage } from '@blueking/chat-x';
-
-  const collapsed = ref(false); // false = 展开，true = 折叠
-  const docs = [{ name: '参考文档', url: 'https://example.com/doc', originFile: 'doc.pdf' }];
-</script>
+```ts
+const collapsed = ref(false); // false = 展开，true = 折叠
 ```
 
 **渲染效果（展开状态）**
@@ -309,21 +308,15 @@ FlowAgentContent（activityType = 'flow_agent'）
 
 ```vue
 <template>
-  <ActivityMessage
-    v-model:collapsed="collapsed"
-    :content="flowContent"
-    :status="status"
-    :activity-type="MessageContentType.FlowAgent"
+  <MessageRender
+    :message="message"
+    :on-interrupt-resume="handleInterruptResume"
   />
 </template>
 
 <script setup lang="ts">
-  import { ref } from 'vue';
-  import { ActivityMessage, MessageContentType, MessageStatus } from '@blueking/chat-x';
-  import type { BkFlowMessageContent } from '@blueking/chat-x';
-
-  const collapsed = ref(false);
-  const status = ref(MessageStatus.Complete);
+  import { MessageRender, MessageContentType, MessageRole, MessageStatus } from '@blueking/chat-x';
+  import type { BkFlowMessageContent, OnInterruptResume } from '@blueking/chat-x';
 
   const flowContent: BkFlowMessageContent = [
     {
@@ -348,18 +341,6 @@ FlowAgentContent（activityType = 'flow_agent'）
           skip: false,
           type: 'ServiceActivity',
         },
-        node2: {
-          id: 'node2',
-          name: '数据转换',
-          state: 'FINISHED',
-          elapsed_time: 45,
-          start_time: '2025-01-01 10:00:12',
-          finish_time: '2025-01-01 10:00:57',
-          loop: 1,
-          retry: 0,
-          skip: false,
-          type: 'ServiceActivity',
-        },
         node3: {
           id: 'node3',
           name: '结果写入',
@@ -370,11 +351,51 @@ FlowAgentContent（activityType = 'flow_agent'）
           loop: 1,
           retry: 0,
           skip: false,
+          retryable: true,
+          skippable: true,
           type: 'ServiceActivity',
         },
       },
     },
   ];
+
+  const message = {
+    id: '3',
+    messageId: '3',
+    role: MessageRole.Activity,
+    activityType: MessageContentType.FlowAgent,
+    status: MessageStatus.Complete,
+    uid: 'activity-flow-1',
+    content: flowContent,
+  };
+
+  const handleInterruptResume: OnInterruptResume = async payload => {
+    console.log('节点重试/跳过', payload);
+  };
+</script>
+```
+
+## 未知 activityType（不渲染）
+
+未映射的 `activityType` 不会回退到引用文档模式，组件直接不渲染：
+
+```vue
+<template>
+  <MessageRender :message="message" />
+  <!-- 页面上无任何活动内容输出 -->
+</template>
+
+<script setup lang="ts">
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  const message = {
+    id: 'x',
+    messageId: 'x',
+    role: MessageRole.Activity,
+    activityType: 'unknown_activity',
+    status: MessageStatus.Complete,
+    content: [{ name: '不会展示', url: '#', originFile: 'a.md' }],
+  };
 </script>
 ```
 
@@ -517,20 +538,25 @@ enum MessageContentType {
 
 ### Props
 
-| 属性名       | 类型                                                                        | 默认值 | 说明                                                      |
-| ------------ | --------------------------------------------------------------------------- | ------ | --------------------------------------------------------- |
-| content      | `ReferenceDocumentContent[] \| KnowledgeRagContent \| BkFlowMessageContent` | -      | 内容数据，格式随 `activityType` 不同                      |
-| activityType | `'knowledge_rag' \| 'flow_agent' \| 'reference_document' \| string`         | -      | 活动类型，决定渲染模式（知识检索 / FlowAgent / 引用文档） |
-| status       | `MessageStatus`                                                             | -      | 消息状态；在 `knowledge_rag` 模式下影响标题和图标，在 `flow_agent` 模式下影响标题 Loading 状态 |
-| id           | `string \| number`                                                          | -      | 消息 ID                                                   |
-| messageId    | `string \| number`                                                          | -      | 消息唯一标识                                              |
-| onInterruptResume | `OnInterruptResume`                                                    | -      | 仅 `flow_agent` 子组件消费；失败节点「重试 / 跳过」回调，由 `MessageRender` 透传 |
+| 属性名            | 类型                                                                        | 默认值 | 说明                                                                                         |
+| ----------------- | --------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| content           | `ReferenceDocumentContent[] \| KnowledgeRagContent \| BkFlowMessageContent` | -      | 内容数据，格式随 `activityType` 不同                                                         |
+| activityType      | `'knowledge_rag' \| 'flow_agent' \| 'reference_document' \| string`         | -      | 活动类型；仅三种已知值会渲染，其余不渲染                                                     |
+| status            | `MessageStatus`                                                             | -      | `knowledge_rag` 影响标题/图标；`flow_agent` 影响标题 Loading                                 |
+| id                | `string \| number`                                                          | -      | 消息 ID                                                                                      |
+| messageId         | `string \| number`                                                          | -      | 消息唯一标识                                                                                 |
+| uid               | `string`                                                                    | -      | 透传为子组件 `message-uid`，用于侧栏 Tab / 「在对话中定位」                                  |
+| onInterruptResume | `OnInterruptResume`                                                         | -      | 仅 `flow_agent` 子组件消费；失败节点「重试 / 跳过」，由 `MessageRender` 透传                 |
 
 ### v-model
 
 | 属性名    | 类型      | 默认值  | 说明                        |
 | --------- | --------- | ------- | --------------------------- |
 | collapsed | `boolean` | `false` | 内容折叠状态，`true` 为折叠 |
+
+### Events / Slots / Expose
+
+无。
 
 ## 类型定义
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
@@ -3,10 +3,10 @@ name: AssistantMessage AI 助手消息
 slug: assistant-message
 kind: component
 domain: message
-description: 渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。
+description: 渲染助手消息主体、工具调用与文件产物，默认插槽可覆盖正文渲染。
 aiSummary: >
-  渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。
-  源码位置：src/components/chat-message/assistant-message/assistant-message.vue。
+  渲染助手 Markdown 正文、ToolCallRender 工具调用列表，以及 property.artifacts 文件卡片；
+  默认插槽仅覆盖正文。源码位置：src/components/chat-message/assistant-message/assistant-message.vue。
 relatedComponents:
   - slug: message-render
     relation: 由 MessageRender 在 role 为 assistant 时创建
@@ -16,7 +16,7 @@ relatedComponents:
     relation: 多条工具调用由 ToolcallRender 统一渲染
   - slug: file-artifact-panel
     relation: property.artifacts 文件产物点击后在侧栏预览
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -123,48 +123,70 @@ const doubled = computed(() => count.value * 2);
       },
     },
   ];
+
+  // 文件产物（AIFileInfo 元信息；下载/预览链路由 ChatContainer.onArtifactClick 异步获取）
+  const artifactsProperty = {
+    artifacts: [
+      {
+        name: 'report.html',
+        outputId: 'output-1',
+        size: 10240,
+        type: 'html',
+      },
+      {
+        name: 'summary.pdf',
+        outputId: 'output-2',
+        size: 204800,
+        type: 'pdf',
+      },
+    ],
+  };
 </script>
 
 # AssistantMessage AI 助手消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/assistant-message/assistant-message.vue`
 - **能力域**：消息系统
-- **能力说明**：渲染助手消息主体、工具调用与文件内容，默认插槽可覆盖正文渲染。
+- **能力说明**：渲染助手 Markdown 正文、工具调用列表与 `property.artifacts` 文件产物。
 
+> **导出说明**：`AssistantMessage` **未**从 `@blueking/chat-x` 包入口导出（入口同名是 TS interface）。消费方请用 `MessageRender` / `MessageContainer`。下文 `AssistantMessageComp` 为文档站内部相对路径示例。
 
-
-> **能力域**：消息系统
-
-AI 助手消息展示组件，负责渲染 AI 回复的文本内容和工具调用（Tool Calls）结果。
+AI 助手消息展示组件：正文（Markdown）、工具调用（Tool Calls）、文件产物卡片。
 
 ## 渲染管线
 
 ```
 AssistantMessage（根类名：ai-assistant-message）
-├── ai-assistant-message-content（内容区）
-│   └── [default slot] 或 ContentRender → MarkdownContent（Markdown 渲染）
-└── ToolCallRender × N（每个 toolCall 独立渲染，不受 slot 影响）
+├── ai-assistant-message-content（内容区，v-if content）
+│   └── [default slot { content }] 或 ContentRender → MarkdownContent
+├── ToolCallRender × N（toolCalls，不受 slot 影响）
+└── MessageArtifacts（v-if property.artifacts 非空）
+      └── ArtifactFileCard × N（点击 → useArtifactPreview → 侧栏 FileArtifactPanel）
 ```
 
-- **内容区**：`content` 字符串传入 `ContentRender`，内部固定使用 `MessageContentType.Text` 类型，最终由 `MarkdownContent` 渲染 Markdown
-- **工具调用区**：`toolCalls` 数组中每一项渲染一个 `ToolCallRender`，位于内容区**下方**，与 slot 无关
+- **内容区**：`content` 经 `ContentRender`（`MessageContentType.Text`）由 `MarkdownContent` 渲染；default slot 仅收到 `{ content }`
+- **工具调用区**：每个 `toolCall` 渲染一个 `ToolCallRender`，位于内容区下方
+- **文件产物区**：读取 `property.artifacts`，用 `uid ?? String(id)` 作为 `messageUid` 传给 `MessageArtifacts`
 
 ## 基础用法
 
 ```vue
 <template>
-  <AssistantMessage
-    :content="content"
-    :status="status"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { AssistantMessage, MessageStatus } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const content = '你好！我是 AI 助手，有什么可以帮助你的吗？';
-  const status = MessageStatus.Complete;
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    content: '你好！我是 AI 助手，有什么可以帮助你的吗？',
+    status: MessageStatus.Complete,
+  };
 </script>
 ```
 
@@ -183,16 +205,18 @@ AssistantMessage（根类名：ai-assistant-message）
 
 ```vue
 <template>
-  <AssistantMessage
-    :content="markdownContent"
-    status="complete"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { AssistantMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const markdownContent = `## Vue 3 核心特性
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    status: MessageStatus.Complete,
+    content: `## Vue 3 核心特性
 
 Vue 3 引入了多项重要更新：
 
@@ -207,7 +231,8 @@ const count = ref(0);
 const doubled = computed(() => count.value * 2);
 \\\`\\\`\\\`
 
-> 更多详情请参考 [Vue 3 官方文档](https://vuejs.org)。`;
+> 更多详情请参考 [Vue 3 官方文档](https://vuejs.org)。`,
+  };
 </script>
 ```
 
@@ -293,27 +318,30 @@ const doubled = computed(() => count.value * 2);
 
 ```vue
 <template>
-  <AssistantMessage
-    content="让我帮你查询一下天气信息。"
-    :status="MessageStatus.Complete"
-    :tool-calls="toolCalls"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { AssistantMessage, MessageStatus } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const toolCalls = [
-    {
-      id: 'call_1',
-      type: 'function',
-      function: {
-        name: 'get_weather',
-        arguments: '{"city": "北京", "unit": "celsius"}',
-        description: '获取指定城市的天气信息',
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Assistant,
+    content: '让我帮你查询一下天气信息。',
+    status: MessageStatus.Complete,
+    toolCalls: [
+      {
+        id: 'call_1',
+        type: 'function',
+        function: {
+          name: 'get_weather',
+          arguments: '{"city": "北京", "unit": "celsius"}',
+          description: '获取指定城市的天气信息',
+        },
       },
-    },
-  ];
+    ],
+  };
 </script>
 ```
 
@@ -510,20 +538,17 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 
 ```vue
 <template>
-  <AssistantMessage
-    :content="content"
-    :tool-calls="toolCalls"
-  >
+  <MessageRender :message="message">
     <template #default="{ content }">
       <div style="padding: 12px; background: #f0f9ff; border-left: 3px solid #3a84ff; border-radius: 4px;">
-        🤖 {{ content }}
+        {{ content }}
       </div>
     </template>
-  </AssistantMessage>
+  </MessageRender>
 </template>
 ```
 
-> **注意**：使用默认插槽后，内置的 `MarkdownContent`（Markdown 渲染）被替换，需要自行处理内容格式化。
+> **注意**：使用默认插槽后，内置 Markdown 渲染被替换，需自行处理格式化。slot 运行时仅保证 `{ content }`（见 [MessageRender](/components/message/message-render)）。
 
 **渲染效果**
 
@@ -596,28 +621,76 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 </script>
 ```
 
+## 文件产物
+
+当 `property.artifacts` 非空时，在工具调用区下方渲染 `MessageArtifacts` 文件卡片列表。点击卡片会通过 `useArtifactPreview` 打开 `ChatContainer` 侧栏「文件产物」Tab（见 [FileArtifactPanel](/components/message/file-artifact-panel)）。
+
+`AIFileInfo` 仅含元信息（`name` / `outputId` / `size` / `type`）；`download_url` / `preview_url` 由容器 `onArtifactClick` 异步获取。命中唯一文件依赖 `messageUid = uid ?? String(id)` + 卡片下标 + `outputId`。
+
+```vue
+<template>
+  <MessageRender :message="message" />
+</template>
+
+<script setup lang="ts">
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
+  import type { AIFileInfo } from '@blueking/chat-x';
+
+  const artifacts: AIFileInfo[] = [
+    { name: 'report.html', outputId: 'output-1', size: 10240, type: 'html' },
+    { name: 'summary.pdf', outputId: 'output-2', size: 204800, type: 'pdf' },
+  ];
+
+  const message = {
+    id: 'a1',
+    messageId: 'a1',
+    uid: 'assistant-uid-1',
+    role: MessageRole.Assistant,
+    status: MessageStatus.Complete,
+    content: '已为你生成分析报告：',
+    property: { artifacts },
+  };
+</script>
+```
+
+**渲染效果（文档站内部示例；无 Provider 时卡片不可点击预览）**
+
+<div class="demo">
+  <AssistantMessageComp
+    uid="assistant-uid-1"
+    content="已为你生成分析报告："
+    status="complete"
+    :property="artifactsProperty"
+  />
+</div>
+
 ## API
 
 ### Props
 
 组件 Props 来自 `Partial<AssistantMessage>`（所有字段均可选）：
 
-| 属性名    | 类型                    | 说明                                                           |
-| --------- | ----------------------- | -------------------------------------------------------------- |
-| content   | `string`                | AI 回复的文本内容，支持 Markdown，`undefined` 时渲染为空字符串 |
-| status    | `MessageStatus`         | 消息状态，影响 Markdown 渲染模式和 ToolCallRender 的状态标题   |
-| toolCalls | `ToolCall[]`            | 工具调用列表，每项渲染一个 `ToolCallRender`                    |
-| id        | `number \| string`      | 消息 ID                                                        |
-| messageId | `number \| string`      | 消息唯一标识                                                   |
-| name      | `string`                | 消息发送者名称（可选）                                         |
-| role      | `MessageRole.Assistant` | 消息角色，固定为 `'assistant'`                                 |
-| property  | `object`                | 消息附加属性，本组件不使用，由父组件（`MessageContainer`）消费 |
+| 属性名    | 类型                    | 说明                                                                                      |
+| --------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| content   | `string`                | AI 回复文本，支持 Markdown；空值时不渲染内容区                                            |
+| status    | `MessageStatus`         | 影响 ContentRender / ToolCallRender 状态表现                                              |
+| toolCalls | `ToolCall[]`            | 工具调用列表，每项渲染一个 `ToolCallRender`                                               |
+| id        | `number \| string`      | 消息 ID；无 `uid` 时回退为 `messageUid`                                                   |
+| messageId | `number \| string`      | 消息唯一标识                                                                              |
+| uid       | `string`                | 优先作为文件产物命中 / 「在对话中定位」的 `messageUid`                                    |
+| name      | `string`                | 消息发送者名称（可选）                                                                    |
+| role      | `MessageRole.Assistant` | 消息角色，固定为 `'assistant'`                                                            |
+| property  | `{ artifacts?: AIFileInfo[]; extra?: ... }` | **本组件消费** `property.artifacts` 渲染文件卡片；`extra` 等由上层按需使用 |
 
 ### Slots
 
-| 插槽名  | 参数                  | 说明                                                 |
-| ------- | --------------------- | ---------------------------------------------------- |
-| default | `{ content: string }` | 替换内容区渲染，toolCalls 在内容区外独立渲染不受影响 |
+| 插槽名  | 参数                  | 说明                                                              |
+| ------- | --------------------- | ----------------------------------------------------------------- |
+| default | `{ content: string }` | 替换内容区渲染；toolCalls / MessageArtifacts 在内容区外独立渲染 |
+
+### Events / Expose
+
+无。
 
 ## 类型定义
 
@@ -659,10 +732,6 @@ interface ToolMessage extends BaseMessage<MessageRole.Tool, string> {
 - **流式输出**：`streaming` 状态下 Markdown 自动补全未闭合语法，配合流式响应实时更新
 - **自动渲染**：通过 `MessageContainer` 对 `role: 'assistant'` 消息自动处理，无需手动引入
 - **自定义内容渲染**：通过默认插槽替换内置 Markdown 渲染器，保留工具调用渲染
-
-## 文件产物
-
-当 `property.artifacts` 非空时，消息底部渲染文件卡片列表；点击卡片会在 `ChatContainer` 侧栏「文件产物」Tab 内聚合预览当前会话所有文件。为在多消息、同名文件场景下命中唯一文件，`AssistantMessage` 会把自身 `uid`（回退 `id`）作为 `messageUid` 与卡片下标一并透传。预览状态由 [useArtifactPreview](/composables/use-artifact-preview) 管理，面板渲染见 [FileArtifactPanel 文件产物预览](/components/message/file-artifact-panel)。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -6,15 +6,18 @@ domain: message
 description: 汇总当前会话全部文件产物，支持搜索、选中与 HTML / PDF 预览，挂载在 ChatContainer 侧栏「文件产物」Tab。
 aiSummary: >
   汇总当前会话所有 AssistantMessage 的 artifacts，支持关键词搜索、列表选中与预览；
-  HTML 走 fetch + iframe srcdoc 渲染，其余类型直接用 previewUrl（后台转好的 PDF）iframe 展示。
+  download_url / preview_url 通过 onArtifactClick 异步获取；HTML 用 download_url fetch + iframe srcdoc，
+  其余类型用 preview_url（后台转好的 PDF）iframe 展示；取链过程展示 MessageLoading。
   源码位置：src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue。
 relatedComponents:
   - slug: assistant-message
     relation: 文件产物来源于 AssistantMessage.property.artifacts
   - slug: chat-container
-    relation: 面板挂载在侧栏「文件产物」Tab（固定、不可关闭）
+    relation: 面板挂载在侧栏「文件产物」Tab（固定、不可关闭），并通过 onArtifactClick 异步取链
   - slug: execution-summary
     relation: 同为 ChatContainer 侧栏 Tab 面板，交互形态一致
+  - slug: message-loading
+    relation: 异步取链 / HTML 拉取过程使用 MessageLoading
 sinceVersion: 0.0.20
 ---
 
@@ -26,7 +29,7 @@ sinceVersion: 0.0.20
 - **能力域**：消息系统
 - **能力说明**：汇总当前会话全部文件产物，支持搜索、选中与 HTML / PDF 预览。
 
-> **能力域**：消息系统
+> **导出说明**：内部侧栏面板组件，**通常不直接使用**；由 `ChatContainer` 在「文件产物」Tab 内自动挂载。
 
 点击 AI 回复中的[文件卡片](/components/message/assistant-message)后，`ChatContainer` 侧栏会弹出固定的「文件产物」Tab，聚合展示当前会话**所有** `AssistantMessage` 的文件产物，并命中被点击的文件进行预览。
 
@@ -37,10 +40,12 @@ sinceVersion: 0.0.20
 - **会话级聚合**：拍平当前会话所有 `AssistantMessage.property.artifacts`，统一在一个列表内展示
 - **唯一命中**：同一会话可能出现多个消息 + 同名文件，文件名不可作唯一键，统一用 `messageUid#消息内下标#outputId` 生成全局唯一 id
 - **关键词搜索**：按文件名实时过滤列表
+- **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 缓存获取 `download_url` / `preview_url`
 - **分类型预览**：
-  - **HTML**：前端 `fetch(file.url)` 拉取 HTML 字符串，用 `<iframe srcdoc>` 渲染，带加载 / 失败重试态
-  - **其余类型**：`previewUrl` 是后台转换好的 PDF 链接，直接作为 `<iframe src>` 展示
-- **下载**：列表项与预览头部均可下载源文件（`file.url`）
+  - **HTML**：`fetch(download_url)` 拉取 HTML 字符串，用 `<iframe srcdoc>` 渲染
+  - **其余类型**：`preview_url` 是后台转换好的 PDF 链接，直接作为 `<iframe src>` 展示
+- **Loading**：取链 / HTML 拉取过程在预览区展示 [MessageLoading](/components/helper/message-loading)；下载图标展示 bkui `Loading` spin
+- **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
 
 ## 触发链路
 
@@ -50,11 +55,13 @@ ArtifactFileCard（点击文件卡片）
        └─ useArtifactPreviewProvider（ChatContainer 内）
             ├─ 记录命中文件 activeArtifactId
             └─ onOpen → addCustomTab('file-artifact') 展开并选中侧栏 Tab
-                 └─ FileArtifactPanel（渲染列表 + 预览）
+                 └─ FileArtifactPanel
+                      ├─ resolveArtifactUrls(file) → onArtifactClick（带 outputId 缓存）
+                      └─ MessageLoading → 渲染预览 / 下载
 ```
 
 - 文件卡片通过 `useArtifactPreviewConsumer` 注入预览上下文，无 Provider 时卡片不可点击（兜底 `undefined`）
-- `ChatContainer` 通过 `useArtifactPreviewProvider` 提供上下文，并把「打开侧栏 Tab」这一副作用以 `onOpen` 注入，保持 composable 职责单一（只维护命中文件这一份状态）
+- `ChatContainer` 通过 `useArtifactPreviewProvider` 提供上下文，并把「打开侧栏 Tab」这一副作用以 `onOpen` 注入，保持 composable 职责单一
 - 侧栏「文件产物」Tab 固定不可关闭，`order: -1` 排在「执行情况」之前；会话切换或无文件产物时自动移除
 
 ## 唯一 id 规则
@@ -74,8 +81,8 @@ Provider 侧聚合与文件卡片侧透传必须使用同一规则，保证命�
 
 | 文件类型 | 预览字段 | 渲染方式 |
 | -------- | -------- | -------- |
-| `html`   | `file.url` | `fetch(url)` 拿到 HTML 字符串 → `<iframe srcdoc>` 渲染，切换文件会中断上一次请求避免竞态 |
-| 其余     | `file.previewUrl` | 后台已转换为 PDF，直接 `<iframe src="previewUrl">` 展示 |
+| `html`   | `download_url`（`onArtifactClick` 返回） | `fetch(download_url)` 拿到 HTML 字符串 → `<iframe srcdoc>` 渲染，切换文件会中断上一次请求避免竞态 |
+| 其余     | `preview_url`（`onArtifactClick` 返回） | 后台已转换为 PDF，直接 `<iframe src="preview_url">` 展示 |
 
 ## API
 
@@ -92,6 +99,10 @@ Provider 侧聚合与文件卡片侧透传必须使用同一规则，保证命�
 | ------ | ----------------- | -------------------------- |
 | select | `(id: string)`    | 列表内切换选中文件，参数为文件 `artifactId` |
 
+### Slots / Expose
+
+无。
+
 ## 类型定义
 
 ```typescript
@@ -102,14 +113,22 @@ type SessionArtifact = AIFileInfo & {
   artifactId: string; // 全局唯一 id：messageUid#index#outputId
   messageUid: string; // 所属 AssistantMessage 的 uid
 };
+
+type AIFileInfo = {
+  name: string;
+  outputId: string;
+  size: number;
+  type: AIFileType;
+};
 ```
 
 ## 关联 Composable
 
-预览状态由 [useArtifactPreview](/composables/use-artifact-preview) 提供，Provider / Consumer 通过 `ARTIFACT_PREVIEW_TOKEN` 通信。容器侧 `useArtifactPreviewProvider` 维护 `activeArtifactId` 并通过 `onOpen` 打开侧栏 Tab；文件卡片侧 `useArtifactPreviewConsumer` 触发 `openPreview`。
+预览状态由 [useArtifactPreview](/composables/use-artifact-preview) 提供，Provider / Consumer 通过 `ARTIFACT_PREVIEW_TOKEN` 通信。容器侧 `useArtifactPreviewProvider` 维护 `activeArtifactId`、封装 `resolveArtifactUrls`（含缓存），并通过 `onOpen` 打开侧栏 Tab；文件卡片 / 面板侧 `useArtifactPreviewConsumer` 触发预览与取链。
 
 ## 关联组件
 
 - [AssistantMessage](/components/message/assistant-message) — 文件产物来源（`property.artifacts`）
-- [ChatContainer](/components/setup/chat-container) — 侧栏「文件产物」Tab 挂载场景
+- [ChatContainer](/components/setup/chat-container) — 侧栏「文件产物」Tab 挂载场景，提供 `onArtifactClick`
+- [MessageLoading](/components/helper/message-loading) — 预览区异步加载态
 - [ExecutionSummary](/components/agent/execution-summary) — 同为侧栏 Tab 面板

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/info-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/info-message.md
@@ -12,7 +12,7 @@ relatedComponents:
     relation: 由 MessageRender 在 role 为 info 时创建
   - slug: message-container
     relation: 嵌入消息列表时由 MessageContainer 统一布局与滚动
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -20,15 +20,14 @@ sinceVersion: 1.0.0
 </script>
 
 # InfoMessage 信息消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/info-message/info-message.vue`
 - **能力域**：消息系统
 - **能力说明**：渲染居中的系统信息提示。
 
-
-
-> **能力域**：消息系统
+> **导出说明**：`InfoMessage` **未**从包入口导出（入口同名是 TS interface）。消费方经 `MessageRender` / `MessageContainer` 使用。下文 `InfoMessageComp` 为文档站内部示例。
 
 系统信息分隔组件，在聊天消息列表中以**居中虚线分隔条**的形式展示非对话类信息（会话重置、时间节点、状态变更等）。
 
@@ -46,13 +45,19 @@ sinceVersion: 1.0.0
 
 ```vue
 <template>
-  <InfoMessage :content="content" />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { InfoMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const content = '以下是新的对话';
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Info,
+    content: '以下是新的对话',
+    status: MessageStatus.Complete,
+  };
 </script>
 ```
 
@@ -68,11 +73,20 @@ sinceVersion: 1.0.0
 
 ```vue
 <template>
-  <InfoMessage :content="['会话已重置', '以下是新的对话']" />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { InfoMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
+
+  // 运行时 content 兼容 string[]（TS 类型声明多为 string）
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Info,
+    content: ['会话已重置', '以下是新的对话'],
+    status: MessageStatus.Complete,
+  };
 </script>
 ```
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/loading-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/loading-message.md
@@ -14,7 +14,7 @@ relatedComponents:
     relation: role 为 loading 时由 MessageRender 渲染
   - slug: ai-loading
     relation: 内部使用 AiLoading 基础组件
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -22,19 +22,18 @@ sinceVersion: 1.0.0
 </script>
 
 # LoadingMessage 加载中消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/loading-message/loading-message.vue`
 - **能力域**：消息系统
 - **能力说明**：消息列表中的加载占位，默认使用 AiLoading，也支持默认插槽覆盖。
 
+> **导出说明**：`LoadingMessage` **未**从包入口导出。消费方经 `MessageRender`（`role: 'loading'`）或由 `MessageContainer` 自动注入。下文 `LoadingMessageComp` 为文档站内部示例。
 
+加载等待状态组件：`AiLoading`（18px）+ 默认文案「请求中...」。可通过默认插槽自定义文案。
 
-> **能力域**：消息系统
-
-加载等待状态组件，展示 AI 正在处理请求时的过渡动画。由旋转渐变环 + 脉冲星形图标（蓝→紫→粉渐变）和"请求中..."文案组成。支持通过默认插槽自定义加载文案。
-
-> **提示**：此组件通常**不需要手动使用**，`MessageContainer` 会在满足条件时自动注入。
+> **提示**：通常**不需要手动使用**，`MessageContainer` / `useMessageGroup` 会在满足条件时自动注入。
 
 ## 渲染效果
 
@@ -44,15 +43,31 @@ sinceVersion: 1.0.0
 
 ## 基础用法
 
-组件无 Props，直接引入渲染即可：
+组件无 Props。文档站内部示例：
 
 ```vue
 <template>
-  <LoadingMessage />
+  <LoadingMessageComp />
+</template>
+```
+
+消费方经 `MessageRender`：
+
+```vue
+<template>
+  <MessageRender
+    :message="{
+      id: 'loading',
+      messageId: '',
+      role: MessageRole.Loading,
+      content: '',
+      status: MessageStatus.Pending,
+    }"
+  />
 </template>
 
 <script setup lang="ts">
-  import { LoadingMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 </script>
 ```
 
@@ -62,16 +77,13 @@ sinceVersion: 1.0.0
 
 ## 自定义加载文案
 
-通过默认插槽可覆盖默认的"请求中..."文案：
+通过默认插槽覆盖「请求中...」：
 
 ```vue
 <template>
-  <LoadingMessage>正在思考中，请稍候...</LoadingMessage>
+  <!-- 文档站内部示例 -->
+  <LoadingMessageComp>正在思考中，请稍候...</LoadingMessageComp>
 </template>
-
-<script setup lang="ts">
-  import { LoadingMessage } from '@blueking/chat-x';
-</script>
 ```
 
 <div class="demo">
@@ -91,15 +103,18 @@ sinceVersion: 1.0.0
 
 ## 在 MessageContainer 中的自动注入
 
-`MessageContainer` 在构建消息分组列表时，检测到**消息列表最后一条为用户消息**（`role === 'user'`）时，自动在末尾追加一个 Loading 消息组：
+`useMessageGroup` 构建分组时，若**最后一条为用户消息**且 **`renderMode !== RenderMode.Share`**，自动在末尾追加 Loading 组：
 
 ```typescript
-// MessageContainer 内部逻辑（简化）
-if (messages.at(-1)?.role === MessageRole.User) {
+// use-message-group.ts（简化）
+const shouldAppendLoading =
+  messages.at(-1)?.role === MessageRole.User && renderMode !== RenderMode.Share;
+
+if (shouldAppendLoading) {
   list.push({
     messages: [
       {
-        role: MessageRole.Loading, // 'loading'
+        role: MessageRole.Loading,
         content: '',
         status: MessageStatus.Pending,
         id: 'loading',
@@ -111,7 +126,8 @@ if (messages.at(-1)?.role === MessageRole.User) {
 }
 ```
 
-当下一条 AI 消息（`role: 'assistant'`）到来后，最后一条不再是用户消息，Loading 组自动消失。
+- 下一条 AI 消息到来后，末尾不再是 user，Loading 组自动消失
+- **分享预览**（`renderMode === RenderMode.Share`）**不会**注入 Loading，避免分享页出现「请求中」占位
 
 **触发示例**：
 
@@ -151,6 +167,7 @@ if (messages.at(-1)?.role === MessageRole.User) {
 - **默认插槽**：可通过默认插槽自定义加载文案，未传入时显示内置的 "请求中..."
 - **i18n 支持**：默认文案 "请求中..." 通过内置 `t()` 函数处理，英文环境自动显示 "Requesting..."
 - **选择模式**：`MessageContainer` 开启 `enableSelection` 时，Loading 消息组不显示复选框
+- **分享模式**：`renderMode === RenderMode.Share` 时不自动注入 Loading
 - **自动生命周期**：Loading 组随消息列表变化自动插入/移除，无需手动控制
 
 ## API

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/message-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/message-render.md
@@ -16,7 +16,7 @@ relatedComponents:
     relation: role 为 user 时渲染用户消息
   - slug: interrupt-message
     relation: role 为 interrupt 时渲染 InterruptMessageRender
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -148,17 +148,16 @@ export function useCounter(initialValue = 0) {
 </script>
 
 # MessageRender 消息渲染器
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/message-render/message-render.vue`
 - **能力域**：消息系统
-- **能力说明**：按 message.role 分发到用户、助手、工具、推理、活动、中断等消息组件。
+- **能力说明**：按 `message.role` 分发到用户、助手、工具、推理、活动、中断等消息组件。
 
+> **导出说明**：`MessageRender` **已**从 `@blueking/chat-x` 包入口导出，消费方可直接 import。下文 `MessageRenderComp` 为文档站相对路径 demo，与包入口行为一致。
 
-
-> **能力域**：消息系统
-
-统一的消息渲染入口，通过 `message.role` 字段自动派发到对应的子组件。整个渲染过程由一个 `computed` 属性完成，无额外状态。
+统一的消息渲染入口，通过 `message.role` 派发到对应子组件；由单个 `computed` 完成，无额外状态。
 
 ## 渲染架构
 
@@ -320,7 +319,7 @@ MessageRender
 
 ### 流式输出（streaming）
 
-`status: 'streaming'` 时，`AssistantMessage` 内部展示打字光标，内容可实时追加：
+`status: 'streaming'` 时，默认回退的 `ContentRender` / `MarkdownContent` 会按流式规则补全未闭合语法；内容由外部逐步追加：
 
 ```vue
 <script setup lang="ts">
@@ -379,65 +378,74 @@ MessageRender
 
 ## 自定义内容渲染（default slot）
 
-`default` slot **仅对 `role: 'assistant'` 生效**，用于替换默认的 `ContentRender`。未提供 slot 时回退渲染 `<ContentRender :content="message.content" :status="message.status" />`。
+`default` slot **仅对 `role: 'assistant'` 生效**，用于替换默认的 `ContentRender`。
+
+未提供 slot 时，内部回退为：
+
+```ts
+h(ContentRender, { content: message.content || '', status: message.status }, /* codeHeader */)
+```
+
+自定义 slot 时，运行时参数来自 `AssistantMessage` 的 `v-bind`，**仅保证 `{ content }`**。需要 `status` 时请从外层 `message.status` 读取（不要依赖 slot 内的 `status`）。
 
 ```vue
 <template>
-  <MessageRender
-    :message="message"
-    :on-action="handleAction"
-  >
-    <template #default="{ content, status }">
-      <!-- 完全接管内容区域渲染 -->
+  <MessageRender :message="message">
+    <template #default="{ content }">
       <MyMarkdownRenderer
         :content="content"
-        :streaming="status === 'streaming'"
+        :streaming="message.status === 'streaming'"
       />
     </template>
   </MessageRender>
 </template>
 ```
 
-slot 参数类型与 `AssistantMessage` 的 slot 保持一致（`Partial<AssistantMessage>`），主要使用：
+| 参数      | 类型     | 说明                         |
+| --------- | -------- | ---------------------------- |
+| `content` | `string` | 消息内容（运行时保证）       |
 
-| 参数      | 类型            | 说明         |
-| --------- | --------------- | ------------ |
-| `content` | `string`        | 消息内容     |
-| `status`  | `MessageStatus` | 当前消息状态 |
+## 与 MessageContainer / ChatContainer 配合
 
-## 与 MessageContainer 配合
-
-在 `MessageContainer` 的 `default` slot 中使用，可替换默认的 `MessageRender` 渲染逻辑：
+自定义 `ChatContainer` 的 `#message` 时，插槽参数只有 `message` / `messageToolsStatus` / `onInterruptResume`。用户消息工具相关回调需由外层自行绑定透传，否则删除/编辑/复制/引用会失效（AI 消息工具栏在 `MessageContainer` 内渲染，不受 `#message` 影响）：
 
 ```vue
 <template>
-  <MessageContainer
+  <ChatContainer
     :messages="messages"
     :message-status="messageStatus"
     :on-agent-action="handleAgentAction"
     :on-user-action="handleUserAction"
-    @stop-streaming="handleStopStreaming"
+    :common-tippy-options="commonTippyOptions"
   >
-    <template #default="{ message, messageToolsStatus }">
-      <!-- 自定义 MessageRender 的行为 -->
+    <template #message="{ message, messageToolsStatus, onInterruptResume }">
       <MessageRender
         :message="message"
         :message-tools-status="messageToolsStatus"
         :on-action="handleUserAction"
-        :on-input-confirm="handleInputConfirm"
+        :on-input-confirm="(content, docSchema) => handleUserInputConfirm(message, content, docSchema)"
+        :on-shortcut-confirm="formModel => handleUserShortcutConfirm(message, formModel)"
+        :tippy-options="commonTippyOptions"
+        :on-interrupt-resume="onInterruptResume"
       >
         <template
           v-if="message.role === 'assistant'"
-          #default="{ content, status }"
+          #default="{ content }"
         >
           <MyCustomContent
             :content="content"
-            :status="status"
+            :status="message.status"
+          />
+        </template>
+        <template #codeHeader="{ language, token }">
+          <MyCodeActions
+            :language="language"
+            :token="token"
           />
         </template>
       </MessageRender>
     </template>
-  </MessageContainer>
+  </ChatContainer>
 </template>
 ```
 
@@ -457,11 +465,11 @@ slot 参数类型与 `AssistantMessage` 的 slot 保持一致（`Partial<Assista
 
 ### Slots
 
-| 插槽名           | 参数                                         | 说明                                                                                                    |
-| ---------------- | -------------------------------------------- | ------------------------------------------------------------------------------------------------------- |
-| answeredQuestion | `{ item, index, status }`                    | 自定义 UserQuestion 已回答回显，透传给 InterruptMessageRender → UserQuestionAnsweredCard 的 `#answer`   |
-| codeHeader       | `{ language: string; token: Token[] }`       | 代码块头部自定义操作区域，透传给 ContentRender → MarkdownContent → CodeContent；**仅对 assistant 生效** |
-| default          | `{ content: string, status: MessageStatus }` | 替换 AssistantMessage 的内容区域渲染；**仅对 `role: 'assistant'` 生效**                                 |
+| 插槽名           | 参数                                   | 说明                                                                                                    |
+| ---------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| answeredQuestion | `{ item, index, status }`              | 自定义 UserQuestion 已回答回显，透传给 InterruptMessageRender → UserQuestionAnsweredCard 的 `#answer`   |
+| codeHeader       | `{ language: string; token: Token[] }` | 代码块头部自定义操作区域，透传给 ContentRender → MarkdownContent → CodeContent；**仅对 assistant 生效** |
+| default          | `{ content: string }`                  | 替换 AssistantMessage 内容区；**仅对 assistant 生效**；运行时仅保证 `content`（`status` 请读外层 message） |
 
 ## 消息类型映射
 
@@ -491,6 +499,7 @@ enum MessageRole {
   Tool = 'tool',
   Activity = 'activity',
   Loading = 'loading',
+  Interrupt = 'interrupt',
 }
 
 // 消息状态

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/reasoning-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/reasoning-message.md
@@ -14,7 +14,7 @@ relatedComponents:
     relation: 推理结束后通常紧跟 Assistant 的正式回复
   - slug: markdown-content
     relation: 内容区通过 Markdown 渲染推理文本
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -26,15 +26,14 @@ sinceVersion: 1.0.0
 </script>
 
 # ReasoningMessage 推理消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/reasoning-message/reasoning-message.vue`
 - **能力域**：消息系统
 - **能力说明**：渲染推理过程，覆盖加载、错误与 Markdown 内容展示。
 
-
-
-> **能力域**：消息系统
+> **导出说明**：`ReasoningMessage` **未**从包入口导出（入口同名是 TS interface）。消费方经 `MessageRender` / `MessageContainer` 使用。下文 `ReasoningMessageComp` 为文档站内部示例。
 
 AI 思维链（Chain-of-Thought）推理过程展示组件。由**可点击标题栏**和**内容区域**组成，内容区支持 Markdown 渲染。`duration` 传入后自动折叠一次，用户可随时点击标题展开/收起。
 
@@ -60,17 +59,19 @@ AI 思维链（Chain-of-Thought）推理过程展示组件。由**可点击标�
 
 ```vue
 <template>
-  <ReasoningMessage
-    :content="content"
-    :status="status"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { ReasoningMessage, MessageStatus } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const status = MessageStatus.Complete;
-  const content = ['让我分析一下这个问题...', '首先需要考虑以下几个方面...'];
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.Reasoning,
+    status: MessageStatus.Complete,
+    content: ['让我分析一下这个问题...', '首先需要考虑以下几个方面...'],
+  };
 </script>
 ```
 
@@ -173,11 +174,12 @@ const { stop } = watch(
 通过 `v-model:collapsed` 从外部读取或设置折叠状态：
 
 ```vue
+<!-- 文档站内部示例：组件本体支持 v-model:collapsed；消费方一般经 MessageRender 渲染 -->
 <template>
   <button @click="collapsed = !collapsed">
     {{ collapsed ? '展开推理' : '收起推理' }}
   </button>
-  <ReasoningMessage
+  <ReasoningMessageComp
     v-model:collapsed="collapsed"
     :content="content"
     :status="status"
@@ -187,7 +189,7 @@ const { stop } = watch(
 
 <script setup lang="ts">
   import { ref } from 'vue';
-  import { ReasoningMessage, MessageStatus } from '@blueking/chat-x';
+  import { MessageStatus } from '@blueking/chat-x';
 
   const collapsed = ref(false);
   const status = MessageStatus.Complete;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/tool-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/tool-message.md
@@ -3,9 +3,9 @@ name: ToolMessage 工具消息
 slug: tool-message
 kind: component
 domain: message
-description: 渲染工具返回内容，JSON 场景交给 DescPanel 展示。
+description: 渲染工具返回内容，JSON 场景交给 DescPanel + HighlightKeyword 展示。
 aiSummary: >
-  渲染工具返回内容，JSON 场景交给 DescPanel 展示。
+  渲染工具返回内容；DescPanel 解析 JSON 为 key-value，嵌套值 JSON.stringify 后经 HighlightKeyword 展示。
   源码位置：src/components/chat-message/tool-message/tool-message.vue。
 relatedComponents:
   - slug: assistant-message
@@ -14,61 +14,70 @@ relatedComponents:
     relation: 独立 tool 角色消息由 MessageRender 渲染为 ToolMessage
   - slug: desc-panel
     relation: 内部使用 DescPanel 展示「返回内容」
-sinceVersion: 1.0.0
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
   import ToolMessageComp from '../../../src/components/chat-message/tool-message/tool-message.vue'
+
+  const nestedJson = JSON.stringify({
+    result: 'success',
+    data: { city: '北京', meta: { humidity: 45, tags: ['晴', '微风'] } },
+  });
 </script>
 
 # ToolMessage 工具消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/tool-message/tool-message.vue`
 - **能力域**：消息系统
-- **能力说明**：渲染工具返回内容，JSON 场景交给 DescPanel 展示。
+- **能力说明**：渲染工具返回内容，JSON 场景交给 DescPanel + HighlightKeyword 展示。
 
+> **导出说明**：`ToolMessage` **未**从包入口导出（入口同名是 TS interface）。消费方经 `MessageRender` / `ToolcallRender` 使用。下文 `ToolMessageComp` 为文档站内部示例。
 
+工具执行结果展示组件。内部通过 `DescPanel` 渲染，标题固定为「返回内容」，可解析 JSON 为 key-value 列表。
 
-> **能力域**：消息系统
-
-工具（Function Call）执行结果展示组件。内部通过 `DescPanel` 渲染，标题固定为"返回内容"，支持将 JSON 自动解析为 key-value 列表。
-
-> **通常不需要直接使用此组件**。`ToolcallRender` 在 `toolCall.toolMessage` 有值时会自动内联渲染；`MessageContainer` 处理 `role: 'tool'` 消息时也会通过 `MessageRender` 自动渲染。
+> **通常不需要直接使用**。`ToolcallRender` 在 `toolCall.toolMessage` 有值时内联渲染；`role: 'tool'` 也可由 `MessageRender` 渲染。
 
 ## 渲染架构
 
 ```
 ToolMessage
-└── DescPanel（desc="content || (typeof error === 'string' ? error : undefined)"，title="返回内容"）
-      ├── JSON.parse(desc) 成功且结果为 object/array
-      │     └── key-value 列表（v-for 遍历）
-      │           值超长时截断 + overflow-tips tooltip
-      └── 其他（parse 失败 / 结果为基本类型）
-            └── 纯文本展示
+└── DescPanel（desc = content || (typeof error === 'string' ? error : undefined)，title="返回内容"）
+      ├── JSON.parse 成功且结果为 object/array（排除 null）
+      │     └── key-value 列表
+      │           · key / value 均经 HighlightKeyword 展示
+      │           · 嵌套 object/array：JSON.stringify 后展示（无 overflow-tips）
+      └── 其他（parse 失败 / 标量）
+            └── HighlightKeyword 纯文本
 ```
 
 ## 基础用法
 
 ```vue
 <template>
-  <ToolMessage
-    :content="content"
-    tool-call-id="call_1"
-    :duration="850"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { ToolMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const content = JSON.stringify({
-    city: '北京',
-    temperature: 22,
-    weather: '晴',
-    humidity: '45%',
-    wind: '东北风 3 级',
-  });
+  const message = {
+    id: 't1',
+    messageId: 't1',
+    role: MessageRole.Tool,
+    status: MessageStatus.Complete,
+    toolCallId: 'call_1',
+    duration: 850,
+    content: JSON.stringify({
+      city: '北京',
+      temperature: 22,
+      weather: '晴',
+      humidity: '45%',
+      wind: '东北风 3 级',
+    }),
+  };
 </script>
 ```
 
@@ -98,18 +107,22 @@ ToolMessage
 
 ```vue
 <template>
-  <ToolMessage
-    content=""
-    :error="error"
-    tool-call-id="call_3"
-    :duration="5000"
-  />
+  <MessageRender :message="message" />
 </template>
 
 <script setup lang="ts">
-  import { ToolMessage } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const error = 'Connection timeout: database server is unreachable (timeout: 5000ms)';
+  const message = {
+    id: 't3',
+    messageId: 't3',
+    role: MessageRole.Tool,
+    status: MessageStatus.Error,
+    toolCallId: 'call_3',
+    duration: 5000,
+    content: '',
+    error: 'Connection timeout: database server is unreachable (timeout: 5000ms)',
+  };
 </script>
 ```
 
@@ -135,24 +148,34 @@ ToolMessage
 | 解析失败（非法 JSON）       | 捕获异常，返回原字符串          | 纯文本                              |
 | `content` 和 `error` 均为空 | `''` → 解析失败                 | 空内容区                            |
 
-> **注意**：JSON 数组在 JavaScript 中 `typeof [] === 'object'` 为 `true`，因此数组会以 `0:`、`1:`、`2:` 为键渲染为 key-value 列表，而**非**纯文本。
+> **注意**：JSON 数组 `typeof [] === 'object'`，会以 `0:`、`1:`、`2:` 为键渲染为列表，而非整段纯文本。
 
-**嵌套对象值的处理**：当 value 本身是对象时，`{{ value }}` 会渲染为 `[object Object]`，但 hover 展示的 overflow-tips 会显示 `JSON.stringify(value)` 的完整字符串。
+**嵌套对象 / 数组值**：`DescPanel` 用 `JSON.stringify(value)` 转成字符串后交给 `HighlightKeyword`，**不再**使用 overflow-tips。
 
 ```typescript
-// ✅ 渲染为 key-value 列表
+// key-value 列表
 const jsonObject = '{"city":"北京","temperature":22}';
 
-// ✅ 渲染为 index-keyed 列表（0: item1, 1: item2）
+// index-keyed 列表（0: item1, 1: item2）
 const jsonArray = '["item1","item2","item3"]';
 
-// ✅ 渲染为纯文本（基本类型）
-const jsonNumber = '42';
-const jsonBool = 'true';
+// 嵌套值 stringify 展示
+const nested = '{"result":"success","data":{"city":"北京","meta":{"humidity":45}}}';
 
-// ✅ 渲染为纯文本（解析失败）
+// 标量 / 非法 JSON → 纯文本
+const jsonNumber = '42';
 const plainText = '查询成功，共返回 10 条记录。';
 ```
+
+**嵌套 JSON 渲染效果**
+
+<div class="demo">
+  <ToolMessageComp
+    :content="nestedJson"
+    tool-call-id="call_nested"
+    :duration="420"
+  />
+</div>
 
 ## 与 ToolcallRender 的关系
 
@@ -223,8 +246,8 @@ const messages = [
 
 | 属性名     | 类型               | 说明                                                                            |
 | ---------- | ------------------ | ------------------------------------------------------------------------------- |
-| content    | `string`           | 工具执行返回内容；与 `error` 通过 `\|\|` 决定优先级，**truthy 时 error 被忽略** |
-| error      | `string`           | 工具执行错误信息；仅当 `content` 为 falsy 且 `error` 为 `string` 类型时展示     |
+| content    | `string`                 | 工具执行返回内容；与 `error` 通过 `\|\|` 决定优先级，**truthy 时 error 被忽略** |
+| error      | `boolean \| string`      | 类型上可为 boolean；**仅当为 `string` 且 content 为 falsy 时**才会展示           |
 | toolCallId | `string`           | 关联的工具调用 ID（透传，组件内不使用）                                         |
 | duration   | `number`           | 工具执行耗时（毫秒，透传，组件内不使用）                                        |
 | status     | `MessageStatus`    | 消息状态（透传，组件内不使用）                                                  |
@@ -247,10 +270,14 @@ interface ToolMessage {
   content: string;
   toolCallId: string; // 关联的 ToolCall.id
   duration: number; // 工具执行耗时（毫秒）
-  error?: string; // 执行错误信息
+  error?: boolean | string; // 仅 string 会展示在 DescPanel
   name?: string;
 }
 ```
+
+### Events / Slots / Expose
+
+无。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
@@ -3,10 +3,10 @@ name: UserMessage 用户消息
 slug: user-message
 kind: component
 domain: message
-description: 渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。
+description: 渲染用户消息，支持纯文本、键值引用、文件附件和编辑态输入。
 aiSummary: >
-  渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。
-  源码位置：src/components/chat-message/user-message/user-message.vue。
+  渲染用户消息：纯文本（非 Markdown）、键值引用、二进制附件与编辑态 ChatInput / ShortcutRender；
+  工具栏含 copy / cite / edit / delete。源码位置：src/components/chat-message/user-message/user-message.vue。
 relatedComponents:
   - slug: message-render
     relation: 由 MessageRender 在 role 为 user 时创建
@@ -14,7 +14,9 @@ relatedComponents:
     relation: 消息工具栏交互与状态由 MessageTools 体系承载
   - slug: message-container
     relation: 嵌入列表时由 MessageContainer 管理分组与多选
-sinceVersion: 1.0.0
+  - slug: chat-input
+    relation: 编辑态普通消息使用 ChatInput
+sinceVersion: 0.0.20
 ---
 
 <script lang="ts" setup>
@@ -106,17 +108,16 @@ sinceVersion: 1.0.0
 </script>
 
 # UserMessage 用户消息
+
 ## 源码事实
 
 - **源码位置**：`src/components/chat-message/user-message/user-message.vue`
 - **能力域**：消息系统
-- **能力说明**：渲染用户消息，支持文本、键值、Markdown、引用、文件和编辑态输入。
+- **能力说明**：渲染用户消息：纯文本、键值引用、文件附件与编辑态输入（**不**渲染 Markdown）。
 
+> **导出说明**：`UserMessage` **未**从 `@blueking/chat-x` 包入口导出（入口同名是 TS interface）。消费方请用 `MessageRender` / `MessageContainer`。下文 `UserMessageComp` 为文档站内部相对路径示例。
 
-
-> **能力域**：消息系统
-
-用户消息展示组件，右对齐显示用户发送的消息内容。支持纯文本、多媒体（图片/文件）、文本引用、结构化引用、快捷指令等多种内容形式，以及消息的内联编辑功能。
+用户消息展示组件，右对齐。支持纯文本、多媒体（图片/文件）、文本引用、结构化引用、快捷指令，以及内联编辑。
 
 ## 组件结构
 
@@ -140,7 +141,7 @@ sinceVersion: 1.0.0
 └── MessageTools（.ai-user-message-tools）
       v-if: messageToolsStatus !== 'hidden'
       visibility: hidden（默认）→ visible（:hover 时）
-      tools: [copy, cite, edit]，updateTools: []
+      tools: [copy, cite, edit, delete]，updateTools: []
 ```
 
 **编辑模式**（点击 `edit` 按钮后 `isEdit=true`）
@@ -163,22 +164,29 @@ sinceVersion: 1.0.0
 
 ## 基础用法
 
-`content` 为字符串时，通过 `TextContent` 渲染（内部使用 `MarkdownContent`，支持 Markdown 语法）。
+`content` 为字符串时，通过 `TextContent` 以**纯文本**插值渲染（`{{ content }}`），**不**走 Markdown。
 
 ```vue
 <template>
-  <UserMessage
-    :content="content"
+  <MessageRender
+    :message="message"
     :on-action="handleAction"
   />
 </template>
 
 <script setup lang="ts">
-  import { UserMessage, type IToolBtn } from '@blueking/chat-x';
+  import { MessageRender, MessageRole, MessageStatus, type IToolBtn } from '@blueking/chat-x';
 
-  const content = '你好，请帮我分析以下这段 Python 代码的性能瓶颈。';
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.User,
+    content: '你好，请帮我分析以下这段 Python 代码的性能瓶颈。',
+    status: MessageStatus.Complete,
+  };
 
   const handleAction = async (tool: IToolBtn) => {
+    // copy / edit 有内置行为；cite / delete 需业务侧处理
     console.log('工具操作:', tool.id);
   };
 </script>
@@ -188,7 +196,7 @@ sinceVersion: 1.0.0
   <UserMessageComp :content="textContent" :on-action="handleAction" />
 </div>
 
-> **工具栏**：鼠标悬停时，消息下方出现「复制」「引用」「编辑」三个操作按钮（CSS `visibility` 切换，始终占位）。
+> **工具栏**：悬停时显示「复制」「引用」「编辑」「删除」（CSS `visibility`，始终占位）。
 
 ## 多媒体消息
 
@@ -201,20 +209,26 @@ sinceVersion: 1.0.0
 
 ```vue
 <script setup lang="ts">
-  import { UserMessage, MessageContentType } from '@blueking/chat-x';
+  import { MessageRender, MessageContentType, MessageRole, MessageStatus } from '@blueking/chat-x';
 
-  const content = [
-    {
-      type: MessageContentType.Binary, // 'binary'
-      url: 'https://example.com/screenshot.png',
-      mimeType: 'image/png',
-      filename: 'screenshot.png',
-    },
-    {
-      type: MessageContentType.Text, // 'text'
-      text: '请帮我分析这张架构图，指出其中的问题。',
-    },
-  ];
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.User,
+    status: MessageStatus.Complete,
+    content: [
+      {
+        type: MessageContentType.Binary,
+        url: 'https://example.com/screenshot.png',
+        mimeType: 'image/png',
+        filename: 'screenshot.png',
+      },
+      {
+        type: MessageContentType.Text,
+        text: '请帮我分析这张架构图，指出其中的问题。',
+      },
+    ],
+  };
 </script>
 ```
 
@@ -237,12 +251,14 @@ sinceVersion: 1.0.0
 
 ```vue
 <script setup lang="ts">
-  import { UserMessage } from '@blueking/chat-x';
-
-  const content = '这段代码每次循环都发起请求，应该如何优化？';
-  const property = {
-    extra: {
-      cite: '// 原始代码\nfor (let i = 0; i < arr.length; i++) {\n  fetch(`/api/${arr[i]}`)\n}',
+  // 消费方将 property 挂在 message 上，经 MessageRender 透传
+  const message = {
+    role: 'user',
+    content: '这段代码每次循环都发起请求，应该如何优化？',
+    property: {
+      extra: {
+        cite: '// 原始代码\nfor (let i = 0; i < arr.length; i++) {\n  fetch(`/api/${arr[i]}`)\n}',
+      },
     },
   };
 </script>
@@ -262,18 +278,20 @@ sinceVersion: 1.0.0
 
 ```vue
 <script setup lang="ts">
-  import { UserMessage } from '@blueking/chat-x';
-
-  const content = '请帮我分析这份报表的数据趋势。';
-  const property = {
-    extra: {
-      cite: {
-        title: '销售数据分析',
-        data: [
-          { key: '报表名称', value: '2024 年 Q4 销售报表' },
-          { key: '时间范围', value: '2024年10月 - 12月' },
-          { key: '数据量', value: '12,580 条' },
-        ],
+  const message = {
+    role: 'user',
+    content: '请帮我分析这份报表的数据趋势。',
+    property: {
+      extra: {
+        cite: {
+          title: '销售数据分析',
+          type: 'structured',
+          data: [
+            { key: '报表名称', value: '2024 年 Q4 销售报表' },
+            { key: '时间范围', value: '2024年10月 - 12月' },
+            { key: '数据量', value: '12,580 条' },
+          ],
+        },
       },
     },
   };
@@ -302,34 +320,35 @@ sinceVersion: 1.0.0
 
 ```vue
 <script setup lang="ts">
-  import { UserMessage } from '@blueking/chat-x';
-
-  const content = '请帮我翻译这段文字';
-  const property = {
-    extra: {
-      shortcut: {
-        id: 'translate',
-        name: '翻译',
-        components: [
-          {
-            type: 'select',
-            key: 'targetLang',
-            name: '目标语言',
-            default: 'en',
-            options: [
-              { label: '英文', value: 'en' },
-              { label: '中文', value: 'zh' },
-            ],
-          },
-          {
-            type: 'textarea',
-            key: 'content',
-            name: '翻译内容',
-            fillBack: true,
-            default: '请帮我翻译这段文字',
-          },
-        ],
-        formModel: { targetLang: 'en', content: '请帮我翻译这段文字' },
+  const message = {
+    role: 'user',
+    content: '请帮我翻译这段文字',
+    property: {
+      extra: {
+        shortcut: {
+          id: 'translate',
+          name: '翻译',
+          components: [
+            {
+              type: 'select',
+              key: 'targetLang',
+              name: '目标语言',
+              default: 'en',
+              options: [
+                { label: '英文', value: 'en' },
+                { label: '中文', value: 'zh' },
+              ],
+            },
+            {
+              type: 'textarea',
+              key: 'content',
+              name: '翻译内容',
+              fillBack: true,
+              default: '请帮我翻译这段文字',
+            },
+          ],
+          formModel: { targetLang: 'en', content: '请帮我翻译这段文字' },
+        },
       },
     },
   };
@@ -365,8 +384,8 @@ binaryFiles 有值 → 进入编辑模式（editContent 可为空）
 
 ```vue
 <template>
-  <UserMessage
-    :content="content"
+  <MessageRender
+    :message="message"
     :on-action="handleAction"
     :on-input-confirm="handleInputConfirm"
     :on-shortcut-confirm="handleShortcutConfirm"
@@ -374,25 +393,35 @@ binaryFiles 有值 → 进入编辑模式（editContent 可为空）
 </template>
 
 <script setup lang="ts">
-  import { UserMessage, type IToolBtn, type TagSchema } from '@blueking/chat-x';
+  import {
+    MessageRender,
+    MessageRole,
+    MessageStatus,
+    type IToolBtn,
+    type TagSchema,
+    type UserMessage,
+  } from '@blueking/chat-x';
 
-  const content = '请帮我优化这段代码';
+  const message = {
+    id: '1',
+    messageId: '1',
+    role: MessageRole.User,
+    content: '请帮我优化这段代码',
+    status: MessageStatus.Complete,
+  };
 
   const handleAction = async (tool: IToolBtn) => {
-    // tool.id === 'edit'  → 组件内部自动切换编辑模式
-    // tool.id === 'copy'  → 自动复制（字符串直接复制，数组 JSON.stringify 后复制）
-    // tool.id === 'cite'  → 由外部 onAction 处理（组件内无内置行为）
+    // edit → 组件内切编辑态；copy → 组件内复制
+    // cite / delete → 无内置行为，业务侧处理（如删除会话消息）
     console.log('工具:', tool.id);
   };
 
-  const handleInputConfirm = async (content: string | InputContent[], docSchema: TagSchema) => {
-    console.log('编辑后内容:', content);
-    // 重新发送消息
+  const handleInputConfirm = async (content: UserMessage['content'], docSchema: TagSchema) => {
+    console.log('编辑后内容:', content, docSchema);
   };
 
   const handleShortcutConfirm = async (formModel: Record<string, unknown>) => {
     console.log('快捷指令表单:', formModel);
-    // 重新发送快捷指令
   };
 </script>
 ```
@@ -403,50 +432,85 @@ binaryFiles 有值 → 进入编辑模式（editContent 可为空）
 
 **内置工具列表（`CONST_USER_MESSAGE_TOOLS`）**
 
-| 工具 ID | 名称 | 内置行为                                     |
-| ------- | ---- | -------------------------------------------- |
-| `copy`  | 复制 | 字符串直接复制；数组 `JSON.stringify` 后复制 |
-| `cite`  | 引用 | 无内置行为，需通过 `onAction` 外部处理       |
-| `edit`  | 编辑 | 切换 `isEdit=true`，进入编辑模式             |
+| 工具 ID  | 名称 | 内置行为                                     |
+| -------- | ---- | -------------------------------------------- |
+| `copy`   | 复制 | 字符串直接复制；数组 `JSON.stringify` 后复制 |
+| `cite`   | 引用 | 无内置行为，需通过 `onAction` 外部处理       |
+| `edit`   | 编辑 | 切换 `isEdit=true`，进入编辑模式             |
+| `delete` | 删除 | 无内置行为，需通过 `onAction` 外部处理       |
 
 ```vue
-<!-- 隐藏工具按钮（从 DOM 移除，不占位） -->
-<UserMessage :content="content" message-tools-status="hidden" />
+<!-- 经 MessageRender 控制工具栏状态 -->
+<MessageRender
+  :message="message"
+  message-tools-status="hidden"
+/>
+<MessageRender
+  :message="message"
+  message-tools-status="disabled"
+/>
+```
 
-<!-- 禁用工具按钮（保留占位，不可点击，无 hover 效果） -->
-<UserMessage :content="content" message-tools-status="disabled" />
+## supportUpload 透传
+
+编辑态 `ChatInput` 的上传能力来自 `injectGlobalConfig().supportUpload`（通常由 `ChatContainer` 的 `supportUpload` prop 注册）。自定义 `#message` 插槽时须把同一配置链路保留，否则编辑态会与主输入区不一致。
+
+```vue
+<template>
+  <ChatContainer
+    :messages="messages"
+    :support-upload="true"
+    :on-agent-action="handleAgentAction"
+    :on-user-action="handleUserAction"
+  >
+    <template #message="{ message, messageToolsStatus, onInterruptResume }">
+      <MessageRender
+        :message="message"
+        :message-tools-status="messageToolsStatus"
+        :on-action="handleUserAction"
+        :on-input-confirm="(content, docSchema) => handleUserInputConfirm(message, content, docSchema)"
+        :on-shortcut-confirm="formModel => handleUserShortcutConfirm(message, formModel)"
+        :on-interrupt-resume="onInterruptResume"
+      />
+    </template>
+  </ChatContainer>
+</template>
 ```
 
 ## API
 
 ### Props
 
-| 属性名             | 类型                                                                         | 说明                                                      |
-| ------------------ | ---------------------------------------------------------------------------- | --------------------------------------------------------- |
-| content            | `string \| InputContent[]`                                                   | 消息内容，字符串或含 text/binary 的数组                   |
-| property           | `{ extra?: MessageExtra }`                                                   | 消息附加属性，包含引用、快捷指令、context 等信息          |
-| messageToolsStatus | `MessageToolsStatus`                                                         | 工具按钮状态，`disabled` 禁用、`hidden` 从 DOM 移除       |
-| onAction           | `(tool: IToolBtn) => Promise<void>`                                          | 工具按钮回调；`copy`/`edit` 有内置行为，`cite` 需外部处理 |
-| onInputConfirm     | `(content: string \| InputContent[], docSchema: TagSchema) => Promise<void>` | 普通消息编辑确认回调                                      |
-| onShortcutConfirm  | `(formModel: Record<string, unknown>) => Promise<void>`                      | 快捷指令消息编辑确认回调                                  |
-| tippyOptions       | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>`   | 自定义工具栏 Tippy 配置，透传给内部 `MessageTools` 组件   |
+| 属性名             | 类型                                                                                       | 说明                                                                      |
+| ------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| content            | `string \| InputContent[]`                                                                 | 消息内容，字符串或含 text/binary 的数组                                   |
+| property           | `{ extra?: MessageExtra; artifacts?: AIFileInfo[] }`                                       | 附加属性；本组件消费 `extra.cite` / `shortcut` / `context`                |
+| messageToolsStatus | `MessageToolsStatus`                                                                       | 工具按钮状态，`disabled` 禁用、`hidden` 从 DOM 移除                       |
+| onAction           | `MessageToolsProps['onAction']`                                                            | 工具回调；`copy`/`edit` 有内置行为，`cite`/`delete` 需外部处理            |
+| onInputConfirm     | `(content: UserMessage['content'], docSchema: TagSchema) => Promise<void>`                 | 普通消息编辑确认回调                                                      |
+| onShortcutConfirm  | `(formModel: Record<string, unknown>) => Promise<void>`                                    | 快捷指令消息编辑确认回调                                                  |
+| tippyOptions       | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>`                 | 自定义工具栏 Tippy 配置，透传给内部 `MessageTools`                        |
+
+### Events / Slots / Expose
+
+无。
 
 ### 全局配置依赖
 
-编辑模式下的 `ChatInput` 会通过 `injectGlobalConfig()` 获取全局配置中的 `supportUpload` 值。需要确保祖先组件（通常是 `ChatContainer`）已调用 `useGlobalConfig()` 注册配置。
+编辑态 `ChatInput` 通过 `injectGlobalConfig()` 读取 `supportUpload`。祖先需已 `useGlobalConfig()`（通常由 `ChatContainer` 注册）。
 
 ## 类型定义
 
 ```typescript
 // 文本内容项
 interface TextInputContent {
-  type: 'text'; // MessageContentType.Text
+  type: 'text';
   text: string;
 }
 
 // 二进制内容项（图片、文件）
 interface BinaryContent {
-  type: 'binary'; // MessageContentType.Binary
+  type: 'binary';
   url?: string;
   mimeType?: string;
   filename?: string;
@@ -454,28 +518,27 @@ interface BinaryContent {
 
 type InputContent = TextInputContent | BinaryContent;
 
-// 消息附加属性
-interface MessageExtra {
-  // 文本引用（字符串）：渲染在气泡外 CiteContent
-  cite?: string;
-
-  // 结构化引用（对象）：渲染在气泡内 KeyValueContent；与 context 配合可重建 ShortcutRender
-  cite?: {
-    title?: string;
-    data: Array<{ key: string; value: string }>;
-  };
-
-  // 快捷指令：编辑时渲染 ShortcutRender（优先于 cite+context 路径）
-  shortcut?: Shortcut;
-
-  // 上下文变量：与结构化 cite 配合，在编辑模式下动态构建 ShortcutComponent[]
+// property.extra（与源码 BaseMessage.property.extra 对齐）
+type MessageExtra = {
+  // 文本引用 或 结构化引用（互斥 union，不是两个同名字段）
+  cite?:
+    | string
+    | {
+        title: string;
+        type: 'structured';
+        data: Array<{ key: string; value: string }>;
+      };
+  command?: string;
+  pause?: boolean;
+  shortcut?: Partial<Shortcut>;
   context?: Array<{
     __key: string;
     __label: string;
     __value: string;
     fillBack?: boolean;
+    context_type?: string;
   }>;
-}
+};
 ```
 
 ## 关联组件

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -566,8 +566,9 @@ ai-chat-container（:data-ai-size="size"）
 - **触发**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 命中该文件并 `addCustomTab` 弹出侧栏
 - **排序 / 关闭**：`order: -1` 排在「执行情况」之前，`closable: false` 不可关闭
 - **显隐解耦**：该 Tab 存在时，侧栏展示不再受「`executionGroups` 为空」约束（即使当前会话没有执行类消息，也能独立展示文件产物侧栏）；会话切换或无文件产物时自动移除并重置命中态
-- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染文件列表与预览（HTML 走 `fetch` + `iframe srcdoc`，其余类型用 `previewUrl` 的 PDF）
-- **状态管理**：命中与切换由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片内）
+- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染文件列表与预览；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取（HTML 用 `download_url` fetch + `iframe srcdoc`，其余类型用 `preview_url` 的 PDF）
+- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）
+- **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
 
 详见 [FileArtifactPanel 文件产物预览](/components/message/file-artifact-panel) 与 [useArtifactPreview 文件产物预览](/composables/use-artifact-preview)。
 
@@ -976,6 +977,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | size               | `'normal' \| 'small'`                                                        | `'small'` | 字号主题档位：`small` 为 12px 基准，`normal` 为 14px 基准；根节点设置 `data-ai-size` 并注入 `useGlobalConfig`                                |
 | resizeProps        | `{ disabled?: boolean; initialDivide?: number \| string; max?: number; min?: number }` | —        | 透传给内部 `ResizeLayout` 的可选配置，与默认 `collapsible: false`、`immediate: true`、`min: 400` 合并；`placement` 始终取自本组件 `placement`；`initialDivide` 可为像素数字或百分比等字符串（与 bkui ResizeLayout 一致） |
 | onCustomTabChange  | `(tab: CustomTab) => Promise<any>`                                           | —        | 自定义 Tab 切换回调，返回值作为 Tab 组件 props                                                                                                |
+| onArtifactClick    | `(file: AIFileInfo) => Promise<{ download_url?: string; preview_url?: string }>` | —        | 点击文件产物时异步获取下载 / 预览链接（按 `outputId` 缓存）；未传则隐藏下载、预览无数据 |
 
 > 完整 Props 列表请参考 [ChatInput](/components/input/chat-input) 和 [MessageContainer](/components/setup/message-container) 文档。
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -7,6 +7,7 @@ description: >-
   Provider 在 ChatContainer 中创建，Consumer 在深层文件卡片中注入使用。
 aiSummary: >
   useArtifactPreviewProvider 维护 activeArtifactId，openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
+  并通过 getOnArtifactClick 封装 resolveArtifactUrls（按 outputId 缓存 download_url / preview_url）；
   useArtifactPreviewConsumer 在后代注入同一套 API。buildArtifactId 用 messageUid#index#outputId 生成唯一 id。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
 relatedComponents:
@@ -25,7 +26,7 @@ sinceVersion: 0.0.20
 
 Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatContainer` 中创建，负责维护当前命中的文件 id；Consumer 在深层 `ArtifactFileCard` 中注入，用于点击卡片触发预览。
 
-**职责边界**：composable 只维护「命中文件」这一份数据状态；打开侧栏 Tab（`addCustomTab`）、聚合会话文件列表、渲染预览面板等副作用由 `ChatContainer` 承担，通过 `onOpen` 回调注入，避免直接依赖 `useCustomTab`。
+**职责边界**：composable 维护「命中文件」与「URL 解析缓存」；打开侧栏 Tab（`addCustomTab`）、聚合会话文件列表、渲染预览面板等副作用由 `ChatContainer` 承担，通过 `onOpen` / `getOnArtifactClick` 回调注入，避免直接依赖 `useCustomTab`。
 
 ## 函数签名
 
@@ -33,11 +34,15 @@ Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatCo
 
 ```typescript
 function useArtifactPreviewProvider(options: {
+  /** 读取业务侧异步取链回调（getter 保持对 props 变更敏感） */
+  getOnArtifactClick?: () => OnArtifactClick | undefined;
   /** 命中文件后触发：由容器负责 addCustomTab + 展开侧栏 + 选中 Tab */
   onOpen: (artifactId: string) => void;
 }): {
   activeArtifactId: ShallowRef<string>;
+  canResolveArtifactUrl: ComputedRef<boolean>;
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
+  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
   setActiveArtifactId: (id: string) => void;
 };
 ```
@@ -49,7 +54,9 @@ function useArtifactPreviewConsumer():
   | undefined
   | {
       activeArtifactId: Ref<string>;
+      canResolveArtifactUrl: ComputedRef<boolean>;
       openPreview: (payload: OpenArtifactPreviewPayload) => void;
+      resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
       setActiveArtifactId: (id: string) => void;
     };
 ```
@@ -82,6 +89,7 @@ const { addCustomTab, removeCustomTab } = useCustomTabProvider({ /* ... */ });
 const { sessionArtifacts } = useMessageGroup({ keyword, messages, selectedUserMessages });
 
 const { activeArtifactId, setActiveArtifactId } = useArtifactPreviewProvider({
+  getOnArtifactClick: () => props.onArtifactClick,
   onOpen: () => {
     addCustomTab({
       closable: false,
@@ -147,13 +155,15 @@ const handleCardClick = () => {
 | 属性/方法名         | 类型                                      | 说明                                                                 |
 | ------------------- | ----------------------------------------- | -------------------------------------------------------------------- |
 | activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 id（`messageUid#index#outputId`）                     |
+| canResolveArtifactUrl | `ComputedRef<boolean>`                  | 是否具备异步取链能力（有 `onArtifactClick` 时为 true，下载按钮据此显隐） |
 | openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：计算 id、更新命中态、调用 `onOpen`             |
+| resolveArtifactUrls | `(file: AIFileInfo) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 并按 `outputId` 缓存结果；并发请求去重 |
 | setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 id；侧栏列表内切换选中时使用                        |
 
 ## 类型定义
 
 ```typescript
-import type { AIFileInfo } from '@blueking/chat-x';
+import type { AIFileInfo, ArtifactUrlResult, OnArtifactClick } from '@blueking/chat-x';
 
 /** 打开预览时的入参：文件 + 消息内下标 + 所属消息 uid */
 type OpenArtifactPreviewPayload = {
@@ -169,6 +179,12 @@ type OpenArtifactPreviewPayload = {
 type SessionArtifact = AIFileInfo & {
   artifactId: string;
   messageUid: string;
+};
+
+/** onArtifactClick 返回值（snake_case） */
+type ArtifactUrlResult = {
+  download_url?: string;
+  preview_url?: string;
 };
 ```
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物点击通过 API 获取下载和预览链接
ID: 1070093903136417365

## 改动
- AIFileInfo: 移除同步 url/previewUrl，新增 OnArtifactClick / ArtifactUrlResult
- ChatContainer / use-artifact-preview: 透传 onArtifactClick，异步解析并缓存 download_url / preview_url
- ArtifactFileCard / FileArtifactPanel: 下载与预览改为异步取链，支持 loading / 重试 / 空态
- playground + wikis: 同步 mock 与文档

## 影响面
- 消费方需传入 onArtifactClick；未传时隐藏下载、预览区无数据（不兼容旧同步 url 字段）

## 测试
- [ ] 点击文件卡片触发 onArtifactClick，侧栏预览展示 loading 后正常渲染
- [ ] 未传 onArtifactClick 时不展示下载、预览为空态
- [ ] 下载图标异步取链期间为 loading，完成后触发下载
- [ ] 相关 vitest（artifact-file-card / file-artifact-panel / use-artifact-preview）通过（本轮未运行）

Made with [Cursor](https://cursor.com)