### PR TITLE
fix: 修复 RabbitMQ SSE replay 乱序 --story=1070093903135579259

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -338,8 +338,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
 
-        # flush 与 peek+buffer 合并的互斥锁（per thread_id，进程内）
-        # 防止 flush 在 peek 和 buffer 合并之间清空 buffer 导致消息丢失/重复
+        # flush 与 replay peek 的互斥锁（per thread_id，进程内）
+        # 避免 replay 读取到本进程尚未完整发布的 flush 批次
         self._flush_peek_locks: dict[str, threading.Lock] = {}
         self._flush_peek_locks_guard = threading.Lock()
 
@@ -834,7 +834,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """批量推送缓冲区中的所有消息到 RabbitMQ
 
         对每个 thread_id，在 _flush_peek_lock 内完成"取出 buffer + publish"的原子操作，
-        确保与 get_messages_since（peek + buffer 合并）互斥，避免消息丢失/重复。
+        确保与 get_messages_since 的 queue peek 互斥，避免 replay 观察到未完整发布的 flush 批次。
         """
         # 快速检查是否有消息需要 flush
         with self._buffer_lock:
@@ -1124,8 +1124,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
 
-                    # flush_peek_lock 保护 peek + buffer 合并这两步的原子性，
-                    # 防止 flush 在 peek 之后、buffer 合并之前清空 buffer 导致消息丢失。
+                    # replay offset 只描述 RabbitMQ 已提交队列，不能包含本地未发布 buffer。
+                    # flush_peek_lock 避免读取到本进程尚未完整发布的 flush 批次。
                     with flush_peek_lock:
                         all_messages = self._peek_queue_messages(channel, main_queue_name)
 
@@ -1138,9 +1138,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 restored,
                             )
                             all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        with self._buffer_lock:
-                            all_messages.extend(self._message_buffer.get(thread_id, []))
 
                 next_offset = len(all_messages)
                 if next_offset > offset:

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -5,6 +5,7 @@ import threading
 import time
 
 import pytest
+
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
@@ -210,6 +211,34 @@ class TestRabbitMQMessageHandler:
         assert all(result == expected for result in results)
 
         self._wait_until_empty(handler, thread_id)
+
+    def test_replay_waits_until_a_long_buffer_is_committed(self, handler, thread_id, monkeypatch):
+        """Replay offset 只推进到 RabbitMQ 已提交日志，不包含本地未发布 buffer。"""
+        committed_messages = [f"committed-{index}" for index in range(1_000)]
+        buffered_messages = [f"buffered-{index}" for index in range(1_000)]
+
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+
+        for message in committed_messages:
+            handler.put(thread_id, message)
+        handler.flush(thread_id)
+
+        messages, offset = handler.get_messages_since(thread_id, offset=0, timeout=5)
+        assert messages == committed_messages
+        assert offset == 1_000
+
+        for message in buffered_messages:
+            handler.put(thread_id, message)
+
+        with pytest.raises(TimeoutError):
+            handler.get_messages_since(thread_id, offset=offset, timeout=0.1)
+
+        handler.flush(thread_id)
+        messages, next_offset = handler.get_messages_since(thread_id, offset=offset, timeout=5)
+
+        assert messages == buffered_messages
+        assert next_offset == 2_000
 
     def test_consumer_reconnect_with_dlq(self, handler, thread_id):
         """测试消费者断开后重连可以从死信队列恢复消息


### PR DESCRIPTION
## 背景

RabbitMQ SSE replay 过去把两个不同一致性层级的数据源合并：

- RabbitMQ 主队列：已经发布、可用于 replay 的会话日志。
- 进程内 buffer：尚未发布的暂存消息。

`get_messages_since()` 使用合并后的长度生成 `next_offset`。当旧批次正在 flush、后续消息已经进入 buffer 时，consumer 会先读到后续 buffer 并推进 offset；旧批次随后进入主队列后，已经被推进的 offset 会跳过或重读消息，形成确定的乱序/重复。

## 顶层约束

Replay offset 只描述 RabbitMQ 主队列：

- replay 只读取主队列中已经可见的消息；
- 本地 buffer 只负责批量发布，不参与 replay 视图和 offset 计算；
- 旧批次发布完成后，consumer 再按主队列顺序读取。

## 改动

- 删除 `get_messages_since()` 中主队列与 `_message_buffer` 的合并。
- 保留现有 replay lock、flush/peek lock 和旧 DLQ 恢复逻辑，不改 flush 生命周期。
- 增加真实 RabbitMQ 长队列回归：1000 条已提交消息 + 1000 条未提交 buffer；buffer 未 flush 时 replay 必须等待，flush 后从 offset 1000 精确返回后 1000 条，最终 offset 为 2000。

## 明确不包含

- InMemory handler 改造。
- snapshot/replay 去重。
- Stop、取消、generation、consumer 生命周期或资源清理修复。
- 自适应 flush、队列裁剪、SSE delta 合并。

## 验证

- 回归测试 red/green：恢复旧的 buffer 合并代码时长队列用例失败，应用本修复后通过。
- RabbitMQ 相关集合：15 passed，2 deselected。
- 2 个 deselected 是当前 develop 的既有失败：
  - `test_live_chat`：未配置 LangGraph checkpointer。
  - `test_mark_completed_deletes_signal_queues`：测试对 exclusive consumer queue 生命周期的既有假设不成立。
- Ruff、格式和 diff whitespace 检查通过。
- 当前 worktree 本地模板应用已启动，`http://local.woa.com:8000/` 返回 302；实际加载的 `aidev_agent` 路径来自本 PR worktree，RabbitMQ handler 已启用。
