### PR TITLE
fix: 模型选择器 Tippy 类型与样式规范小修 --story=136513115

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
@@ -321,11 +321,6 @@
   appearance: none;
 }
 
-.ai-markdown-body ::input-placeholder {
-  color: inherit;
-  opacity: 0.54;
-}
-
 .ai-markdown-body ::-webkit-file-upload-button {
   font: inherit;
   appearance: auto;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector.vue
@@ -27,7 +27,7 @@
 <script setup lang="ts">
   import { computed, shallowRef, toRef, useTemplateRef } from 'vue';
 
-  import { type TippyOptions, Tippy } from 'vue-tippy';
+  import { type TippyOptions, Tippy, useTippy } from 'vue-tippy';
 
   import { t } from '../../../lang/lang';
   import ModelSelectorPanel from './model-selector-panel.vue';
@@ -64,7 +64,7 @@
   /** 当前选中的模型（值为 llm_name，v-model） */
   const selectedModel = defineModel<string>();
 
-  const tippyRef = useTemplateRef<InstanceType<typeof Tippy>>('tippyRef');
+  const tippyRef = useTemplateRef<InstanceType<typeof Tippy> & ReturnType<typeof useTippy>>('tippyRef');
   const panelRef = useTemplateRef<InstanceType<typeof ModelSelectorPanel>>('panelRef');
   const isExpanded = shallowRef(false);
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -261,7 +261,7 @@
       background-color: #e1ecff;
       border-radius: 4px;
 
-      :deep(.ai-text-content) {
+      .ai-text-content {
         width: auto;
         padding: 0;
         background-color: transparent;


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】模型选择器 Tippy 类型与样式规范小修
ID: 1070093903136513115

## 改动
- model-selector: 补全 Tippy 实例引用 TypeScript 类型
- user-message: 去掉 `:deep(.ai-text-content)`，改用普通后代选择器
- markdown-content: 删除非标准 `::input-placeholder` 规则

## 影响面
- 类型与样式规范调整，无业务逻辑变更

## 测试
- [ ] ModelSelector 展开/收起、选模型正常，类型无报错
- [ ] 用户消息气泡内文本样式与改前一致
- [ ] Markdown 渲染与输入占位表现无回归

Made with [Cursor](https://cursor.com)