### PR TITLE
feat: add original knowledge score strategy --story=1070093903135931166

### DIFF
--- a/src/agent/aidev_agent/core/nodes/knowledge.py
+++ b/src/agent/aidev_agent/core/nodes/knowledge.py
@@ -29,7 +29,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.runnables import RunnableConfig
 
 from aidev_agent.core.ag_ui.types import ActivityMessage, CustomMessageType
-from aidev_agent.enums import ActivityType
+from aidev_agent.enums import ActivityType, FineGrainedScoreType
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
 from aidev_agent.packages.langchain_core.retrievers.kb_rag import KnowledgeRag, KnowledgeRagRetrieveResult
 from aidev_agent.packages.langchain_core.retrievers.utils import (
@@ -61,7 +61,7 @@ class AidevKnowledgeOutputState(KnowledgeRagRetrieveResult):
 
 
 def filter_and_select_topk(
-    docs: list, score_threshold: float | None = None, topk: int = 20, sort_key: str = "fine_grained_score"
+    docs: list, score_threshold: float | None = None, topk: int = 20, sort_key: str | None = "fine_grained_score"
 ) -> list:
     """
     根据分数阈值过滤并选择 topk 文档。
@@ -71,9 +71,7 @@ def filter_and_select_topk(
         docs: 召回的文档列表，每个文档包含 metadata.fine_grained_score
         score_threshold: 分数阈值，低于此阈值的文档将被过滤，None 表示不过滤
         topk: 返回的最大文档数量
-        sort_key: 展示排序使用的分数字段；EMBEDDING（保留原始顺序）传 ``rrf_score`` 以尊重
-            资源侧多路 RRF 融合顺序，缺失时回退 ``fine_grained_score``，无回归。
-            过滤阈值仍固定用 ``fine_grained_score``，不受此参数影响。
+        sort_key: 展示排序使用的分数字段；``None`` 表示保留召回顺序。
 
     Returns:
         过滤并排序后的 topk 文档列表
@@ -83,6 +81,9 @@ def filter_and_select_topk(
 
     if score_threshold is not None:
         docs = [doc for doc in docs if doc.get("metadata", {}).get("fine_grained_score", 0) >= score_threshold]
+
+    if sort_key is None:
+        return docs[:topk]
 
     def _score(doc):
         metadata = doc.get("metadata", {})
@@ -308,7 +309,12 @@ class AidevKnowledgeNode(BaseKnowledgeNode):
         ret = cast(AidevKnowledgeOutputState, ret)
         ret["retrieved_docs"] = filter_and_select_topk(
             knowledge_resources_emb_recalled,
-            self.score_threshold,
+            (
+                None
+                if self.knowledge_query_options.knowledge_resource_fine_grained_score_type
+                == FineGrainedScoreType.ORIGINAL
+                else self.score_threshold
+            ),
             self.topk,
             sort_key=resolve_display_sort_key(self.knowledge_query_options.knowledge_resource_fine_grained_score_type),
         )

--- a/src/agent/aidev_agent/enums.py
+++ b/src/agent/aidev_agent/enums.py
@@ -29,7 +29,7 @@ class ChatContentStatus(enum.Enum):
     ERROR = "error"
     SUCCESS = "success"
     COMPLETE = "complete"
-    PENDING = "pending" #前端根据最后一条content状态为pending判断发起轮询
+    PENDING = "pending"  # 前端根据最后一条content状态为pending判断发起轮询
 
 
 class IntentStatus(enum.Enum):
@@ -49,6 +49,7 @@ class FineGrainedScoreType(enum.Enum):
     LLM = "LLM"
     EXCLUSIVE_SIMILARITY_MODEL = "EXCLUSIVE_SIMILARITY_MODEL"
     EMBEDDING = "EMBEDDING"
+    ORIGINAL = "ORIGINAL"
 
 
 class IndependentQueryMode(enum.Enum):

--- a/src/agent/aidev_agent/packages/langchain_core/retrievers/kb_rag.py
+++ b/src/agent/aidev_agent/packages/langchain_core/retrievers/kb_rag.py
@@ -64,13 +64,13 @@ class KnowledgeRagRetrieveResult(TypedDict):
         - knowledge_resources_highly_relevant: 高相关性资源
         - knowledge_resources_moderately_relevant: 中等相关性资源
         - knowledge_resources_lowly_relevant: 低相关性资源
-        - knowledge_resources_emb_recalled: 所有 embedding 召回的资源（含细粒度分数），用于 AIDev 产品页面检索测试
+        - knowledge_resources_emb_recalled: 所有粗召回资源（非 ORIGINAL 时含细粒度分数），用于 AIDev 产品页面检索测试
 
     其中：knowledge_content 和 knowledge_qa_content 会被用于后续 Model 节点的 prompt_var 拼接
     其中：decision 和 with_qa_response 用于 后续 Model 选择模板
     其中：reference_doc 用于给 invoke 提供返回知识库召回了哪些文档
     其中：knowledge_resources_highly_relevant，knowledge_resources_moderately_relevant， knowledge_resources_lowly_relevant 用于审计返回知识相关性
-    其中：knowledge_resources_emb_recalled 用于 AIDev 产品页面检索测试，返回所有召回资源（带细粒度分数）
+    其中：knowledge_resources_emb_recalled 用于 AIDev 产品页面检索测试，返回所有粗召回资源
     """
 
     decision: Decision
@@ -512,8 +512,12 @@ class KnowledgeRag:
             )
             fine_grained_scores = [float(fine_grained_score) for fine_grained_score in fine_grained_scores]
         elif fine_grained_score_type == FineGrainedScoreType.EMBEDDING:
-            # 直接使用emb分数作为最终的细粒度相似度分数
-            fine_grained_scores = [float(emb_score) for _, emb_score in context_docs_with_scores]
+            # EMBEDDING 只复用 dense 召回分；RRF/BM25/scalar 分数不能作为 embedding 拒答依据。
+            fine_grained_scores = [
+                self._get_dense_embedding_score(doc, fallback_score) for doc, fallback_score in context_docs_with_scores
+            ]
+        elif fine_grained_score_type == FineGrainedScoreType.ORIGINAL:
+            raise ValueError("ORIGINAL 模式不计算细粒度分数，应直接保留粗召回结果")
         else:
             raise ValueError(
                 f"当前仅支持以下计算细粒度相关分数的方式：{[score_type for score_type in FineGrainedScoreType]}，"
@@ -521,6 +525,21 @@ class KnowledgeRag:
             )
 
         return fine_grained_scores
+
+    @staticmethod
+    def _get_dense_embedding_score(doc: Document, fallback_score: float) -> float:
+        """读取 dense 原始分，兼容尚未提供显式 ``dense_score`` 的纯 dense 旧数据。"""
+        metadata = doc.metadata
+        retrieval_source = metadata.get("retrieval_source") or metadata.get("retrieval_weight_key")
+        if retrieval_source not in (None, "dense", "vector", "fulltext"):
+            raise ValueError(f"EMBEDDING 细粒度评分仅支持 dense 召回文档，但收到 retrieval_source={retrieval_source!r}")
+
+        dense_score = metadata.get("dense_score")
+        if dense_score is None:
+            dense_score = metadata.get("retrieval_score", fallback_score)
+        dense_score = float(dense_score)
+        metadata["dense_score"] = dense_score
+        return dense_score
 
     def separate_docs_by_scores(self, context_docs_with_scores, fine_grained_scores, reject_threshold):
         """
@@ -935,26 +954,34 @@ class KnowledgeRag:
             (Document(**item), item.get("metadata", {}).get("__score__", 0.0)) for item in fusion_docs
         ]
 
-        fine_grained_scores = self.calculate_fine_grained_scores(
-            knowledge_query_options.knowledge_resource_fine_grained_score_type,
-            query_for_search,
-            llm,
-            context_docs_with_scores,
-            knowledge_query_options,
-            **kwargs,
-        )
+        if knowledge_query_options.knowledge_resource_fine_grained_score_type == FineGrainedScoreType.ORIGINAL:
+            knowledge_resources_emb_recalled = [
+                copy.deepcopy(context_doc.dict()) for context_doc, _ in context_docs_with_scores
+            ]
+            knowledge_resources_lowly_relevant = []
+            knowledge_resources_moderately_relevant = []
+            knowledge_resources_highly_relevant = knowledge_resources_emb_recalled
+        else:
+            fine_grained_scores = self.calculate_fine_grained_scores(
+                knowledge_query_options.knowledge_resource_fine_grained_score_type,
+                query_for_search,
+                llm,
+                context_docs_with_scores,
+                knowledge_query_options,
+                **kwargs,
+            )
 
-        # 根据分数分类文档
-        (
-            knowledge_resources_emb_recalled,
-            knowledge_resources_lowly_relevant,
-            knowledge_resources_moderately_relevant,
-            knowledge_resources_highly_relevant,
-        ) = self.separate_docs_by_scores(
-            context_docs_with_scores,
-            fine_grained_scores,
-            knowledge_query_options.knowledge_resource_reject_threshold,
-        )
+            # 根据分数分类文档
+            (
+                knowledge_resources_emb_recalled,
+                knowledge_resources_lowly_relevant,
+                knowledge_resources_moderately_relevant,
+                knowledge_resources_highly_relevant,
+            ) = self.separate_docs_by_scores(
+                context_docs_with_scores,
+                fine_grained_scores,
+                knowledge_query_options.knowledge_resource_reject_threshold,
+            )
 
         # 决策逻辑
         if (not knowledge_resources_emb_recalled) or (

--- a/src/agent/aidev_agent/packages/langchain_core/retrievers/utils.py
+++ b/src/agent/aidev_agent/packages/langchain_core/retrievers/utils.py
@@ -5,6 +5,7 @@ from langchain_core.documents import Document
 from langchain_core.messages import HumanMessage, SystemMessage
 
 from aidev_agent.core.ag_ui.types import CustomMessageType
+from aidev_agent.enums import FineGrainedScoreType
 from aidev_agent.packages.langchain_core.models.utils import is_deepseek_r1_series_models, remove_thinking_process
 from aidev_agent.packages.model_management.registry import RegistryPluginMixIn
 from aidev_agent.utils.decorator import timeit
@@ -56,19 +57,10 @@ def deduplicate_knowledge_chunks(knowledge_chunks):
     return list({item["metadata"]["uid"]: item for item in knowledge_chunks}.values())
 
 
-def resolve_display_sort_key(fine_grained_score_type) -> str:
-    """确定展示排序使用的分数字段。
-
-    - EMBEDDING（「保留原始顺序」）：按 ``rrf_score`` 排序，尊重资源侧多路 RRF 融合顺序
-      （已含 BM25 词法通道），不被各通道原始 ``fine_grained_score``（emb/bm25 量纲不一）打乱；
-    - LLM / EXCLUSIVE_SIMILARITY_MODEL：仍按 ``fine_grained_score`` 重排（这两种本就是重排语义）。
-
-    注意：拒答分级用的仍是 ``fine_grained_score``（见 ``separate_docs_by_scores``），此处只改
-    展示排序键，不影响拒答阈值判定。
-    """
-
-    if str(getattr(fine_grained_score_type, "value", fine_grained_score_type)) == "EMBEDDING":
-        return "rrf_score"
+def resolve_display_sort_key(fine_grained_score_type: FineGrainedScoreType | str) -> str | None:
+    """ORIGINAL 保留粗召回/RRF 顺序，其余策略按细粒度分排序。"""
+    if str(getattr(fine_grained_score_type, "value", fine_grained_score_type)) == FineGrainedScoreType.ORIGINAL.value:
+        return None
     return "fine_grained_score"
 
 
@@ -80,21 +72,25 @@ def _sort_score(item, sort_key: str) -> float:
     return metadata.get("fine_grained_score", 0) or 0
 
 
-def deduplicate_knowledge_file_paths(knowledge_chunks, sort_key: str = "fine_grained_score"):
+def deduplicate_knowledge_file_paths(knowledge_chunks, sort_key: str | None = "fine_grained_score"):
     """按照 file path 进行去重，且只保留 metadata，且按照指定分数（默认 fine_grained_score）降序排序"""
     unique_items = list(
         {item["metadata"]["file_path"]: {"metadata": item["metadata"]} for item in knowledge_chunks}.values()
     )
+    if sort_key is None:
+        return unique_items
     return sorted(unique_items, key=lambda x: _sort_score(x, sort_key), reverse=True)
 
 
-def filter_and_select_topk(items, score_threshold, topk, sort_key: str = "fine_grained_score"):
+def filter_and_select_topk(items, score_threshold, topk, sort_key: str | None = "fine_grained_score"):
     if score_threshold:
         filtered_items = [
             item for item in items if item.get("metadata", {}).get("fine_grained_score", 0) >= score_threshold
         ]
     else:
         filtered_items = items
+    if sort_key is None:
+        return filtered_items[:topk]
     sorted_items = sorted(filtered_items, key=lambda x: _sort_score(x, sort_key), reverse=True)
     return sorted_items[:topk]
 

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -146,7 +146,7 @@ class KnowledgeSettings(BaseModel):
     # --- 召回参数 ---
     knowledge_resource_fine_grained_score_type: FineGrainedScoreType = Field(
         default=FineGrainedScoreType(os.getenv("KNOWLEDGE_FINE_GRAINED_SCORE_TYPE", "LLM")),
-        description="相关性判断模型",
+        description="相关性判断方式；ORIGINAL 表示跳过细粒度评分、拒答阈值和二次排序",
     )
     knowledge_resource_reject_threshold: Tuple[float, float] = Field(
         default=(
@@ -265,6 +265,25 @@ class KnowledgeSettings(BaseModel):
         default=os.getenv("ENABLE_AGENTIC_RAG_TOOL", "false").lower() == "true",
         description="控制是否开启知识库召回工具",
     )
+
+    @model_validator(mode="after")
+    def validate_embedding_score_channels(self):
+        """EMBEDDING 分数仅适用于 dense 召回。"""
+        if self.knowledge_resource_fine_grained_score_type != FineGrainedScoreType.EMBEDDING:
+            return self
+
+        if self.recall_channels is None:
+            self.recall_channels = ["dense"]
+            return self
+
+        channels = list(dict.fromkeys(self.recall_channels))
+        if channels != ["dense"]:
+            raise ValueError(
+                "EMBEDDING 细粒度评分仅支持 recall_channels=['dense']；"
+                f"当前为 {channels!r}，混合或 sparse 召回请改用 LLM/EXCLUSIVE_SIMILARITY_MODEL/ORIGINAL"
+            )
+        self.recall_channels = channels
+        return self
 
 
 class IntentRecognition(BaseModel):

--- a/src/agent/tests/core/nodes/test_knowledge.py
+++ b/src/agent/tests/core/nodes/test_knowledge.py
@@ -6,11 +6,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from langchain_core.messages import HumanMessage
-from langgraph.graph import END, START, StateGraph
-from langgraph.store.memory import InMemoryStore
-from typing_extensions import TypedDict
-
 from aidev_agent.core.nodes.knowledge import (
     AgentKnowledgeNode,
     AidevKnowledgeNode,
@@ -18,8 +13,12 @@ from aidev_agent.core.nodes.knowledge import (
     filter_and_select_topk,
     make_knowledge_node,
 )
-from aidev_agent.enums import Decision
+from aidev_agent.enums import Decision, FineGrainedScoreType
 from aidev_agent.pydantic_models import AgentOptions, KnowledgebaseSettings, KnowledgeSettings
+from langchain_core.messages import HumanMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.store.memory import InMemoryStore
+from typing_extensions import TypedDict
 
 # ============================================================================
 # 测试状态定义
@@ -391,6 +390,27 @@ class TestAidevKnowledgeNode:
 
         # 验证只返回 topk 个文档
         assert len(result["retrieved_docs"]) == 2
+
+    @patch("aidev_agent.core.nodes.knowledge.KnowledgeRag")
+    def test_call_original_skips_score_threshold_and_preserves_order(self, mock_rag_class, mock_llm):
+        recalled = [
+            {"metadata": {"uid": "first"}},
+            {"metadata": {"uid": "second", "fine_grained_score": 0.01}},
+        ]
+        mock_rag_instance = MagicMock()
+        mock_rag_instance.retrieve.return_value = create_mock_retrieve_result(knowledge_resources_emb_recalled=recalled)
+        mock_rag_class.return_value = mock_rag_instance
+        settings = KnowledgeSettings(knowledge_resource_fine_grained_score_type=FineGrainedScoreType.ORIGINAL)
+
+        node = AidevKnowledgeNode(
+            llm=mock_llm,
+            knowledge_query_options=settings,
+            score_threshold=0.99,
+            topk=10,
+        )
+        result = run_knowledge_node_in_graph(node, {"query": "test query"})
+
+        assert [doc["metadata"]["uid"] for doc in result["retrieved_docs"]] == ["first", "second"]
 
     @patch("aidev_agent.core.nodes.knowledge.KnowledgeRag")
     def test_get_query_priority(self, mock_rag_class, mock_llm, mock_knowledge_settings):

--- a/src/agent/tests/packages/langchain_core/retrievers/test_display_sort_order.py
+++ b/src/agent/tests/packages/langchain_core/retrievers/test_display_sort_order.py
@@ -1,11 +1,5 @@
 # -*- coding: utf-8 -*-
-"""展示排序按 fine_grained_score_type 分流的单测。
-
-覆盖点②：EMBEDDING（「保留原始顺序」）应尊重资源侧多路 RRF 融合顺序（含 BM25 词法通道），
-按 ``rrf_score`` 排序，而不是按各通道量纲不一的 ``fine_grained_score`` 重排导致 BM25 精确命中
-被挤到 top2；LLM / EXCLUSIVE_SIMILARITY_MODEL 仍按 ``fine_grained_score`` 重排。
-拒答分级仍固定用 ``fine_grained_score``，不受影响。
-"""
+"""细粒度评分策略对应的展示排序单测。"""
 
 import pytest
 from aidev_agent.enums import FineGrainedScoreType
@@ -19,11 +13,12 @@ from aidev_agent.packages.langchain_core.retrievers.utils import (
 @pytest.mark.parametrize(
     "score_type, expected",
     [
-        (FineGrainedScoreType.EMBEDDING, "rrf_score"),
         (FineGrainedScoreType.LLM, "fine_grained_score"),
         (FineGrainedScoreType.EXCLUSIVE_SIMILARITY_MODEL, "fine_grained_score"),
-        ("EMBEDDING", "rrf_score"),
+        (FineGrainedScoreType.EMBEDDING, "fine_grained_score"),
+        (FineGrainedScoreType.ORIGINAL, None),
         ("LLM", "fine_grained_score"),
+        ("ORIGINAL", None),
         (None, "fine_grained_score"),
     ],
 )
@@ -38,23 +33,22 @@ def _doc(file_path, uid, fine_grained_score, rrf_score=None):
     return {"metadata": metadata}
 
 
-def test_dedup_embedding_orders_by_rrf_score():
-    # BM25 精确命中：rrf 更高但 embedding 相似度更低（量纲不同）。
-    docs = [
-        _doc("a", "u_a", fine_grained_score=0.90, rrf_score=0.20),  # 语义相近但非目标
-        _doc("b", "u_b", fine_grained_score=0.55, rrf_score=0.80),  # BM25 精确命中，应排 top1
-    ]
-    ordered = deduplicate_knowledge_file_paths(docs, sort_key=resolve_display_sort_key(FineGrainedScoreType.EMBEDDING))
-    assert [d["metadata"]["uid"] for d in ordered] == ["u_b", "u_a"]
-
-
-def test_dedup_llm_orders_by_fine_grained_score():
+def test_dedup_scored_mode_orders_by_fine_grained_score():
     docs = [
         _doc("a", "u_a", fine_grained_score=0.90, rrf_score=0.20),
         _doc("b", "u_b", fine_grained_score=0.55, rrf_score=0.80),
     ]
     ordered = deduplicate_knowledge_file_paths(docs, sort_key=resolve_display_sort_key(FineGrainedScoreType.LLM))
     assert [d["metadata"]["uid"] for d in ordered] == ["u_a", "u_b"]
+
+
+def test_dedup_original_mode_preserves_recall_order():
+    docs = [
+        _doc("b", "u_b", fine_grained_score=0.55, rrf_score=0.80),
+        _doc("a", "u_a", fine_grained_score=0.90, rrf_score=0.20),
+    ]
+    ordered = deduplicate_knowledge_file_paths(docs, sort_key=resolve_display_sort_key(FineGrainedScoreType.ORIGINAL))
+    assert [d["metadata"]["uid"] for d in ordered] == ["u_b", "u_a"]
 
 
 def test_dedup_default_is_fine_grained_score():
@@ -76,18 +70,17 @@ def test_dedup_rrf_missing_falls_back_no_regression():
     assert [d["metadata"]["uid"] for d in ordered] == ["u_a", "u_b"]
 
 
-def test_filter_topk_embedding_orders_by_rrf_but_threshold_uses_fine_grained():
+def test_filter_topk_original_mode_preserves_recall_order_without_score_filter():
     docs = [
-        _doc("a", "u_a", fine_grained_score=0.90, rrf_score=0.20),
         _doc("b", "u_b", fine_grained_score=0.55, rrf_score=0.80),
+        _doc("a", "u_a", fine_grained_score=0.90, rrf_score=0.20),
         _doc("c", "u_c", fine_grained_score=0.05, rrf_score=0.99),  # 阈值过滤掉（fine_grained 太低）
     ]
     result = filter_and_select_topk(
         docs,
-        score_threshold=0.1,
+        score_threshold=None,
         topk=10,
-        sort_key=resolve_display_sort_key(FineGrainedScoreType.EMBEDDING),
+        sort_key=resolve_display_sort_key(FineGrainedScoreType.ORIGINAL),
     )
     uids = [d["metadata"]["uid"] for d in result]
-    assert "u_c" not in uids  # 拒答阈值仍用 fine_grained_score
-    assert uids == ["u_b", "u_a"]  # 展示顺序用 rrf_score
+    assert uids == ["u_b", "u_a", "u_c"]

--- a/src/agent/tests/packages/langchain_core/retrievers/test_kb_rag.py
+++ b/src/agent/tests/packages/langchain_core/retrievers/test_kb_rag.py
@@ -19,11 +19,10 @@ to the current version of the project delivered to anyone in the future.
 from unittest.mock import MagicMock, patch
 
 import pytest
-from langchain_core.documents import Document
-
 from aidev_agent.enums import Decision, FineGrainedScoreType
 from aidev_agent.packages.langchain_core.retrievers.kb_rag import KnowledgeRag
 from aidev_agent.pydantic_models import KnowledgeSettings
+from langchain_core.documents import Document
 
 
 def create_mock_llm_response(content: str):
@@ -53,6 +52,18 @@ def create_multimodal_query(text: str = "蓝鲸是什么") -> list[dict]:
         {"type": "image_url", "image_url": {"url": "https://example.com/test.png"}},
         {"type": "text", "text": text},
     ]
+
+
+def create_retrieval_doc(uid: str, score: float) -> dict:
+    return {
+        "page_content": uid,
+        "metadata": {
+            "uid": uid,
+            "file_path": f"{uid}.md",
+            "knowledge_base_id": 1,
+            "__score__": score,
+        },
+    }
 
 
 class TestKnowledgeRag:
@@ -350,13 +361,15 @@ class TestKnowledgeRag:
 
     @patch("aidev_agent.packages.langchain_core.retrievers.kb_rag.calculate_similarity")
     def test_calculate_fine_grained_scores_embedding(self, mock_calculate_similarity):
-        """测试 calculate_fine_grained_scores 方法 - EMBEDDING 类型"""
+        """EMBEDDING 使用 dense 原始分，而不是 RRF 融合分。"""
         mock_llm = MagicMock()
         rag = KnowledgeRag(llm=mock_llm)
-        knowledge_settings = create_knowledge_settings()
+        knowledge_settings = KnowledgeSettings(
+            knowledge_resource_fine_grained_score_type=FineGrainedScoreType.EMBEDDING
+        )
 
-        doc = Document(page_content="test content", metadata={})
-        context_docs_with_scores = [(doc, 0.85)]
+        doc = Document(page_content="test content", metadata={"retrieval_source": "vector", "retrieval_score": 0.85})
+        context_docs_with_scores = [(doc, 0.2)]
 
         result = rag.calculate_fine_grained_scores(
             fine_grained_score_type=FineGrainedScoreType.EMBEDDING,
@@ -368,7 +381,35 @@ class TestKnowledgeRag:
         )
 
         assert result == [0.85]
+        assert doc.metadata["dense_score"] == 0.85
         mock_calculate_similarity.assert_not_called()
+
+    def test_calculate_fine_grained_scores_embedding_rejects_sparse_score(self):
+        rag = KnowledgeRag(llm=MagicMock())
+        doc = Document(page_content="test content", metadata={"retrieval_source": "sparse"})
+
+        with pytest.raises(ValueError, match="仅支持 dense 召回文档"):
+            rag.calculate_fine_grained_scores(
+                FineGrainedScoreType.EMBEDDING,
+                "query",
+                MagicMock(),
+                [(doc, 3.981)],
+                KnowledgeSettings(knowledge_resource_fine_grained_score_type=FineGrainedScoreType.EMBEDDING),
+                input="query",
+            )
+
+    def test_calculate_fine_grained_scores_original_is_not_a_scoring_strategy(self):
+        rag = KnowledgeRag(llm=MagicMock())
+
+        with pytest.raises(ValueError, match="ORIGINAL 模式不计算细粒度分数"):
+            rag.calculate_fine_grained_scores(
+                FineGrainedScoreType.ORIGINAL,
+                "query",
+                MagicMock(),
+                [],
+                KnowledgeSettings(knowledge_resource_fine_grained_score_type=FineGrainedScoreType.ORIGINAL),
+                input="query",
+            )
 
     def test_calculate_fine_grained_scores_invalid_type(self):
         """测试 calculate_fine_grained_scores 方法 - 无效的类型"""
@@ -485,6 +526,38 @@ class TestKnowledgeRag:
 
         assert result["decision"] == Decision.GENERAL_QA
         assert mock_retriever.search_knowledge_index_specific.call_args.kwargs["query"] == "蓝鲸是什么"
+
+    @patch("aidev_agent.packages.langchain_core.retrievers.kb_rag.dispatch_rag_event_chunk")
+    def test_retrieve_original_skips_scoring_rejection_and_secondary_sort(self, _mock_dispatch):
+        mock_retriever = MagicMock()
+        mock_retriever.search_knowledge_index_specific.return_value = [
+            create_retrieval_doc("first", 0.8),
+            create_retrieval_doc("second", 0.7),
+        ]
+        rag = KnowledgeRag(llm=MagicMock(), kb_retriever=mock_retriever)
+        settings = KnowledgeSettings(
+            knowledge_items=[{"id": 1}],
+            with_index_specific_search_init=False,
+            with_rrf=False,
+            knowledge_resource_fine_grained_score_type=FineGrainedScoreType.ORIGINAL,
+            knowledge_resource_reject_threshold=(0.99, 1.0),
+        )
+
+        with (
+            patch.object(rag, "calculate_fine_grained_scores") as mock_calculate,
+            patch.object(rag, "separate_docs_by_scores") as mock_separate,
+        ):
+            result = rag.retrieve("query", settings, input="query")
+
+        mock_calculate.assert_not_called()
+        mock_separate.assert_not_called()
+        assert result["decision"] == Decision.PRIVATE_QA
+        for relevance in ("lowly", "moderately"):
+            assert not result[f"knowledge_resources_{relevance}_relevant"]
+        expected_uids = ["first", "second"]
+        assert [doc["metadata"]["uid"] for doc in result["knowledge_resources_highly_relevant"]] == expected_uids
+        assert [doc["metadata"]["uid"] for doc in result["reference_doc"]] == expected_uids
+        assert all("fine_grained_score" not in doc["metadata"] for doc in result["knowledge_resources_emb_recalled"])
 
     @patch("aidev_agent.packages.langchain_core.retrievers.kb_rag.conditional_dispatch_custom_event")
     @patch("aidev_agent.packages.langchain_core.retrievers.kb_rag.invoke_decorator")

--- a/src/agent/tests/packages/langchain_core/retrievers/test_rrf_weights_payload.py
+++ b/src/agent/tests/packages/langchain_core/retrievers/test_rrf_weights_payload.py
@@ -1,4 +1,5 @@
 import pytest
+from aidev_agent.enums import FineGrainedScoreType
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
 from aidev_agent.pydantic_models import KnowledgeSettings
 
@@ -92,3 +93,22 @@ def test_index_specific_search_omits_channels_when_not_configured(monkeypatch):
 
     assert "recall_channels" not in captured_payload
     assert "scalar" not in captured_payload
+
+
+def test_index_specific_search_forces_dense_channel_for_embedding(monkeypatch):
+    captured_payload = {}
+    monkeypatch.setattr(
+        BkRetriever, "_search_knowledge_by_client", lambda _self, data: captured_payload.update(data) or []
+    )
+
+    BkRetriever().search_knowledge_index_specific(
+        knowledge_items=[],
+        knowledge_bases=[],
+        query="legacy",
+        topk=5,
+        knowledge_query_options=KnowledgeSettings(
+            knowledge_resource_fine_grained_score_type=FineGrainedScoreType.EMBEDDING
+        ),
+    )
+
+    assert captured_payload["recall_channels"] == ["dense"]

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock, patch
 
+import pytest
+from aidev_agent.enums import FineGrainedScoreType
 from aidev_agent.pydantic_models import (
     AgentExecutorKwargs,
     AgentOptions,
@@ -7,9 +9,11 @@ from aidev_agent.pydantic_models import (
     ExecuteKwargs,
     IntentRecognition,
     KnowledgebaseSettings,
+    KnowledgeSettings,
     SessionContentExtra,
 )
 from aidev_agent.services.common_agent import CommonQAAgent
+from pydantic import ValidationError
 
 
 def test_chat_prompt():
@@ -29,6 +33,32 @@ def test_legacy_agent_options_allow_extra_fields():
     assert options.intent_recognition_options.model_extra["agent_type"] == "deepseek_r1"
     assert options.knowledge_query_options.model_extra["document_fragment_count"] == 3
     assert KnowledgebaseSettings().rejection_message
+
+
+def test_embedding_score_defaults_to_dense_recall():
+    settings = KnowledgeSettings(knowledge_resource_fine_grained_score_type=FineGrainedScoreType.EMBEDDING)
+
+    assert settings.recall_channels == ["dense"]
+
+
+@pytest.mark.parametrize("recall_channels", [None, [], ["sparse"], ["dense", "sparse"]])
+def test_original_score_type_accepts_all_recall_channels(recall_channels):
+    settings = KnowledgeSettings(
+        knowledge_resource_fine_grained_score_type=FineGrainedScoreType.ORIGINAL,
+        recall_channels=recall_channels,
+    )
+
+    assert settings.knowledge_resource_fine_grained_score_type == FineGrainedScoreType.ORIGINAL
+    assert settings.recall_channels == recall_channels
+
+
+@pytest.mark.parametrize("recall_channels", [[], ["sparse"], ["dense", "sparse"]])
+def test_embedding_score_rejects_non_dense_recall(recall_channels):
+    with pytest.raises(ValidationError, match="仅支持 recall_channels"):
+        KnowledgeSettings(
+            knowledge_resource_fine_grained_score_type=FineGrainedScoreType.EMBEDDING,
+            recall_channels=recall_channels,
+        )
 
 
 class TestAgentExecutorKwargs:

--- a/src/agent/tests/utils/test_migrations.py
+++ b/src/agent/tests/utils/test_migrations.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from aidev_agent.enums import FineGrainedScoreType
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.packages.langchain_core.models.mock import MockChatModel
 from aidev_agent.pydantic_models import AgentOptions, IntentRecognition, KnowledgebaseSettings, KnowledgeSettings
@@ -111,3 +112,15 @@ def test_legacy_knowledge_options_preserve_pure_scalar_retrieval_layers():
 
     assert migrated.recall_channels == []
     assert migrated.scalar_expression == 'eq("status","enabled")'
+
+
+def test_legacy_knowledge_options_preserve_original_score_type():
+    options = AgentOptions(
+        knowledge_query_options=KnowledgebaseSettings(
+            knowledge_resource_fine_grained_score_type=FineGrainedScoreType.ORIGINAL
+        )
+    )
+
+    migrated = migration_knowledge_query_options_from_agent_options_v1(options)
+
+    assert migrated.knowledge_resource_fine_grained_score_type == FineGrainedScoreType.ORIGINAL


### PR DESCRIPTION
## Background

Hybrid retrieval can combine dense and sparse results with RRF. Those scores do not share the same scale as dense embedding similarity, so they must not be reused by embedding rejection thresholds.

## Changes

- Add `ORIGINAL` to the existing fine-grained score strategy field.
- Make `ORIGINAL` skip fine-grained score calculation, rejection thresholds, and secondary sorting while preserving rough-recall/RRF order.
- Restore `EMBEDDING` to dense-similarity semantics and reject explicit sparse or hybrid channel configurations.
- Preserve the original order in knowledge references and retrieval-test output.
- Add coverage for configuration validation, legacy option migration, score selection, rejection bypass, and ordering.

## Compatibility

Clients that mean “preserve original order” should send `ORIGINAL`. `EMBEDDING` now represents dense similarity and is restricted to the dense recall channel.

## Verification

- Relevant unit tests: 96 passed.
- Full agent suite: 1508 passed, 24 skipped, 2 xfailed; 2 existing RabbitMQ integration tests could not connect to the local test service.
- Pre-commit hooks passed for all changed files.
