### PR TITLE
fix: 修复了 ask_user 推送流消息时，没卡片消息的问题

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -371,9 +371,7 @@ class LangGraphAgent:
             metadata=metadata or None,
         )
 
-    async def _emit_run_end_extras(
-        self, state_values: State, thread_id: str
-    ) -> AsyncGenerator[Any, None]:
+    async def _emit_run_end_extras(self, state_values: State, thread_id: str) -> AsyncGenerator[Any, None]:
         """本轮 run 收尾扩展点：MESSAGES_SNAPSHOT 之后、RUN_FINISHED 之前每 run 触发一次。
 
         父类默认 no-op；子类覆写以 yield 自定义事件，异常须自行兜底避免阻断 RUN_FINISHED。

--- a/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
@@ -5,7 +5,6 @@ from logging import getLogger
 from typing import Any, Callable
 
 from ag_ui.core import (
-    ActivitySnapshotEvent,
     BaseEvent,
     CustomEvent,
     EventType,
@@ -100,9 +99,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             lines.append(f"[{server_name}] {message}")
         return "\n".join(lines)
 
-    async def _emit_run_end_extras(
-        self, state_values: State, thread_id: str
-    ) -> AsyncGenerator[Any, None]:
+    async def _emit_run_end_extras(self, state_values: State, thread_id: str) -> AsyncGenerator[Any, None]:
         """RUN_FINISHED 前的通用扩展点：若注入了 hook，转发其产出的事件序列。
 
         本方法不感知任何业务语义（如 PV / PaaS / artifacts），业务实现由构造时注入的
@@ -120,7 +117,6 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             dispatch_event=self._dispatch_event,
         ):
             yield ev
-
 
     async def run(self, input: RunAgentInput) -> AsyncGenerator[str, None]:
         """运行 Agent 并生成编码后的事件流"""
@@ -214,28 +210,33 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         """续流首帧回放：在 SDK 任何事件之前先回放一条"终态形态"事件。
 
         让前端能立即据此把原中断卡片更新为最终状态（关闭弹窗）。
-        支持 approval（RUN_FINISHED）和 ask_user_question（ACTIVITY_SNAPSHOT）两种中断类型。
+        支持 approval 和 ask_user_question 两种中断类型，统一构造 RunFinishedEvent。
 
-        注意：此方法仅负责 SSE 输出。ask_user_question 路径的 DB 写入由
-        handle_activity_snapshot 消费经 _dispatch_event 派发的 ACTIVITY_SNAPSHOT 事件完成。
+        注意：ask_user_question 路径的 RunFinishedEvent 走 _dispatch_event（DB writer
+        通过 handle_run_finished 消费事件写 DB），approval 路径的 RunFinishedEvent
+        保持直发（DB 已在审批回调时落库）。
+
+        ask_user_question 路径额外推送 MESSAGES_SNAPSHOT：前端 handleRunFinishedEvent
+        只标记 loading 完成，不更新消息列表中的 interrupt 卡片内容。前端依赖
+        MESSAGES_SNAPSHOT 的覆盖式语义来渲染 interrupt 卡片的 resolved 终态
+        （outcome.type=success + result.payload.answers）。
         """
         resume_event = self._build_resume_finished_event(input)
         if resume_event is not None:
             try:
-                # D-01: ask_user_question 路径的 ACTIVITY_SNAPSHOT 走 _dispatch_event，
-                # 让 DB writer 通过 handle_activity_snapshot 消费事件写入 DB。
-                # approval 路径的 RUN_FINISHED 保持直发（D-02），不走 _dispatch_event——
-                # approval 续流首帧是"回放"（DB 已在审批回调时落库），走 _dispatch_event
-                # 会让 handle_run_finished 重复触发后台续流 worker。
-                if getattr(resume_event, "type", None) == EventType.ACTIVITY_SNAPSHOT:
-                    self._dispatch_event(resume_event)
+                self._dispatch_event(resume_event)
                 yield event_encoder.encode(resume_event)
-                if getattr(resume_event, "type", None) == EventType.ACTIVITY_SNAPSHOT:
-                    updated_snapshot = self._build_updated_messages_snapshot(input)
-                    if updated_snapshot is not None:
-                        yield event_encoder.encode(updated_snapshot)
             except Exception:
                 logger.exception("[Resume] Failed to emit resume event")
+
+            # ask_user_question 续流：推送 MESSAGES_SNAPSHOT 让前端渲染 interrupt 卡片终态
+            if self._ask_user_question_interrupts:
+                try:
+                    snapshot = self._build_updated_messages_snapshot(input, resume_event)
+                    if snapshot is not None:
+                        yield event_encoder.encode(snapshot)
+                except Exception:
+                    logger.exception("[Resume] Failed to emit MESSAGES_SNAPSHOT for ask_user_question")
 
     def _build_resume_finished_event(self, input: RunAgentInput) -> RunFinishedEvent | None:
         """构造续流首条"终态形态"事件（支持 approval 和 ask_user_question）。
@@ -254,6 +255,76 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             return self._build_resume_ask_user_question_finished_event(input)
 
         return None
+
+    def _build_updated_messages_snapshot(
+        self, input: RunAgentInput, resume_event: RunFinishedEvent
+    ) -> MessageSnapshotEventExtend | None:
+        """构造续流后的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态形态。
+
+        前端 handleRunFinishedEvent 只标记 loading 完成，不更新消息列表中 interrupt 卡片的 content。
+        前端依赖 MESSAGES_SNAPSHOT 的覆盖式语义（list.value = messages.map(...)）来触发 Vue 响应式更新，
+        渲染 interrupt 卡片的 resolved 终态（outcome.type=success + result.payload.answers）。
+
+        从 input.messages 中找到 role=interrupt 的消息，替换其 content 为 RunFinishedEvent 的终态 content（outcome + result），其余消息不变。
+
+        仅 ask_user_question 路径调用；approval 路径的 DB 已在后台 worker 写好，
+        input.messages 中的 interrupt 记录已是 resolved 终态，无需额外处理。
+        """
+        messages = list(getattr(input, "messages", []) or [])
+        if not messages:
+            return None
+
+        # 从 RunFinishedEvent 提取终态 outcome / result
+        outcome = getattr(resume_event, "outcome", None)
+        result = getattr(resume_event, "result", None)
+        if outcome is None:
+            return None
+
+        # 序列化为 dict（与 MESSAGES_SNAPSHOT 的 API 格式一致）
+        if hasattr(outcome, "model_dump"):
+            outcome_dict = outcome.model_dump(mode="json", by_alias=True, exclude_none=True)
+        else:
+            outcome_dict = outcome if isinstance(outcome, dict) else {}
+        if hasattr(result, "model_dump"):
+            result_dict = result.model_dump(mode="json", by_alias=True, exclude_none=True)
+        else:
+            result_dict = result if isinstance(result, dict) else {}
+
+        # 构造与 DB 中 upgrade_content_to_success 输出一致的终态 content：
+        # {"outcome": {type, interrupts}, "result": {id, interruptId, status, payload, ...}}
+        # 注意：result 是单个 dict（不是 list），与 DB 落库格式一致。
+        terminal_content = {
+            "outcome": outcome_dict,
+            "result": result_dict,
+        }
+
+        # 替换 interrupt 消息的 content
+        updated_messages = []
+        found_interrupt = False
+        for msg in messages:
+            msg_dict = msg if isinstance(msg, dict) else (msg.model_dump() if hasattr(msg, "model_dump") else dict(msg))
+            if msg_dict.get("content") == "正在调用工具...":
+                msg_dict["content"] = ""
+            if not found_interrupt and msg_dict.get("role") == "interrupt":
+                msg_dict = dict(msg_dict)
+                msg_dict["content"] = terminal_content
+                msg_dict["status"] = "complete"
+                # 补充 DB 中断消息的顶层字段（前端可能依赖这些字段渲染卡片）
+                interrupts = outcome_dict.get("interrupts", [])
+                if interrupts:
+                    first = interrupts[0]
+                    msg_dict["reason"] = first.get("reason", "")
+                    msg_dict["interrupt_id"] = first.get("id", "")
+                found_interrupt = True
+            updated_messages.append(msg_dict)
+
+        if not found_interrupt:
+            return None
+
+        return MessageSnapshotEventExtend(
+            type=EventType.MESSAGES_SNAPSHOT,
+            messages=updated_messages,
+        )
 
     def _resolve_resume_context(self, input: RunAgentInput) -> tuple[str, list]:
         """从 input.resume / forwarded_props 解析 (interruptId, answers)。
@@ -284,57 +355,6 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             interrupt_id = (self._ask_user_question_interrupts[0] or {}).get("id", "") or ""
         return interrupt_id, resume_answers
 
-    def _build_updated_messages_snapshot(self, input: RunAgentInput):
-        """构造续流后的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态形态。
-
-        前端 handleActivitySnapshotEvent 只更新 message.content 不触发 computed 重新计算，
-        需要通过 MESSAGES_SNAPSHOT 替换整个数组引用让 activeUserQuestionInterrupt 失效。
-
-        从 input.messages 中找到 role=interrupt 的消息，替换其 content 为
-        ACTIVITY_SNAPSHOT 的终态 content（outcome.type=success），其余消息不变。
-        """
-        messages = list(getattr(input, "messages", []) or [])
-        if not messages:
-            return None
-
-        # WR-03：复用 _resolve_resume_context 解析 resume（与 _build_resume_ask_user_question_finished_event 共享）
-        interrupt_id, resume_answers = self._resolve_resume_context(input)
-
-        # 复用 AskUserQuestionOutcomeBuilder 构造终态 content（与 ACTIVITY_SNAPSHOT 一致），
-        # 确保 MESSAGES_SNAPSHOT 的 outcome 也含 interrupts 字段。
-        # D-05: resume_answers 通过参数注入 builder，不再需要调用方后修正。
-        outcome_dict, result_dict = AskUserQuestionOutcomeBuilder.build_run_finished_payload(
-            self._ask_user_question_interrupts, "resolved", resume_answers=resume_answers
-        )
-        terminal_content = {
-            "message": "用户问题已回答",
-            "outcome": outcome_dict,
-            "result": [result_dict] if result_dict else [],
-            "runId": interrupt_id,
-            "threadId": input.thread_id or "",
-        }
-
-        # 替换 interrupt 消息的 content
-        updated_messages = []
-        found_interrupt = False
-        for msg in messages:
-            msg_dict = msg if isinstance(msg, dict) else (msg.model_dump() if hasattr(msg, "model_dump") else dict(msg))
-            # 找到 role=interrupt 的消息，替换 content
-            if not found_interrupt and msg_dict.get("role") == "interrupt":
-                msg_dict = dict(msg_dict)
-                msg_dict["content"] = terminal_content
-                msg_dict["status"] = "complete"
-                found_interrupt = True
-            updated_messages.append(msg_dict)
-
-        if not found_interrupt:
-            return None
-
-        return MessageSnapshotEventExtend(
-            type=EventType.MESSAGES_SNAPSHOT,
-            messages=updated_messages,
-        )
-
     def _should_emit_resume_approval_finished(self) -> bool:
         """是否需要在续流首位发送"终态 RUN_FINISHED"（approval 专用）。
 
@@ -354,40 +374,27 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         first = self._approval_interrupts[0] or {}
         return isinstance(first, dict) and first.get("reason") == TOOL_APPROVAL_REASON
 
-    def _build_resume_ask_user_question_finished_event(self, input: RunAgentInput):
-        """构造 ask_user_question 续流首条 ACTIVITY_SNAPSHOT 事件。
+    def _build_resume_ask_user_question_finished_event(self, input: RunAgentInput) -> RunFinishedEvent:
+        """构造 ask_user_question 续流首条 RunFinishedEvent 事件（与 approval 路径对称）。
 
-        前端通过 ACTIVITY_SNAPSHOT（activityType=interrupt）关闭弹窗：
-        - content.outcome.type = "success"
-        - content.result[0] 含 interruptId / payload.answers / reason / status
-        - content.runId = interruptId（前端据此关联弹窗）
-        - content.threadId
-        - replace = true（替换原弹窗内容）
+        通过 RunFinishedEvent（outcome.type=success）关闭弹窗：
+        - outcome.interrupts 含完整中断数据（深拷贝 + status 刷写为 resolved）
+        - result 含 interruptId / payload.answers / reason / status
+        - run_id = interruptId（前端据此关联弹窗）
         """
-        # WR-03：复用 _resolve_resume_context 解析 resume（与 _build_updated_messages_snapshot 共享）
         interrupt_id, resume_answers = self._resolve_resume_context(input)
 
         # 调用 AskUserQuestionOutcomeBuilder 构造终态 (outcome, result)——
         # 与 approval 续流路径对称（ApprovalOutcomeBuilder.build_run_finished_payload）。
-        # outcome 含 interrupts 字段（深拷贝 + status 刷写为 resolved），让前端能拿到已答问题的历史中断数据。
-        # D-05: resume_answers 通过参数注入 builder，不再需要调用方后修正。
         outcome_dict, result_dict = AskUserQuestionOutcomeBuilder.build_run_finished_payload(
             self._ask_user_question_interrupts, "resolved", resume_answers=resume_answers
         )
-        content = {
-            "message": "用户问题已回答",
-            "outcome": outcome_dict,
-            "result": [result_dict] if result_dict else [],
-            "runId": interrupt_id,
-            "threadId": input.thread_id or "",
-        }
-
-        return ActivitySnapshotEvent(
-            type=EventType.ACTIVITY_SNAPSHOT,
-            messageId=interrupt_id,
-            activityType="interrupt",
-            content=content,
-            replace=True,
+        return RunFinishedEvent(
+            type=EventType.RUN_FINISHED,
+            thread_id=input.thread_id or "",
+            run_id=interrupt_id,
+            outcome=outcome_dict,
+            result=result_dict,
         )
 
     def _build_resume_approval_finished_event(self, input: RunAgentInput) -> RunFinishedEvent:
@@ -529,20 +536,12 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         """
         name = event.get("name", "")
         if name == CustomMessageType.KNOWLEDGE_RAG_RESULT.value:
-            # 旧 _handle_reference_document 从 event.raw_event.get("data",{}).get("data",[]) 取出数组，
-            # 构造 value=list 的新 CustomEvent 只推给 SSE。但 D-12 合流后 DB 也会收到这个精简事件，
-            # 而 DB 侧 handle_reference_document 依赖 event.value 是 dict 才能取 message_id（base.py:861-862
-            # 的 isinstance(event.value, dict) 判断）——list 会 fallback 到 {}，导致 message_id=None、
-            # reference_documents=[]、直接 return，知识库引用文档不再写库（数据丢失回归）。
-            #
-            # 修复：直接透传构造完整 dict 的 CustomEvent（原样保留 value=event["data"]）。
-            # 该 event["data"] 即 {"message_id":..., "data":[...], "duration":...} 完整 dict。
-            # 透传后 DB 收到 event.value 是完整 dict → isinstance(dict) 为 True → message_id 正确提取 → 写库正常。
-            # SSE 前端消费 event.value.data 字段，多出的 message_id/duration 被容错忽略，不破坏 SSE 协议。
+            # value 为纯 list 供 SSE 渲染（前端只认 list 格式），
+            # raw_event 保留完整 dict 供 DB 侧提取 message_id + data
             yield CustomEvent(
                 type=EventType.CUSTOM,
                 name=name,
-                value=event["data"],
+                value=event.get("data", {}).get("data", []),
                 raw_event=event,
             )
             return

--- a/src/agent/aidev_agent/core/ag_ui/ask_user_question.py
+++ b/src/agent/aidev_agent/core/ag_ui/ask_user_question.py
@@ -23,9 +23,10 @@ from typing import Any, Literal
 from pydantic import BaseModel
 
 from aidev_agent.core.ag_ui.utils import get_interrupt_value
+from aidev_agent.enums import PromptRole
 
 # ---------------------------------------------------------------------- #
-# 常量（D-15, D-16）
+# 常量
 # ---------------------------------------------------------------------- #
 
 ASK_USER_QUESTION_REASON = "aidev:user_question"
@@ -39,9 +40,18 @@ ASK_USER_QUESTION_REASON = "aidev:user_question"
 ASK_USER_QUESTION_STATE_KEY = "ask_user_question"
 """ask_user_question 状态在 ``additional_kwargs`` 中的 key（D-10 旁路）。"""
 
+INTERRUPT_STATUS_PENDING = "pending"
+"""中断状态：待处理。"""
+
+INTERRUPT_STATUS_RESOLVED = "resolved"
+"""中断状态：已解决。"""
+
+INTERRUPT_STATUS_CANCELLED = "cancelled"
+"""中断状态：已取消。"""
+
 
 # ---------------------------------------------------------------------- #
-# D-09 完整问题模型 Pydantic 定义
+# 完整问题模型 Pydantic 定义
 # ---------------------------------------------------------------------- #
 
 
@@ -53,7 +63,7 @@ class AskUserQuestionOption(BaseModel):
 
 
 class AskUserQuestionItem(BaseModel):
-    """单问题项 —— 协议 metadata.questions 数组元素（D-02）。"""
+    """单问题项 —— 协议 metadata.questions 数组元素。"""
 
     header: str
     multiSelect: bool = False
@@ -62,15 +72,15 @@ class AskUserQuestionItem(BaseModel):
 
 
 class AskUserQuestionMetadata(BaseModel):
-    """ask_user_question interrupt 的 metadata 字段（D-02, D-04）。
+    """ask_user_question interrupt 的 metadata 字段。
 
     metadata 仅含 questions 数组（+ 运行时 type/status 字段），所有
-    ask_user_question 专属字段承载于 ``metadata.questions`` 内（D-08），
+    ask_user_question 专属字段承载于 ``metadata.questions`` 内，
     顶层复用 AG-UI ``Interrupt`` 模型，不修改 ``ag_ui/types.py``。
     """
 
     type: Literal["ask_user_question"] = "ask_user_question"
-    status: Literal["pending", "resolved", "cancelled"] = "pending"
+    status: Literal["pending", "resolved", "cancelled"] = INTERRUPT_STATUS_PENDING
     questions: list[AskUserQuestionItem]
 
 
@@ -128,43 +138,10 @@ class AskUserQuestionOutcomeBuilder:
         }
 
     @classmethod
-    def build_run_finished_payload(
-        cls,
-        interrupts: list[dict],
-        status: str,
-        resume_answers: list | None = None,
-    ) -> tuple[dict, dict]:
-        """构造续流首条 ``RUN_FINISHED`` 事件需要的 ``(outcome, result)`` 字典对。
-
-        与 ``ApprovalOutcomeBuilder.build_run_finished_payload`` 形态对称：
-        ``outcome.type == "success"``，``result`` 为 ``interrupts[0]`` 的
-        扁平化版本。差异：``status`` 为 ``"resolved" | "cancelled"``（无审批
-        三态），``_apply_status_to_interrupt_metadata`` 不刷写 ticket。
-
-        Args:
-            interrupts: ask_user_question 中断记录列表（深拷贝后使用，入参不污染）。
-            status: 终态状态（``"resolved" | "cancelled"``）。
-            resume_answers: 用户本轮 resume 提交的 answers（权威来源）。
-                首次中断入库时 metadata 不含 answers（answers 只走 resume payload），
-                因此 ``_build_result_from_first_interrupt`` 从 metadata 取到的 answers
-                永远为 None。传入此参数后注入到 ``result["payload"]["answers"]``，
-                与 ``upgrade_content_to_success`` 对称。None 或空列表时保留 builder 默认 ``[]``。
-        """
-        safe_interrupts = copy.deepcopy(interrupts) if interrupts else []
-        cls._apply_status_to_interrupt_metadata(safe_interrupts, status)
-        outcome = {"type": "success", "interrupts": safe_interrupts}
-        result = cls._build_result_from_first_interrupt(safe_interrupts[0]) if safe_interrupts else {}
-        # D-05: resume_answers 是用户刚提交答案的权威来源（首次中断入库时 metadata 无 answers，
-        # answers 只走 resume payload），注入到 result["payload"]["answers"]，与 upgrade_content_to_success 对称。
-        if resume_answers and isinstance(result, dict):
-            result["payload"]["answers"] = list(resume_answers)
-        return outcome, result
-
-    @classmethod
     def upgrade_content_to_success(
         cls,
         content: Any,
-        status: str = "resolved",
+        status: str = INTERRUPT_STATUS_RESOLVED,
         resume_answers: list | None = None,
     ) -> dict | None:
         """将 ask_user_question 中断 content 升级为"终态形态"。
@@ -215,6 +192,39 @@ class AskUserQuestionOutcomeBuilder:
         if resume_answers and isinstance(new_content["result"], dict):
             new_content["result"]["payload"]["answers"] = list(resume_answers)
         return new_content
+
+    @classmethod
+    def build_run_finished_payload(
+        cls,
+        interrupts: list[dict],
+        status: str,
+        resume_answers: list | None = None,
+    ) -> tuple[dict, dict]:
+        """构造续流首条 ``RUN_FINISHED`` 事件需要的 ``(outcome, result)`` 字典对。
+
+        与 ``ApprovalOutcomeBuilder.build_run_finished_payload`` 形态对称：
+        ``outcome.type == "success"``，``result`` 为 ``interrupts[0]`` 的
+        扁平化版本。差异：``status`` 为 ``"resolved" | "cancelled"``（无审批
+        三态），``_apply_status_to_interrupt_metadata`` 不刷写 ticket。
+
+        Args:
+            interrupts: ask_user_question 中断记录列表（深拷贝后使用，入参不污染）。
+            status: 终态状态（``"resolved" | "cancelled"``）。
+            resume_answers: 用户本轮 resume 提交的 answers（权威来源）。
+                首次中断入库时 metadata 不含 answers（answers 只走 resume payload），
+                因此 ``_build_result_from_first_interrupt`` 从 metadata 取到的 answers
+                永远为 None。传入此参数后注入到 ``result["payload"]["answers"]``，
+                与 ``upgrade_content_to_success`` 对称。None 或空列表时保留 builder 默认 ``[]``。
+        """
+        safe_interrupts = copy.deepcopy(interrupts) if interrupts else []
+        cls._apply_status_to_interrupt_metadata(safe_interrupts, status)
+        outcome = {"type": "success", "interrupts": safe_interrupts}
+        result = cls._build_result_from_first_interrupt(safe_interrupts[0]) if safe_interrupts else {}
+        # D-05: resume_answers 是用户刚提交答案的权威来源（首次中断入库时 metadata 无 answers，
+        # answers 只走 resume payload），注入到 result["payload"]["answers"]，与 upgrade_content_to_success 对称。
+        if resume_answers and isinstance(result, dict):
+            result["payload"]["answers"] = list(resume_answers)
+        return outcome, result
 
 
 # ---------------------------------------------------------------------- #
@@ -267,7 +277,7 @@ class AskUserQuestionHandler:
         interrupt_id = f"int-question-{tool_call_id}-{uuid.uuid4().hex[:8]}"
         metadata: dict[str, Any] = {
             "type": "ask_user_question",
-            "status": "pending",
+            "status": INTERRUPT_STATUS_PENDING,
             "questions": questions,
         }
         # D-05: expiresAt 顶层字段，未传入时自动生成 24h 后过期
@@ -366,12 +376,144 @@ class AskUserQuestionHandler:
         return AskUserQuestionOutcomeBuilder
 
 
+# ---------------------------------------------------------------------- #
+# 协议层纯函数（Phase 14.1 — 从 services/nodes 层下沉的协议解析逻辑）
+# ---------------------------------------------------------------------- #
+
+
+def find_pending_interrupt(contents: list[dict], interrupt_id: str) -> tuple[Any, dict, dict] | None:
+    """遍历 DB contents 找匹配的 pending ask_user_question interrupt 记录。
+
+    逆序遍历（最新记录优先），双重过滤 ``role == PromptRole.INTERRUPT.value``
+    + ``status == "pending"``，解析 content JSON，匹配 ``interrupts[0].id``
+    且 ``reason == ASK_USER_QUESTION_REASON``。
+
+    Returns:
+        ``(content_id, raw_db_content, db_item)`` 元组，或 None（未找到）。
+    """
+    for item in reversed(contents):
+        if not isinstance(item, dict):
+            continue
+        if item.get("role") != PromptRole.INTERRUPT.value:
+            continue
+        if item.get("status") != INTERRUPT_STATUS_PENDING:
+            continue
+        raw_content = item.get("content")
+        try:
+            parsed = json.loads(raw_content) if isinstance(raw_content, str) else raw_content
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        parsed_outcome = parsed.get("outcome") or {}
+        parsed_interrupts = parsed_outcome.get("interrupts") or []
+        if not parsed_interrupts:
+            continue
+        parsed_first = parsed_interrupts[0] if isinstance(parsed_interrupts[0], dict) else {}
+        if parsed_first.get("id") == interrupt_id and parsed_first.get("reason") == ASK_USER_QUESTION_REASON:
+            return item.get("id"), parsed, item
+    return None
+
+
+def build_updated_builtin_property(db_item: dict, interrupt_id: str, status: str) -> dict:
+    """从 DB item 的 property 构造更新后的 builtin_property 字段。
+
+    保留已有字段，追加/覆写 ``status`` / ``message_id`` / ``interrupt_id``
+    / ``reason``（``ASK_USER_QUESTION_REASON``）。用于续流成功后更新 DB
+    interrupt 记录。
+
+    Returns:
+        更新后的 builtin_property dict（不修改入参 db_item）。
+    """
+    prop = db_item.get("property") if isinstance(db_item, dict) else None
+    if isinstance(prop, str):
+        try:
+            prop = json.loads(prop)
+        except (TypeError, ValueError):
+            prop = {}
+    if not isinstance(prop, dict):
+        prop = {}
+    raw_builtin = prop.get("builtin_property")
+    if not isinstance(raw_builtin, dict):
+        raw_builtin = {}
+    updated_builtin = dict(raw_builtin)
+    updated_builtin["status"] = status
+    updated_builtin["message_id"] = interrupt_id
+    updated_builtin["interrupt_id"] = interrupt_id
+    updated_builtin["reason"] = ASK_USER_QUESTION_REASON
+    return updated_builtin
+
+
+def filter_ask_user_question_interrupts(tasks: Any) -> list[dict]:
+    """从 graph state tasks 过滤 reason == ASK_USER_QUESTION 的 interrupts。
+
+    双层遍历 ``for task in tasks`` → ``for intr in task.interrupts or []``，
+    ``intr.value`` 为 str 时 ``json.loads`` 解析，过滤 reason 匹配的 value。
+
+    Returns:
+        匹配的 interrupt value（dict）列表。
+    """
+    interrupts: list[dict] = []
+    if not tasks:
+        return interrupts
+    for task in tasks:
+        for intr in getattr(task, "interrupts", None) or []:
+            value = getattr(intr, "value", intr)
+            if isinstance(value, str):
+                try:
+                    value = json.loads(value)
+                except (TypeError, ValueError):
+                    continue
+            if isinstance(value, dict) and value.get("reason") == ASK_USER_QUESTION_REASON:
+                interrupts.append(value)
+    return interrupts
+
+
+def parse_resume_answers(resume_value: Any) -> Any:
+    """从 interrupt() 的返回值（ResumeItem 列表）中提取用户答案。
+
+    interrupt() 返回 Command(resume=...) 的 resume 值。生产环境中 chat.py
+    传入 ``[ResumeItem(...)]`` 列表，每项含 interruptId/status/payload，
+    用户答案在 ``payload.answers`` 中。直接 graph.ainvoke(Command(resume=...))
+    测试场景中 resume 值可能是裸 answers 字典。
+
+    Returns:
+        提取出的用户答案（answers 列表或原始值），供写入 state 供工具函数读取。
+    """
+    if resume_value is None:
+        return None
+    if isinstance(resume_value, list) and resume_value:
+        first = resume_value[0]
+        if isinstance(first, dict):
+            payload = first.get("payload")
+            if isinstance(payload, dict) and "answers" in payload:
+                return payload["answers"]
+            if payload is not None:
+                return payload
+        return first
+    if isinstance(resume_value, dict):
+        if "answers" in resume_value:
+            return resume_value["answers"]
+        payload = resume_value.get("payload")
+        if isinstance(payload, dict) and "answers" in payload:
+            return payload["answers"]
+        return resume_value
+    return resume_value
+
+
 __all__ = [
     "ASK_USER_QUESTION_REASON",
     "ASK_USER_QUESTION_STATE_KEY",
+    "INTERRUPT_STATUS_CANCELLED",
+    "INTERRUPT_STATUS_PENDING",
+    "INTERRUPT_STATUS_RESOLVED",
     "AskUserQuestionHandler",
     "AskUserQuestionItem",
     "AskUserQuestionOutcomeBuilder",
     "AskUserQuestionMetadata",
     "AskUserQuestionOption",
+    "find_pending_interrupt",
+    "build_updated_builtin_property",
+    "filter_ask_user_question_interrupts",
+    "parse_resume_answers",
 ]

--- a/src/agent/aidev_agent/core/nodes/interrupt/user_question.py
+++ b/src/agent/aidev_agent/core/nodes/interrupt/user_question.py
@@ -11,47 +11,13 @@ from langgraph.types import Command, interrupt
 from aidev_agent.core.ag_ui.ask_user_question import (
     ASK_USER_QUESTION_REASON,
     AskUserQuestionHandler,
+    parse_resume_answers,
 )
 from aidev_agent.core.ag_ui.types import LangGraphEventTypes
 
 logger = logging.getLogger(__name__)
 
 ASK_USER_QUESTION_TOOL_NAME = "ask_user_question"
-
-
-def _extract_answer_from_resume(resume_value: Any) -> Any:
-    """从 interrupt() 的返回值（ResumeItem 列表）中提取用户答案。
-
-    interrupt() 返回 Command(resume=...) 的 resume 值。生产环境中 chat.py 传入
-    [ResumeItem(...)] 列表，每项含 interruptId/status/payload，用户答案在
-    payload.answers 中。直接 graph.ainvoke(Command(resume=...)) 测试场景中
-    resume 值可能是裸 answers 字典。
-
-    Returns:
-        提取出的用户答案（answers 列表或原始值），供写入 state 供工具函数读取。
-    """
-    if resume_value is None:
-        return None
-    # ResumeItem 列表形态：[{"interruptId": ..., "status": ..., "payload": {"answers": [...]}}]
-    if isinstance(resume_value, list) and resume_value:
-        first = resume_value[0]
-        if isinstance(first, dict):
-            payload = first.get("payload")
-            if isinstance(payload, dict) and "answers" in payload:
-                return payload["answers"]
-            # payload 本身可能就是答案
-            if payload is not None:
-                return payload
-        return first
-    # 裸字典形态：{"answers": [...]} 或 {"interruptId": ..., "payload": {"answers": [...]}}
-    if isinstance(resume_value, dict):
-        if "answers" in resume_value:
-            return resume_value["answers"]
-        payload = resume_value.get("payload")
-        if isinstance(payload, dict) and "answers" in payload:
-            return payload["answers"]
-        return resume_value
-    return resume_value
 
 
 class UserQuestionStrategy:
@@ -114,7 +80,7 @@ class UserQuestionStrategy:
 
         answer = interrupt(payload)  # 首次抛 GraphInterrupt，续流返回 answer
 
-        resolved_answer = _extract_answer_from_resume(answer)
+        resolved_answer = parse_resume_answers(answer)
         logger.info(
             "[AskUserQuestion] interrupt() 返回: tool_call_id=%s, answer=%s",
             tool_call_id,
@@ -128,4 +94,4 @@ class UserQuestionStrategy:
         )
 
 
-__all__ = ["UserQuestionStrategy", "_extract_answer_from_resume", "ASK_USER_QUESTION_TOOL_NAME"]
+__all__ = ["UserQuestionStrategy", "ASK_USER_QUESTION_TOOL_NAME"]

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -21,7 +21,7 @@ from pydantic import BaseModel, Field
 from aidev_agent.api.bk_agent import BkAgentApi
 from aidev_agent.config import settings
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
-from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
+from aidev_agent.core.ag_ui.ask_user_question import filter_ask_user_question_interrupts
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
     InterruptMessage,
@@ -266,17 +266,7 @@ class ChatCompletionAgent(BaseModel):
                 len(tasks),
                 self.thread_id,
             )
-            interrupts = []
-            for task in tasks:
-                for intr in task.interrupts or []:
-                    value = intr.value
-                    if isinstance(value, str):
-                        try:
-                            value = json.loads(value)
-                        except Exception:
-                            continue
-                    if isinstance(value, dict) and value.get("reason") == ASK_USER_QUESTION_REASON:
-                        interrupts.append(value)
+            interrupts = filter_ask_user_question_interrupts(tasks)
             logger.info(
                 "[AskUserQuestion] _query_ask_user_question_interrupts: found %d ask_user_question interrupts",
                 len(interrupts),
@@ -793,9 +783,7 @@ class ChatCompletionAgent(BaseModel):
             approve_result=approve_result,
             approval_interrupts=approval_interrupts,
             ask_user_question_interrupts=ask_user_question_interrupts,
-            run_end_extras_hook=build_artifacts_generated_hook(
-                self.resource_manager, self.executor_info
-            ),
+            run_end_extras_hook=build_artifacts_generated_hook(self.resource_manager, self.executor_info),
         )
 
         return self._stream_with_queue(

--- a/src/agent/aidev_agent/services/event_handlers/agui_writer.py
+++ b/src/agent/aidev_agent/services/event_handlers/agui_writer.py
@@ -10,7 +10,12 @@ from logging import getLogger
 from typing import Any
 
 from aidev_agent.api.bk_aidev import Client
-from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, AskUserQuestionOutcomeBuilder
+from aidev_agent.core.ag_ui.ask_user_question import (
+    ASK_USER_QUESTION_REASON,
+    AskUserQuestionOutcomeBuilder,
+    build_updated_builtin_property,
+    find_pending_interrupt,
+)
 from aidev_agent.core.ag_ui.types import RunFinishedOutcomeType
 from aidev_agent.enums import ActivityType, PromptRole, SessionsStatus
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
@@ -118,7 +123,11 @@ class AGUISessionWriter(BaseSessionWriter):
         )
 
     def handle_run_finished(self, event) -> None:
-        """处理 RUN_FINISHED 事件，额外检测中断并触发后台续流。"""
+        """处理 RUN_FINISHED 事件，额外检测中断并触发后台续流。
+
+        ask_user_question 续流首帧 RunFinishedEvent（outcome.type=success）在非
+        interrupt 分支通过 _handle_ask_user_question_resume_finished 完成 DB 终态写入。
+        """
         super().handle_run_finished(event)
 
         outcome = getattr(event, "outcome", None)
@@ -161,50 +170,40 @@ class AGUISessionWriter(BaseSessionWriter):
 
         self._clear_pending_interrupt_context()
 
-    def handle_activity_snapshot(self, event) -> None:
-        """处理 ACTIVITY_SNAPSHOT 事件：从事件 content 提取 answers 更新 DB interrupt 记录。
+        # ask_user_question 续流首帧 RunFinishedEvent（outcome.type=success）：
+        # 从 event.outcome.interrupts[0] 提取 interrupt_id，
+        # 从 event.result 提取 resume_answers，查 DB pending 记录并更新为 resolved 终态。
+        if outcome and outcome_type != "interrupt":
+            self._handle_ask_user_question_resume_finished(event)
 
-        替代原 _resolve_pending_interrupts 的 DB 查询路径。
-        ACTIVITY_SNAPSHOT 事件携带终态 content（outcome/result/answers），
-        无需再从 DB 查询 pending 记录——但仍需从 DB 查 content_id（BaseSessionWriter
-        每次请求是新实例，内存中无 content_id 映射）。
+    def _handle_ask_user_question_resume_finished(self, event) -> None:
+        """ask_user_question 续流首帧 RunFinishedEvent 的 DB 终态写入。
 
-        数据源变更：不再使用实例属性注入，改为从 event.content（JSON 解析后的 dict）的 result[0].payload.answers 提取。
+        从 event.outcome.interrupts[0].id 提取 interrupt_id，
+        从 event.result.payload.answers 提取 resume_answers，
+        查 DB pending 记录并更新为 resolved 终态。
         """
-        # 从事件 content 提取 answers 和 interrupt_id
-        content = getattr(event, "content", None)
-        if isinstance(content, str):
-            try:
-                content = json.loads(content)
-            except (TypeError, ValueError):
-                logger.exception("[AskUserQuestion] handle_activity_snapshot: content JSON 解析失败")
-                return
-        if not isinstance(content, dict):
+        # 1. 从 RunFinishedEvent 提取 interrupt_id + resume_answers
+        outcome = getattr(event, "outcome", None)
+        if isinstance(outcome, dict):
+            interrupts = outcome.get("interrupts") or []
+        else:
+            interrupts = getattr(outcome, "interrupts", []) if outcome else []
+        if not interrupts:
             return
+        first_interrupt = interrupts[0] if isinstance(interrupts[0], dict) else {}
+        if first_interrupt.get("reason") != ASK_USER_QUESTION_REASON:
+            return  # 非 ask_user_question，跳过
+        interrupt_id = first_interrupt.get("id")
+        if not interrupt_id:
+            return
+        # resume_answers 从 event.result 提取（result 是 _build_result_from_first_interrupt 的 dict）
+        result = getattr(event, "result", None)
+        resume_answers = []
+        if isinstance(result, dict):
+            resume_answers = result.get("payload", {}).get("answers") or []
 
-        # 从 content.result[0] 提取 answers（D-03 数据源变更）
-        result_list = content.get("result") or []
-        if not result_list or not isinstance(result_list[0], dict):
-            return
-        first_result = result_list[0]
-        resume_answers = first_result.get("payload", {}).get("answers") or []
-
-        # 从 content.outcome.interrupts[0] 提取 interrupt_id / reason
-        outcome_obj = content.get("outcome") or {}
-        interrupt_list = outcome_obj.get("interrupts") or []
-        if not interrupt_list:
-            return
-        first_intr = interrupt_list[0] if isinstance(interrupt_list[0], dict) else {}
-        intr_reason = first_intr.get("reason")
-        intr_id = first_intr.get("id")
-        if intr_reason != ASK_USER_QUESTION_REASON:
-            return
-        if not intr_id:
-            return
-
-        message_id = intr_id
-
-        # 从 DB 查询 pending interrupt 记录的 content_id
+        # 2. DB I/O：查询 session contents
         headers = {"X-BKAIDEV-USER": self.username} if self.username else {}
         try:
             contents = (
@@ -216,72 +215,39 @@ class AGUISessionWriter(BaseSessionWriter):
             )
         except Exception:
             logger.exception(
-                "[AskUserQuestion] handle_activity_snapshot: 查询 session contents 失败: session_code=%s",
+                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 查询 session contents 失败: session_code=%s",
                 self.session_code,
             )
             return
 
-        content_id = None
-        raw_db_content = None
-        db_item = None
-        for item in reversed(contents):
-            if item.get("role") != PromptRole.INTERRUPT.value:
-                continue
-            if item.get("status") != "pending":
-                continue
-            raw_content = item.get("content")
-            try:
-                parsed = json.loads(raw_content) if isinstance(raw_content, str) else raw_content
-            except (TypeError, ValueError):
-                continue
-            if not isinstance(parsed, dict):
-                continue
-            parsed_outcome = parsed.get("outcome") or {}
-            parsed_interrupts = parsed_outcome.get("interrupts") or []
-            if not parsed_interrupts:
-                continue
-            parsed_first = parsed_interrupts[0] if isinstance(parsed_interrupts[0], dict) else {}
-            if parsed_first.get("id") == message_id and parsed_first.get("reason") == ASK_USER_QUESTION_REASON:
-                content_id = item.get("id")
-                raw_db_content = parsed
-                db_item = item
-                break
-
-        if content_id is None or raw_db_content is None:
+        # 3. 协议匹配：找 pending interrupt 记录（纯函数）
+        found = find_pending_interrupt(contents, interrupt_id)
+        if found is None:
             logger.warning(
-                "[AskUserQuestion] handle_activity_snapshot: 未找到 pending interrupt 记录, "
+                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 未找到 pending interrupt 记录, "
                 "message_id=%s, session_code=%s",
-                message_id,
+                interrupt_id,
                 self.session_code,
             )
             return
+        content_id, raw_db_content, db_item = found
 
+        # 4. 调用已有 OutcomeBuilder（已在 core/ag_ui）
         upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
             raw_db_content, "resolved", resume_answers=resume_answers
         )
         if upgraded is None:
             logger.warning(
-                "[AskUserQuestion] handle_activity_snapshot: upgrade_content_to_success 返回 None, content_id=%s",
+                "[AskUserQuestion] _handle_ask_user_question_resume_finished: upgrade_content_to_success 返回 None, content_id=%s",
                 content_id,
             )
             return
 
+        # 5. 构造 updated_builtin（纯函数）
+        updated_builtin = build_updated_builtin_property(db_item, interrupt_id, "resolved")
+
+        # 6. DB I/O：更新 content
         try:
-            prop = db_item.get("property")
-            if isinstance(prop, str):
-                try:
-                    prop = json.loads(prop)
-                except (TypeError, ValueError):
-                    prop = {}
-            if not isinstance(prop, dict):
-                prop = {}
-            updated_builtin = prop.get("builtin_property") or {}
-            if not isinstance(updated_builtin, dict):
-                updated_builtin = {}
-            updated_builtin["status"] = "resolved"
-            updated_builtin["message_id"] = message_id
-            updated_builtin["interrupt_id"] = message_id
-            updated_builtin["reason"] = ASK_USER_QUESTION_REASON
             self._do_update_content(
                 content_id=content_id,
                 payload={
@@ -297,12 +263,12 @@ class AGUISessionWriter(BaseSessionWriter):
             logger.info(
                 "[AskUserQuestion] interrupt 记录更新为 resolved: content_id=%s, message_id=%s, session_code=%s",
                 content_id,
-                message_id,
+                interrupt_id,
                 self.session_code,
             )
         except Exception:
             logger.exception(
-                "[AskUserQuestion] handle_activity_snapshot: 更新 interrupt 记录失败, content_id=%s, session_code=%s",
+                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 更新 interrupt 记录失败, content_id=%s, session_code=%s",
                 content_id,
                 self.session_code,
             )

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -22,6 +22,7 @@ from typing import Any, Callable
 from ag_ui.core import BaseEvent, CustomEvent, EventType, RunErrorEvent
 from ag_ui.core.events import RawEvent, TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent
 
+from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, AskUserQuestionHandler
 from aidev_agent.core.ag_ui.event_builders import build_model_end_payload, should_switch_thinking_step
 from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
 from aidev_agent.core.ag_ui.types import (
@@ -168,8 +169,6 @@ class BaseSessionWriter(ABC):
             self.handle_thinking_message_end(event)
         elif event.type == EventType.TOOL_CALL_RESULT:
             self.handle_tool_call_result(event)
-        elif event.type == EventType.ACTIVITY_SNAPSHOT:
-            self.handle_activity_snapshot(event)
         elif event.type == EventType.RUN_FINISHED:
             self.handle_run_finished(event)
 
@@ -542,44 +541,64 @@ class BaseSessionWriter(ABC):
                 # 直接从 serialized_interrupts（即 content 中的数据）提取 builtin_property，
                 # 避免 AG-UI Interrupt 对象序列化时丢失审批字段
                 serialized = serialized_interrupts[idx] if idx < len(serialized_interrupts) else {}
-                metadata = serialized.get("metadata") or {}
-                ticket = metadata.get("ticket") or {}
-                # 工具入参：优先取 metadata.toolArgs，兜底取 serialized.toolArgs
-                tool_args = metadata.get("toolArgs")
-                if not isinstance(tool_args, dict):
-                    tool_args = serialized.get("toolArgs")
-                if not isinstance(tool_args, dict):
-                    tool_args = {}
-                builtin_property = {
-                    "message_id": interrupt_id,
-                    "type": metadata.get("type") or serialized.get("type") or "tool_approval",
-                    "interrupt_id": interrupt_id,
-                    "reason": serialized.get("reason"),
-                    "tool_call_id": serialized.get("toolCallId") or serialized.get("tool_call_id"),
-                    "tool_name": metadata.get("toolName") or serialized.get("toolName") or serialized.get("toolName"),
-                    "tool_args": tool_args,
-                    "callback_token": metadata.get("callbackToken") or serialized.get("callbackToken"),
-                    "ticket_sn": ticket.get("sn") or metadata.get("ticketSn") or serialized.get("ticketSn"),
-                    "graph_thread_id": getattr(event, "thread_id", ""),
-                }
-                # 记录从 outcome.interrupts 提取的字段，方便排查是否完整
-                logger.info(
-                    "[ToolApproval] handle_run_finished interrupt builtin_property: "
-                    "interrupt_id=%s, callback_token=%s, ticket_sn=%s, tool_name=%s, keys=%s",
-                    interrupt_id,
-                    builtin_property.get("callback_token"),
-                    builtin_property.get("ticket_sn"),
-                    builtin_property.get("tool_name"),
-                    list(builtin_property.keys()),
-                )
+                serialized_reason = serialized.get("reason")
+
+                if serialized_reason == ASK_USER_QUESTION_REASON:
+                    # ask_user_question 路径：启用 extract_builtin_property（D-02）
+                    # 字段集：questions/options/answers/multiSelect（无 callback_token/ticket_sn/tool_name）
+                    builtin_property = AskUserQuestionHandler().extract_builtin_property(
+                        interrupt_id, interrupt, graph_thread_id=getattr(event, "thread_id", "")
+                    )
+                    logger.info(
+                        "[AskUserQuestion] handle_run_finished interrupt builtin_property: "
+                        "interrupt_id=%s, reason=%s, keys=%s",
+                        interrupt_id,
+                        serialized_reason,
+                        list(builtin_property.keys()),
+                    )
+                else:
+                    # approval 路径：现有逻辑零改动（base.py 原 L543-562）
+                    metadata = serialized.get("metadata") or {}
+                    ticket = metadata.get("ticket") or {}
+                    # 工具入参：优先取 metadata.toolArgs，兜底取 serialized.toolArgs
+                    tool_args = metadata.get("toolArgs")
+                    if not isinstance(tool_args, dict):
+                        tool_args = serialized.get("toolArgs")
+                    if not isinstance(tool_args, dict):
+                        tool_args = {}
+                    builtin_property = {
+                        "message_id": interrupt_id,
+                        "type": metadata.get("type") or serialized.get("type") or "tool_approval",
+                        "interrupt_id": interrupt_id,
+                        "reason": serialized.get("reason"),
+                        "tool_call_id": serialized.get("toolCallId") or serialized.get("tool_call_id"),
+                        "tool_name": metadata.get("toolName")
+                        or serialized.get("toolName")
+                        or serialized.get("toolName"),
+                        "tool_args": tool_args,
+                        "callback_token": metadata.get("callbackToken") or serialized.get("callbackToken"),
+                        "ticket_sn": ticket.get("sn") or metadata.get("ticketSn") or serialized.get("ticketSn"),
+                        "graph_thread_id": getattr(event, "thread_id", ""),
+                    }
+                    # 记录从 outcome.interrupts 提取的字段，方便排查是否完整
+                    logger.info(
+                        "[ToolApproval] handle_run_finished interrupt builtin_property: "
+                        "interrupt_id=%s, callback_token=%s, ticket_sn=%s, tool_name=%s, keys=%s",
+                        interrupt_id,
+                        builtin_property.get("callback_token"),
+                        builtin_property.get("ticket_sn"),
+                        builtin_property.get("tool_name"),
+                        list(builtin_property.keys()),
+                    )
+
                 self._upsert_interrupt_session_content(
                     message_id=interrupt_id,
                     content=run_finished_content,
                     builtin_property=builtin_property,
                 )
         elif outcome and outcome_type != "interrupt":
-            # ask_user_question 续流的 DB 写入改由 handle_activity_snapshot 接管
-            # （ACTIVITY_SNAPSHOT 事件经 _dispatch_event 派发到 DB writer）。
+            # ask_user_question 续流的 DB 写入由 AGUISessionWriter.handle_run_finished
+            # 的 _handle_ask_user_question_resume_finished 完成（消费 RunFinishedEvent）。
             # approval 的 interrupt 状态由审批回调 API 更新。
             logger.info(
                 "[handle_run_finished] outcome != interrupt, session_code=%s, outcome_type=%s",
@@ -597,16 +616,6 @@ class BaseSessionWriter(ABC):
 
         BaseSessionWriter 默认空实现（无 DB 查询能力）。子类（如 AGUISessionWriter）
         可重写此方法，从 DB 查询 pending 的 interrupt 记录并更新为 resolved 终态。
-        """
-
-    def handle_activity_snapshot(self, event: BaseEvent) -> None:
-        """处理 ACTIVITY_SNAPSHOT 事件（ask_user_question 续流首帧回放）。
-
-        默认空实现。子类（如 AGUISessionWriter）可重写此方法，从事件 content
-        提取终态数据（answers）更新 DB 中的 pending interrupt 记录为 resolved。
-
-        此方法替代了原 _resolve_pending_interrupts 的 DB 查询路径——
-        ACTIVITY_SNAPSHOT 事件携带终态 content（含 answers），无需再从 DB 查询。
         """
 
     def _write_cancelled_messages(self, thinking_content: str) -> None:
@@ -894,7 +903,7 @@ class BaseSessionWriter(ABC):
             event: RawEvent（on_custom_event）或 knowledge_rag_result 的 CustomEvent
         """
         if isinstance(event, CustomEvent):
-            event_data = event.value if isinstance(event.value, dict) else {}
+            event_data = event.raw_event.get("data", {}) if event.raw_event else {}
         else:
             event_data = event.event.get("data", {})
         message_id = event_data.get("message_id")
@@ -945,7 +954,6 @@ class BaseSessionWriter(ABC):
             },
         )
         self._written_message_ids.add(message_id)
-
 
     def handle_flow_agent_result(self, event) -> None:
         """处理 Flow Agent 结果事件，回写 activity 消息

--- a/src/agent/tests/core/ag_ui/test_ask_user_question_protocol.py
+++ b/src/agent/tests/core/ag_ui/test_ask_user_question_protocol.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""ask_user_question 协议层纯函数单元测试。
+
+覆盖 Phase 14.1 D-01/D-03/D-04 抽出的 4 个纯函数的边界值：
+find_pending_interrupt / build_updated_builtin_property /
+filter_ask_user_question_interrupts / parse_resume_answers。
+"""
+
+import json
+from types import SimpleNamespace
+
+from aidev_agent.core.ag_ui.ask_user_question import (
+    ASK_USER_QUESTION_REASON,
+    build_updated_builtin_property,
+    filter_ask_user_question_interrupts,
+    find_pending_interrupt,
+    parse_resume_answers,
+)
+from aidev_agent.enums import PromptRole
+
+# ------------------------------------------------------------------ #
+# find_pending_interrupt
+# ------------------------------------------------------------------ #
+
+
+def test_find_pending_interrupt_empty():
+    assert find_pending_interrupt([], "int-1") is None
+
+
+def test_find_pending_interrupt_match():
+    raw_content = {
+        "outcome": {
+            "interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}],
+        },
+    }
+    item = {
+        "id": 42,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_content),
+    }
+    result = find_pending_interrupt([item], "int-1")
+    assert result is not None
+    content_id, raw_db_content, db_item = result
+    assert content_id == 42
+    assert raw_db_content["outcome"]["interrupts"][0]["id"] == "int-1"
+    assert db_item is item
+
+
+def test_find_pending_interrupt_wrong_role():
+    item = {
+        "id": 42,
+        "role": "activity",
+        "status": "pending",
+        "content": "{}",
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+def test_find_pending_interrupt_wrong_status():
+    item = {
+        "id": 42,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "complete",
+        "content": "{}",
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+def test_find_pending_interrupt_wrong_id():
+    raw_content = {
+        "outcome": {
+            "interrupts": [{"id": "int-other", "reason": ASK_USER_QUESTION_REASON}],
+        },
+    }
+    item = {
+        "id": 42,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_content),
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+def test_find_pending_interrupt_reversed_order():
+    """逆序遍历，最新记录优先。"""
+    raw_old = {
+        "outcome": {"interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}]},
+    }
+    raw_new = {
+        "outcome": {"interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}]},
+    }
+    old_item = {
+        "id": 1,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_old),
+    }
+    new_item = {
+        "id": 2,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_new),
+    }
+    result = find_pending_interrupt([old_item, new_item], "int-1")
+    assert result is not None
+    content_id, _, _ = result
+    assert content_id == 2  # 逆序，new_item 先匹配
+
+
+def test_find_pending_interrupt_reason_not_ask_user_question():
+    """匹配 id 但 reason 非 ASK_USER_QUESTION_REASON 时不返回。"""
+    raw_content = {
+        "outcome": {"interrupts": [{"id": "int-1", "reason": "aidev:tool_approval"}]},
+    }
+    item = {
+        "id": 42,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_content),
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+def test_find_pending_interrupt_content_not_json():
+    """content 非 JSON 字符串时跳过该记录。"""
+    item = {
+        "id": 1,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": "not json",
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+def test_find_pending_interrupt_missing_interrupts_field():
+    """outcome 缺少 interrupts 字段时跳过该记录。"""
+    raw_content = {"outcome": {}}
+    item = {
+        "id": 1,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(raw_content),
+    }
+    assert find_pending_interrupt([item], "int-1") is None
+
+
+# ------------------------------------------------------------------ #
+# build_updated_builtin_property
+# ------------------------------------------------------------------ #
+
+
+def test_build_updated_builtin_property_basic():
+    db_item = {"property": {"builtin_property": {"existing": "val"}}}
+    result = build_updated_builtin_property(db_item, "int-1", "resolved")
+    assert result["existing"] == "val"
+    assert result["status"] == "resolved"
+    assert result["message_id"] == "int-1"
+    assert result["interrupt_id"] == "int-1"
+    assert result["reason"] == ASK_USER_QUESTION_REASON
+
+
+def test_build_updated_builtin_property_no_property():
+    db_item = {}
+    result = build_updated_builtin_property(db_item, "int-1", "resolved")
+    assert result["status"] == "resolved"
+    assert result["interrupt_id"] == "int-1"
+
+
+def test_build_updated_builtin_property_json_string_property():
+    db_item = {"property": json.dumps({"builtin_property": {"foo": "bar"}})}
+    result = build_updated_builtin_property(db_item, "int-1", "resolved")
+    assert result["foo"] == "bar"
+    assert result["status"] == "resolved"
+
+
+def test_build_updated_builtin_property_does_not_mutate_input():
+    db_item = {"property": {"builtin_property": {"existing": "val"}}}
+    build_updated_builtin_property(db_item, "int-1", "resolved")
+    # db_item 的 builtin_property 不应被修改
+    assert "status" not in db_item["property"]["builtin_property"]
+
+
+def test_build_updated_builtin_property_property_invalid_json():
+    """property 为无效 JSON 字符串时回退到空 dict 再追加字段。"""
+    db_item = {"property": "not json"}
+    result = build_updated_builtin_property(db_item, "int-id", "resolved")
+    assert result["status"] == "resolved"
+    assert result["reason"] == ASK_USER_QUESTION_REASON
+
+
+def test_build_updated_builtin_property_builtin_not_dict():
+    """builtin_property 非 dict 时回退到空 dict。"""
+    db_item = {"property": {"builtin_property": "not a dict"}}
+    result = build_updated_builtin_property(db_item, "int-id", "resolved")
+    assert result["status"] == "resolved"
+    assert result["message_id"] == "int-id"
+
+
+def test_build_updated_builtin_property_cancelled_status():
+    """status=cancelled 时正确写入。"""
+    result = build_updated_builtin_property({}, "int-id", "cancelled")
+    assert result["status"] == "cancelled"
+
+
+# ------------------------------------------------------------------ #
+# filter_ask_user_question_interrupts
+# ------------------------------------------------------------------ #
+
+
+def test_filter_ask_user_question_interrupts_empty():
+    assert filter_ask_user_question_interrupts([]) == []
+
+
+def test_filter_ask_user_question_interrupts_none():
+    assert filter_ask_user_question_interrupts(None) == []
+
+
+def test_filter_ask_user_question_interrupts_match():
+    intr_value = {"reason": ASK_USER_QUESTION_REASON, "id": "int-1"}
+    task = SimpleNamespace(
+        interrupts=[SimpleNamespace(value=intr_value)],
+    )
+    result = filter_ask_user_question_interrupts([task])
+    assert len(result) == 1
+    assert result[0]["id"] == "int-1"
+
+
+def test_filter_ask_user_question_interrupts_json_string_value():
+    intr_value = json.dumps({"reason": ASK_USER_QUESTION_REASON, "id": "int-1"})
+    task = SimpleNamespace(
+        interrupts=[SimpleNamespace(value=intr_value)],
+    )
+    result = filter_ask_user_question_interrupts([task])
+    assert len(result) == 1
+    assert result[0]["id"] == "int-1"
+
+
+def test_filter_ask_user_question_interrupts_wrong_reason():
+    task = SimpleNamespace(
+        interrupts=[SimpleNamespace(value={"reason": "aidev:tool_approval"})],
+    )
+    assert filter_ask_user_question_interrupts([task]) == []
+
+
+def test_filter_ask_user_question_interrupts_no_interrupts_attr():
+    task = SimpleNamespace()
+    assert filter_ask_user_question_interrupts([task]) == []
+
+
+def test_filter_ask_user_question_interrupts_task_interrupts_none():
+    """task.interrupts 为 None 时跳过。"""
+    task = SimpleNamespace(interrupts=None)
+    assert filter_ask_user_question_interrupts([task]) == []
+
+
+def test_filter_ask_user_question_interrupts_invalid_json_string():
+    """intr.value 为无效 JSON 字符串时跳过。"""
+    task = SimpleNamespace(interrupts=[SimpleNamespace(value="not json")])
+    assert filter_ask_user_question_interrupts([task]) == []
+
+
+def test_filter_ask_user_question_interrupts_multiple_tasks():
+    """多个 task 混合 reason，只保留 ASK_USER_QUESTION_REASON。"""
+    v1 = {"reason": ASK_USER_QUESTION_REASON, "id": "q1"}
+    v2 = {"reason": "other", "id": "x1"}
+    v3 = {"reason": ASK_USER_QUESTION_REASON, "id": "q2"}
+    tasks = [
+        SimpleNamespace(interrupts=[SimpleNamespace(value=v1)]),
+        SimpleNamespace(interrupts=[SimpleNamespace(value=v2)]),
+        SimpleNamespace(interrupts=[SimpleNamespace(value=v3)]),
+    ]
+    result = filter_ask_user_question_interrupts(tasks)
+    assert len(result) == 2
+    assert result[0]["id"] == "q1"
+    assert result[1]["id"] == "q2"
+
+
+def test_filter_ask_user_question_interrupts_multiple_per_task():
+    """单个 task 含多个匹配 interrupt 时全部保留。"""
+    v1 = {"reason": ASK_USER_QUESTION_REASON, "id": "q1"}
+    v2 = {"reason": ASK_USER_QUESTION_REASON, "id": "q2"}
+    task = SimpleNamespace(interrupts=[SimpleNamespace(value=v1), SimpleNamespace(value=v2)])
+    result = filter_ask_user_question_interrupts([task])
+    assert len(result) == 2
+
+
+# ------------------------------------------------------------------ #
+# parse_resume_answers
+# ------------------------------------------------------------------ #
+
+
+def test_parse_resume_answers_none():
+    assert parse_resume_answers(None) is None
+
+
+def test_parse_resume_answers_list_with_payload_answers():
+    resume_value = [{"interruptId": "x", "status": "resolved", "payload": {"answers": ["a"]}}]
+    assert parse_resume_answers(resume_value) == ["a"]
+
+
+def test_parse_resume_answers_list_with_payload_no_answers():
+    resume_value = [{"payload": "direct-value"}]
+    assert parse_resume_answers(resume_value) == "direct-value"
+
+
+def test_parse_resume_answers_list_first_not_dict():
+    resume_value = ["raw-answer"]
+    assert parse_resume_answers(resume_value) == "raw-answer"
+
+
+def test_parse_resume_answers_dict_with_answers():
+    assert parse_resume_answers({"answers": ["a", "b"]}) == ["a", "b"]
+
+
+def test_parse_resume_answers_dict_with_payload():
+    assert parse_resume_answers({"payload": {"answers": ["c"]}}) == ["c"]
+
+
+def test_parse_resume_answers_dict_no_answers():
+    assert parse_resume_answers({"foo": "bar"}) == {"foo": "bar"}
+
+
+def test_parse_resume_answers_scalar():
+    assert parse_resume_answers(42) == 42
+    assert parse_resume_answers("hello") == "hello"
+
+
+def test_parse_resume_answers_empty_list():
+    """空列表返回空列表（非 None）。"""
+    assert parse_resume_answers([]) == []

--- a/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
+++ b/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
@@ -12,6 +12,7 @@ from aidev_agent.core.ag_ui.types import (
     ExtendAssistantMessage,
     MessageSnapshotEventExtend,
     ResumeItem,
+    RunFinishedInterruptOutcome,
     RunFinishedSuccessOutcome,
     serialize_run_finished_outcome,
 )
@@ -77,9 +78,7 @@ async def test_handle_single_event_suppresses_approval_tool_call(monkeypatch):
     }
     agent = AidevAGUIAgent(name="test-agent", graph=MagicMock(), tools={"skill_tool": tool})
 
-    events = [
-        ev async for ev in agent._handle_single_event({"event": "on_chat_model_stream"}, {})
-    ]
+    events = [ev async for ev in agent._handle_single_event({"event": "on_chat_model_stream"}, {})]
 
     # 审批工具的 ToolCallStartEvent 被抑制（不 yield）
     assert len(events) == 0
@@ -104,9 +103,7 @@ async def test_handle_single_event_enhances_non_approval_tool_call(monkeypatch):
     tool.metadata = {}
     agent = AidevAGUIAgent(name="test-agent", graph=MagicMock(), tools={"normal_tool": tool})
 
-    events = [
-        ev async for ev in agent._handle_single_event({"event": "on_chat_model_stream"}, {})
-    ]
+    events = [ev async for ev in agent._handle_single_event({"event": "on_chat_model_stream"}, {})]
 
     assert len(events) == 1
     assert isinstance(events[0], ExtendToolCallStartEvent)
@@ -374,7 +371,6 @@ async def test_run_finished_preserves_ask_user_question_metadata(monkeypatch):
 
     async def _fake_parent_run_interrupt(self, input):  # noqa: ARG001
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t", run_id="r")
-        from aidev_agent.core.ag_ui.types import RunFinishedInterruptOutcome
 
         outcome = serialize_run_finished_outcome(
             RunFinishedInterruptOutcome(interrupts=[_ask_user_question_interrupt_dict()])
@@ -411,7 +407,6 @@ async def test_run_finished_still_truncates_approval_metadata(monkeypatch):
 
     async def _fake_parent_run_approval(self, input):  # noqa: ARG001
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id="t", run_id="r")
-        from aidev_agent.core.ag_ui.types import RunFinishedInterruptOutcome
 
         outcome = serialize_run_finished_outcome(RunFinishedInterruptOutcome(interrupts=[_approval_interrupt_dict()]))
         yield RunFinishedEvent(
@@ -444,7 +439,10 @@ async def test_run_finished_still_truncates_approval_metadata(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_resume_ask_user_question_emits_first_frame_run_finished(monkeypatch):
-    """ask_user_question 续流时应发首帧 RUN_FINISHED（outcome=success），关闭前端弹窗。"""
+    """ask_user_question 续流时应发首帧 RUN_FINISHED（outcome=success），关闭前端弹窗。
+
+    Phase 14.2: 续流首帧从 ACTIVITY_SNAPSHOT 改为 RUN_FINISHED（与 approval 对齐）。
+    """
     monkeypatch.setattr(LangGraphAGUIAgent, "run", _fake_parent_run_normal)
 
     auq_interrupts = [_ask_user_question_interrupt_dict()]
@@ -487,44 +485,38 @@ async def test_resume_ask_user_question_emits_first_frame_run_finished(monkeypat
     ]
     payloads = [json.loads(chunk[6:]) for chunk in chunks]
 
-    # 首条 MESSAGES_SNAPSHOT 之后紧跟 ACTIVITY_SNAPSHOT（首帧回放，关闭弹窗）
+    # Phase 14.2: 首条 MESSAGES_SNAPSHOT 之后紧跟 RUN_FINISHED（续流首帧回放），
+    # 然后是额外的 MESSAGES_SNAPSHOT（更新 interrupt 卡片终态），
+    # 最后是 SDK 的 RUN_STARTED / RUN_FINISHED
     types = [p["type"] for p in payloads]
     assert types[0] == EventType.MESSAGES_SNAPSHOT.value
-    assert types[1] == EventType.ACTIVITY_SNAPSHOT.value, f"首帧回放 ACTIVITY_SNAPSHOT 未发出，types={types}"
+    assert types[1] == EventType.RUN_FINISHED.value, f"首帧回放 RUN_FINISHED 未发出，types={types}"
 
-    activity_snapshot = payloads[1]
-    assert activity_snapshot["activityType"] == "interrupt"
-    assert activity_snapshot["messageId"] == auq_interrupts[0]["id"]
-    assert activity_snapshot["replace"] is True
-
-    content = activity_snapshot["content"]
-    assert content["outcome"]["type"] == "success"
-    # 修复后 outcome 含 interrupts 字段（来自 AskUserQuestionOutcomeBuilder.build_run_finished_payload）
-    assert "interrupts" in content["outcome"], "outcome 应含 interrupts 字段"
-    assert len(content["outcome"]["interrupts"]) > 0, "interrupts 应非空"
+    # RUN_FINISHED 事件：顶层 outcome / result / runId
+    run_finished = payloads[1]
+    assert run_finished["runId"] == auq_interrupts[0]["id"], "runId 应为 interruptId，让前端据此关闭弹窗"
+    assert run_finished["outcome"]["type"] == "success"
+    assert "interrupts" in run_finished["outcome"], "outcome 应含 interrupts 字段"
+    assert len(run_finished["outcome"]["interrupts"]) > 0, "interrupts 应非空"
     # interrupts[0] 应为已答问题的历史快照，status 刷写为 resolved
-    auq_interrupt = content["outcome"]["interrupts"][0]
+    auq_interrupt = run_finished["outcome"]["interrupts"][0]
     assert auq_interrupt["reason"] == "aidev:user_question"
     assert auq_interrupt["metadata"]["status"] == "resolved"
-    assert content["runId"] == auq_interrupts[0]["id"], "runId 应为 interruptId，让前端据此关闭弹窗"
 
-    # result 是数组，每项含 interruptId/payload/reason/status（前端协议）
-    result_list = content.get("result")
-    assert isinstance(result_list, list), f"result 应为数组，实际: {type(result_list)}"
-    assert len(result_list) == 1
-    result_item = result_list[0]
-    assert result_item["interruptId"] == auq_interrupts[0]["id"]
-    assert result_item["reason"] == "aidev:user_question"
-    assert result_item["status"] == "resolved"
+    # result 是 dict（来自 AskUserQuestionOutcomeBuilder.build_run_finished_payload）
+    result = run_finished.get("result")
+    assert isinstance(result, dict), f"result 应为 dict，实际: {type(result)}"
+    assert result["interruptId"] == auq_interrupts[0]["id"]
+    assert result["reason"] == "aidev:user_question"
+    assert result["status"] == "resolved"
     # WR-02 修复：断言 answers 内容等于 resume payload 的值，而非仅 key 存在。
-    # resume payload（第 433 行）answers = [{"question": "q", "answer": [{"label": "a", "description": "d"}]}]
-    # 修复前 builder 从 metadata.answers 取值（fixture metadata 无 answers）→ []，此断言会失败
-    assert result_item["payload"]["answers"] == [{"question": "q", "answer": [{"label": "a", "description": "d"}]}], (
+    # resume payload answers = [{"question": "q", "answer": [{"label": "a", "description": "d"}]}]
+    assert result["payload"]["answers"] == [{"question": "q", "answer": [{"label": "a", "description": "d"}]}], (
         "result.payload.answers 应来自 resume payload（用户刚提交的答案），而非空的 metadata.answers"
     )
 
-    # ACTIVITY_SNAPSHOT 之后应推送额外的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态
-    assert types[2] == EventType.MESSAGES_SNAPSHOT.value, f"ACTIVITY_SNAPSHOT 后应推送 MESSAGES_SNAPSHOT，types={types}"
+    # RUN_FINISHED 之后应推送额外的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态
+    assert types[2] == EventType.MESSAGES_SNAPSHOT.value, f"RUN_FINISHED 后应推送 MESSAGES_SNAPSHOT，types={types}"
     updated_snapshot = payloads[2]
     updated_messages = updated_snapshot.get("messages", [])
     interrupt_msgs = [m for m in updated_messages if m.get("role") == "interrupt"]
@@ -534,7 +526,7 @@ async def test_resume_ask_user_question_emits_first_frame_run_finished(monkeypat
     assert updated_interrupt["content"]["outcome"]["type"] == "success", (
         "interrupt 消息 content.outcome.type 应为 success"
     )
-    # MESSAGES_SNAPSHOT 的 terminal_content 也应含 interrupts（与 ACTIVITY_SNAPSHOT 一致，使用同一个 builder）
+    # MESSAGES_SNAPSHOT 的 content.outcome 也应含 interrupts
     assert "interrupts" in updated_interrupt["content"]["outcome"], (
         "MESSAGES_SNAPSHOT 的 outcome 也应含 interrupts 字段"
     )

--- a/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
@@ -5,11 +5,15 @@
 如果中间的 AIMessage(tool_call) 或 InterruptRecord 缺失，前端显示会丢失中间部分。
 """
 
+import json
+
 import pytest
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
+from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, AskUserQuestionOutcomeBuilder
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
 )
+from aidev_agent.core.ag_ui.utils import get_schema_keys
 from aidev_agent.core.graphs.react.graph import ReActAgentBuilder
 from aidev_agent.enums import PromptRole
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
@@ -17,6 +21,7 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import MemorySaver
+from tests.core.ag_ui._prepare_stream_helper import prepare_stream_data_for_agent
 
 
 class _FakeToolCallingLLM(BaseChatModel):
@@ -87,38 +92,44 @@ class _RecordingSessionWriter(BaseSessionWriter):
     def set_streaming_finished(self):
         pass
 
-    def handle_activity_snapshot(self, event) -> None:
-        """D-03/D-04: 从 ACTIVITY_SNAPSHOT 事件 content 提取 answers 更新 DB interrupt 记录。"""
-        import json as _json
+    def handle_run_finished(self, event) -> None:
+        """Phase 14.2: 重写以支持 ask_user_question 续流终态写入。
 
-        from aidev_agent.core.ag_ui.ask_user_question import (
-            ASK_USER_QUESTION_REASON,
-            AskUserQuestionOutcomeBuilder,
+        super().handle_run_finished(event) 处理流式消息回写 + interrupt 首次落库，
+        非 interrupt 分支调用 _handle_ask_user_question_resume_finished 完成 DB 更新。
+        """
+        super().handle_run_finished(event)
+
+        outcome = getattr(event, "outcome", None)
+        outcome_type = (
+            outcome.get("type") if isinstance(outcome, dict) else getattr(outcome, "type", None) if outcome else None
         )
-        from aidev_agent.enums import PromptRole
+        if outcome and outcome_type != "interrupt":
+            self._handle_ask_user_question_resume_finished(event)
 
-        content = getattr(event, "content", None)
-        if isinstance(content, str):
-            try:
-                content = _json.loads(content)
-            except (TypeError, ValueError):
-                return
-        if not isinstance(content, dict):
+    def _handle_ask_user_question_resume_finished(self, event) -> None:
+        """Phase 14.2: 从 RunFinishedEvent outcome/result 提取数据更新 DB interrupt 记录。
+
+        替代原 handle_activity_snapshot（已删除），逻辑从 event.outcome.interrupts[0] +
+        event.result.payload.answers 提取数据，查 in-memory _db_records 更新。
+        """
+        outcome = getattr(event, "outcome", None)
+        if isinstance(outcome, dict):
+            interrupts = outcome.get("interrupts") or []
+        else:
+            interrupts = getattr(outcome, "interrupts", []) if outcome else []
+        if not interrupts:
             return
-        result_list = content.get("result") or []
-        if not result_list or not isinstance(result_list[0], dict):
+        first_interrupt = interrupts[0] if isinstance(interrupts[0], dict) else {}
+        if first_interrupt.get("reason") != ASK_USER_QUESTION_REASON:
             return
-        resume_answers = result_list[0].get("payload", {}).get("answers") or []
-        outcome_obj = content.get("outcome") or {}
-        interrupt_list = outcome_obj.get("interrupts") or []
-        if not interrupt_list:
+        interrupt_id = first_interrupt.get("id")
+        if not interrupt_id:
             return
-        first_intr = interrupt_list[0] if isinstance(interrupt_list[0], dict) else {}
-        if first_intr.get("reason") != ASK_USER_QUESTION_REASON:
-            return
-        message_id = first_intr.get("id")
-        if not message_id:
-            return
+        result = getattr(event, "result", None)
+        resume_answers = []
+        if isinstance(result, dict):
+            resume_answers = result.get("payload", {}).get("answers") or []
 
         for content_id, rec in self._db_records.items():
             if rec.get("role") != PromptRole.INTERRUPT.value:
@@ -128,7 +139,7 @@ class _RecordingSessionWriter(BaseSessionWriter):
             raw_content = rec.get("content")
             if isinstance(raw_content, str):
                 try:
-                    parsed = _json.loads(raw_content)
+                    parsed = json.loads(raw_content)
                 except (TypeError, ValueError):
                     continue
             else:
@@ -139,7 +150,7 @@ class _RecordingSessionWriter(BaseSessionWriter):
             if not parsed_intrs:
                 continue
             parsed_first = parsed_intrs[0] if isinstance(parsed_intrs[0], dict) else {}
-            if parsed_first.get("id") != message_id:
+            if parsed_first.get("id") != interrupt_id:
                 continue
             upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
                 parsed, "resolved", resume_answers=resume_answers
@@ -168,8 +179,6 @@ def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
     续流时 graph checkpoint 保留了中断记录，测试需像生产一样提取并传给 AidevAGUIAgent，
     否则 _build_resume_ask_user_question_finished_event 不会触发，writer 拿不到 resume_answers。
     """
-    from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
-
     try:
         agent_state = graph.get_state(config)
         tasks = agent_state.tasks if agent_state.tasks else []
@@ -178,8 +187,6 @@ def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
             for intr in task.interrupts or []:
                 value = intr.value
                 if isinstance(value, str):
-                    import json
-
                     try:
                         value = json.loads(value)
                     except Exception:
@@ -257,9 +264,6 @@ async def test_interrupt_writes_assistant_and_interrupt_records():
     )
 
     # Phase 11.8: 预处理前移到 agent_input 构造之前（消除 model_copy + 消除 agui_entry 依赖）
-    from aidev_agent.core.ag_ui.utils import get_schema_keys
-    from tests.core.ag_ui._prepare_stream_helper import prepare_stream_data_for_agent
-
     agent_state = await graph.aget_state(config)
     schema_keys = get_schema_keys(graph, config, ["messages", "tools", "copilotkit"])
     preprocessed = prepare_stream_data_for_agent(
@@ -335,9 +339,6 @@ async def test_resume_preserves_prior_messages_and_writes_final_reply():
     config = _config_with_thread(cfg, "test-db-write-2")
 
     # Phase 11.8: 预处理前移（消除 model_copy + 消除 agui_entry 依赖）
-    from aidev_agent.core.ag_ui.utils import get_schema_keys
-    from tests.core.ag_ui._prepare_stream_helper import prepare_stream_data_for_agent
-
     # 第一次调用 — 触发中断
     agent_input1 = AgentInput(
         thread_id="test-db-write-2",

--- a/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
@@ -21,16 +21,22 @@
 3. 观察续流后 DB interrupt 记录是否被更新为 resolved
 """
 
+import json
+
 import pytest
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
+from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
 from aidev_agent.core.ag_ui.types import AgentInput
+from aidev_agent.core.ag_ui.utils import get_schema_keys
 from aidev_agent.core.graphs.react.graph import ReActAgentBuilder
 from aidev_agent.enums import PromptRole
+from aidev_agent.services.agent.chat import ChatAgentBuilder, ChatPrompt
 from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.outputs import ChatGeneration, ChatResult
 from langgraph.checkpoint.memory import MemorySaver
+from tests.core.ag_ui._prepare_stream_helper import prepare_stream_data_for_agent
 
 
 class _FakeToolCallingLLM(BaseChatModel):
@@ -172,8 +178,6 @@ def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
     使 _build_resume_ask_user_question_finished_event 能触发 ACTIVITY_SNAPSHOT 事件，
     经 _dispatch_event 派发给 writer 的 handle_activity_snapshot。
     """
-    from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
-
     try:
         agent_state = graph.get_state(config)
         tasks = agent_state.tasks if agent_state.tasks else []
@@ -182,8 +186,6 @@ def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
             for intr in task.interrupts or []:
                 value = intr.value
                 if isinstance(value, str):
-                    import json
-
                     try:
                         value = json.loads(value)
                     except Exception:
@@ -227,9 +229,6 @@ async def test_resume_with_frontend_dict_format_updates_interrupt():
     )
 
     # Phase 11.8: 预处理前移（消除 model_copy + 消除 agui_entry 依赖）
-    from aidev_agent.core.ag_ui.utils import get_schema_keys
-    from tests.core.ag_ui._prepare_stream_helper import prepare_stream_data_for_agent
-
     agent_state1 = await graph.aget_state(config)
     schema_keys1 = get_schema_keys(graph, config, ["messages", "tools", "copilotkit"])
     preprocessed1 = prepare_stream_data_for_agent(
@@ -389,8 +388,6 @@ def test_filter_unmatched_tool_calls_preserves_ask_user_question():
     如果 _filter_unmatched_tool_calls 过滤掉这条 assistant 消息，续流时
     MESSAGES_SNAPSHOT 会丢失 AI(AskUser) 部分。
     """
-    from aidev_agent.services.agent.chat import ChatAgentBuilder, ChatPrompt
-
     builder = ChatAgentBuilder.__new__(ChatAgentBuilder)
     # 构造 chat_history：user -> assistant(tool_call=ask_user_question) -> interrupt
     chat_history = [

--- a/src/agent/tests/core/interrupt/test_ask_user_question_interrupt.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_interrupt.py
@@ -415,9 +415,9 @@ async def test_resume_first_frame_calls_outcome_builder(monkeypatch):
         )
     ]
 
-    # builder 应被调用至少 2 次（_build_resume_ask_user_question_finished_event 1 次 + _build_updated_messages_snapshot 1 次）
-    assert call_count["n"] >= 2, (
-        f"AskUserQuestionOutcomeBuilder.build_run_finished_payload 应被调用 >=2 次（ACTIVITY_SNAPSHOT + MESSAGES_SNAPSHOT），"
+    # Phase 14.2: builder 仅被调用 1 次（RunFinishedEvent，MESSAGES_SNAPSHOT 已取消）
+    assert call_count["n"] >= 1, (
+        f"AskUserQuestionOutcomeBuilder.build_run_finished_payload 应被调用 >=1 次（RunFinishedEvent），"
         f"实际 {call_count['n']} 次"
     )
     # 确保确实产生了 SSE 事件（非空流）
@@ -497,32 +497,20 @@ async def test_resume_first_frame_result_answers_from_resume_payload(monkeypatch
     ]
     payloads = [json.loads(chunk[6:]) for chunk in chunks]
 
-    # 找到 ACTIVITY_SNAPSHOT 事件
-    activity_snapshot = next(p for p in payloads if p["type"] == EventType.ACTIVITY_SNAPSHOT.value)
-    content = activity_snapshot["content"]
-    result_list = content["result"]
-    assert isinstance(result_list, list) and len(result_list) == 1
-    result_item = result_list[0]
+    # Phase 14.2: ACTIVITY_SNAPSHOT 已改为 RunFinishedEvent
+    # RunFinishedEvent 的 result 是 dict（非 list），内含 payload.answers
+    run_finished = next(p for p in payloads if p["type"] == EventType.RUN_FINISHED.value)
+    result_dict = run_finished.get("result", {})
+    assert isinstance(result_dict, dict)
 
     # WR-01 核心断言：result.payload.answers 等于 resume payload 的 answers（非空，非 metadata.answers）
-    assert result_item["payload"]["answers"] == expected_answers, (
-        f"ACTIVITY_SNAPSHOT result.payload.answers 应等于 resume payload answers "
-        f"({expected_answers})，实际: {result_item['payload']['answers']}"
+    assert result_dict.get("payload", {}).get("answers") == expected_answers, (
+        f"RunFinishedEvent result.payload.answers 应等于 resume payload answers "
+        f"({expected_answers})，实际: {result_dict.get('payload', {}).get('answers')}"
     )
 
-    # MESSAGES_SNAPSHOT 的 interrupt 消息 content.result[0].payload.answers 也应一致
-    # 注意：流中有两个 MESSAGES_SNAPSHOT——首帧（原始 interrupt content）和 ACTIVITY_SNAPSHOT 后的更新帧（终态 content）。
-    # 需取第二个（更新帧），其 interrupt 消息 content 含终态 result。
+    # Phase 14.2: MESSAGES_SNAPSHOT 已取消（D-03），仅保留首帧 MESSAGES_SNAPSHOT
     messages_snapshots = [p for p in payloads if p["type"] == EventType.MESSAGES_SNAPSHOT.value]
-    assert len(messages_snapshots) >= 2, (
-        f"应至少有 2 个 MESSAGES_SNAPSHOT（首帧 + 更新帧），实际: {len(messages_snapshots)}"
-    )
-    updated_snapshot = messages_snapshots[-1]
-    interrupt_msgs = [m for m in updated_snapshot.get("messages", []) if m.get("role") == "interrupt"]
-    assert interrupt_msgs, "更新后的 MESSAGES_SNAPSHOT 应包含 interrupt 消息"
-    updated_result = interrupt_msgs[0]["content"]["result"]
-    assert isinstance(updated_result, list) and len(updated_result) == 1
-    assert updated_result[0]["payload"]["answers"] == expected_answers, (
-        f"MESSAGES_SNAPSHOT result.payload.answers 应等于 resume payload answers "
-        f"({expected_answers})，实际: {updated_result[0]['payload']['answers']}"
+    assert len(messages_snapshots) >= 1, (
+        f"应至少有 1 个 MESSAGES_SNAPSHOT（首帧），实际: {len(messages_snapshots)}"
     )

--- a/src/agent/tests/core/interrupt/test_ask_user_question_interrupt_trigger.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_interrupt_trigger.py
@@ -8,14 +8,15 @@
 3. 续流（Command(resume=...)）后图恢复，interrupt() 返回值成为 ToolMessage 内容
 """
 
+import json
 from typing import Any, List, Optional, Sequence
 
 import pytest
 from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
 from aidev_agent.core.graphs.react.graph import ReActAgentBuilder
-from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
 from langchain_core.tools import BaseTool
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.types import Command
@@ -52,7 +53,6 @@ class _FakeToolCallingLLM(BaseChatModel):
         else:
             msg = responses[idx]
         object.__setattr__(self, "_call_index", idx + 1)
-        from langchain_core.outputs import ChatGeneration, ChatResult
         return ChatResult(generations=[ChatGeneration(message=msg)])
 
     async def _agenerate(self, messages: List[BaseMessage], stop: Optional[List[str]] = None, **kwargs: Any):
@@ -132,7 +132,7 @@ async def test_ask_user_question_triggers_interrupt():
     tasks = state.tasks or []
     interrupts = []
     for task in tasks:
-        for intr in (task.interrupts or []):
+        for intr in task.interrupts or []:
             interrupts.append(intr)
     assert interrupts, "state.tasks 中无 interrupt 记录，interrupt() 未触发"
 
@@ -140,7 +140,6 @@ async def test_ask_user_question_triggers_interrupt():
     first_intr = interrupts[0]
     value = first_intr.value
     if isinstance(value, str):
-        import json
         value = json.loads(value)
     assert isinstance(value, dict), f"interrupt.value 非 dict: {type(value)}"
     assert value.get("reason") == ASK_USER_QUESTION_REASON, (
@@ -206,13 +205,12 @@ async def test_ask_user_question_interrupt_payload_structure():
     tasks = state.tasks or []
     interrupts = []
     for task in tasks:
-        for intr in (task.interrupts or []):
+        for intr in task.interrupts or []:
             interrupts.append(intr)
     assert interrupts, "无 interrupt 记录"
 
     value = interrupts[0].value
     if isinstance(value, str):
-        import json
         value = json.loads(value)
 
     assert value["reason"] == ASK_USER_QUESTION_REASON

--- a/src/agent/tests/services/test_knowledge_rag_result_db.py
+++ b/src/agent/tests/services/test_knowledge_rag_result_db.py
@@ -128,24 +128,24 @@ class TestKnowledgeRagResultDBWrite:
         assert builtin_prop["message_id"] == KNOWLEDGE_MESSAGE_ID
         assert KNOWLEDGE_MESSAGE_ID in writer._written_message_ids
 
-    def test_handle_reference_document_does_not_write_when_value_is_list(self):
-        """反向回归防护：如果 event.value 是 list（旧的精简转换结果），
-        handle_reference_document 应该不写入（因为 fallback 到 {} 后 reference_documents 为空）。
-        这个测试证明旧精简逻辑确实导致数据丢失，从而验证 D-14 修复的必要性。
+    def test_handle_reference_document_does_not_write_when_raw_event_missing(self):
+        """防护：如果 CustomEvent 的 raw_event 为 None 或缺少 data 字段，
+        handle_reference_document 应不写入（因为 event_data={} → reference_documents=[] → return）。
         """
         writer = _ConcreteSessionWriter.__new__(_ConcreteSessionWriter)
         writer._written_message_ids = set()
         writer._create_session_content = MagicMock()
 
-        # 构造旧精简逻辑会产生的 event：value 是 list（不是 dict）
+        # 构造 raw_event 为 None 的 event（边界情况）
         simplified_event = CustomEvent(
             type=EventType.CUSTOM,
             name=CustomMessageType.KNOWLEDGE_RAG_RESULT.value,
-            value=REFERENCE_DOC_DATA,  # list，不是 dict —— 旧精简逻辑的结果
+            value=REFERENCE_DOC_DATA,  # list，不是 dict
+            raw_event=None,
         )
         writer.handle_reference_document(simplified_event)
 
-        # 旧精简逻辑导致：isinstance(list, dict) 为 False → event_data={} → reference_documents=[] → return
+        # raw_event=None → event_data={} → reference_documents=[] → return
         writer._create_session_content.assert_not_called()
         assert KNOWLEDGE_MESSAGE_ID not in writer._written_message_ids
 


### PR DESCRIPTION
fix: 修复了 ask_user 推送流消息后, 没有卡片消息的问题
aidev_agent 中， _emit_resume_replay_events 重新构造了 messages_snapshot ask_user_question 中， 重构了 run_finished_payload 的部分
user_question 中，移除了事件转化的部分
agui_writer 中，移除了事件转化的部分
fix: 修复了之前流传输导致知识库结果没有返回和入库的回归问题
fix: 修复了chat_model_end 没有设置front_end_display导致意外入库的问题