### PR TITLE
fix: 修复 aidev_agent 事件循环与 producer 流式堆栈问题（already running / StreamLostError）并补全链路日志 --story=136206810

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -27,7 +27,7 @@ from langchain_core.outputs import ChatGenerationChunk, ChatResult
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, PrivateAttr, model_validator
 
 from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
@@ -62,6 +62,18 @@ class ApiGwMixin(BaseModel):
 class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
+    _owns_http_async_client: bool = PrivateAttr(default=False)
+
+    @classmethod
+    def get_setup_instance(cls, **kwargs) -> "ChatModel":
+        owns_http_async_client = False
+        if kwargs.get("http_async_client") is None and kwargs.get("async_client") is None:
+            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient()
+            owns_http_async_client = True
+
+        model = super().get_setup_instance(**kwargs)
+        model._owns_http_async_client = owns_http_async_client
+        return model
 
     @model_validator(mode="before")
     @classmethod

--- a/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
+++ b/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
@@ -738,7 +738,15 @@ class AgentStreamAdapter:
         )
 
     # 流协议处理
-    def stream_standard_event(self, agent_e, cfg, input_state, skip_thought=False, timeout: int = 30):
+    def stream_standard_event(
+        self,
+        agent_e,
+        cfg,
+        input_state,
+        skip_thought=False,
+        timeout: int = 30,
+        async_finalizer=None,
+    ):
         try:
             protocol = BkAiStreamingProtocol(
                 skip_thought=skip_thought,
@@ -755,7 +763,7 @@ class AgentStreamAdapter:
                 durability="exit",
             )
             _aiter = async_generator_with_timeout(_aiter, timeout=timeout)
-            g = async_to_sync_generator(_aiter)
+            g = async_to_sync_generator(_aiter, async_finalizer=async_finalizer)
             yield from protocol.stream_standard_event(g)
         except Exception:
             logger.error(traceback.format_exc())

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -528,12 +528,13 @@ class BaseResourceManager(abc.ABC):
                         ),
                     )
 
-        coros = [_load_tool(server_name, selected_tools_map, i + 1) for i, server_name in enumerate(new_server_config)]
-
         async def _load_all_tools():
+            coros = [
+                _load_tool(server_name, selected_tools_map, i + 1) for i, server_name in enumerate(new_server_config)
+            ]
             return await asyncio.gather(*coros)
 
-        coro_results = run_coro_sync(_load_all_tools())
+        coro_results = run_coro_sync(_load_all_tools)
         tools_list: List[StructuredTool] = []
         failures: List[McpToolFetchFailure] = []
         for tlist, fail in coro_results:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -274,7 +274,7 @@ class ChatCompletionAgent(BaseModel):
         因为非流式路径（ainvoke）不经过 prepare_stream。
         """
         try:
-            agent_state = run_coro_sync(agent_e.aget_state(cfg))
+            agent_state = run_coro_sync(lambda: agent_e.aget_state(cfg))
             checkpoint_messages = agent_state.values.get("messages", [])
             non_system_checkpoint_msgs = [m for m in checkpoint_messages if not isinstance(m, SystemMessage)]
 
@@ -297,7 +297,7 @@ class ChatCompletionAgent(BaseModel):
 
                 if remove_ops:
                     run_coro_sync(
-                        agent_e.aupdate_state(
+                        lambda: agent_e.aupdate_state(
                             cfg,
                             {"messages": remove_ops},
                             as_node="__start__",
@@ -402,7 +402,7 @@ class ChatCompletionAgent(BaseModel):
                     finally:
                         await self._aclose_chat_models()
 
-                result = run_coro_sync(_ainvoke_with_cleanup(), timeout=execute_kwargs.invoke_timeout)
+                result = run_coro_sync(_ainvoke_with_cleanup, timeout=execute_kwargs.invoke_timeout)
                 result_output = result.get("messages")[-1]
                 return_data = {
                     "choices": [{"delta": {"role": "assistant", "content": result_output.content}}],
@@ -590,7 +590,7 @@ class ChatCompletionAgent(BaseModel):
                     try:
                         yield from replay
                     finally:
-                        run_coro_sync(self._aclose_chat_models())
+                        run_coro_sync(self._aclose_chat_models)
                     return
             yield from async_to_sync_generator(
                 agui_entry.run(agent_input),
@@ -620,7 +620,7 @@ class ChatCompletionAgent(BaseModel):
         try:
             replay_cfg = dict(cfg)
             replay_cfg["configurable"] = {**cfg.get("configurable", {}), "thread_id": thread_id}
-            state = run_coro_sync(agent_e.aget_state(replay_cfg))
+            state = run_coro_sync(lambda: agent_e.aget_state(replay_cfg))
         except Exception:
             logger.warning(
                 "[ResumeReplay] aget_state failed, fallback to astream, thread_id=%s",

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -225,6 +225,25 @@ class ChatCompletionAgent(BaseModel):
             finally:
                 self.runtime_backend_resolver = None
 
+    async def _aclose_chat_models(self) -> None:
+        """在模型执行 loop 上关闭当前 agent 自己创建的异步 HTTP client。"""
+        clients: dict[int, tuple[Any, list[BaseChatModel]]] = {}
+        for model in (self.chat_model, self.chat_model_non_thinking):
+            if model is None or not getattr(model, "_owns_http_async_client", False):
+                continue
+            client = getattr(model, "http_async_client", None)
+            if client is not None:
+                clients.setdefault(id(client), (client, []))[1].append(model)
+
+        for client, owners in clients.values():
+            try:
+                await client.aclose()
+            except Exception:
+                logger.warning("ChatCompletionAgent: 关闭模型异步 HTTP client 失败", exc_info=True)
+            else:
+                for model in owners:
+                    model._owns_http_async_client = False
+
     def _query_approval_status(self, session_code: str) -> dict | None:
         """查询 gongfeng 后端判断是否需要续流，并从 interrupt 记录获取审批结果及 interrupts。
 
@@ -376,10 +395,14 @@ class ChatCompletionAgent(BaseModel):
                 input_state: dict[str, Any] = {"messages": messages, "execute_kwargs": execute_kwargs}
                 if platform_pv:
                     input_state["runtime_paas_sbx_pv"] = platform_pv
-                result = run_coro_sync(
-                    agent_e.ainvoke(input_state, cfg),
-                    timeout=execute_kwargs.invoke_timeout,
-                )
+
+                async def _ainvoke_with_cleanup():
+                    try:
+                        return await agent_e.ainvoke(input_state, cfg)
+                    finally:
+                        await self._aclose_chat_models()
+
+                result = run_coro_sync(_ainvoke_with_cleanup(), timeout=execute_kwargs.invoke_timeout)
                 result_output = result.get("messages")[-1]
                 return_data = {
                     "choices": [{"delta": {"role": "assistant", "content": result_output.content}}],
@@ -402,7 +425,12 @@ class ChatCompletionAgent(BaseModel):
         _input: dict[str, Any] = {"messages": messages}
         if platform_pv:
             _input["runtime_paas_sbx_pv"] = platform_pv
-        return agent_e.agent.stream_standard_event(agent_e, cfg, _input)
+        return agent_e.agent.stream_standard_event(
+            agent_e,
+            cfg,
+            _input,
+            async_finalizer=self._aclose_chat_models,
+        )
 
     def _stream(
         self, agent_e: Runnable, cfg: RunnableConfig, messages: list[BaseMessage], execute_kwargs: ExecuteKwargs
@@ -498,9 +526,7 @@ class ChatCompletionAgent(BaseModel):
             thread_id=queue_thread_id or agent_input.thread_id,
             defer_cleanup_on_complete=background_only,
         )
-        producer = self._build_resume_aware_producer(
-            agui_entry, agent_input, agent_e=agent_e, cfg=cfg, resume=resume
-        )
+        producer = self._build_resume_aware_producer(agui_entry, agent_input, agent_e=agent_e, cfg=cfg, resume=resume)
 
         # ---- 阶段 1：同步拉取头部帧并直接 yield ----
         head_frames = []
@@ -561,9 +587,15 @@ class ChatCompletionAgent(BaseModel):
                         "(scheme B fallback), thread_id=%s",
                         agent_input.thread_id,
                     )
-                    yield from replay
+                    try:
+                        yield from replay
+                    finally:
+                        run_coro_sync(self._aclose_chat_models())
                     return
-            yield from async_to_sync_generator(agui_entry.run(agent_input))
+            yield from async_to_sync_generator(
+                agui_entry.run(agent_input),
+                async_finalizer=self._aclose_chat_models,
+            )
 
         return _gen()
 
@@ -603,8 +635,7 @@ class ChatCompletionAgent(BaseModel):
         is_terminal = len(next_nodes) == 0 and not interrupts
         if not is_terminal:
             logger.info(
-                "[ResumeReplay] graph not terminal (next=%s, interrupts=%d), use normal resume astream, "
-                "thread_id=%s",
+                "[ResumeReplay] graph not terminal (next=%s, interrupts=%d), use normal resume astream, thread_id=%s",
                 next_nodes,
                 len(interrupts),
                 thread_id,

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -535,7 +535,11 @@ class ChatCompletionAgent(BaseModel):
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+        yield from helper.stream(
+            remaining_producer,
+            on_complete=self._on_complete,
+            event_handler=self.event_handler,
+        )
 
     @staticmethod
     def _extract_head_frames(

--- a/src/agent/aidev_agent/services/agent/flow.py
+++ b/src/agent/aidev_agent/services/agent/flow.py
@@ -135,7 +135,7 @@ class FlowAgentCompletionAgent(BaseModel):
         """
         stream_thread_id = self.session_code or self.thread_id
         helper = GeneratorStreamingHelper(thread_id=stream_thread_id)
-        return helper.stream(self._run_flow())
+        return helper.stream(self._run_flow(), event_handler=self.event_handler)
 
     def stop(self):
         """停止 Flow Agent"""

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import json
 import pickle
 import queue
@@ -18,12 +19,28 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import QueueNamePrefixes
+from .constants import EOD_CHUNK, HEARTBEAT_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
 
 env = Env()
+
+
+def _msg_signature(msg: Any) -> str:
+    """为单条队列消息生成稳定指纹，用于 peek 跨轮对比定位丢失消息。
+
+    心跳/EOD 用固定标记；其余消息用 pickle 字节长度 + md5 前 8 位，避免打印完整内容。
+    """
+    if msg == HEARTBEAT_CHUNK:
+        return "HB"
+    if msg == EOD_CHUNK:
+        return "EOD"
+    try:
+        blob = pickle.dumps(msg)
+        return f"c{len(blob)}:{hashlib.md5(blob).hexdigest()[:8]}"
+    except Exception as e:
+        return f"c?:{repr(msg)[:40]}:{e}"
 
 
 class RabbitMQConnectionPool:
@@ -621,20 +638,46 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 return False
 
     def release_producer(self, thread_id: str) -> None:
-        """释放会话级生产者写入权。"""
+        """释放会话级生产者写入权。
+        """
         lock_queue = self._get_producer_lock_queue_name(thread_id)
         with self._producer_lock_guard:
             connection = self._producer_lock_connections.pop(thread_id, None)
 
         if not connection:
+            logger.info(
+                "[RabbitMQ] producer lock release skipped (no connection) thread_id=%s queue=%s",
+                thread_id,
+                lock_queue,
+            )
             return
 
+        logger.info(
+            "[RabbitMQ] release_producer enter thread_id=%s queue=%s connection_is_open=%s",
+            thread_id,
+            lock_queue,
+            getattr(connection, "is_open", None),
+        )
         channel = None
+        connection_already_closed = False
         try:
             if getattr(connection, "is_open", False):
-                channel = connection.channel()
-                with contextlib.suppress(Exception):
-                    channel.queue_delete(queue=lock_queue)
+                try:
+                    channel = connection.channel()
+                    with contextlib.suppress(Exception):
+                        channel.queue_delete(queue=lock_queue)
+                except Exception as e:
+                    # 连接已被对端重置/关闭：exclusive queue 随连接断开自动删除，
+                    # 无需再 queue_delete，降级走连接清理路径，不让异常冒泡
+                    connection_already_closed = True
+                    channel = None
+                    logger.warning(
+                        "[RabbitMQ] producer lock connection already closed, skip queue_delete "
+                        "thread_id=%s queue=%s error=%s",
+                        thread_id,
+                        lock_queue,
+                        e,
+                    )
         finally:
             if channel and getattr(channel, "is_open", False):
                 with contextlib.suppress(Exception):
@@ -642,7 +685,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if getattr(connection, "is_open", False):
                 with contextlib.suppress(Exception):
                     connection.close()
-            logger.info("[RabbitMQ] producer lock released thread_id=%s queue=%s", thread_id, lock_queue)
+            logger.info(
+                "[RabbitMQ] producer lock released thread_id=%s queue=%s connection_already_closed=%s",
+                thread_id,
+                lock_queue,
+                connection_already_closed,
+            )
 
     def _ensure_active_consumer_queue(self, channel: Any, thread_id: str) -> str:
         queue_name = self._get_active_consumer_queue_name(thread_id)
@@ -867,6 +915,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
                     logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
+                    flush_has_eod = any(m == EOD_CHUNK for m in messages)
+                    logger.info(
+                        "[EOD] flush thread_id=%s published=%d has_eod=%s (background)",
+                        thread_id, len(messages), flush_has_eod,
+                    )
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1034,6 +1087,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                    # 诊断：记录 flush 数量与是否含 EOD，定位 EOD 是否真正入队
+                    flush_has_eod = any(m == EOD_CHUNK for m in messages_to_flush)
+                    logger.info(
+                        "[EOD] flush thread_id=%s published=%d has_eod=%s",
+                        thread_id, len(messages_to_flush), flush_has_eod,
+                    )
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1093,9 +1152,17 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。"""
+        """非破坏性读取队列中的全部消息。
+
+        诊断：basic_get + basic_nack(requeue=True) 在大队列上反复执行不可靠，
+        nack requeue 会破坏 FIFO 且可能丢消息。此处记录 message_count、实际 get 数、
+        是否含 EOD、nack 异常，用于定位 starved 时消息（含 EOD）丢失环节。
+        """
         messages = []
         delivery_tags = []
+        message_count = 0
+        peek_eod = False
+        nack_error = None
 
         try:
             queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
@@ -1105,10 +1172,30 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if not method_frame:
                     break
                 delivery_tags.append(method_frame.delivery_tag)
-                messages.append(pickle.loads(body))
+                msg = pickle.loads(body)
+                messages.append(msg)
+                if not peek_eod and msg == EOD_CHUNK:
+                    peek_eod = True
         finally:
             for tag in delivery_tags:
-                channel.basic_nack(delivery_tag=tag, requeue=True)
+                try:
+                    channel.basic_nack(delivery_tag=tag, requeue=True)
+                except Exception as e:
+                    nack_error = e
+            # 诊断：message_count 与实际 get 数不一致 / nack 失败 / EOD 状态
+            if message_count != len(messages) or nack_error is not None or peek_eod:
+                logger.warning(
+                    "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
+                    queue_name, message_count, len(messages), nack_error, peek_eod,
+                )
+            # 诊断：每轮 peek 打印队列全部消息指纹，跨轮对比定位丢失消息（含 EOD）
+            sigs = [_msg_signature(m) for m in messages]
+            hb_count = sigs.count("HB")
+            logger.warning(
+                "[PEEK-TRACE] queue=%s declared=%d got=%d hb=%d eod=%s nack_error=%s",
+                queue_name, message_count, len(messages), hb_count, peek_eod, nack_error,
+            )
+            logger.warning("[PEEK-TRACE-SIGS] queue=%s sigs=%s", queue_name, " ".join(sigs))
 
         return messages
 
@@ -1139,8 +1226,16 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             )
                             all_messages = self._peek_queue_messages(channel, main_queue_name)
 
+                        queue_count = len(all_messages)
                         with self._buffer_lock:
-                            all_messages.extend(self._message_buffer.get(thread_id, []))
+                            buffer_msgs = self._message_buffer.get(thread_id, [])
+                            all_messages.extend(buffer_msgs)
+                        queue_has_eod = any(m == EOD_CHUNK for m in all_messages[:queue_count])
+                        buffer_has_eod = any(m == EOD_CHUNK for m in buffer_msgs)
+                        logger.info(
+                            "[EOD-REPLAY] thread_id=%s offset=%d queue_count=%d queue_has_eod=%s buffer_count=%d buffer_has_eod=%s",
+                            thread_id, offset, queue_count, queue_has_eod, len(buffer_msgs), buffer_has_eod,
+                        )
 
                 next_offset = len(all_messages)
                 if next_offset > offset:

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1,5 +1,4 @@
 import contextlib
-import hashlib
 import json
 import pickle
 import queue
@@ -19,28 +18,12 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import EOD_CHUNK, HEARTBEAT_CHUNK, QueueNamePrefixes
+from .constants import EOD_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
 
 env = Env()
-
-
-def _msg_signature(msg: Any) -> str:
-    """为单条队列消息生成稳定指纹，用于 peek 跨轮对比定位丢失消息。
-
-    心跳/EOD 用固定标记；其余消息用 pickle 字节长度 + md5 前 8 位，避免打印完整内容。
-    """
-    if msg == HEARTBEAT_CHUNK:
-        return "HB"
-    if msg == EOD_CHUNK:
-        return "EOD"
-    try:
-        blob = pickle.dumps(msg)
-        return f"c{len(blob)}:{hashlib.md5(blob).hexdigest()[:8]}"
-    except Exception as e:
-        return f"c?:{repr(msg)[:40]}:{e}"
 
 
 class RabbitMQConnectionPool:
@@ -638,8 +621,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 return False
 
     def release_producer(self, thread_id: str) -> None:
-        """释放会话级生产者写入权。
-        """
+        """释放会话级生产者写入权。"""
         lock_queue = self._get_producer_lock_queue_name(thread_id)
         with self._producer_lock_guard:
             connection = self._producer_lock_connections.pop(thread_id, None)
@@ -915,11 +897,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
                     logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
-                    flush_has_eod = any(m == EOD_CHUNK for m in messages)
-                    logger.info(
-                        "[EOD] flush thread_id=%s published=%d has_eod=%s (background)",
-                        thread_id, len(messages), flush_has_eod,
-                    )
+                    if EOD_CHUNK in messages:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d (background)",
+                            thread_id,
+                            len(messages),
+                        )
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1087,12 +1070,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
-                    # 诊断：记录 flush 数量与是否含 EOD，定位 EOD 是否真正入队
-                    flush_has_eod = any(m == EOD_CHUNK for m in messages_to_flush)
-                    logger.info(
-                        "[EOD] flush thread_id=%s published=%d has_eod=%s",
-                        thread_id, len(messages_to_flush), flush_has_eod,
-                    )
+                    if EOD_CHUNK in messages_to_flush:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d",
+                            thread_id,
+                            len(messages_to_flush),
+                        )
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1152,16 +1135,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。
-
-        诊断：basic_get + basic_nack(requeue=True) 在大队列上反复执行不可靠，
-        nack requeue 会破坏 FIFO 且可能丢消息。此处记录 message_count、实际 get 数、
-        是否含 EOD、nack 异常，用于定位 starved 时消息（含 EOD）丢失环节。
-        """
+        """非破坏性读取队列中的全部消息，仅在读取或 requeue 异常时记录诊断。"""
         messages = []
         delivery_tags = []
         message_count = 0
-        peek_eod = False
         nack_error = None
 
         try:
@@ -1174,28 +1151,21 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 delivery_tags.append(method_frame.delivery_tag)
                 msg = pickle.loads(body)
                 messages.append(msg)
-                if not peek_eod and msg == EOD_CHUNK:
-                    peek_eod = True
         finally:
             for tag in delivery_tags:
                 try:
                     channel.basic_nack(delivery_tag=tag, requeue=True)
                 except Exception as e:
                     nack_error = e
-            # 诊断：message_count 与实际 get 数不一致 / nack 失败 / EOD 状态
-            if message_count != len(messages) or nack_error is not None or peek_eod:
+            if message_count != len(messages) or nack_error is not None:
                 logger.warning(
                     "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
-                    queue_name, message_count, len(messages), nack_error, peek_eod,
+                    queue_name,
+                    message_count,
+                    len(messages),
+                    nack_error,
+                    EOD_CHUNK in messages,
                 )
-            # 诊断：每轮 peek 打印队列全部消息指纹，跨轮对比定位丢失消息（含 EOD）
-            sigs = [_msg_signature(m) for m in messages]
-            hb_count = sigs.count("HB")
-            logger.warning(
-                "[PEEK-TRACE] queue=%s declared=%d got=%d hb=%d eod=%s nack_error=%s",
-                queue_name, message_count, len(messages), hb_count, peek_eod, nack_error,
-            )
-            logger.warning("[PEEK-TRACE-SIGS] queue=%s sigs=%s", queue_name, " ".join(sigs))
 
         return messages
 
@@ -1226,16 +1196,9 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             )
                             all_messages = self._peek_queue_messages(channel, main_queue_name)
 
-                        queue_count = len(all_messages)
                         with self._buffer_lock:
                             buffer_msgs = self._message_buffer.get(thread_id, [])
                             all_messages.extend(buffer_msgs)
-                        queue_has_eod = any(m == EOD_CHUNK for m in all_messages[:queue_count])
-                        buffer_has_eod = any(m == EOD_CHUNK for m in buffer_msgs)
-                        logger.info(
-                            "[EOD-REPLAY] thread_id=%s offset=%d queue_count=%d queue_has_eod=%s buffer_count=%d buffer_has_eod=%s",
-                            thread_id, offset, queue_count, queue_has_eod, len(buffer_msgs), buffer_has_eod,
-                        )
 
                 next_offset = len(all_messages)
                 if next_offset > offset:

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1,4 +1,5 @@
 import contextlib
+import hashlib
 import json
 import pickle
 import queue
@@ -18,12 +19,28 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import QueueNamePrefixes
+from .constants import EOD_CHUNK, HEARTBEAT_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
 
 env = Env()
+
+
+def _msg_signature(msg: Any) -> str:
+    """为单条队列消息生成稳定指纹，用于 peek 跨轮对比定位丢失消息。
+
+    心跳/EOD 用固定标记；其余消息用 pickle 字节长度 + md5 前 8 位，避免打印完整内容。
+    """
+    if msg == HEARTBEAT_CHUNK:
+        return "HB"
+    if msg == EOD_CHUNK:
+        return "EOD"
+    try:
+        blob = pickle.dumps(msg)
+        return f"c{len(blob)}:{hashlib.md5(blob).hexdigest()[:8]}"
+    except Exception as e:
+        return f"c?:{repr(msg)[:40]}:{e}"
 
 
 class RabbitMQConnectionPool:
@@ -621,20 +638,46 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 return False
 
     def release_producer(self, thread_id: str) -> None:
-        """释放会话级生产者写入权。"""
+        """释放会话级生产者写入权。
+        """
         lock_queue = self._get_producer_lock_queue_name(thread_id)
         with self._producer_lock_guard:
             connection = self._producer_lock_connections.pop(thread_id, None)
 
         if not connection:
+            logger.info(
+                "[RabbitMQ] producer lock release skipped (no connection) thread_id=%s queue=%s",
+                thread_id,
+                lock_queue,
+            )
             return
 
+        logger.info(
+            "[RabbitMQ] release_producer enter thread_id=%s queue=%s connection_is_open=%s",
+            thread_id,
+            lock_queue,
+            getattr(connection, "is_open", None),
+        )
         channel = None
+        connection_already_closed = False
         try:
             if getattr(connection, "is_open", False):
-                channel = connection.channel()
-                with contextlib.suppress(Exception):
-                    channel.queue_delete(queue=lock_queue)
+                try:
+                    channel = connection.channel()
+                    with contextlib.suppress(Exception):
+                        channel.queue_delete(queue=lock_queue)
+                except Exception as e:
+                    # 连接已被对端重置/关闭：exclusive queue 随连接断开自动删除，
+                    # 无需再 queue_delete，降级走连接清理路径，不让异常冒泡
+                    connection_already_closed = True
+                    channel = None
+                    logger.warning(
+                        "[RabbitMQ] producer lock connection already closed, skip queue_delete "
+                        "thread_id=%s queue=%s error=%s",
+                        thread_id,
+                        lock_queue,
+                        e,
+                    )
         finally:
             if channel and getattr(channel, "is_open", False):
                 with contextlib.suppress(Exception):
@@ -642,7 +685,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if getattr(connection, "is_open", False):
                 with contextlib.suppress(Exception):
                     connection.close()
-            logger.info("[RabbitMQ] producer lock released thread_id=%s queue=%s", thread_id, lock_queue)
+            logger.info(
+                "[RabbitMQ] producer lock released thread_id=%s queue=%s connection_already_closed=%s",
+                thread_id,
+                lock_queue,
+                connection_already_closed,
+            )
 
     def _ensure_active_consumer_queue(self, channel: Any, thread_id: str) -> str:
         queue_name = self._get_active_consumer_queue_name(thread_id)
@@ -867,6 +915,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
                     logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
+                    flush_has_eod = any(m == EOD_CHUNK for m in messages)
+                    logger.info(
+                        "[EOD] flush thread_id=%s published=%d has_eod=%s (background)",
+                        thread_id, len(messages), flush_has_eod,
+                    )
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1034,6 +1087,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                    # 诊断：记录 flush 数量与是否含 EOD，定位 EOD 是否真正入队
+                    flush_has_eod = any(m == EOD_CHUNK for m in messages_to_flush)
+                    logger.info(
+                        "[EOD] flush thread_id=%s published=%d has_eod=%s",
+                        thread_id, len(messages_to_flush), flush_has_eod,
+                    )
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1093,9 +1152,17 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。"""
+        """非破坏性读取队列中的全部消息。
+
+        诊断：basic_get + basic_nack(requeue=True) 在大队列上反复执行不可靠，
+        nack requeue 会破坏 FIFO 且可能丢消息。此处记录 message_count、实际 get 数、
+        是否含 EOD、nack 异常，用于定位 starved 时消息（含 EOD）丢失环节。
+        """
         messages = []
         delivery_tags = []
+        message_count = 0
+        peek_eod = False
+        nack_error = None
 
         try:
             queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
@@ -1105,10 +1172,30 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if not method_frame:
                     break
                 delivery_tags.append(method_frame.delivery_tag)
-                messages.append(pickle.loads(body))
+                msg = pickle.loads(body)
+                messages.append(msg)
+                if not peek_eod and msg == EOD_CHUNK:
+                    peek_eod = True
         finally:
             for tag in delivery_tags:
-                channel.basic_nack(delivery_tag=tag, requeue=True)
+                try:
+                    channel.basic_nack(delivery_tag=tag, requeue=True)
+                except Exception as e:
+                    nack_error = e
+            # 诊断：message_count 与实际 get 数不一致 / nack 失败 / EOD 状态
+            if message_count != len(messages) or nack_error is not None or peek_eod:
+                logger.warning(
+                    "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
+                    queue_name, message_count, len(messages), nack_error, peek_eod,
+                )
+            # 诊断：每轮 peek 打印队列全部消息指纹，跨轮对比定位丢失消息（含 EOD）
+            sigs = [_msg_signature(m) for m in messages]
+            hb_count = sigs.count("HB")
+            logger.warning(
+                "[PEEK-TRACE] queue=%s declared=%d got=%d hb=%d eod=%s nack_error=%s",
+                queue_name, message_count, len(messages), hb_count, peek_eod, nack_error,
+            )
+            logger.warning("[PEEK-TRACE-SIGS] queue=%s sigs=%s", queue_name, " ".join(sigs))
 
         return messages
 

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1,5 +1,4 @@
 import contextlib
-import hashlib
 import json
 import pickle
 import queue
@@ -19,28 +18,12 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import EOD_CHUNK, HEARTBEAT_CHUNK, QueueNamePrefixes
+from .constants import EOD_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
 
 env = Env()
-
-
-def _msg_signature(msg: Any) -> str:
-    """为单条队列消息生成稳定指纹，用于 peek 跨轮对比定位丢失消息。
-
-    心跳/EOD 用固定标记；其余消息用 pickle 字节长度 + md5 前 8 位，避免打印完整内容。
-    """
-    if msg == HEARTBEAT_CHUNK:
-        return "HB"
-    if msg == EOD_CHUNK:
-        return "EOD"
-    try:
-        blob = pickle.dumps(msg)
-        return f"c{len(blob)}:{hashlib.md5(blob).hexdigest()[:8]}"
-    except Exception as e:
-        return f"c?:{repr(msg)[:40]}:{e}"
 
 
 class RabbitMQConnectionPool:
@@ -638,8 +621,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 return False
 
     def release_producer(self, thread_id: str) -> None:
-        """释放会话级生产者写入权。
-        """
+        """释放会话级生产者写入权。"""
         lock_queue = self._get_producer_lock_queue_name(thread_id)
         with self._producer_lock_guard:
             connection = self._producer_lock_connections.pop(thread_id, None)
@@ -915,11 +897,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
                     logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
-                    flush_has_eod = any(m == EOD_CHUNK for m in messages)
-                    logger.info(
-                        "[EOD] flush thread_id=%s published=%d has_eod=%s (background)",
-                        thread_id, len(messages), flush_has_eod,
-                    )
+                    if EOD_CHUNK in messages:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d (background)",
+                            thread_id,
+                            len(messages),
+                        )
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1087,12 +1070,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
-                    # 诊断：记录 flush 数量与是否含 EOD，定位 EOD 是否真正入队
-                    flush_has_eod = any(m == EOD_CHUNK for m in messages_to_flush)
-                    logger.info(
-                        "[EOD] flush thread_id=%s published=%d has_eod=%s",
-                        thread_id, len(messages_to_flush), flush_has_eod,
-                    )
+                    if EOD_CHUNK in messages_to_flush:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d",
+                            thread_id,
+                            len(messages_to_flush),
+                        )
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1152,16 +1135,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。
-
-        诊断：basic_get + basic_nack(requeue=True) 在大队列上反复执行不可靠，
-        nack requeue 会破坏 FIFO 且可能丢消息。此处记录 message_count、实际 get 数、
-        是否含 EOD、nack 异常，用于定位 starved 时消息（含 EOD）丢失环节。
-        """
+        """非破坏性读取队列中的全部消息，仅在读取或 requeue 异常时记录诊断。"""
         messages = []
         delivery_tags = []
         message_count = 0
-        peek_eod = False
         nack_error = None
 
         try:
@@ -1174,28 +1151,21 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 delivery_tags.append(method_frame.delivery_tag)
                 msg = pickle.loads(body)
                 messages.append(msg)
-                if not peek_eod and msg == EOD_CHUNK:
-                    peek_eod = True
         finally:
             for tag in delivery_tags:
                 try:
                     channel.basic_nack(delivery_tag=tag, requeue=True)
                 except Exception as e:
                     nack_error = e
-            # 诊断：message_count 与实际 get 数不一致 / nack 失败 / EOD 状态
-            if message_count != len(messages) or nack_error is not None or peek_eod:
+            if message_count != len(messages) or nack_error is not None:
                 logger.warning(
                     "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
-                    queue_name, message_count, len(messages), nack_error, peek_eod,
+                    queue_name,
+                    message_count,
+                    len(messages),
+                    nack_error,
+                    EOD_CHUNK in messages,
                 )
-            # 诊断：每轮 peek 打印队列全部消息指纹，跨轮对比定位丢失消息（含 EOD）
-            sigs = [_msg_signature(m) for m in messages]
-            hb_count = sigs.count("HB")
-            logger.warning(
-                "[PEEK-TRACE] queue=%s declared=%d got=%d hb=%d eod=%s nack_error=%s",
-                queue_name, message_count, len(messages), hb_count, peek_eod, nack_error,
-            )
-            logger.warning("[PEEK-TRACE-SIGS] queue=%s sigs=%s", queue_name, " ".join(sigs))
 
         return messages
 

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -302,8 +302,9 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     REPLAY_LOCK_PREFIX: ClassVar[str] = "aidev_agent.replay_lock."
     ACTIVE_CONSUMER_PREFIX: ClassVar[str] = "aidev_agent.consumer_active."
     QUEUE_TTL_MS: ClassVar[int] = QueueTTLConfig.QUEUE_EXPIRE_MS
+    BUFFER_FLUSH_INTERVAL: ClassVar[float] = 0.5
     REPLAY_LOCK_RETRY_INTERVAL: ClassVar[float] = 0.05
-    REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.1
+    REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.5
 
     _instance: Optional["RabbitMQMessageHandler"] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
@@ -842,11 +843,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             logger.info("RabbitMQ daemon thread stopped")
 
     def _daemon_worker(self) -> None:
-        """后台守护线程工作函数：每隔 0.1 秒批量推送消息到 RabbitMQ"""
+        """后台守护线程工作函数：每隔 0.5 秒批量推送消息到 RabbitMQ"""
         while self._daemon_running:
             try:
-                # 等待 0.1 秒或直到停止事件触发
-                if self._daemon_stop_event.wait(timeout=0.1):
+                # 等待批量刷新周期或直到停止事件触发
+                if self._daemon_stop_event.wait(timeout=self.BUFFER_FLUSH_INTERVAL):
                     break
 
                 # 批量推送消息

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -429,9 +429,10 @@ class GeneratorStreamingHelper:
         cancel_event: threading.Event,
         has_pending: bool,
         on_complete: Callable[[], None] | None = None,
-    ) -> tuple[threading.Thread | None, bool, bool]:
+    ) -> tuple[threading.Thread | None, bool, bool, threading.Event | None]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
         producer_thread: threading.Thread | None = None
+        producer_succeeded_event: threading.Event | None = None
         is_resuming = False
         enable_heartbeat_check = False
         supports_replay_from_start = self._supports_replay_from_start()
@@ -442,7 +443,7 @@ class GeneratorStreamingHelper:
                     "Producer already active for thread_id=%s, consuming existing replay stream",
                     self.thread_id,
                 )
-                return producer_thread, True, True
+                return producer_thread, True, True, producer_succeeded_event
 
             try:
                 self.message_handler.clear(self.thread_id)
@@ -451,15 +452,16 @@ class GeneratorStreamingHelper:
                 self.message_handler.release_producer(self.thread_id)
                 raise
 
+            producer_succeeded_event = threading.Event()
             producer_thread = threading.Thread(
                 target=self._producer,
-                args=(generator, cancel_event, on_complete, True),
+                args=(generator, cancel_event, on_complete, True, producer_succeeded_event),
                 daemon=True,
             )
             producer_thread.start()
             logger.info(f"Started producer for thread_id={self.thread_id}")
             enable_heartbeat_check = True
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
         if supports_replay_from_start:
             is_resuming = True
@@ -467,7 +469,7 @@ class GeneratorStreamingHelper:
                 "Pending messages exist for thread_id=%s, replaying cached stream from start",
                 self.thread_id,
             )
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
         self.message_handler.wait_for_previous_consumer(self.thread_id, timeout=3.0)
         restored = self.message_handler.restore_messages(self.thread_id)
@@ -476,7 +478,7 @@ class GeneratorStreamingHelper:
             f"Pending messages exist for thread_id={self.thread_id}, "
             f"restored {restored} messages from DLQ, consuming from start"
         )
-        return producer_thread, is_resuming, enable_heartbeat_check
+        return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
     # ---- L1 观测：consumer 循环内联耗时 WARNING 阈值（秒），仅日志用途 ----
     _CHECK_CONSUMER_SLOW_SEC = 2.0
@@ -494,6 +496,7 @@ class GeneratorStreamingHelper:
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
         producer_thread: threading.Thread | None = None,
+        producer_succeeded_event: threading.Event | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -658,10 +661,12 @@ class GeneratorStreamingHelper:
                     time_since_last = time.time() - last_message_time
                     if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
                         # 兜底：nack(requeue=True) 在大队列上反复 peek 会静默丢消息（含 EOD），
-                        # consumer 收不到 EOD 而误判 starved。此时若 producer 线程已结束，
-                        # 说明流确实结束（EOD 已发送），按正常完成处理，避免误报。
+                        # consumer 收不到 EOD 而误判 starved。仅当 producer 线程已结束且
+                        # 明确记录 EOD flush 成功时，才按正常完成处理，避免掩盖 producer
+                        # 异常或消息投递失败。
                         producer_finished = producer_thread is not None and not producer_thread.is_alive()
-                        if producer_finished:
+                        producer_succeeded = producer_succeeded_event is not None and producer_succeeded_event.is_set()
+                        if producer_finished and producer_succeeded:
                             logger.info(
                                 "[EOD] starved 兜底：producer 已结束，按正常完成处理 thread_id=%s",
                                 self.thread_id,
@@ -689,7 +694,8 @@ class GeneratorStreamingHelper:
                         logger.error(
                             f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "
                             f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
-                            f"replay_offset={replay_offset} producer_finished={producer_finished}"
+                            f"replay_offset={replay_offset} producer_finished={producer_finished} "
+                            f"producer_succeeded={producer_succeeded}"
                         )
                         exit_reason = "starved"
                         raise RuntimeError(
@@ -768,6 +774,7 @@ class GeneratorStreamingHelper:
         # 注册为当前活跃消费者
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
+        producer_succeeded_event: threading.Event | None = None
         consumer_exit_reason: str | None = None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
@@ -778,11 +785,13 @@ class GeneratorStreamingHelper:
                 return
 
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
-            producer_thread, is_resuming, enable_heartbeat_check = self._start_or_resume_stream(
-                generator=generator,
-                cancel_event=cancel_event,
-                has_pending=has_pending,
-                on_complete=on_complete,
+            producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event = (
+                self._start_or_resume_stream(
+                    generator=generator,
+                    cancel_event=cancel_event,
+                    has_pending=has_pending,
+                    on_complete=on_complete,
+                )
             )
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
@@ -791,6 +800,7 @@ class GeneratorStreamingHelper:
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
                 producer_thread=producer_thread,
+                producer_succeeded_event=producer_succeeded_event,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -886,6 +896,7 @@ class GeneratorStreamingHelper:
         cancel_event: threading.Event | None = None,
         on_complete: Callable[[], None] | None = None,
         release_producer: bool = False,
+        producer_succeeded_event: threading.Event | None = None,
     ) -> None:
         """生产者线程：将生成器产生的消息推送到队列
 
@@ -896,10 +907,7 @@ class GeneratorStreamingHelper:
         并 yield RUN_FINISHED 事件，确保前端能收到完整的结束信号。
         """
         _producer_start = time.monotonic()
-        logger.info(
-            f"[PRODUCER] start thread_id={self.thread_id} "
-            f"thread={threading.current_thread().name}"
-        )
+        logger.info(f"[PRODUCER] start thread_id={self.thread_id} thread={threading.current_thread().name}")
         heartbeat_stop_event = threading.Event()
         heartbeat_thread: threading.Thread | None = None
         # 跨进程取消检查计数器（每 N 个 chunk 检查一次，避免频繁访问 RabbitMQ）
@@ -1009,9 +1017,13 @@ class GeneratorStreamingHelper:
                     logger.exception(f"on_complete callback error in producer: {e}")
 
             # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束
-            logger.info(f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})")
+            logger.info(
+                f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
+            )
             self.message_handler.put(self.thread_id, EOD_CHUNK)
             self.message_handler.flush(self.thread_id)
+            if not producer_error and producer_succeeded_event is not None:
+                producer_succeeded_event.set()
             logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
             # 延迟清理：如果消费者已断开且未重连，主动释放队列资源

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -4,7 +4,7 @@ import uuid
 from logging import getLogger
 from typing import Any, Callable, Generator
 
-from ag_ui.core import EventType, RunErrorEvent
+from ag_ui.core import EventType, RawEvent, RunErrorEvent
 from ag_ui.encoder import EventEncoder
 
 from aidev_agent.utils.event import RunId, emit_run_finished_event
@@ -21,6 +21,10 @@ from .constants import (
 from .factory import message_handler_factory
 
 logger = getLogger(__name__)
+
+_SSE_HEARTBEAT_EVENT = EventEncoder().encode(
+    RawEvent(type=EventType.RAW, event={"type": "heartbeat"}),
+)
 
 # 断点续传时需要过滤的事件类型
 # flow_agent_start 事件在续聊时不应该重复发送，避免前端重新渲染
@@ -597,6 +601,8 @@ class GeneratorStreamingHelper:
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
                             logger.debug(f"Received heartbeat for thread_id={self.thread_id}")
+                            yield _SSE_HEARTBEAT_EVENT
+                            yielded_total += 1
                             continue
                         if item == EOD_CHUNK:
                             logger.info(f"[EOD] Consumer received EOD_CHUNK for thread_id={self.thread_id}")

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -493,6 +493,7 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        producer_thread: threading.Thread | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -595,6 +596,7 @@ class GeneratorStreamingHelper:
                             logger.debug(f"Received heartbeat for thread_id={self.thread_id}")
                             continue
                         if item == EOD_CHUNK:
+                            logger.info(f"[EOD] Consumer received EOD_CHUNK for thread_id={self.thread_id}")
                             should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
                             if on_complete and not supports_replay_from_start:
                                 try:
@@ -653,8 +655,42 @@ class GeneratorStreamingHelper:
                     exit_reason = "preempted"
                     raise
                 except TimeoutError:
-                    if enable_heartbeat_check and (time.time() - last_message_time > HEARTBEAT_TIMEOUT):
-                        logger.error(f"心跳超时 thread_id={self.thread_id}，超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息")
+                    time_since_last = time.time() - last_message_time
+                    if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
+                        # 兜底：nack(requeue=True) 在大队列上反复 peek 会静默丢消息（含 EOD），
+                        # consumer 收不到 EOD 而误判 starved。此时若 producer 线程已结束，
+                        # 说明流确实结束（EOD 已发送），按正常完成处理，避免误报。
+                        producer_finished = producer_thread is not None and not producer_thread.is_alive()
+                        if producer_finished:
+                            logger.info(
+                                "[EOD] starved 兜底：producer 已结束，按正常完成处理 thread_id=%s",
+                                self.thread_id,
+                            )
+                            should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
+                            if on_complete and not supports_replay_from_start:
+                                try:
+                                    on_complete()
+                                except Exception as e:
+                                    logger.exception(f"on_complete callback error (starved fallback): {e}")
+                            if not supports_replay_from_start and not self.defer_cleanup_on_complete:
+                                self.message_handler.mark_completed(self.thread_id)
+                                logger.info(f"Stream completed (starved fallback) for thread_id={self.thread_id}")
+                            elif self.defer_cleanup_on_complete:
+                                logger.info(
+                                    f"Stream completed (starved fallback, background drain) "
+                                    f"for thread_id={self.thread_id}"
+                                )
+                            else:
+                                logger.info(f"Stream completed (starved fallback) for thread_id={self.thread_id}")
+                            if should_notify_cancelled:
+                                self._notify_consumer_cancelled_safely()
+                            exit_reason = "completed"
+                            return exit_reason
+                        logger.error(
+                            f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "
+                            f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
+                            f"replay_offset={replay_offset} producer_finished={producer_finished}"
+                        )
                         exit_reason = "starved"
                         raise RuntimeError(
                             f"生产者心跳超时：超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息，生产者可能已崩溃"
@@ -754,6 +790,7 @@ class GeneratorStreamingHelper:
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
+                producer_thread=producer_thread,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -858,6 +895,11 @@ class GeneratorStreamingHelper:
         而是继续 drain generator 一段时间，等待 Agent 内部的 cancel_checker 触发
         并 yield RUN_FINISHED 事件，确保前端能收到完整的结束信号。
         """
+        _producer_start = time.monotonic()
+        logger.info(
+            f"[PRODUCER] start thread_id={self.thread_id} "
+            f"thread={threading.current_thread().name}"
+        )
         heartbeat_stop_event = threading.Event()
         heartbeat_thread: threading.Thread | None = None
         # 跨进程取消检查计数器（每 N 个 chunk 检查一次，避免频繁访问 RabbitMQ）
@@ -947,6 +989,12 @@ class GeneratorStreamingHelper:
             except Exception as encode_err:
                 logger.exception(f"Failed to encode/send error event for thread_id={self.thread_id}: {encode_err}")
         finally:
+            logger.info(
+                f"[PRODUCER] finally enter thread_id={self.thread_id} "
+                f"producer_error={producer_error} done_event_seen={done_event_seen} "
+                f"draining={draining} "
+                f"elapsed={time.monotonic() - _producer_start:.1f}s"
+            )
             heartbeat_stop_event.set()
             if heartbeat_thread is not None:
                 try:
@@ -961,12 +1009,22 @@ class GeneratorStreamingHelper:
                     logger.exception(f"on_complete callback error in producer: {e}")
 
             # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束
+            logger.info(f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})")
             self.message_handler.put(self.thread_id, EOD_CHUNK)
             self.message_handler.flush(self.thread_id)
-            logger.debug(f"Producer finished, sent EOD_CHUNK for thread_id={self.thread_id}")
+            logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
             # 延迟清理：如果消费者已断开且未重连，主动释放队列资源
             # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争
             self._schedule_session_cleanup(done_event_seen=done_event_seen)
             if release_producer:
-                self.message_handler.release_producer(self.thread_id)
+                logger.info(
+                    f"[PRODUCER] releasing producer lock thread_id={self.thread_id} "
+                    f"elapsed={time.monotonic() - _producer_start:.1f}s"
+                )
+                # 兜底：release_producer 内部已对连接断开做容错，这里再加一层
+                # try 防止任何遗漏的异常冒泡导致 _producer 线程异常退出
+                try:
+                    self.message_handler.release_producer(self.thread_id)
+                except Exception as e:
+                    logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -74,6 +74,7 @@ class GeneratorStreamingHelper:
     # 通过 restore_messages 接管已生产的完整内容；窗口内若有消费者接管则跳过清理。
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
+    _HEARTBEAT_TIMEOUT_GRACE = 5.0
 
     @staticmethod
     def _should_filter_on_resume(item: Any) -> bool:
@@ -433,10 +434,10 @@ class GeneratorStreamingHelper:
         cancel_event: threading.Event,
         has_pending: bool,
         on_complete: Callable[[], None] | None = None,
-    ) -> tuple[threading.Thread | None, bool, bool, threading.Event | None]:
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> tuple[threading.Thread | None, bool, bool]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
         producer_thread: threading.Thread | None = None
-        producer_succeeded_event: threading.Event | None = None
         is_resuming = False
         enable_heartbeat_check = False
         supports_replay_from_start = self._supports_replay_from_start()
@@ -447,7 +448,7 @@ class GeneratorStreamingHelper:
                     "Producer already active for thread_id=%s, consuming existing replay stream",
                     self.thread_id,
                 )
-                return producer_thread, True, True, producer_succeeded_event
+                return producer_thread, True, True
 
             try:
                 self.message_handler.clear(self.thread_id)
@@ -456,16 +457,21 @@ class GeneratorStreamingHelper:
                 self.message_handler.release_producer(self.thread_id)
                 raise
 
-            producer_succeeded_event = threading.Event()
             producer_thread = threading.Thread(
                 target=self._producer,
-                args=(generator, cancel_event, on_complete, True, producer_succeeded_event),
+                kwargs={
+                    "generator": generator,
+                    "cancel_event": cancel_event,
+                    "on_complete": on_complete,
+                    "event_handler": event_handler,
+                    "release_producer": True,
+                },
                 daemon=True,
             )
             producer_thread.start()
             logger.info(f"Started producer for thread_id={self.thread_id}")
             enable_heartbeat_check = True
-            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
+            return producer_thread, is_resuming, enable_heartbeat_check
 
         if supports_replay_from_start:
             is_resuming = True
@@ -473,7 +479,7 @@ class GeneratorStreamingHelper:
                 "Pending messages exist for thread_id=%s, replaying cached stream from start",
                 self.thread_id,
             )
-            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
+            return producer_thread, is_resuming, enable_heartbeat_check
 
         self.message_handler.wait_for_previous_consumer(self.thread_id, timeout=3.0)
         restored = self.message_handler.restore_messages(self.thread_id)
@@ -482,7 +488,7 @@ class GeneratorStreamingHelper:
             f"Pending messages exist for thread_id={self.thread_id}, "
             f"restored {restored} messages from DLQ, consuming from start"
         )
-        return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
+        return producer_thread, is_resuming, enable_heartbeat_check
 
     # ---- L1 观测：consumer 循环内联耗时 WARNING 阈值（秒），仅日志用途 ----
     _CHECK_CONSUMER_SLOW_SEC = 2.0
@@ -492,6 +498,25 @@ class GeneratorStreamingHelper:
     _CONSUMER_PROGRESS_EVERY_N = 50
     _CONSUMER_PROGRESS_EVERY_SECONDS = 10.0
 
+    def _emit_terminal_error_events(
+        self,
+        message: str,
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> Generator[str, None, None]:
+        """输出 AG-UI 错误与结束事件，并同步通知会话事件处理器。"""
+        error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=message)
+        if event_handler is not None:
+            try:
+                event_handler(error_event)
+            except Exception:
+                logger.exception("Error dispatching RUN_ERROR for thread_id=%s", self.thread_id)
+        yield EventEncoder().encode(error_event)
+        yield emit_run_finished_event(
+            thread_id=self.thread_id,
+            run_id="error",
+            event_handler=event_handler,
+        )
+
     def _consume_stream_messages(
         self,
         consumer_id: str,
@@ -500,7 +525,7 @@ class GeneratorStreamingHelper:
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
         producer_thread: threading.Thread | None = None,
-        producer_succeeded_event: threading.Event | None = None,
+        event_handler: Callable[[Any], None] | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -521,6 +546,7 @@ class GeneratorStreamingHelper:
         last_progress_ts = time.time()
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        heartbeat_grace_deadline: float | None = None
 
         logger.info(
             "[RabbitMQ] consumer loop enter thread_id=%s consumer_id=%s is_resuming=%s heartbeat_check=%s",
@@ -597,6 +623,7 @@ class GeneratorStreamingHelper:
 
                     if messages:
                         last_message_time = time.time()
+                        heartbeat_grace_deadline = None
 
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
@@ -666,47 +693,34 @@ class GeneratorStreamingHelper:
                 except TimeoutError:
                     time_since_last = time.time() - last_message_time
                     if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
-                        # 兜底：nack(requeue=True) 在大队列上反复 peek 会静默丢消息（含 EOD），
-                        # consumer 收不到 EOD 而误判 starved。仅当 producer 线程已结束且
-                        # 明确记录 EOD flush 成功时，才按正常完成处理，避免掩盖 producer
-                        # 异常或消息投递失败。
                         producer_finished = producer_thread is not None and not producer_thread.is_alive()
-                        producer_succeeded = producer_succeeded_event is not None and producer_succeeded_event.is_set()
-                        if producer_finished and producer_succeeded:
-                            logger.info(
-                                "[EOD] starved 兜底：producer 已结束，按正常完成处理 thread_id=%s",
+
+                        # producer 仍可能存活时仅给予一次短暂宽限，不重新启动 Agent，
+                        # 也不刷新业务执行超时。producer 已结束却未收到 EOD 时按链路异常处理。
+                        if not producer_finished and heartbeat_grace_deadline is None:
+                            heartbeat_grace_deadline = time.monotonic() + self._HEARTBEAT_TIMEOUT_GRACE
+                            logger.warning(
+                                "[RabbitMQ] producer heartbeat grace started thread_id=%s grace=%.1fs replay_offset=%d",
                                 self.thread_id,
+                                self._HEARTBEAT_TIMEOUT_GRACE,
+                                replay_offset,
                             )
-                            should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
-                            if on_complete and not supports_replay_from_start:
-                                try:
-                                    on_complete()
-                                except Exception as e:
-                                    logger.exception(f"on_complete callback error (starved fallback): {e}")
-                            if not supports_replay_from_start and not self.defer_cleanup_on_complete:
-                                self.message_handler.mark_completed(self.thread_id)
-                                logger.info(f"Stream completed (starved fallback) for thread_id={self.thread_id}")
-                            elif self.defer_cleanup_on_complete:
-                                logger.info(
-                                    f"Stream completed (starved fallback, background drain) "
-                                    f"for thread_id={self.thread_id}"
-                                )
-                            else:
-                                logger.info(f"Stream completed (starved fallback) for thread_id={self.thread_id}")
-                            if should_notify_cancelled:
-                                self._notify_consumer_cancelled_safely()
-                            exit_reason = "completed"
-                            return exit_reason
+                            continue
+                        if heartbeat_grace_deadline is not None and time.monotonic() < heartbeat_grace_deadline:
+                            continue
+
                         logger.error(
                             f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "
                             f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
-                            f"replay_offset={replay_offset} producer_finished={producer_finished} "
-                            f"producer_succeeded={producer_succeeded}"
+                            f"replay_offset={replay_offset} producer_finished={producer_finished}"
                         )
-                        exit_reason = "starved"
-                        raise RuntimeError(
-                            f"生产者心跳超时：超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息，生产者可能已崩溃"
+                        yield from self._emit_terminal_error_events(
+                            "Agent 执行中断：生产者心跳超时，请稍后重试",
+                            event_handler=event_handler,
                         )
+                        yielded_total += 2
+                        exit_reason = "heartbeat_timeout"
+                        return exit_reason
                     continue
                 except Exception as exc:
                     # L-5：避免 unexpected 异常被上层 _wrap_streaming_with_status 吞成沉默
@@ -752,6 +766,7 @@ class GeneratorStreamingHelper:
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -762,12 +777,11 @@ class GeneratorStreamingHelper:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+            event_handler: AG-UI 事件处理器，用于同步记录受控错误和结束状态。
 
         Yields:
             生成器产生的数据
 
-        Raises:
-            RuntimeError: 当心跳超时时抛出，表示生产者可能已异常结束
         """
         # 注册取消事件（让 cancel() 可以通知生产者和消费者停止）
         cancel_event = self._register_cancel_event()
@@ -780,7 +794,6 @@ class GeneratorStreamingHelper:
         # 注册为当前活跃消费者
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
-        producer_succeeded_event: threading.Event | None = None
         consumer_exit_reason: str | None = None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
@@ -791,13 +804,12 @@ class GeneratorStreamingHelper:
                 return
 
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
-            producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event = (
-                self._start_or_resume_stream(
-                    generator=generator,
-                    cancel_event=cancel_event,
-                    has_pending=has_pending,
-                    on_complete=on_complete,
-                )
+            producer_thread, is_resuming, enable_heartbeat_check = self._start_or_resume_stream(
+                generator=generator,
+                cancel_event=cancel_event,
+                has_pending=has_pending,
+                on_complete=on_complete,
+                event_handler=event_handler,
             )
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
@@ -806,7 +818,7 @@ class GeneratorStreamingHelper:
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
                 producer_thread=producer_thread,
-                producer_succeeded_event=producer_succeeded_event,
+                event_handler=event_handler,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -901,8 +913,8 @@ class GeneratorStreamingHelper:
         generator: Generator[Any, None, None],
         cancel_event: threading.Event | None = None,
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
         release_producer: bool = False,
-        producer_succeeded_event: threading.Event | None = None,
     ) -> None:
         """生产者线程：将生成器产生的消息推送到队列
 
@@ -995,13 +1007,14 @@ class GeneratorStreamingHelper:
         except Exception as e:
             producer_error = True
             logger.exception(f"Producer error for thread_id={self.thread_id}: {e}")
-            # 将错误信息作为 SSE error event 推送到队列，让消费者能感知并传播给前端
             try:
-                encoder = EventEncoder()
-                error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=f"Producer error: {e}")
-                self.message_handler.put(self.thread_id, encoder.encode(error_event))
+                for event in self._emit_terminal_error_events(
+                    "Agent 执行异常，请稍后重试",
+                    event_handler=event_handler,
+                ):
+                    self.message_handler.put(self.thread_id, event)
             except Exception as encode_err:
-                logger.exception(f"Failed to encode/send error event for thread_id={self.thread_id}: {encode_err}")
+                logger.exception(f"Failed to send terminal error events for thread_id={self.thread_id}: {encode_err}")
         finally:
             logger.info(
                 f"[PRODUCER] finally enter thread_id={self.thread_id} "
@@ -1016,33 +1029,31 @@ class GeneratorStreamingHelper:
                 except Exception as e:
                     logger.exception(f"Error joining heartbeat thread for thread_id={self.thread_id}: {e}")
 
-            if on_complete and self._supports_replay_from_start() and not producer_error:
-                try:
-                    on_complete()
-                except Exception as e:
-                    logger.exception(f"on_complete callback error in producer: {e}")
-
-            # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束
-            logger.info(
-                f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
-            )
-            self.message_handler.put(self.thread_id, EOD_CHUNK)
-            self.message_handler.flush(self.thread_id)
-            if not producer_error and producer_succeeded_event is not None:
-                producer_succeeded_event.set()
-            logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
-
-            # 延迟清理：如果消费者已断开且未重连，主动释放队列资源
-            # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争
-            self._schedule_session_cleanup(done_event_seen=done_event_seen)
-            if release_producer:
+            try:
+                # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。
                 logger.info(
-                    f"[PRODUCER] releasing producer lock thread_id={self.thread_id} "
-                    f"elapsed={time.monotonic() - _producer_start:.1f}s"
+                    f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
                 )
-                # 兜底：release_producer 内部已对连接断开做容错，这里再加一层
-                # try 防止任何遗漏的异常冒泡导致 _producer 线程异常退出
-                try:
-                    self.message_handler.release_producer(self.thread_id)
-                except Exception as e:
-                    logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")
+                self.message_handler.put(self.thread_id, EOD_CHUNK)
+                self.message_handler.flush(self.thread_id)
+                logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
+
+                if on_complete and self._supports_replay_from_start() and not producer_error:
+                    try:
+                        on_complete()
+                    except Exception as e:
+                        logger.exception(f"on_complete callback error in producer: {e}")
+
+                # 延迟清理：如果消费者已断开且未重连，主动释放队列资源。
+                # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争。
+                self._schedule_session_cleanup(done_event_seen=done_event_seen)
+            finally:
+                if release_producer:
+                    logger.info(
+                        f"[PRODUCER] releasing producer lock thread_id={self.thread_id} "
+                        f"elapsed={time.monotonic() - _producer_start:.1f}s"
+                    )
+                    try:
+                        self.message_handler.release_producer(self.thread_id)
+                    except Exception as e:
+                        logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -75,6 +75,7 @@ class GeneratorStreamingHelper:
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
     _HEARTBEAT_TIMEOUT_GRACE = 5.0
+    _HEARTBEAT_TIMEOUT_MESSAGE = "Agent 执行中断：生产者心跳超时，请稍后重试"
 
     @staticmethod
     def _should_filter_on_resume(item: Any) -> bool:
@@ -517,6 +518,28 @@ class GeneratorStreamingHelper:
             event_handler=event_handler,
         )
 
+    def _emit_retryable_heartbeat_timeout(
+        self,
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> Generator[str, None, None]:
+        """先输出 RAW 提示，再中断 SSE 让前端按 network error 重连。"""
+        retry_event = RawEvent(
+            type=EventType.RAW,
+            event={
+                "type": "error",
+                "message": self._HEARTBEAT_TIMEOUT_MESSAGE,
+            },
+        )
+        if event_handler is not None:
+            try:
+                event_handler(retry_event)
+            except Exception:
+                logger.exception("Error dispatching retryable RAW event for thread_id=%s", self.thread_id)
+        yield EventEncoder().encode(retry_event)
+
+        # 后续增加独立重试事件后，前端无需再依赖 transport/network error。
+        raise RuntimeError(self._HEARTBEAT_TIMEOUT_MESSAGE)
+
     def _consume_stream_messages(
         self,
         consumer_id: str,
@@ -714,13 +737,9 @@ class GeneratorStreamingHelper:
                             f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
                             f"replay_offset={replay_offset} producer_finished={producer_finished}"
                         )
-                        yield from self._emit_terminal_error_events(
-                            "Agent 执行中断：生产者心跳超时，请稍后重试",
-                            event_handler=event_handler,
-                        )
-                        yielded_total += 2
+                        yielded_total += 1
                         exit_reason = "heartbeat_timeout"
-                        return exit_reason
+                        yield from self._emit_retryable_heartbeat_timeout(event_handler=event_handler)
                     continue
                 except Exception as exc:
                     # L-5：避免 unexpected 异常被上层 _wrap_streaming_with_status 吞成沉默

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,10 +10,13 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
+from logging import getLogger
 from typing import AsyncGenerator
 
 from aidev_agent.utils import Empty
 from aidev_agent.utils.loop import get_event_loop
+
+logger = getLogger(__name__)
 
 
 async def async_generator_with_timeout(
@@ -50,6 +53,7 @@ def async_to_sync_generator(async_gen):
             async for item in async_gen:
                 await data_queue.put(item)
         except Exception as e:
+            logger.warning(f"[ASYNC] consume_async error: {e}", exc_info=True)
             error = e
         finally:
             await data_queue.put(None)  # 结束信号

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,11 +10,14 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
+import queue
+import threading
+from contextlib import suppress
+from contextvars import copy_context
 from logging import getLogger
-from typing import AsyncGenerator
+from typing import AsyncGenerator, Awaitable, Callable
 
 from aidev_agent.utils import Empty
-from aidev_agent.utils.loop import get_event_loop
 
 logger = getLogger(__name__)
 
@@ -40,32 +43,68 @@ async def async_generator_with_timeout(
         return
 
 
-def async_to_sync_generator(async_gen):
-    data_queue = asyncio.Queue()
+def async_to_sync_generator(
+    async_gen: AsyncGenerator,
+    async_finalizer: Callable[[], Awaitable[None]] | None = None,
+):
+    """在独立 loop 中消费异步生成器，并在同一 loop 执行 finalizer。"""
+    data_queue = queue.Queue()
+    end = object()
     error = None
 
-    loop = get_event_loop()
+    loop = asyncio.new_event_loop()
+    context = copy_context()
+    task_ready = threading.Event()
+    consumer_task = None
 
-    # 定义异步消费任务
     async def consume_async():
         nonlocal error
         try:
             async for item in async_gen:
-                await data_queue.put(item)
+                data_queue.put(item)
         except Exception as e:
             logger.warning(f"[ASYNC] consume_async error: {e}", exc_info=True)
             error = e
         finally:
-            await data_queue.put(None)  # 结束信号
+            if async_finalizer is not None:
+                try:
+                    await async_finalizer()
+                except Exception as e:
+                    if error is None:
+                        error = e
+            data_queue.put(end)
 
-    # 线程运行函数（仅当需要新线程时启动）
-    # 提交异步任务到指定循环
-    asyncio.run_coroutine_threadsafe(consume_async(), loop)
+    def run_loop():
+        nonlocal consumer_task
+        asyncio.set_event_loop(loop)
+        consumer_task = context.run(loop.create_task, consume_async())
+        task_ready.set()
+        try:
+            loop.run_until_complete(consumer_task)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            pending_tasks = asyncio.all_tasks(loop)
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
+            with suppress(RuntimeError):
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
 
-    while True:
-        item = loop.run_until_complete(data_queue.get())
-        if item is None:
-            if error is not None:
-                raise error
-            break
-        yield item
+    loop_thread = threading.Thread(target=run_loop, name="aidev-async-generator", daemon=True)
+    loop_thread.start()
+    task_ready.wait()
+    try:
+        while True:
+            item = data_queue.get()
+            if item is end:
+                if error is not None:
+                    raise error
+                break
+            yield item
+    finally:
+        if not consumer_task.done():
+            loop.call_soon_threadsafe(consumer_task.cancel)
+        loop_thread.join()

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,8 +20,10 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from collections.abc import Awaitable, Callable
 from contextvars import copy_context
 from logging import getLogger
+from typing import Any
 
 logger = getLogger(__name__)
 
@@ -96,14 +98,16 @@ def close_thread_loop() -> None:
     _thread_local.loop = None
 
 
-def run_coro_sync(coro, timeout=None):
+def run_coro_sync(
+    coro_or_factory: Awaitable[Any] | Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
     """Run a coroutine synchronously in the current thread's event loop.
 
     若当前线程没有 running loop，复用线程局部 loop 跑（保持 loop 开启以便
     long-lived async client 复用连接）；若当前线程已有 running loop（嵌套调用
-    场景，如 async→sync 桥接、gevent monkey patch），不能 run_until_complete，
-    否则抛 "This event loop is already running"，此时在独立线程里用 asyncio.run
-    执行协程。
+    场景，如 async→sync 桥接、gevent monkey patch），仅接受协程工厂并在独立
+    线程创建、执行协程，避免把已关联当前 loop 的协程对象直接搬到新 loop。
 
     Note: 正常分支下 event loop 故意保持开启，long-lived async client（如
     httpx.AsyncClient）可跨多次调用复用连接；清理由 atexit 与
@@ -111,14 +115,17 @@ def run_coro_sync(coro, timeout=None):
     """
     loop = get_event_loop()
     if loop.is_running():
-        # 当前线程已有 running loop，run_until_complete 会抛 already running，
-        # 委托给独立线程跑一个全新的 loop
+        if not callable(coro_or_factory):
+            with contextlib.suppress(AttributeError):
+                coro_or_factory.close()
+            raise RuntimeError("run_coro_sync requires a coroutine factory when called from a running event loop")
         logger.warning(
             "[LOOP] run_coro_sync: running loop detected, delegate to new thread, thread=%s",
             threading.current_thread().name,
         )
-        return _run_coro_in_new_thread(coro, timeout)
+        return _run_coro_in_new_thread(coro_or_factory, timeout)
 
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
     if timeout is not None:
         coro = asyncio.wait_for(coro, timeout=timeout)
     try:
@@ -133,21 +140,27 @@ def run_coro_sync(coro, timeout=None):
         raise
 
 
-def _run_coro_in_new_thread(coro, timeout=None):
-    """在独立线程里用 asyncio.run 执行协程，返回结果或重新抛出异常。
+def _run_coro_in_new_thread(
+    coro_factory: Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
+    """在独立线程创建并执行协程，返回结果或重新抛出异常。
 
     用于 run_coro_sync 检测到当前线程已有 running loop 的兜底场景：
-    协程对象本身不绑定 loop，可安全跨线程传递，由新线程的全新 loop 消费。
+    工厂和协程都在新线程的 Context 与 event loop 内运行。
     """
     box: dict = {}
     context = copy_context()
 
+    async def _execute():
+        coro = coro_factory()
+        if timeout is not None:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        return await coro
+
     def _runner():
         try:
-            if timeout is not None:
-                box["value"] = context.run(asyncio.run, asyncio.wait_for(coro, timeout=timeout))
-            else:
-                box["value"] = context.run(asyncio.run, coro)
+            box["value"] = context.run(asyncio.run, _execute())
         except BaseException as err:  # noqa: BLE001
             box["error"] = err
 

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,6 +20,7 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from contextvars import copy_context
 from logging import getLogger
 
 logger = getLogger(__name__)
@@ -139,13 +140,14 @@ def _run_coro_in_new_thread(coro, timeout=None):
     协程对象本身不绑定 loop，可安全跨线程传递，由新线程的全新 loop 消费。
     """
     box: dict = {}
+    context = copy_context()
 
     def _runner():
         try:
             if timeout is not None:
-                box["value"] = asyncio.run(asyncio.wait_for(coro, timeout=timeout))
+                box["value"] = context.run(asyncio.run, asyncio.wait_for(coro, timeout=timeout))
             else:
-                box["value"] = asyncio.run(coro)
+                box["value"] = context.run(asyncio.run, coro)
         except BaseException as err:  # noqa: BLE001
             box["error"] = err
 

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,6 +20,9 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from logging import getLogger
+
+logger = getLogger(__name__)
 
 # Thread-local storage for event loops
 _thread_local = threading.local()
@@ -95,15 +98,63 @@ def close_thread_loop() -> None:
 def run_coro_sync(coro, timeout=None):
     """Run a coroutine synchronously in the current thread's event loop.
 
-    Note: The event loop is intentionally kept open after execution, so that
-    long-lived async clients (e.g. httpx.AsyncClient) can safely reuse their
-    connections across multiple calls on the same thread. Cleanup is handled by
-    atexit registration and by async_to_sync_generator's finally block.
+    若当前线程没有 running loop，复用线程局部 loop 跑（保持 loop 开启以便
+    long-lived async client 复用连接）；若当前线程已有 running loop（嵌套调用
+    场景，如 async→sync 桥接、gevent monkey patch），不能 run_until_complete，
+    否则抛 "This event loop is already running"，此时在独立线程里用 asyncio.run
+    执行协程。
+
+    Note: 正常分支下 event loop 故意保持开启，long-lived async client（如
+    httpx.AsyncClient）可跨多次调用复用连接；清理由 atexit 与
+    async_to_sync_generator 的 finally 块负责。
     """
     loop = get_event_loop()
+    if loop.is_running():
+        # 当前线程已有 running loop，run_until_complete 会抛 already running，
+        # 委托给独立线程跑一个全新的 loop
+        logger.warning(
+            "[LOOP] run_coro_sync: running loop detected, delegate to new thread, thread=%s",
+            threading.current_thread().name,
+        )
+        return _run_coro_in_new_thread(coro, timeout)
+
     if timeout is not None:
         coro = asyncio.wait_for(coro, timeout=timeout)
-    return loop.run_until_complete(coro)
+    try:
+        return loop.run_until_complete(coro)
+    except RuntimeError as e:
+        if "already running" in str(e):
+            logger.error(
+                "[LOOP] run_coro_sync failed: event loop already running. thread=%s, loop=%s",
+                threading.current_thread().name,
+                loop,
+            )
+        raise
+
+
+def _run_coro_in_new_thread(coro, timeout=None):
+    """在独立线程里用 asyncio.run 执行协程，返回结果或重新抛出异常。
+
+    用于 run_coro_sync 检测到当前线程已有 running loop 的兜底场景：
+    协程对象本身不绑定 loop，可安全跨线程传递，由新线程的全新 loop 消费。
+    """
+    box: dict = {}
+
+    def _runner():
+        try:
+            if timeout is not None:
+                box["value"] = asyncio.run(asyncio.wait_for(coro, timeout=timeout))
+            else:
+                box["value"] = asyncio.run(coro)
+        except BaseException as err:  # noqa: BLE001
+            box["error"] = err
+
+    worker = threading.Thread(target=_runner, name="run-coroutine-sync", daemon=True)
+    worker.start()
+    worker.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
 
 
 def _cleanup_thread_loop(loop):

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -16,9 +16,12 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import asyncio
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import openai
 import pytest
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
@@ -38,12 +41,46 @@ TEST_VISION_MODELS = ["qwen3-vl-32B"]
 
 # 测试图片路径
 TEST_IMAGE_PATH = Path(__file__).parent.parent.parent.parent / "mock_data" / "bkaidev.png"
+TEST_BASE_URL = "https://llm-gateway.example.com/v1"
 
 
 def get_test_image_base64() -> str:
     """读取测试图片并返回 base64 编码"""
     with open(TEST_IMAGE_PATH, "rb") as f:
         return base64.b64encode(f.read()).decode("utf-8")
+
+
+def test_chat_model_async_clients_are_isolated_across_worker_threads():
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        models = list(
+            pool.map(
+                lambda index: ChatModel.get_setup_instance(model=f"model-{index}", base_url=TEST_BASE_URL),
+                range(16),
+            )
+        )
+
+    try:
+        clients = [model.http_async_client for model in models]
+        assert len({id(client) for client in clients}) == len(clients)
+        assert all(model._owns_http_async_client for model in models)
+    finally:
+        for client in clients:
+            asyncio.run(client.aclose())
+
+
+def test_chat_model_preserves_caller_owned_async_http_client():
+    client = openai.DefaultAsyncHttpxClient()
+    model = ChatModel.get_setup_instance(
+        model="explicit-client",
+        base_url=TEST_BASE_URL,
+        http_async_client=client,
+    )
+
+    try:
+        assert model.http_async_client is client
+        assert model._owns_http_async_client is False
+    finally:
+        asyncio.run(client.aclose())
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import threading
 import time
@@ -2151,8 +2152,9 @@ class TestTerminalResumeReplay:
         agent_input = SimpleNamespace(thread_id="t1", run_id="r1")
         agent_e = MagicMock()
         state = _fake_graph_state(messages=[HumanMessage(content="hi", id="1")])
+        agent_e.aget_state = AsyncMock(return_value=state)
 
-        with patch(f"{_CHAT_MODULE}.run_coro_sync", return_value=state):
+        with patch(f"{_CHAT_MODULE}.run_coro_sync", side_effect=lambda factory: asyncio.run(factory())):
             agent._build_terminal_resume_replay(
                 agui_entry, agent_input, agent_e, {"configurable": {"thread_id": "session"}}
             )

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
@@ -461,14 +461,11 @@ class TestCommonAgentChatStreaming:
             # 验证错误消息被正确捕获
             # 当前实现：RUN_ERROR 后跟 RUN_FINISHED 作为结束信号
             error_events = [
-                c for c in result_content
-                if c.startswith("data: ") and json.loads(c[6:]).get("type") == "RUN_ERROR"
+                c for c in result_content if c.startswith("data: ") and json.loads(c[6:]).get("type") == "RUN_ERROR"
             ]
             assert len(error_events) >= 1
             error_payload = json.loads(error_events[0][6:])
-            assert error_payload["message"].startswith(
-                "模型调用异常: Authentication failed for model gptoss-999b"
-            )
+            assert error_payload["message"].startswith("模型调用异常: Authentication failed for model gptoss-999b")
             # 最后一条事件应为 RUN_FINISHED
             last_content = result_content[-1]
             assert last_content.startswith("data: ")
@@ -759,6 +756,48 @@ class TestOnComplete:
         )
         list(agent.execute(ExecuteKwargs(stream=True)))
         mock_handler.set_streaming_finished.assert_called_once()
+
+
+class TestChatModelClientCleanup:
+    @pytest.mark.asyncio
+    async def test_owned_client_is_closed_once(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model, chat_model_non_thinking=model)
+
+        with patch.object(client, "aclose", close_spy):
+            await agent._aclose_chat_models()
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+        assert model._owns_http_async_client is False
+
+    def test_non_streaming_execute_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="done", id="message-id")]})
+
+        with (
+            patch.object(agent, "_update_aidev_agent_header"),
+            patch.object(agent, "_get_agent", return_value=(agent_e, {})),
+            patch.object(agent, "_sync_checkpoint_messages"),
+            patch.object(client, "aclose", close_spy),
+        ):
+            result = agent._execute([HumanMessage(content="hello")], ExecuteKwargs(stream=False))
+
+        assert result["choices"][0]["delta"]["content"] == "done"
+        close_spy.assert_awaited_once()
+        assert client.is_closed
 
 
 @pytest.mark.skipif(
@@ -2174,9 +2213,7 @@ class TestTerminalResumeReplay:
             patch.object(agent, "_build_terminal_resume_replay") as mock_replay,
             patch(f"{_CHAT_MODULE}.async_to_sync_generator", return_value=iter(["X"])),
         ):
-            producer = agent._build_resume_aware_producer(
-                agui_entry, agent_input, agent_e=None, cfg=None, resume=False
-            )
+            producer = agent._build_resume_aware_producer(agui_entry, agent_input, agent_e=None, cfg=None, resume=False)
             out = list(producer)
 
         assert out == ["X"]
@@ -2193,9 +2230,7 @@ class TestTerminalResumeReplay:
             patch.object(agent, "_build_terminal_resume_replay") as mock_replay,
             patch(f"{_CHAT_MODULE}.async_to_sync_generator", return_value=iter(["X"])),
         ):
-            producer = agent._build_resume_aware_producer(
-                agui_entry, agent_input, agent_e=None, cfg=None, resume=True
-            )
+            producer = agent._build_resume_aware_producer(agui_entry, agent_input, agent_e=None, cfg=None, resume=True)
             out = list(producer)
 
         assert out == ["X"]

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -1,6 +1,7 @@
 """测试 InMemoryQueueMessageHandler 的基本功能"""
 
 import contextlib
+import json
 import threading
 import time
 
@@ -570,7 +571,7 @@ class TestInMemoryQueueMessageHandler:
         assert handler.is_empty(thread_id)
 
     def test_stream_keeps_alive_when_generator_blocked(self, handler, monkeypatch):
-        """generator 长时间无产出时，独立心跳应维持连接且不超时。"""
+        """generator 长时间无产出时，独立心跳应通过 RAW 事件维持 SSE 连接。"""
         thread_id = "test_stream_heartbeat_keepalive"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 0.05)
@@ -592,7 +593,15 @@ class TestInMemoryQueueMessageHandler:
             yield "late_chunk"
 
         result = list(helper.stream(slow_first_chunk()))
-        assert result == ["late_chunk"]
+        heartbeat_events = [
+            json.loads(chunk.removeprefix("data: "))
+            for chunk in result
+            if isinstance(chunk, str) and chunk.startswith("data: ") and '"type":"RAW"' in chunk
+        ]
+
+        assert result[-1] == "late_chunk"
+        assert heartbeat_events
+        assert all(event == {"type": "RAW", "event": {"type": "heartbeat"}} for event in heartbeat_events)
         assert heartbeat_count > 0
 
     def test_stream_raises_when_heartbeat_timeout(self, handler, monkeypatch):

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -609,8 +609,31 @@ class TestInMemoryQueueMessageHandler:
         with pytest.raises(RuntimeError, match="心跳超时"):
             list(helper.stream(slow_first_chunk()))
 
-    def test_stream_completes_when_producer_finished_without_eod(self, handler, monkeypatch):
-        """producer 已结束但消费者未收到 EOD 时，不应误报心跳超时。"""
+    def test_producer_marks_success_after_eod_flush(self, handler):
+        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_success")
+        producer_succeeded_event = threading.Event()
+
+        helper._producer(iter(["chunk"]), producer_succeeded_event=producer_succeeded_event)
+
+        assert producer_succeeded_event.is_set()
+
+    def test_producer_does_not_mark_success_when_eod_flush_fails(self, handler, monkeypatch):
+        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_flush_failure")
+        producer_succeeded_event = threading.Event()
+
+        def fail_flush(thread_id):
+            raise RuntimeError("flush failed")
+
+        monkeypatch.setattr(handler, "flush", fail_flush)
+
+        with pytest.raises(RuntimeError, match="flush failed"):
+            helper._producer(iter(["chunk"]), producer_succeeded_event=producer_succeeded_event)
+
+        assert not producer_succeeded_event.is_set()
+
+    @pytest.mark.parametrize("producer_succeeded", [True, False])
+    def test_stream_uses_producer_success_state_when_eod_missing(self, handler, monkeypatch, producer_succeeded):
+        """producer 结束后仅在 EOD flush 成功时按正常完成处理。"""
         thread_id = "test_stream_finished_without_eod"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         consumer_id = handler.acquire_consumer(thread_id)
@@ -622,23 +645,30 @@ class TestInMemoryQueueMessageHandler:
         producer_thread = threading.Thread(target=lambda: None)
         producer_thread.start()
         producer_thread.join()
+        producer_succeeded_event = threading.Event()
+        if producer_succeeded:
+            producer_succeeded_event.set()
 
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
         monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
         monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
 
-        result = list(
-            helper._consume_stream_messages(
-                consumer_id=consumer_id,
-                cancel_event=threading.Event(),
-                is_resuming=False,
-                enable_heartbeat_check=True,
-                producer_thread=producer_thread,
+        expectation = contextlib.nullcontext() if producer_succeeded else pytest.raises(RuntimeError, match="心跳超时")
+        with expectation:
+            result = list(
+                helper._consume_stream_messages(
+                    consumer_id=consumer_id,
+                    cancel_event=threading.Event(),
+                    is_resuming=False,
+                    enable_heartbeat_check=True,
+                    producer_thread=producer_thread,
+                    producer_succeeded_event=producer_succeeded_event,
+                )
             )
-        )
 
-        assert result == []
-        assert completed_threads == [thread_id]
+        assert completed_threads == ([thread_id] if producer_succeeded else [])
+        if producer_succeeded:
+            assert result == []
 
 
 class TestMessageHandlerConfig:

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -609,6 +609,37 @@ class TestInMemoryQueueMessageHandler:
         with pytest.raises(RuntimeError, match="心跳超时"):
             list(helper.stream(slow_first_chunk()))
 
+    def test_stream_completes_when_producer_finished_without_eod(self, handler, monkeypatch):
+        """producer 已结束但消费者未收到 EOD 时，不应误报心跳超时。"""
+        thread_id = "test_stream_finished_without_eod"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        consumer_id = handler.acquire_consumer(thread_id)
+        completed_threads = []
+
+        def timeout_without_messages(*, timeout, replay_offset):
+            raise TimeoutError
+
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
+        monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
+
+        result = list(
+            helper._consume_stream_messages(
+                consumer_id=consumer_id,
+                cancel_event=threading.Event(),
+                is_resuming=False,
+                enable_heartbeat_check=True,
+                producer_thread=producer_thread,
+            )
+        )
+
+        assert result == []
+        assert completed_threads == [thread_id]
+
 
 class TestMessageHandlerConfig:
     """测试 Config 解析 + 工厂 + RabbitMQ 降级"""

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -7,6 +7,7 @@ import time
 
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
+from ag_ui.core import EventType
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
     CANCELLED_CHUNK,
@@ -24,6 +25,10 @@ from aidev_agent.utils.event import RunId, emit_run_finished_event
 def _make_run_finished_chunk(thread_id: str, run_id: str) -> str:
     """生成 RUN_FINISHED SSE 字符串，用于测试期望值对比。"""
     return emit_run_finished_event(thread_id=thread_id, run_id=run_id)
+
+
+def _event_types(chunks: list[str]) -> list[str]:
+    return [json.loads(chunk.removeprefix("data: "))["type"] for chunk in chunks if chunk.startswith("data: ")]
 
 
 class ReplayFromStartHandler:
@@ -178,17 +183,18 @@ class TestReplayFromStartStreamingHelper:
     def test_replay_mode_runs_on_complete_in_producer_once(self):
         thread_id = "test_replay_on_complete_once"
         handler = ReplayFromStartHandler()
-        completed = []
+        lifecycle = []
+        handler.flush = lambda _thread_id: lifecycle.append("flush")
 
         result = list(
             GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
                 iter(["chunk_0"]),
-                on_complete=lambda: completed.append(True),
+                on_complete=lambda: lifecycle.append("complete"),
             )
         )
 
         assert result == ["chunk_0"]
-        assert completed == [True]
+        assert lifecycle == ["flush", "complete"]
         assert thread_id not in handler.producer_locks
 
 
@@ -604,31 +610,50 @@ class TestInMemoryQueueMessageHandler:
         assert all(event == {"type": "RAW", "event": {"type": "heartbeat"}} for event in heartbeat_events)
         assert heartbeat_count > 0
 
-    def test_stream_raises_when_heartbeat_timeout(self, handler, monkeypatch):
-        """心跳发送慢于超时阈值时，消费者应抛出心跳超时异常。"""
+    def test_stream_emits_terminal_events_when_heartbeat_timeout(self, handler, monkeypatch):
+        """心跳超时应输出完整终止事件，不能以异常中断 SSE。"""
         thread_id = "test_stream_heartbeat_timeout"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.2)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.05)
+        dispatched = []
+        original_put = handler.put
+
+        def drop_heartbeat(tid, message):
+            if message != streaming_helper_module.HEARTBEAT_CHUNK:
+                original_put(tid, message)
+
+        monkeypatch.setattr(handler, "put", drop_heartbeat)
 
         def slow_first_chunk():
-            time.sleep(0.8)
+            time.sleep(1.2)
             yield "late_chunk"
 
-        with pytest.raises(RuntimeError, match="心跳超时"):
-            list(helper.stream(slow_first_chunk()))
+        result = list(helper.stream(slow_first_chunk(), event_handler=dispatched.append))
 
-    def test_producer_marks_success_after_eod_flush(self, handler):
-        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_success")
-        producer_succeeded_event = threading.Event()
+        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
 
-        helper._producer(iter(["chunk"]), producer_succeeded_event=producer_succeeded_event)
+    def test_producer_error_emits_terminal_events(self, handler):
+        """producer 异常应形成完整终止事件对并同步分发。"""
+        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_error")
+        dispatched = []
 
-        assert producer_succeeded_event.is_set()
+        def broken_generator():
+            yield "chunk"
+            raise RuntimeError("producer failed")
 
-    def test_producer_does_not_mark_success_when_eod_flush_fails(self, handler, monkeypatch):
-        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_flush_failure")
-        producer_succeeded_event = threading.Event()
+        result = list(helper.stream(broken_generator(), event_handler=dispatched.append))
+
+        assert result[0] == "chunk"
+        assert _event_types(result[1:]) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+
+    def test_producer_releases_lock_when_eod_flush_fails(self, handler, monkeypatch):
+        thread_id = "test_producer_flush_failure"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        assert handler.acquire_producer(thread_id)
 
         def fail_flush(thread_id):
             raise RuntimeError("flush failed")
@@ -636,13 +661,15 @@ class TestInMemoryQueueMessageHandler:
         monkeypatch.setattr(handler, "flush", fail_flush)
 
         with pytest.raises(RuntimeError, match="flush failed"):
-            helper._producer(iter(["chunk"]), producer_succeeded_event=producer_succeeded_event)
+            helper._producer(
+                iter(["chunk"]),
+                release_producer=True,
+            )
 
-        assert not producer_succeeded_event.is_set()
+        assert handler.acquire_producer(thread_id)
 
-    @pytest.mark.parametrize("producer_succeeded", [True, False])
-    def test_stream_uses_producer_success_state_when_eod_missing(self, handler, monkeypatch, producer_succeeded):
-        """producer 结束后仅在 EOD flush 成功时按正常完成处理。"""
+    def test_stream_treats_missing_eod_as_error(self, handler, monkeypatch):
+        """即使 producer 标记成功，未消费到 EOD 也不能静默判定完成。"""
         thread_id = "test_stream_finished_without_eod"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         consumer_id = handler.acquire_consumer(thread_id)
@@ -654,30 +681,23 @@ class TestInMemoryQueueMessageHandler:
         producer_thread = threading.Thread(target=lambda: None)
         producer_thread.start()
         producer_thread.join()
-        producer_succeeded_event = threading.Event()
-        if producer_succeeded:
-            producer_succeeded_event.set()
 
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
         monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
         monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
 
-        expectation = contextlib.nullcontext() if producer_succeeded else pytest.raises(RuntimeError, match="心跳超时")
-        with expectation:
-            result = list(
-                helper._consume_stream_messages(
-                    consumer_id=consumer_id,
-                    cancel_event=threading.Event(),
-                    is_resuming=False,
-                    enable_heartbeat_check=True,
-                    producer_thread=producer_thread,
-                    producer_succeeded_event=producer_succeeded_event,
-                )
+        result = list(
+            helper._consume_stream_messages(
+                consumer_id=consumer_id,
+                cancel_event=threading.Event(),
+                is_resuming=False,
+                enable_heartbeat_check=True,
+                producer_thread=producer_thread,
             )
+        )
 
-        assert completed_threads == ([thread_id] if producer_succeeded else [])
-        if producer_succeeded:
-            assert result == []
+        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert completed_threads == []
 
 
 class TestMessageHandlerConfig:

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -610,8 +610,8 @@ class TestInMemoryQueueMessageHandler:
         assert all(event == {"type": "RAW", "event": {"type": "heartbeat"}} for event in heartbeat_events)
         assert heartbeat_count > 0
 
-    def test_stream_emits_terminal_events_when_heartbeat_timeout(self, handler, monkeypatch):
-        """心跳超时应输出完整终止事件，不能以异常中断 SSE。"""
+    def test_stream_emits_raw_then_raises_when_heartbeat_timeout(self, handler, monkeypatch):
+        """心跳超时先输出 RAW，再中断 SSE 触发前端重试。"""
         thread_id = "test_stream_heartbeat_timeout"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
@@ -630,10 +630,17 @@ class TestInMemoryQueueMessageHandler:
             time.sleep(1.2)
             yield "late_chunk"
 
-        result = list(helper.stream(slow_first_chunk(), event_handler=dispatched.append))
+        stream = helper.stream(slow_first_chunk(), event_handler=dispatched.append)
+        error_chunk = next(stream)
 
-        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
-        assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+        assert _event_types([error_chunk]) == ["RAW"]
+        assert json.loads(error_chunk.removeprefix("data: "))["event"] == {
+            "type": "error",
+            "message": helper._HEARTBEAT_TIMEOUT_MESSAGE,
+        }
+        assert [event.type for event in dispatched] == [EventType.RAW]
+        with pytest.raises(RuntimeError, match="生产者心跳超时"):
+            next(stream)
 
     def test_producer_error_emits_terminal_events(self, handler):
         """producer 异常应形成完整终止事件对并同步分发。"""
@@ -686,17 +693,18 @@ class TestInMemoryQueueMessageHandler:
         monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
         monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
 
-        result = list(
-            helper._consume_stream_messages(
-                consumer_id=consumer_id,
-                cancel_event=threading.Event(),
-                is_resuming=False,
-                enable_heartbeat_check=True,
-                producer_thread=producer_thread,
-            )
+        stream = helper._consume_stream_messages(
+            consumer_id=consumer_id,
+            cancel_event=threading.Event(),
+            is_resuming=False,
+            enable_heartbeat_check=True,
+            producer_thread=producer_thread,
         )
 
-        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
+        error_chunk = next(stream)
+        assert _event_types([error_chunk]) == ["RAW"]
+        with pytest.raises(RuntimeError, match="生产者心跳超时"):
+            next(stream)
         assert completed_threads == []
 
 

--- a/src/agent/tests/services/test_rabbitmq_release_producer.py
+++ b/src/agent/tests/services/test_rabbitmq_release_producer.py
@@ -1,0 +1,66 @@
+"""release_producer 容错单测：连接被对端重置时不应抛异常。
+
+复现 celery 日志中 _producer 线程 release_producer → connection.channel()
+抛 StreamLostError 导致 "Exception in thread" 的问题。
+"""
+import threading
+
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler():
+    # 绕过单例 __new__ 与 _init_rabbitmq（后者需要真实 RabbitMQ 连接）
+    handler = object.__new__(RabbitMQMessageHandler)
+    handler._producer_lock_connections = {}
+    handler._producer_lock_guard = threading.Lock()
+    return handler
+
+
+class _FakeConnection:
+    """模拟已被对端重置的 RabbitMQ 连接：本地状态仍认为 open，但底层 stream 已断。"""
+
+    def __init__(self, channel_error):
+        self.is_open = True
+        self._channel_error = channel_error
+        self.closed = False
+
+    def channel(self):
+        raise self._channel_error
+
+    def close(self):
+        self.closed = True
+        self.is_open = False
+
+
+def test_release_producer_tolerates_stream_lost_error():
+    """connection.channel() 抛 StreamLostError 时，release_producer 不应抛异常。"""
+    from pika.exceptions import StreamLostError
+
+    handler = _make_handler()
+    thread_id = "test-stream-lost"
+    conn = _FakeConnection(StreamLostError("Stream connection lost"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)  # 不应抛异常
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_tolerates_connection_reset_error():
+    """connection.channel() 抛 ConnectionResetError 时，release_producer 不应抛异常。"""
+    handler = _make_handler()
+    thread_id = "test-conn-reset"
+    conn = _FakeConnection(ConnectionResetError(104, "Connection reset by peer"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_no_connection_is_safe():
+    """没有待释放的连接时，release_producer 应安全返回。"""
+    handler = _make_handler()
+    handler.release_producer("nonexistent-thread")  # 不应抛异常

--- a/src/agent/tests/services/test_rabbitmq_release_producer.py
+++ b/src/agent/tests/services/test_rabbitmq_release_producer.py
@@ -3,6 +3,7 @@
 复现 celery 日志中 _producer 线程 release_producer → connection.channel()
 抛 StreamLostError 导致 "Exception in thread" 的问题。
 """
+
 import threading
 
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
@@ -64,3 +65,8 @@ def test_release_producer_no_connection_is_safe():
     """没有待释放的连接时，release_producer 应安全返回。"""
     handler = _make_handler()
     handler.release_producer("nonexistent-thread")  # 不应抛异常
+
+
+def test_rabbitmq_read_write_intervals_are_half_second():
+    assert RabbitMQMessageHandler.BUFFER_FLUSH_INTERVAL == 0.5
+    assert RabbitMQMessageHandler.REPLAY_MESSAGE_RETRY_INTERVAL == 0.5

--- a/src/agent/tests/utils/test_async_utils.py
+++ b/src/agent/tests/utils/test_async_utils.py
@@ -47,6 +47,47 @@ def test_async_to_sync_generator():
     assert result == ["run_id-0", "run_id-1", "run_id-2"]
 
 
+@pytest.mark.asyncio
+async def test_async_to_sync_generator_in_running_loop():
+    request_local.run_id = "async"
+
+    result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
+
+    assert result == ["async-0", "async-1", "async-2"]
+
+
+def test_async_to_sync_generator_runs_finalizer_on_consumer_loop():
+    loop_ids: list[int] = []
+
+    async def _gen():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        yield "value"
+
+    async def _finalize():
+        loop_ids.append(id(asyncio.get_running_loop()))
+
+    assert list(async_to_sync_generator(_gen(), async_finalizer=_finalize)) == ["value"]
+    assert len(set(loop_ids)) == 1
+
+
+def test_async_to_sync_generator_finalizes_when_consumer_closes():
+    finalized = False
+
+    async def _gen():
+        yield "value"
+        await asyncio.Event().wait()
+
+    async def _finalize():
+        nonlocal finalized
+        finalized = True
+
+    generator = async_to_sync_generator(_gen(), async_finalizer=_finalize)
+    assert next(generator) == "value"
+    generator.close()
+
+    assert finalized is True
+
+
 async def test_async_gen_with_timeout():
     request_local.run_id = "run_id"
     result = [each async for each in async_generator_with_timeout(gen(), timeout=0.18)]
@@ -63,7 +104,6 @@ def test_async_to_sync_generator_in_worker_thread():
     def _consume():
         request_local.run_id = "worker"
         result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
-        # get_event_loop() 会在 worker 线程缓存事件循环用于复用，has_loop 为 True 是预期行为
         has_loop = hasattr(_thread_local, "loop") and _thread_local.loop is not None
         return result, has_loop
 
@@ -71,4 +111,4 @@ def test_async_to_sync_generator_in_worker_thread():
         result, has_loop = pool.submit(_consume).result()
 
     assert result == ["worker-0", "worker-1", "worker-2"]
-    assert has_loop is True
+    assert has_loop is False

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 
 import pytest
 
@@ -142,13 +143,23 @@ async def test_run_coro_sync_with_running_loop_delegates_to_new_thread():
     复现 construct_mcp 在 async→sync 桥接上下文被调用导致
     "This event loop is already running" 的场景。
     """
-    result = run_coro_sync(sample_async_task(5))
-    assert result == 10
+    marker = ContextVar("marker", default="")
+    token = marker.set("request-context")
+
+    async def _probe():
+        await asyncio.sleep(0)
+        return marker.get()
+
+    try:
+        assert run_coro_sync(_probe()) == "request-context"
+    finally:
+        marker.reset(token)
 
 
 @pytest.mark.asyncio
 async def test_run_coro_sync_with_running_loop_propagates_exception():
     """已有 running loop 时，协程抛出的异常应原样冒泡到调用方。"""
+
     async def _boom():
         raise ValueError("boom")
 

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -133,3 +133,24 @@ def test_run_coro_sync_preserves_worker_thread_loop():
 
     assert result == 10
     assert has_loop is True
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_delegates_to_new_thread():
+    """已有 running loop 时，run_coro_sync 应委托独立线程执行，不抛 already running。
+
+    复现 construct_mcp 在 async→sync 桥接上下文被调用导致
+    "This event loop is already running" 的场景。
+    """
+    result = run_coro_sync(sample_async_task(5))
+    assert result == 10
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_propagates_exception():
+    """已有 running loop 时，协程抛出的异常应原样冒泡到调用方。"""
+    async def _boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_coro_sync(_boom())

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -151,7 +151,7 @@ async def test_run_coro_sync_with_running_loop_delegates_to_new_thread():
         return marker.get()
 
     try:
-        assert run_coro_sync(_probe()) == "request-context"
+        assert run_coro_sync(_probe) == "request-context"
     finally:
         marker.reset(token)
 
@@ -164,4 +164,15 @@ async def test_run_coro_sync_with_running_loop_propagates_exception():
         raise ValueError("boom")
 
     with pytest.raises(ValueError, match="boom"):
-        run_coro_sync(_boom())
+        run_coro_sync(_boom)
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_rejects_coroutine_object():
+    """running loop 下必须传工厂，避免搬运已关联当前 loop 的协程对象。"""
+
+    async def _probe():
+        return "ok"
+
+    with pytest.raises(RuntimeError, match="requires a coroutine factory"):
+        run_coro_sync(_probe())

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 import json
 import random
 import threading
+import time
 from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import Any, Optional, Tuple, cast
 
-from django.db import connections, router, transaction
+from django.db import OperationalError, close_old_connections, connections, router, transaction
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
     WRITES_IDX_MAP,
@@ -39,6 +40,10 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import ChannelProtocol
+
+RETRYABLE_DATABASE_ERROR_CODES = {1205, 1213}
+CHECKPOINT_WRITE_MAX_RETRIES = 3
+CHECKPOINT_WRITE_RETRY_DELAY_SECONDS = 0.05
 
 
 def bulk_upsert(model, objs, update_fields, unique_fields):
@@ -605,17 +610,26 @@ class BKDjangoSaver(BaseCheckpointSaver[str]):
         serialized_metadata = json.loads(json.dumps(raw_metadata, default=str).replace("\\u0000", ""))
         # 使用Django的update_or_create方法
         with self.lock:
-            self.checkpoint_model.objects.update_or_create(
-                thread_id=thread_id,
-                checkpoint_ns=checkpoint_ns,
-                checkpoint_id=checkpoint["id"],
-                defaults={
-                    "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
-                    "type": type_,
-                    "checkpoint": serialized_checkpoint,
-                    "metadata": serialized_metadata,
-                },
-            )
+            for attempt in range(CHECKPOINT_WRITE_MAX_RETRIES):
+                try:
+                    self.checkpoint_model.objects.update_or_create(
+                        thread_id=thread_id,
+                        checkpoint_ns=checkpoint_ns,
+                        checkpoint_id=checkpoint["id"],
+                        defaults={
+                            "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                            "type": type_,
+                            "checkpoint": serialized_checkpoint,
+                            "metadata": serialized_metadata,
+                        },
+                    )
+                    break
+                except OperationalError as exc:
+                    error_code = exc.args[0] if exc.args else None
+                    if error_code not in RETRYABLE_DATABASE_ERROR_CODES or attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1:
+                        raise
+                    close_old_connections()
+                    time.sleep(CHECKPOINT_WRITE_RETRY_DELAY_SECONDS * (2**attempt))
 
         return {
             "configurable": {

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import threading
+
+import pytest
+from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver
+from django.db import OperationalError
+
+
+@pytest.fixture
+def saver(mocker):
+    instance = object.__new__(BKDjangoSaver)
+    instance.lock = threading.Lock()
+    instance.checkpoint_model = mocker.Mock()
+    instance.serde = mocker.Mock()
+    instance.serde.dumps_typed.return_value = ("json", b"checkpoint")
+    return instance
+
+
+@pytest.fixture
+def checkpoint_args():
+    return (
+        {"configurable": {"thread_id": "thread-id"}},
+        {"id": "checkpoint-id"},
+        {},
+        {},
+    )
+
+
+@pytest.mark.parametrize("error_code", [1205, 1213])
+def test_put_retries_transient_database_lock_error(mocker, saver, checkpoint_args, error_code):
+    saver.checkpoint_model.objects.update_or_create.side_effect = [
+        OperationalError(error_code, "retryable"),
+        (mocker.Mock(), True),
+    ]
+    close_old_connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    saver.put(*checkpoint_args)
+
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 2
+    close_old_connections.assert_called_once_with()
+    sleep.assert_called_once_with(0.05)
+
+
+def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args):
+    error = OperationalError(2006, "server has gone away")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpoint_args):
+    error = OperationalError(1213, "deadlock")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 3
+    assert [call.args[0] for call in sleep.call_args_list] == [0.05, 0.1]

--- a/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "aidev-agent[opentelemetry]==2.2.0",
     "aidev-bkplugin==2.2.0",
     "aidev-wxbot==2.2.0",
-    "aidev-ai-blueking==2.2.1b1",
+    "aidev-ai-blueking==2.2.1b6",
     "bk-plugin-framework==2.3.15",
     "bkapi-bk-apigateway==1.0.12",
     "celery==5.4.0",

--- a/template/{{cookiecutter.project_name}}/requirements.txt
+++ b/template/{{cookiecutter.project_name}}/requirements.txt
@@ -1,6 +1,6 @@
 ag-ui-protocol==0.1.10
 aidev-agent==2.2.0
-aidev-ai-blueking==2.2.1b1
+aidev-ai-blueking==2.2.1b6
 aidev-bkplugin==2.2.0
 aidev-wxbot==2.2.0
 aiohappyeyeballs==2.6.1

--- a/template/{{cookiecutter.project_name}}/uv.lock
+++ b/template/{{cookiecutter.project_name}}/uv.lock
@@ -51,7 +51,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aidev-agent", extras = ["opentelemetry"], specifier = "==2.2.0" },
-    { name = "aidev-ai-blueking", specifier = "==2.2.1b1" },
+    { name = "aidev-ai-blueking", specifier = "==2.2.1b6" },
     { name = "aidev-bkplugin", specifier = "==2.2.0" },
     { name = "aidev-wxbot", specifier = "==2.2.0" },
     { name = "bk-plugin-framework", specifier = "==2.3.15" },
@@ -134,15 +134,15 @@ opentelemetry = [
 
 [[package]]
 name = "aidev-ai-blueking"
-version = "2.2.1b1"
+version = "2.2.1b6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aidev-agent" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ad/97/bcee3b83deb60020186187325926bbf60d10122eaf28531152dd0372eeca/aidev_ai_blueking-2.2.1b1.tar.gz", hash = "sha256:579b4649424851efb55cba2a019376b372ce57cb918a6f7aa10ebb9566a81422", size = 3934807, upload-time = "2026-07-10T02:02:31.264Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e1/6a/8c7a2ee2353a00d9ff285b09dce77af2e97657c55b0dd8c1098929d66e95/aidev_ai_blueking-2.2.1b6.tar.gz", hash = "sha256:02c174bae6e3ea66d84e505916fc3c23c6cb6f9f0c6266b07f5cda03e4d8c752", size = 3939943, upload-time = "2026-07-31T02:39:17.007Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/54/98e08ae542ffe5e1ff6f2048cd4b6c6e53b7f329090564e58cc19c787111/aidev_ai_blueking-2.2.1b1-py3-none-any.whl", hash = "sha256:39f679458297b9b0b53987ced9a3e1c08521426e41ba025e04ad350cca99a663", size = 3986644, upload-time = "2026-07-10T02:02:29.692Z" },
+    { url = "https://files.pythonhosted.org/packages/32/15/59980f2b55bad88ec6fd69e949ce5fa94b6fb0be5fe02b7664ac8c4a02fe/aidev_ai_blueking-2.2.1b6-py3-none-any.whl", hash = "sha256:9aaeaddd7c43303b744834df95966060d499a3b9d526d358b7cfb5b148887df6", size = 3991398, upload-time = "2026-07-31T02:39:15.493Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景
bkplugin 会话轮询心跳超时排障（story #136206810）过程中，定位到 `aidev_agent` 框架侧三处堆栈问题，会导致 session 异常 failed 或 producer 线程异常退出。本 PR 只含 `aidev_agent`（`src/agent`）改动，bkplugin 侧改动见 #711 / #713。

## 改动一：`run_coro_sync` running loop 委托（utils/loop.py）
- 检测到事件循环已在运行时，委托独立 daemon 线程 `asyncio.run` 执行协程，避免 `RuntimeError("This event loop is already running")` 导致 session failed
- 加 running loop 诊断日志（loop 来源 / 调用栈），便于定位嵌套调用方

## 改动二：`release_producer` 容错降级（services/messages_handler/rabbitmq.py）
- `connection.channel()` 抛 `StreamLostError` / `ConnectionResetError` 时容错降级，避免 `_producer` 线程异常退出
- `_producer` finally 调用 `release_producer` 加 try 兜底，保证线程不因清理失败而中断
- 加 `release_producer` 连接状态日志

## 改动三：链路日志补全（utils/async_utils.py / streaming_helper.py）
- `async_to_sync_generator` 补 loop 生命周期日志
- `_producer` finally 各阶段加时间戳/状态日志，定位线程退出时机

## 测试
- `src/agent/tests/utils/test_loop.py`：already running 委托独立线程
- `src/agent/tests/services/test_rabbitmq_release_producer.py`：`release_producer` 对 `StreamLostError`/`ConnectionResetError` 容错

## 关联
tapd: #136206810

Made with [Cursor](https://cursor.com)