### PR TITLE
feat: 支持自定义消息工具栏合并扩展 --story=136462100

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -14,6 +14,7 @@
       v-model:selected-model="selectedModel"
       v-model:selected-shortcut="selectedShortcut"
       :enable-selection="false"
+      :message-tools="customMessageTools"
       :messages="messages"
       :model-value="userInput"
       :models="MOCK_MODELS"
@@ -35,6 +36,8 @@
       :shortcuts="shortcuts"
       :size="'small'"
       :support-upload="true"
+      :update-tools="customUpdateTools"
+      @confirm-share="handleConfirmShare"
       @delete-shortcut="handleDeleteShortcut"
       @model-change="handleModelChange"
       @select-shortcut="handleSelectShortcut"
@@ -170,6 +173,7 @@
     AgentIcon,
     ChatContainer,
     CopyIcon,
+    DownloadIcon,
     EditIcon,
     MessageContentType,
     MessageRender,
@@ -1270,9 +1274,32 @@
   //   return undefined;
   // };
 
+  // ── 自定义 AI 消息工具栏 mock ────────────────────────────────
+  // 合并语义：以内置工具为基底，按 id 覆盖同名项、追加新项，其余保留
+  // 主工具组：新增「保存」按钮（自定义图标），并覆盖内置 copy 的 tooltip 文案；cite/rebuild/share 保留
+  const customMessageTools: IToolBtn[] = [
+    // triggerSelection: 点击后复用 share 的多选态，确认走 confirmShare
+    { id: 'save', name: '保存', description: '保存该回答', icon: DownloadIcon, triggerSelection: true },
+    { id: 'copy', description: '复制全文（自定义文案）' },
+    // hidden 标记可移除内置按钮：这里隐藏「分享」
+    { id: 'share', hidden: true },
+  ];
+  // 反馈工具组：在内置 like/unlike/delete 基础上追加「收藏」按钮
+  const customUpdateTools: IToolBtn[] = [
+    { id: 'collect', name: '收藏', description: '收藏到我的空间', icon: EditIcon },
+  ];
+
   const handleAgentAction = async (tool: IToolBtn) => {
     console.log('agent action:', tool);
     await new Promise(resolve => setTimeout(resolve, 2000));
+    if (tool.id === 'save') {
+      console.log('保存该回答');
+      return;
+    }
+    if (tool.id === 'collect') {
+      console.log('收藏到我的空间');
+      return;
+    }
     if (tool.id === 'like' || tool.id === 'unlike') {
       return tool.id === 'like'
         ? ['MCP/工具调用准确', '文档召回准确', '知识匹配精准', '响应迅速及时']
@@ -1295,6 +1322,14 @@
 
   const handleStopSending = async () => {
     console.log('stop sending');
+  };
+
+  // 多选态确认：source 为来源按钮对象，据此区分 share / save 等场景
+  const handleConfirmShare = (selectedMessages: Message[], source?: IToolBtn) => {
+    console.log('confirm selection, source:', source, 'selected messages:', selectedMessages);
+    if (source?.id === 'save') {
+      console.log('保存选中的消息');
+    }
   };
 
   const handleUpload = async (file: File) => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/tool-btn/tool-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/tool-btn/tool-btn.spec.ts
@@ -176,6 +176,57 @@ describe('ToolBtn', () => {
     });
   });
 
+  describe('自定义 icon 测试', () => {
+    const CustomIcon = defineComponent({
+      name: 'CustomIcon',
+      setup() {
+        return () => h('span', { class: 'custom-icon' });
+      },
+    });
+
+    it('传入 icon（组件）时应渲染自定义图标', () => {
+      wrapper = mount(ToolBtn, {
+        props: { id: 'save' as IToolBtn['id'], name: '保存', description: '保存', icon: CustomIcon },
+      });
+
+      expect(wrapper.find('.custom-icon').exists()).toBe(true);
+    });
+
+    it('传入 icon（VNode）时应渲染自定义图标', () => {
+      wrapper = mount(ToolBtn, {
+        props: {
+          id: 'save' as IToolBtn['id'],
+          name: '保存',
+          description: '保存',
+          icon: h('span', { class: 'vnode-icon' }),
+        },
+      });
+
+      expect(wrapper.find('.vnode-icon').exists()).toBe(true);
+    });
+
+    it('icon 优先级应高于内置图标（id 命中内置也用自定义 icon）', () => {
+      wrapper = mount(ToolBtn, {
+        props: { id: 'copy', name: '复制', description: '复制', icon: CustomIcon },
+      });
+
+      expect(wrapper.find('.custom-icon').exists()).toBe(true);
+      expect(wrapper.find('.mock-copy-icon').exists()).toBe(false);
+    });
+
+    it('默认 slot 优先级应高于 icon prop', () => {
+      wrapper = mount(ToolBtn, {
+        props: { id: 'save' as IToolBtn['id'], name: '保存', description: '保存', icon: CustomIcon },
+        slots: {
+          default: () => h('span', { class: 'slot-icon' }),
+        },
+      });
+
+      expect(wrapper.find('.slot-icon').exists()).toBe(true);
+      expect(wrapper.find('.custom-icon').exists()).toBe(false);
+    });
+  });
+
   describe('不同图标类型测试', () => {
     it('应该正确渲染 copy 图标', () => {
       const props = createToolBtnProps('copy', '复制', '复制内容');

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/tool-btn/tool-btn.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/tool-btn/tool-btn.vue
@@ -7,12 +7,15 @@
     @click="handleClick"
   >
     <slot>
-      <template v-if="id && id in ToolIconsMap">
-        <component :is="ToolIconsMap[id]" />
-      </template>
-      <template v-else>
-        <div>{{ name }}</div>
-      </template>
+      <component
+        :is="icon"
+        v-if="icon"
+      />
+      <component
+        :is="ToolIconsMap[id as ToolIcons]"
+        v-else-if="id && id in ToolIconsMap"
+      />
+      <div v-else>{{ name }}</div>
     </slot>
   </div>
 </template>
@@ -23,6 +26,7 @@
 
   import { ToolIconsMap } from '../../../icons/tools';
 
+  import type { ToolIcons } from '../../../icons/tools';
   import type { IToolBtn } from '../../../types';
 
   import 'tippy.js/dist/tippy.css';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -1266,4 +1266,81 @@ describe('ChatContainer', () => {
       expect(wrapper.find('.custom-tab-label').exists()).toBe(true);
     });
   });
+
+  describe('多选态触发与来源参数测试', () => {
+    const messages = [createUserMessage('1', 'Hello'), createAssistantMessage('2', 'Hi')];
+
+    // MessageContainer 的 onAgentAction 即内部 handleAgentAction
+    const getAgentAction = () =>
+      wrapper.findComponent({ name: 'MessageContainer' }).props('onAgentAction') as (
+        tool: Record<string, unknown>,
+        msgs: Message[],
+      ) => Promise<unknown>;
+
+    it('点击标记 triggerSelection 的工具应进入多选态（渲染 SelectionFooter）', async () => {
+      wrapper = mount(ChatContainer, { props: { ...defaultProps, messages } });
+      await nextTick();
+      expect(wrapper.find('.mock-selection-footer').exists()).toBe(false);
+
+      await getAgentAction()({ id: 'save', triggerSelection: true }, []);
+      await nextTick();
+
+      expect(wrapper.find('.mock-selection-footer').exists()).toBe(true);
+    });
+
+    it('点击 share 按钮应进入多选态', async () => {
+      wrapper = mount(ChatContainer, { props: { ...defaultProps, messages } });
+      await nextTick();
+
+      await getAgentAction()({ id: 'share' }, []);
+      await nextTick();
+
+      expect(wrapper.find('.mock-selection-footer').exists()).toBe(true);
+    });
+
+    it('普通工具（无 triggerSelection）不应进入多选态且应调用 onAgentAction', async () => {
+      const onAgentAction = vi.fn();
+      wrapper = mount(ChatContainer, { props: { ...defaultProps, messages, onAgentAction } });
+      await nextTick();
+
+      const copyTool = { id: 'copy' };
+      await getAgentAction()(copyTool, []);
+      await nextTick();
+
+      expect(wrapper.find('.mock-selection-footer').exists()).toBe(false);
+      expect(onAgentAction).toHaveBeenCalledWith(copyTool, []);
+    });
+
+    it('确认多选应 emit confirmShare 并携带来源工具对象作为第二参数', async () => {
+      wrapper = mount(ChatContainer, { props: { ...defaultProps, messages } });
+      await nextTick();
+
+      const saveTool = { id: 'save', name: '保存', triggerSelection: true };
+      await getAgentAction()(saveTool, []);
+      await nextTick();
+
+      await wrapper.findComponent({ name: 'SelectionFooter' }).vm.$emit('confirm');
+      await nextTick();
+
+      const emitted = wrapper.emitted('confirmShare');
+      expect(emitted).toBeTruthy();
+      // onConfirmShare mock 返回 []，第二参数为来源工具对象
+      expect(emitted?.[0]?.[0]).toEqual([]);
+      expect(emitted?.[0]?.[1]).toEqual(saveTool);
+    });
+
+    it('share 确认时第二参数来源应为 share 工具对象', async () => {
+      wrapper = mount(ChatContainer, { props: { ...defaultProps, messages } });
+      await nextTick();
+
+      await getAgentAction()({ id: 'share' }, []);
+      await nextTick();
+
+      await wrapper.findComponent({ name: 'SelectionFooter' }).vm.$emit('confirm');
+      await nextTick();
+
+      const emitted = wrapper.emitted('confirmShare');
+      expect(emitted?.[0]?.[1]).toEqual({ id: 'share' });
+    });
+  });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -166,6 +166,7 @@
             :enable-selection="isShareMode"
             :message-groups="messageGroups"
             :message-status="inputStatus"
+            :message-tools="messageTools"
             :message-tools-status="messageToolsStatus"
             :message-tools-tippy-options="commonTippyOptions"
             :messages="messages"
@@ -176,6 +177,7 @@
             :on-user-input-confirm="onUserInputConfirm"
             :on-user-shortcut-confirm="onUserShortcutConfirm"
             :render-mode="renderMode"
+            :update-tools="updateTools"
             @stop-streaming="emits('stopStreaming')"
           >
             <template #group="{ group }">
@@ -216,7 +218,7 @@
               :is-all-selected="isAllSelected"
               :loading="false"
               :selected-count="selectedUserMessages.length"
-              @cancel="onCancelShare"
+              @cancel="handleCancelShare"
               @confirm="handleConfirmShare"
               @toggle-all="onToggleShareAll"
             />
@@ -452,7 +454,7 @@
       MessageContainerEmits & {
         (e: 'shortcutClose'): void;
         (e: 'shortcutSubmit', formModel: Record<string, unknown>): void;
-        (e: 'confirmShare', messages: Message[]): void;
+        (e: 'confirmShare', messages: Message[], source?: IToolBtn): void;
         (e: 'collapseChange', isCollapse: boolean, resizeAsideWidth: number): void;
       }
   >();
@@ -485,6 +487,8 @@
 
   const keyword = shallowRef('');
   const selectedUserMessages = deepRef<Message[]>([]);
+  // 记录触发多选态的按钮（share 或标记 triggerSelection 的自定义按钮），确认时作为来源参数回传
+  const selectionSource = shallowRef<IToolBtn>();
   const resizeAsideWidth = shallowRef<number>(400);
   const resizeMainWidth = computed(() => {
     return `calc(100% - ${resizeAsideWidth.value}px)`;
@@ -605,8 +609,9 @@
    * @param messages - 消息
    */
   const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
-    // 点击分享按钮，切换到分享模式
-    if (tool.id === 'share') {
+    // 点击分享，或业务标记了 triggerSelection 的自定义按钮（如保存），进入多选态；确认复用 confirmShare
+    if (tool.id === 'share' || tool.triggerSelection) {
+      selectionSource.value = tool;
       isShareMode.value = true;
       return;
     }
@@ -616,11 +621,18 @@
    * 点击确认分享
    */
   const handleConfirmShare = () => {
-    emits('confirmShare', onConfirmShare());
+    // 第二个参数为来源按钮对象，业务据此区分 share / save 等不同确认场景
+    emits('confirmShare', onConfirmShare(), selectionSource.value);
     nextTick(() => {
       isShareMode.value = false;
       selectedUserMessages.value = [];
+      selectionSource.value = undefined;
     });
+  };
+  // 取消多选态时同步清理来源标记
+  const handleCancelShare = () => {
+    onCancelShare();
+    selectionSource.value = undefined;
   };
 
   const handleResizing = (w: number) => {
@@ -643,7 +655,7 @@
       isShareMode.value = true;
     },
     exitShareMode: () => {
-      onCancelShare();
+      handleCancelShare();
     },
   });
 </script>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.spec.ts
@@ -46,6 +46,12 @@ vi.mock('../../../icons', () => ({
       return () => h('span', { class: 'mock-arrow-icon' });
     },
   }),
+  ArrowLeftIcon: defineComponent({
+    name: 'ArrowLeftIcon',
+    setup() {
+      return () => h('span', { class: 'mock-arrow-left-icon' });
+    },
+  }),
   SearchIcon: defineComponent({
     name: 'SearchIcon',
     setup() {
@@ -177,7 +183,8 @@ describe('ModelSelector', () => {
         },
       });
 
-      const input = wrapper.find('.ai-model-selector-panel-search-input');
+      // .ai-model-selector-panel-search-input 是 BkInput 根节点（div），需定位内部真实 input
+      const input = wrapper.find('.ai-model-selector-panel-search-input input');
       await input.setValue('deep');
 
       const visibleNames = wrapper.findAll('.ai-model-selector-panel-option-name').map(node => node.text());

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/use-model-selector.spec.ts
@@ -86,7 +86,7 @@ describe('useModelSelector', () => {
     const wrapper = mount(Host);
     await nextTick();
 
-    result?.keyword.value = 'claude';
+    if (result) result.keyword.value = 'claude';
     await nextTick();
     expect(result?.filteredModels.value).toEqual([models[1]]);
 
@@ -131,7 +131,7 @@ describe('useModelSelector', () => {
     const wrapper = mount(Host);
     await nextTick();
 
-    result?.keyword.value = 'gpt';
+    if (result) result.keyword.value = 'gpt';
     await nextTick();
     result?.resetKeyword();
     await nextTick();

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.spec.ts
@@ -112,6 +112,7 @@ vi.mock('../../message-tools/message-tools.vue', () => ({
     props: {
       messageToolsStatus: { type: String, default: undefined },
       messageTools: { type: Array, default: undefined },
+      updateTools: { type: Array, default: undefined },
       onAction: { type: Function, default: null },
       tippyOptions: { type: Object, default: undefined },
     },
@@ -124,6 +125,10 @@ vi.mock('../../message-tools/message-tools.vue', () => ({
             'data-message-tools-status': props.messageToolsStatus,
             'data-has-tippy-options': props.tippyOptions !== undefined ? 'true' : undefined,
             'data-tools-count': props.messageTools?.length,
+            'data-update-tools-count': props.updateTools?.length,
+            // 序列化工具明细，便于单测断言合并/覆盖/隐藏结果
+            'data-tools-json': JSON.stringify(props.messageTools ?? []),
+            'data-update-tools-json': JSON.stringify(props.updateTools ?? []),
           },
           'Message Tools',
         );
@@ -1443,6 +1448,70 @@ describe('MessageContainer', () => {
       const messageTools = wrapper.find('.mock-message-tools');
       expect(messageTools.exists()).toBe(true);
       expect(Number(messageTools.attributes('data-tools-count'))).toBe(4);
+    });
+  });
+
+  describe('messageTools / updateTools 合并测试', () => {
+    // 读取 mock 序列化的工具明细
+    const readTools = (w: VueWrapper, attr: 'data-tools-json' | 'data-update-tools-json') =>
+      JSON.parse(w.find('.mock-message-tools').attributes(attr) ?? '[]') as Array<{
+        description?: string;
+        id?: string;
+      }>;
+
+    const mountAssistant = (extra: Record<string, unknown>) => {
+      const messages: Message[] = [createAssistantMessage('1', 'Hello', 1)];
+      return mount(MessageContainer, {
+        props: { ...defaultProps, messages, messageGroups: buildGroups(messages), ...extra },
+      });
+    };
+
+    it('传入 messageTools 中的新 id 应追加到内置列表末尾', async () => {
+      wrapper = mountAssistant({ messageTools: [{ id: 'save', name: '保存', description: '保存' }] });
+      await nextTick();
+
+      const tools = readTools(wrapper, 'data-tools-json');
+      expect(tools.length).toBe(5);
+      expect(tools.at(-1)?.id).toBe('save');
+    });
+
+    it('传入 messageTools 中的同 id 应字段级覆盖内置项且不新增', async () => {
+      wrapper = mountAssistant({ messageTools: [{ id: 'copy', description: '复制全文' }] });
+      await nextTick();
+
+      const tools = readTools(wrapper, 'data-tools-json');
+      expect(tools.length).toBe(4);
+      expect(tools.find(tool => tool.id === 'copy')?.description).toBe('复制全文');
+    });
+
+    it('messageTools 中标记 hidden 的内置项应被过滤', async () => {
+      wrapper = mountAssistant({ messageTools: [{ id: 'share', hidden: true }] });
+      await nextTick();
+
+      const tools = readTools(wrapper, 'data-tools-json');
+      expect(tools.length).toBe(3);
+      expect(tools.some(tool => tool.id === 'share')).toBe(false);
+    });
+
+    it('不传 updateTools 时应使用内置反馈工具（like/unlike/delete）', async () => {
+      wrapper = mountAssistant({});
+      await nextTick();
+
+      const tools = readTools(wrapper, 'data-update-tools-json');
+      expect(tools.map(tool => tool.id)).toEqual(['like', 'unlike', 'delete']);
+    });
+
+    it('传入 updateTools 的新 id 应追加，hidden 项应被过滤', async () => {
+      wrapper = mountAssistant({
+        updateTools: [
+          { id: 'collect', name: '收藏', description: '收藏' },
+          { id: 'delete', hidden: true },
+        ],
+      });
+      await nextTick();
+
+      const tools = readTools(wrapper, 'data-update-tools-json');
+      expect(tools.map(tool => tool.id)).toEqual(['like', 'unlike', 'collect']);
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -82,6 +82,7 @@
             :on-action="(tool: IToolBtn) => handleAgentAction(tool, group.messages)"
             :style="{ visibility: group.isHover ? 'visible' : 'hidden' }"
             :tippy-options="props.messageToolsTippyOptions"
+            :update-tools="updateTools"
             @feedback="
               (tool: IToolBtn, reasonList: string[], otherReason: string) =>
                 props.onAgentFeedback?.(tool, group.messages, reasonList, otherReason)
@@ -130,7 +131,7 @@
   import { Checkbox } from 'bkui-vue';
 
   import { type Message, type UserMessage, MessageRole, MessageStatus } from '../../../ag-ui/types';
-  import { CONST_MESSAGE_TOOLS, RenderMode } from '../../../common';
+  import { CONST_MESSAGE_TOOLS, CONST_UPDATE_TOOLS, RenderMode } from '../../../common';
   import { type MessageGroup, useClipboard, useContainerScrollProvider } from '../../../composables';
   import { ArrowDownIcon, CloseCircleIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
@@ -152,6 +153,8 @@
     messageGroups: MessageGroup[]; // 消息分组列表
     messages: Message[];
     messageStatus?: MessageStatus;
+    // 自定义 AI 消息主工具组（copy/cite/rebuild/share 一排）；以内置列表为基底，按 id 覆盖同名项、追加新项
+    messageTools?: IToolBtn[];
     messageToolsStatus?: MessageToolsStatus; // 工具按钮状态  disabled 禁用 hidden 隐藏
     messageToolsTippyOptions?: MessageToolsProps['tippyOptions'];
     onAgentAction?: AgentActionCallback;
@@ -159,6 +162,8 @@
     onInterruptResume?: OnInterruptResume; // ag-ui human-in-the-loop 中断响应回调
     onUserAction?: UserActionCallback;
     renderMode?: RenderMode;
+    // 自定义 AI 消息反馈工具组（like/unlike/delete 一排）；以内置列表为基底，按 id 覆盖同名项、追加新项
+    updateTools?: IToolBtn[];
   } & {
     onUserInputConfirm?: (message: Message, content: UserMessage['content'], docSchema: TagSchema) => Promise<void>;
     onUserShortcutConfirm?: (message: Message, formModel: Record<string, unknown>) => Promise<void>;
@@ -217,9 +222,26 @@
     messageContainerBottomRef,
   );
   const { copy } = useClipboard();
+  /**
+   * 按 id 合并工具列表：以内置列表为基底，同 id 覆盖（字段级合并）、新 id 追加，其余保留；
+   * 最后过滤掉标记 hidden 的项，实现「隐藏内置按钮」（如 { id: 'share', hidden: true }）。
+   * @param base 内置基底列表
+   * @param extra 业务自定义列表
+   */
+  const mergeToolsById = (base: IToolBtn[], extra?: IToolBtn[]): IToolBtn[] => {
+    if (!extra?.length) return base;
+    const merged = base.map(tool => {
+      const override = extra.find(item => item.id === tool.id);
+      return override ? { ...tool, ...override } : tool;
+    });
+    const appended = extra.filter(item => !base.some(tool => tool.id === item.id));
+    return [...merged, ...appended].filter(tool => !tool.hidden);
+  };
   const messageTools = computed(() => {
-    return CONST_MESSAGE_TOOLS.filter(tool => props.renderMode !== RenderMode.Test || tool.id !== 'share');
+    const tools = mergeToolsById(CONST_MESSAGE_TOOLS, props.messageTools);
+    return tools.filter(tool => props.renderMode !== RenderMode.Test || tool.id !== 'share');
   });
+  const updateTools = computed(() => mergeToolsById(CONST_UPDATE_TOOLS, props.updateTools));
   // Share 模式仅展示历史消息，过滤自动注入或外部传入的 Loading 占位组
   const visibleMessageGroups = computed(() =>
     props.renderMode === RenderMode.Share

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/tool.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/tool.ts
@@ -24,7 +24,9 @@
  * IN THE SOFTWARE.
  */
 
-import type { ToolIconsMap } from '../icons/tools';
+import type { Component, VNode } from 'vue';
+
+import type { ToolIcons } from '../icons/tools';
 import type { TippyOptions } from 'vue-tippy';
 
 export enum MessageToolsStatus {
@@ -36,6 +38,13 @@ export type AITippyProps = Partial<Pick<TippyOptions, 'appendTo' | 'placement' |
 
 export interface IToolBtn {
   description?: string;
-  id?: keyof typeof ToolIconsMap;
+  // 隐藏该按钮：配合按 id 合并使用，如 { id: 'share', hidden: true } 可移除内置项
+  hidden?: boolean;
+  // 自定义图标（组件或 VNode），优先级高于内置 ToolIconsMap；配合自定义 id 使用
+  icon?: Component | VNode;
+  // 内置 id 保留自动补全，同时允许业务自定义任意字符串（如 'save'）
+  id?: (string & {}) | ToolIcons;
   name?: string;
+  // 标记该按钮点击后进入多选态（复用 share 的选择流程），确认走 confirmShare
+  triggerSelection?: boolean;
 }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/message-tools.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/message-tools.md
@@ -437,11 +437,15 @@ const CONST_UPDATE_TOOLS = [
 
 ```typescript
 import { MessageToolsStatus, type IToolBtn } from '@blueking/chat-x';
+import type { Component, VNode } from 'vue';
 
 interface IToolBtn {
-  id?: keyof typeof ToolIconsMap; // 工具唯一标识；与 ToolIconsMap 匹配时显示内置图标，否则显示 name 文本
+  id?: (string & {}) | ToolIcons; // 工具唯一标识；命中 ToolIconsMap 显示内置图标，否则显示 name 文本；支持业务自定义字符串
   name?: string; // 工具名称，无对应图标时显示；也用作 tooltip fallback
   description?: string; // tooltip 文本
+  icon?: Component | VNode; // 自定义图标（组件/VNode），优先级高于内置 ToolIconsMap[id]
+  hidden?: boolean; // 按 id 合并时隐藏该按钮（仅在 MessageContainer/ChatContainer 合并语义下生效）
+  triggerSelection?: boolean; // 标记点击后进入多选态（复用 share 选择流程），确认走 confirmShare
 }
 
 enum MessageToolsStatus {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/tool-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/feedback/tool-btn.md
@@ -55,8 +55,9 @@ div.ai-tool-btn（v-tippy，flex，min-width: 20px，height: 20px，border-radiu
   disabled=true → .is-disabled（color: #979ba5; cursor: not-allowed）
   :not(.is-disabled):hover → color: #4d4f56; background: #eaebf0
   │
-  └── <slot>（默认内容，可完全自定义）
-        ├── [id && id in ToolIconsMap] → <component :is="ToolIconsMap[id]" />（SVG 图标）
+  └── <slot>（默认内容，可完全自定义；优先级最高）
+        ├── [icon] → <component :is="icon" />（自定义图标组件/VNode，优先级高于内置图标）
+        ├── [id && id in ToolIconsMap] → <component :is="ToolIconsMap[id]" />（内置 SVG 图标）
         └── [其他] → <div>{{ name }}</div>（文本回退，XSS 安全）
 
 Tippy：content=description, theme='ai-chat-box', disabled=true 时 onShow 返回 false 不显示
@@ -273,6 +274,28 @@ click 事件：disabled=true 时被 JS 拦截，不触发 emit
   </div>
 </div>
 
+## 自定义图标（icon 属性）
+
+当内置 `ToolIconsMap` 未覆盖所需图标时，可通过 `icon` 传入自定义图标组件或 VNode（如业务新增的「保存」按钮）。`icon` 的渲染优先级高于内置图标，因此即便 `id` 命中内置图标，也会以 `icon` 为准。
+
+```vue
+<template>
+  <ToolBtn
+    id="save"
+    name="保存"
+    description="保存该回答"
+    :icon="DownloadIcon"
+    @click="handleClick"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ToolBtn, DownloadIcon } from '@blueking/chat-x';
+</script>
+```
+
+> 优先级从高到低：默认插槽 `>` `icon` 属性 `>` 内置 `ToolIconsMap[id]` `>` `name` 文本回退。
+
 ## 自定义插槽内容
 
 通过默认插槽可完全替换内置图标/文本，适用于预置 `ToolIconsMap` 未覆盖的图标场景（如侧栏全屏按钮）：
@@ -309,9 +332,10 @@ click 事件：disabled=true 时被 JS 拦截，不触发 emit
 
 | 属性名       | 类型                                                                       | 必填 | 默认值 | 说明                                                                                                               |
 | ------------ | -------------------------------------------------------------------------- | ---- | ------ | ------------------------------------------------------------------------------------------------------------------ |
-| id           | `keyof typeof ToolIconsMap`                                                | 否   | —      | 按钮标识；在 `ToolIconsMap` 中时渲染对应 SVG 图标，否则渲染 `name` 文本；使用插槽自定义内容时可省略                  |
+| id           | `(string & {}) \| ToolIcons`                                               | 否   | —      | 按钮标识；命中 `ToolIconsMap` 时渲染对应 SVG 图标，否则渲染 `name` 文本；支持业务自定义任意字符串（如 `save`）      |
 | name         | `string`                                                                   | 否   | —      | 按钮名称；`id` 无对应图标时作为文本内容渲染                                                                        |
 | description  | `string`                                                                   | 否   | —      | Tippy tooltip 内容；`disabled=true` 时不显示 tooltip                                                               |
+| icon         | `Component \| VNode`                                                        | 否   | —      | 自定义图标组件或 VNode；优先级高于内置 `ToolIconsMap[id]`，低于默认插槽                                             |
 | active       | `boolean`                                                                  | 否   | —      | 激活态；`true` 时追加 `.is-active`（字色由 `id` 决定：`like`/`activeLike` 为蓝色 `#3a84ff`，其他为红色 `#E71818`） |
 | disabled     | `boolean`                                                                  | 否   | —      | 禁用态；`true` 时追加 `.is-disabled`，阻止 click 事件，隐藏 tooltip                                                |
 | tippyOptions | `Partial<Omit<TippyOptions, 'getReferenceClientRect' \| 'triggerTarget'>>` | 否   | —      | 自定义 Tippy 配置，与内部默认配置合并；可用于控制 `content`、`appendTo`、`placement` 等                            |
@@ -331,11 +355,16 @@ click 事件：disabled=true 时被 JS 拦截，不触发 emit
 ## 类型定义
 
 ```typescript
+import type { Component, VNode } from 'vue';
+
 // 来自 @blueking/chat-x 导出
 interface IToolBtn {
-  id?: keyof typeof ToolIconsMap; // 预置 ID；省略时走 name 文本或插槽
+  id?: (string & {}) | ToolIcons; // 内置 ID 保留自动补全，同时允许业务自定义任意字符串（如 'save'）
   name?: string;
   description?: string;
+  icon?: Component | VNode; // 自定义图标，优先级高于内置 ToolIconsMap
+  hidden?: boolean; // 按 id 合并时隐藏该按钮（如 { id: 'share', hidden: true } 移除内置项）
+  triggerSelection?: boolean; // 标记点击后进入多选态（复用 share 选择流程），确认走 confirmShare
 }
 
 // ToolBtn 完整 Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -883,13 +883,52 @@ ai-chat-container（:data-ai-size="size"）
 </template>
 
 <script setup lang="ts">
-  import { type Message } from '@blueking/chat-x';
+  import { type IToolBtn, type Message } from '@blueking/chat-x';
 
-  const handleConfirmShare = (selectedMessages: Message[]) => {
+  // 第二参数 source 为触发多选态的按钮对象，可据此区分 share / save 等不同确认场景
+  const handleConfirmShare = (selectedMessages: Message[], source?: IToolBtn) => {
+    if (source?.id === 'save') {
+      console.log('保存选中的消息:', selectedMessages);
+      return;
+    }
     console.log('分享消息:', selectedMessages);
   };
 </script>
 ```
+
+### 自定义按钮触发多选（triggerSelection）
+
+除内置「分享」外，任意自定义工具按钮标记 `triggerSelection: true` 后，点击即可复用同一套多选流程（勾选消息 → `SelectionFooter` 确认），确认时同样触发 `confirmShare`。配合 `messageTools` / `updateTools`（合并规则见 [MessageContainer · 自定义消息工具栏](/components/setup/message-container)）即可扩展如「保存」「收藏到空间」等批量操作。
+
+```vue
+<template>
+  <ChatContainer
+    v-model="inputValue"
+    :messages="messages"
+    message-status="complete"
+    :message-tools="customMessageTools"
+    :on-agent-action="handleAgentAction"
+    @confirm-share="handleConfirmShare"
+  />
+</template>
+
+<script setup lang="ts">
+  import { DownloadIcon, type IToolBtn, type Message } from '@blueking/chat-x';
+
+  const customMessageTools: IToolBtn[] = [
+    // 追加「保存」按钮，点击进入多选态；确认走 confirmShare
+    { id: 'save', name: '保存', description: '保存该回答', icon: DownloadIcon, triggerSelection: true },
+  ];
+
+  const handleConfirmShare = (selectedMessages: Message[], source?: IToolBtn) => {
+    if (source?.id === 'save') {
+      // 处理「保存」批量确认
+    }
+  };
+</script>
+```
+
+> `triggerSelection` 的按钮不会调用 `onAgentAction`，而是直接进入多选态；未标记该字段（且非 `share`）的按钮仍走 `onAgentAction`。
 
 **渲染效果**（点击 AI 回复工具栏中的「分享」按钮进入多选模式）
 
@@ -912,10 +951,10 @@ ai-chat-container（:data-ai-size="size"）
 
 **分享流程**：
 
-1. 用户点击消息工具栏中的「分享」按钮
+1. 用户点击消息工具栏中的「分享」按钮（或任意 `triggerSelection: true` 的自定义按钮）
 2. 进入多选模式，用户勾选要分享的消息
 3. 底部 `SelectionFooter` 提供全选、取消、确认操作
-4. 确认后触发 `confirmShare` 事件，携带选中的消息列表
+4. 确认后触发 `confirmShare` 事件，携带选中的消息列表与触发按钮对象（`source`）
 
 ## 模型选择
 
@@ -1052,7 +1091,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | stopStreaming  | —                                      | 点击「停止生成」按钮                 |
 | shortcutClose  | —                                      | 关闭快捷指令表单                     |
 | shortcutSubmit | `(formModel: Record<string, unknown>)` | 提交快捷指令表单                     |
-| confirmShare   | `(messages: Message[])`                | 确认分享，携带选中的消息             |
+| confirmShare   | `(messages: Message[], source?: IToolBtn)` | 确认分享/多选，携带选中的消息与触发按钮对象（`source`，用于区分 share/save 等场景） |
 | collapseChange | `(isCollapse: boolean, width: number)` | 侧边栏折叠/展开状态变化              |
 | selectShortcut | `(shortcut: Shortcut)`                 | 选择快捷指令（继承自 ChatInput）     |
 | deleteShortcut | —                                      | 删除已选快捷指令（继承自 ChatInput） |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
@@ -689,6 +689,51 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
   </div>
 </div>
 
+## 自定义消息工具栏
+
+`messageTools`（左侧）与 `updateTools`（右侧反馈区）用于在**内置工具的基础上做增量定制**，无需重写整份列表。二者分别与内置 `CONST_MESSAGE_TOOLS`、`CONST_UPDATE_TOOLS` 按 `id` 合并，规则如下：
+
+- **覆盖**：`id` 命中内置项时，做字段级浅合并（仅覆盖传入的字段，其余保留），不新增条目
+- **追加**：`id` 为内置列表中不存在的新值时，追加到该组末尾（如自定义「保存」「收藏」按钮）
+- **隐藏**：传入 `{ id: 'xxx', hidden: true }` 可移除对应内置项（如隐藏「分享」）
+- **自定义图标**：通过 `icon`（组件/VNode）为自定义按钮提供图标，优先级高于内置 `ToolIconsMap`
+- 不传 `messageTools` / `updateTools` 时，各自使用内置默认列表
+
+```vue
+<template>
+  <MessageContainer
+    :messages="messages"
+    :message-groups="messageGroups"
+    message-status="complete"
+    :message-tools="customMessageTools"
+    :update-tools="customUpdateTools"
+    :on-agent-action="handleAgentAction"
+    @stop-streaming="handleStopStreaming"
+  />
+</template>
+
+<script setup lang="ts">
+  import { MessageContainer, DownloadIcon, type IToolBtn, type Message } from '@blueking/chat-x';
+
+  const customMessageTools: IToolBtn[] = [
+    { id: 'save', name: '保存', description: '保存该回答', icon: DownloadIcon }, // 追加新按钮
+    { id: 'copy', description: '复制全文' }, // 覆盖内置 copy 的 description
+    { id: 'share', hidden: true }, // 隐藏内置「分享」
+  ];
+  const customUpdateTools: IToolBtn[] = [
+    { id: 'collect', name: '收藏', description: '收藏到我的空间', icon: DownloadIcon },
+  ];
+
+  const handleAgentAction = async (tool: IToolBtn, messages: Message[]) => {
+    if (tool.id === 'save') {
+      // 处理保存
+    }
+  };
+</script>
+```
+
+> **合并优先级**：`RenderMode.Test` 下仍会额外过滤掉「分享」按钮（即便合并后存在）；即测试模式对 `share` 的过滤在自定义合并之后生效。
+
 ## 工具栏状态控制
 
 通过 `messageToolsStatus` 控制消息工具栏的显示状态。常见用法：流式输出期间禁用工具栏：
@@ -978,6 +1023,8 @@ AI 回复状态为 `error` 时，消息以错误样式展示：
 | messages                 | `Message[]`                                                                                  | —       | **必填**，消息列表                                                                                                                       |
 | messageGroups            | `MessageGroup[]`                                                                             | —       | 预计算的消息分组；传入时跳过内部分组逻辑，由 `ChatContainer` 通过 `useMessageGroup` 提供                                                 |
 | messageStatus            | `MessageStatus`                                                                              | —       | 当前整体消息状态，控制底部「停止生成」按钮显示；`ChatContainer` 会结合末尾 Loading 占位推导 `fetching` 等再传入                                                                                                   |
+| messageTools             | `IToolBtn[]`                                                                                 | —       | AI 消息左侧工具（复制/引用等）的自定义配置；按 `id` 与内置 `CONST_MESSAGE_TOOLS` 合并（覆盖同 id、追加新 id、`hidden` 过滤），详见「自定义消息工具栏」 |
+| updateTools              | `IToolBtn[]`                                                                                 | —       | AI 消息右侧反馈工具（点赞/踩/删除等）的自定义配置；按 `id` 与内置 `CONST_UPDATE_TOOLS` 合并，规则同上                                     |
 | messageToolsStatus       | `MessageToolsStatus`                                                                         | —       | 工具栏状态，透传给 `MessageTools` 和 `MessageRender`                                                                                     |
 | messageToolsTippyOptions | `AITippyProps`                                                                               | —       | 透传给 `MessageTools` 和 `MessageRender`（进而透传给 `UserMessage` 的工具栏）的 Tippy 配置，用于自定义 tooltip 挂载点、位置等（如 `appendTo`、`placement`、`zIndex`） |
 | enableSelection          | `boolean`                                                                                    | `false` | 是否启用多选模式                                                                                                                         |


### PR DESCRIPTION
## 背景
TAPD: chat-x 支持自定义消息工具栏（messageTools/updateTools 合并扩展）
ID: 1070093903136462100

## 改动
- `src/types/tool.ts`: IToolBtn 扩展 icon / hidden / triggerSelection，id 支持自定义字符串
- `tool-btn`: 支持自定义 icon，优先级 slot > icon > 内置 > name
- `message-container`: messageTools / updateTools 按 id 合并（覆盖 / 追加 / hidden）
- `chat-container`: 透传工具配置；triggerSelection 进入多选；confirmShare 增加 source
- `playground` / `wikis` / 相关 `*.spec.ts`: 示例、文档与单测同步

## 影响面
- ChatContainer / MessageContainer 消费方可增量定制消息工具栏
- confirmShare 签名新增可选第二参数 source（向后兼容）
- 未传 messageTools / updateTools 时行为与原先一致

## 测试
- [ ] messageTools / updateTools 追加、覆盖、hidden 过滤符合预期
- [ ] ToolBtn 自定义 icon 与优先级正确
- [ ] triggerSelection 进入多选，confirmShare 携带来源工具
- [ ] 内置 share 与普通 onAgentAction 行为不变
- [ ] 相关单测通过（本次交付前未运行）

Made with [Cursor](https://cursor.com)