### PR TITLE
fix: bkplugin 轮询补 run_worker 幂等保护与输出提取诊断日志 --story=136206810

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
@@ -16,12 +16,13 @@
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from aidev_agent.config import settings as agent_settings
-from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole
+from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole, SessionsStatus
 from aidev_agent.packages.resource_manager.agent import AgentResourceManager
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent import AgentInstanceFactory
@@ -212,11 +213,42 @@ class BkpluginAgentRunner(ABC):
         chat_context: list[dict] | None = None,
     ) -> None:
         """Celery worker 入口：捕获异常并写 session 失败状态。"""
+        logger.info(
+            "[Bkplugin] run_worker enter session_code=%s turn_id=%s thread=%s",
+            session_code,
+            execute_payload.get("turn_id") or "",
+            threading.current_thread().name,
+        )
         try:
             self.invoke_agent(session_code, execute_payload, chat_context=chat_context or [])
         except Exception as e:
             logger.exception("[Bkplugin] worker error session_code=%s", session_code)
-            SessionManager(self.username or "").save_stream_failure(
+            manager = SessionManager(self.username or "")
+            # 幂等保护：心跳超时误报时 producer 实际已完成（session=FINISHED），
+            # 不应再覆盖为 FAILED。仅当 session 仍处于非终态时才写失败，
+            # 避免覆盖已确定的终态（FINISHED/CANCELLED/FAILED）。
+            try:
+                current_status = str(manager.retrieve_session(session_code).get("status") or "")
+            except Exception:
+                logger.exception(
+                    "[Bkplugin] retrieve_session failed before save_stream_failure session_code=%s",
+                    session_code,
+                )
+                current_status = ""
+            if current_status in (
+                SessionsStatus.FINISHED.value,
+                SessionsStatus.CANCELLED.value,
+                SessionsStatus.FAILED.value,
+            ):
+                logger.warning(
+                    "[Bkplugin] skip save_stream_failure: session already %s "
+                    "(likely heartbeat-timeout false positive) session_code=%s exc=%r",
+                    current_status,
+                    session_code,
+                    e,
+                )
+                return
+            manager.save_stream_failure(
                 session_code,
                 f"Agent 执行异常: {e}",
                 turn_id=execute_payload.get("turn_id") or "",

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -238,26 +238,59 @@ class SessionManager:
         if status in (SessionsStatus.PENDING.value, SessionsStatus.RUNNING.value):
             return PluginPollTaskState.RUNNING, ""
         if status in (SessionsStatus.FAILED.value, SessionsStatus.CANCELLED.value):
-            return PluginPollTaskState.FAILED, "Agent 执行失败"
-        if status == SessionsStatus.FINISHED.value:
-            return PluginPollTaskState.SUCCESS, self._last_assistant_output(
+            # 取回 save_stream_failure 写入的实际异常内容，避免 UI 只显示通用 "Agent 执行失败"
+            return PluginPollTaskState.FAILED, self._last_output(
                 self.list_session_contents(session_code),
                 turn_id=turn_id,
+                statuses=(ChatContentStatus.ERROR.value,),
+            ) or "Agent 执行失败"
+        if status == SessionsStatus.FINISHED.value:
+            return PluginPollTaskState.SUCCESS, self._last_output(
+                self.list_session_contents(session_code),
+                turn_id=turn_id,
+                statuses=(ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value),
             )
         return PluginPollTaskState.RUNNING, ""
 
     @staticmethod
-    def _last_assistant_output(items: list[dict], *, turn_id: str = "") -> str:
-        """取最后一条有内容的 assistant/ai；有 ``turn_id`` 时仅取同轮消息。"""
+    def _last_output(
+        items: list[dict],
+        *,
+        turn_id: str = "",
+        statuses: tuple[str, ...],
+    ) -> str:
+        """取最后一条指定 status 的 assistant/ai 内容；有 ``turn_id`` 时仅取同轮消息。
+
+        FINISHED 取 COMPLETE/SUCCESS 的正常回复；FAILED/CANCELLED 取 ERROR 的实际异常
+        （save_stream_failure 写入），避免上层只看到通用 "Agent 执行失败"。
+        """
         assistant_roles = (PromptRole.ASSISTANT.value, PromptRole.AI.value)
-        for item in reversed(items):
-            if item.get("role") not in assistant_roles:
+        matched = ""
+        for idx, item in enumerate(reversed(items)):
+            role = item.get("role")
+            item_turn = (item.get("property") or {}).get("turn_id")
+            status = item.get("status")
+            content = str(item.get("content") or "").strip()
+            if role not in assistant_roles:
                 continue
-            if turn_id and (item.get("property") or {}).get("turn_id") != turn_id:
+            if turn_id and item_turn != turn_id:
+                logger.warning(
+                    "[POLL-EXTRACT] skip by turn_id mismatch idx=%s role=%s status=%s "
+                    "item_turn=%s poll_turn=%s content_prefix=%s",
+                    idx, role, status, item_turn, turn_id, content[:40],
+                )
                 continue
-            if item.get("status") not in (ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value):
+            if status not in statuses:
+                logger.warning(
+                    "[POLL-EXTRACT] skip by status idx=%s role=%s status=%s expect=%s content_prefix=%s",
+                    idx, role, status, statuses, content[:40],
+                )
                 continue
-            text = str(item.get("content") or "").strip()
-            if text:
-                return text
-        return ""
+            if content:
+                matched = content
+                break
+        logger.warning(
+            "[POLL-EXTRACT] result turn_id=%s statuses=%s total=%s matched_prefix=%s",
+            turn_id, statuses, len(items), matched[:80],
+        )
+        return matched

--- a/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
@@ -266,3 +266,41 @@ class TestBkpluginExecution:
         assert runner.execute_kwargs["session_code"] == "thread-x"
         assert runner.plugin_context == [{"k": "v"}]
         mock_resolve.assert_called_once_with("alice")
+
+    def test_run_worker_skips_save_stream_failure_when_session_finished(self, monkeypatch):
+        """心跳超时误报：producer 实际已完成（session=FINISHED），不应覆盖为 FAILED。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(
+            agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时"))
+        )
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.FINISHED.value}
+        monkeypatch.setattr(
+            "aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm
+        )
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.retrieve_session.assert_called_once_with("sess-1")
+        mock_sm.save_stream_failure.assert_not_called()
+
+    def test_run_worker_calls_save_stream_failure_when_session_running(self, monkeypatch):
+        """producer 真崩溃：session 仍 RUNNING 时应写失败。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(
+            agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时"))
+        )
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.RUNNING.value}
+        monkeypatch.setattr(
+            "aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm
+        )
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.save_stream_failure.assert_called_once_with("sess-1", ANY, turn_id="t1")
+


### PR DESCRIPTION
## 背景
承接 #711（bkplugin 会话轮询心跳超时误报修复，story #136206810）。线上验证发现：
1. 心跳超时误报时 `run_worker` 仍会调 `save_stream_failure`，把 producer 实际已完成的 `FINISHED` session 覆盖为 `FAILED`；
2. `FAILED` 时 `poll_task_state` 只返回通用 "Agent 执行失败"，丢失 `save_stream_failure` 写入的实际异常；
3. `FINISHED` 但输出提取为空时缺少诊断，无法定位是 `turn_id` 不匹配还是 `status` 不匹配。

本 PR 在 #711 基础上补齐幂等保护、异常透传与输出提取诊断日志。

## 改动一：`run_worker` 幂等保护（agent_bkplugin.py）
- 入口加 `[Bkplugin] run_worker enter` 日志（session_code/turn_id/thread）
- except 块先 `retrieve_session` 查当前 status，若已是终态（`FINISHED`/`CANCELLED`/`FAILED`）则 `skip save_stream_failure`，避免心跳超时误报覆盖已确定的终态
- `retrieve_session` 失败时打异常日志并降级为空 status，不影响主流程

## 改动二：输出提取重构与诊断（agent_session.py）
- `_last_assistant_output` 重构为 `_last_output`，新增 `statuses` 参数：
  - `FINISHED` 取 `COMPLETE`/`SUCCESS` 的正常回复
  - `FAILED`/`CANCELLED` 取 `ERROR` 的实际异常（`save_stream_failure` 写入），不再只返回通用 "Agent 执行失败"
- 加 `[POLL-EXTRACT]` WARNING 级诊断日志，逐条记录 skip 原因（turn_id mismatch / status mismatch）及最终 result，定位"无输出"根因

## 测试
- `test_run_worker_skips_save_stream_failure_when_session_finished`：session=FINISHED 时不写失败
- `test_run_worker_calls_save_stream_failure_when_session_running`：session=RUNNING 时正常写失败

## 关联
tapd: #136206810

Made with [Cursor](https://cursor.com)