### PR TITLE
feat: 【chat-x】文件产物预览按类型策略化 --story=136559114

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -109,77 +109,237 @@ export const MOCK_SHORTCUTS = [
   },
 ] as Shortcut[];
 
-// AI 生成的文件产物（流式阶段仅含元信息；download_url / preview_url 由 onArtifactClick 异步返回）
+// ---------------------------------------------------------------------------
+// 文件产物 Mock（元信息 + 正文；download_url / preview_url 由 onArtifactClick 异步返回）
+// txt / markdown / html：Blob URL，供前端 fetch 后原生渲染
+// pdf / jpg：仍走 preview_url iframe（后台转 pdf 的模拟）
+// ---------------------------------------------------------------------------
+
+/** txt：纯文本预览正文 */
+export const MOCK_ARTIFACT_TXT_CONTENT = `蓝鲸可观测平台 · 周例会纪要（草稿）
+时间：2026-07-21 14:00–15:30
+地点：线上会议（腾讯会议）
+主持人：张明 | 记录人：李华
+
+一、上周回顾
+1. 告警收敛规则已上线，P1 告警量下降约 35%。
+2. 日志查询慢查询优化：冷热分层已完成灰度，平均查询耗时从 8.2s 降至 2.6s。
+3. Agent 侧文件产物预览联调阻塞项：markdown / txt 需前端直渲染，不再依赖 preview_url。
+
+二、本周计划
+1. 完成文件产物侧栏预览（html / txt / markdown）验收。
+2. 推进「监控大盘 HTML 报告」导出模板评审。
+3. 补齐 JSON 配置产物的 schema 校验与下载埋点。
+
+三、风险与依赖
+- PDF 转码服务高峰期偶发超时，需确认 SLA（负责人：王强，本周五前给结论）。
+- 设计稿标注与主题变量对齐仍有 3 处待确认。
+
+四、待办
+[ ] 前端：txt / markdown 预览联调 — 李华 / 07-28
+[ ] 后端：download_url 鉴权时效文档 — 赵磊 / 07-29
+[ ] 产品：导出报告字段清单 — 陈静 / 07-30
+
+备注：本稿仅供内部同步，正式纪要将在会后 24h 内发布到 iWiki。
+`;
+
+/** markdown：MarkdownContent 预览正文 */
+export const MOCK_ARTIFACT_MARKDOWN_CONTENT = `# 蓝鲸可观测 · 系统配置说明
+
+> 适用版本：chat-x ≥ 0.0.47｜更新：2026-07-28
+
+## 1. 概述
+
+本文档描述 Agent 产出**文件产物**时，前端侧栏预览与下载的配置约定。流式阶段消息仅携带文件元信息；真实链接通过 \`onArtifactClick\` 异步获取。
+
+## 2. 预览策略
+
+| 文件类型 | 加载方式 | 渲染 |
+| --- | --- | --- |
+| \`html\` | \`download_url\` → fetch | iframe \`srcdoc\` |
+| \`txt\` | \`download_url\` → fetch | 浏览器纯文本（\`pre\`） |
+| \`markdown\` | \`download_url\` → fetch | 项目 \`MarkdownContent\` |
+| \`json\` | \`download_url\` → fetch | 纯文本（同 txt） |
+| \`pdf\` / \`jpg\` | \`preview_url\` | iframe（后台转 PDF） |
+
+## 3. 接入示例
+
+\`\`\`ts
+const onArtifactClick = async (file: AIFileInfo) => {
+  const res = await api.getArtifactUrls(file.outputId);
+  return {
+    download_url: res.download_url,
+    preview_url: res.preview_url,
+  };
+};
+\`\`\`
+
+## 4. 注意事项
+
+1. **鉴权**：\`download_url\` / \`preview_url\` 建议带短时效签名，避免直链泄露。
+2. **竞态**：侧栏切换文件时需中断上一次 fetch，防止旧内容覆盖。
+3. **安全**：HTML 预览使用 \`srcdoc\`，勿将不可信脚本注入到宿主页面。
+
+## 5. 检查清单
+
+- [x] Pdf 预览可用
+- [x] Html 直渲染
+- [ ] Txt / Markdown 直渲染验收
+- [ ] 下载埋点与失败重试
+
+---
+
+如有疑问请联系 **可观测前端小组**。
+`;
+
+/** html：iframe srcdoc 预览正文 */
+export const MOCK_ARTIFACT_HTML_CONTENT = `<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8" />
+  <title>监控大盘周报</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 24px; color: #1d2126; }
+    h1 { font-size: 20px; margin: 0 0 8px; }
+    .meta { color: #979ba5; font-size: 12px; margin-bottom: 20px; }
+    .cards { display: flex; gap: 12px; flex-wrap: wrap; }
+    .card { flex: 1; min-width: 140px; padding: 16px; background: #f5f7fa; border-radius: 8px; }
+    .card strong { display: block; font-size: 24px; color: #3a84ff; margin-top: 8px; }
+    table { width: 100%; border-collapse: collapse; margin-top: 20px; font-size: 13px; }
+    th, td { border: 1px solid #dcdee5; padding: 8px 10px; text-align: left; }
+    th { background: #f0f1f5; }
+  </style>
+</head>
+<body>
+  <h1>业务监控大盘 · 周报预览</h1>
+  <p class="meta">统计周期：2026-07-14 ~ 2026-07-20｜生成时间：2026-07-21 09:12</p>
+  <div class="cards">
+    <div class="card">P1 告警<strong>42</strong></div>
+    <div class="card">平均恢复时长<strong>18 min</strong></div>
+    <div class="card">可用性<strong>99.95%</strong></div>
+  </div>
+  <table>
+    <thead><tr><th>服务</th><th>错误率</th><th>P99 延迟</th><th>状态</th></tr></thead>
+    <tbody>
+      <tr><td>aidev-agent</td><td>0.12%</td><td>320ms</td><td>正常</td></tr>
+      <tr><td>chat-gateway</td><td>0.08%</td><td>180ms</td><td>正常</td></tr>
+      <tr><td>artifact-preview</td><td>1.40%</td><td>1.2s</td><td>关注</td></tr>
+    </tbody>
+  </table>
+</body>
+</html>`;
+
+/** json：配置样例正文（与 txt 相同，fetch 后纯文本预览） */
+export const MOCK_ARTIFACT_JSON_CONTENT = `{
+  "service": "bk-observe-agent",
+  "env": "prod",
+  "alert": {
+    "p1_threshold": 5,
+    "mute_window_min": 30,
+    "channels": ["wecom", "email"]
+  },
+  "dashboard": {
+    "refresh_sec": 60,
+    "panels": ["error_rate", "latency_p99", "saturation"]
+  }
+}
+`;
+
 export const MOCK_FILE_ARTIFACTS: AIFileInfo[] = [
   {
-    name: '项目立项书.pdf',
+    name: '可观测平台立项说明书.pdf',
     outputId: 'artifact-pdf',
     size: 245_760,
     type: AIFileType.Pdf,
   },
   {
-    name: '系统配置系统配置系统配置系统配置系统配置系统配置系统配置系统配置.md',
+    name: '文件产物预览-系统配置说明.md',
     outputId: 'artifact-markdown',
-    size: 4_096,
+    size: MOCK_ARTIFACT_MARKDOWN_CONTENT.length,
     type: AIFileType.Markdown,
   },
   {
-    name: 'demo.json',
+    name: '告警策略配置.json',
     outputId: 'artifact-json',
-    size: 1_280,
+    size: MOCK_ARTIFACT_JSON_CONTENT.length,
     type: AIFileType.Json,
   },
   {
-    name: '自然风光.jpg',
+    name: '机房巡检现场照片.jpg',
     outputId: 'artifact-jpg',
     size: 1_048_576,
     type: AIFileType.Jpg,
   },
   {
-    name: 'dashboard_preview.html',
+    name: '监控大盘周报.html',
     outputId: 'artifact-html',
-    size: 8_192,
+    size: MOCK_ARTIFACT_HTML_CONTENT.length,
     type: AIFileType.Html,
   },
   {
-    name: '会议纪要草稿.txt',
+    name: '周例会纪要-0721.txt',
     outputId: 'artifact-txt',
-    size: 2_048,
+    size: MOCK_ARTIFACT_TXT_CONTENT.length,
     type: AIFileType.Txt,
   },
 ];
 
-/** playground 模拟 onArtifactClick：按 outputId 异步返回 download_url / preview_url */
-export const MOCK_ARTIFACT_URL_MAP: Record<string, { download_url: string; preview_url: string }> = {
-  'artifact-pdf': {
-    download_url: 'https://example.com/download/project.pdf',
-    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
-  },
-  'artifact-markdown': {
-    download_url: 'https://example.com/download/config.md',
-    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
-  },
-  'artifact-json': {
-    download_url: 'https://example.com/download/demo.json',
-    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
-  },
-  'artifact-jpg': {
-    download_url: 'https://example.com/download/scenery.jpg',
-    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
-  },
-  'artifact-html': {
-    download_url: 'data:text/html,<h1>dashboard preview</h1><p>mock html artifact</p>',
-    preview_url: 'https://example.com/preview/dashboard.html',
-  },
-  'artifact-txt': {
-    download_url: 'https://example.com/download/meeting.txt',
-    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
-  },
+type MockArtifactUrl = {
+  download_url?: string;
+  preview_url?: string;
 };
 
-export const mockArtifactClick = async (file: AIFileInfo) => {
-  await new Promise(resolve => setTimeout(resolve, 1400));
-  return MOCK_ARTIFACT_URL_MAP[file.outputId] ?? {};
+/** 仅 iframe 类型需要的静态 preview_url；文本类 download_url 运行时用 Blob 生成 */
+const MOCK_ARTIFACT_STATIC_URL: Record<string, MockArtifactUrl> = {
+  'artifact-pdf': {
+    download_url: 'https://example.com/download/observe-project.pdf',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-json': {},
+  'artifact-jpg': {
+    download_url: 'https://picsum.photos/seed/bk-observe/1200/800.jpg',
+    preview_url: 'https://mozilla.github.io/pdf.js/web/compressed.tracemonkey-pldi-09.pdf',
+  },
+  'artifact-markdown': {},
+  'artifact-html': {},
+  'artifact-txt': {},
+};
+
+const MOCK_TEXT_ARTIFACT_BODY: Record<string, { body: string; mime: string }> = {
+  'artifact-html': { body: MOCK_ARTIFACT_HTML_CONTENT, mime: 'text/html' },
+  'artifact-json': { body: MOCK_ARTIFACT_JSON_CONTENT, mime: 'application/json' },
+  'artifact-markdown': { body: MOCK_ARTIFACT_MARKDOWN_CONTENT, mime: 'text/markdown' },
+  'artifact-txt': { body: MOCK_ARTIFACT_TXT_CONTENT, mime: 'text/plain' },
+};
+
+/** 缓存 Blob URL，避免重复 createObjectURL */
+const mockArtifactBlobUrlCache = new Map<string, string>();
+
+const getMockTextDownloadUrl = (outputId: string) => {
+  const cached = mockArtifactBlobUrlCache.get(outputId);
+  if (cached) {
+    return cached;
+  }
+  const item = MOCK_TEXT_ARTIFACT_BODY[outputId];
+  if (!item) {
+    return undefined;
+  }
+  const url = URL.createObjectURL(new Blob([item.body], { type: `${item.mime};charset=utf-8` }));
+  mockArtifactBlobUrlCache.set(outputId, url);
+  return url;
+};
+
+/** 兼容旧导出名：静态映射 + 文本类占位（真实 download_url 见 mockArtifactClick） */
+export const MOCK_ARTIFACT_URL_MAP: Record<string, MockArtifactUrl> = MOCK_ARTIFACT_STATIC_URL;
+
+export const mockArtifactClick = async (file: AIFileInfo): Promise<MockArtifactUrl> => {
+  await new Promise(resolve => setTimeout(resolve, 600));
+  const staticUrls = MOCK_ARTIFACT_STATIC_URL[file.outputId] ?? {};
+  const textDownloadUrl = getMockTextDownloadUrl(file.outputId);
+  return {
+    ...staticUrls,
+    ...(textDownloadUrl ? { download_url: textDownloadUrl } : {}),
+  };
 };
 
 // 带文件产物的会话消息，用于 playground 调试 artifacts 展示
@@ -187,7 +347,7 @@ export const MOCK_ARTIFACTS_MESSAGES = [
   {
     id: 'mock-artifacts-user',
     role: MessageRole.User,
-    content: '帮我把监控方案的相关文件生成出来',
+    content: '帮我把本周监控方案相关的产出文件都整理出来，方便评审。',
     name: 'user',
     status: MessageStatus.Complete,
     messageId: 'mock-artifacts-user',
@@ -195,7 +355,8 @@ export const MOCK_ARTIFACTS_MESSAGES = [
   {
     id: 'mock-artifacts-assistant',
     role: MessageRole.Assistant,
-    content: '收到，我已经为你设计好，请查阅',
+    content:
+      '已为你生成一组评审材料：立项 PDF、配置说明 Markdown、告警 JSON、巡检照片、大盘周报 HTML，以及周例会纪要 TXT。可点击卡片在侧栏预览或下载。',
     name: 'react_agent',
     status: MessageStatus.Complete,
     messageId: 'mock-artifacts-assistant',

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/markdown-content/markdown-content.css
@@ -7,6 +7,8 @@
 /* stylelint-disable no-duplicate-selectors */
 
 /* stylelint-disable custom-property-pattern */
+
+
 .ai-markdown-body {
   --base-size-16: 16px;
   --base-size-24: 24px;
@@ -916,8 +918,10 @@
   font-size: 85%;
   line-height: 1.45;
   color: var(--fgColor-default);
-  background-color: var(--bgColor-muted);
+  background-color: #282c34;
   border-radius: 6px;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
 }
 
 .ai-markdown-body pre code,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
@@ -1,0 +1,175 @@
+import { computed, defineComponent, h, ref } from 'vue';
+
+import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AIFileType } from '../../../../../ag-ui/types/file';
+import { ARTIFACT_PREVIEW_TOKEN } from '../../../../../composables/use-artifact-preview';
+import ArtifactPreviewHost from './artifact-preview-host.vue';
+
+import type { AIFileInfo } from '../../../../../ag-ui/types/file';
+import type { SessionArtifact } from '../../../../../composables/use-artifact-preview';
+
+vi.mock('bkui-vue', () => ({
+  Button: defineComponent({
+    emits: ['click'],
+    setup: (_, { emit, slots }) => () =>
+      h('button', { class: 'mock-btn', onClick: () => emit('click') }, slots.default?.()),
+  }),
+}));
+
+vi.mock('../../../../message-loading/message-loading.vue', () => ({
+  default: defineComponent({
+    name: 'MessageLoading',
+    setup: () => () => h('div', { class: 'mock-message-loading' }),
+  }),
+}));
+
+vi.mock('../../../../chat-content/markdown-content/markdown-content.vue', () => ({
+  default: defineComponent({
+    name: 'MarkdownContent',
+    props: { content: { required: true, type: String } },
+    setup: props => () => h('div', { class: 'mock-markdown-content' }, props.content),
+  }),
+}));
+
+const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
+  name: '项目立项书.pdf',
+  outputId: 'output-1',
+  size: 1024,
+  type: AIFileType.Pdf,
+  ...overrides,
+});
+
+const createSessionArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifact => ({
+  ...createFile(),
+  artifactId: 'message-1#0#output-1',
+  messageUid: 'message-1',
+  ...overrides,
+});
+
+const createPreviewContext = (overrides: Record<string, unknown> = {}) => ({
+  activeArtifactId: ref(''),
+  canResolveArtifactUrl: computed(() => true),
+  openPreview: vi.fn(),
+  resolveArtifactUrls: vi.fn().mockResolvedValue({
+    download_url: 'https://example.com/download',
+    preview_url: 'https://example.com/preview.pdf',
+  }),
+  setActiveArtifactId: vi.fn(),
+  ...overrides,
+});
+
+const mountHost = (file?: AIFileInfo, previewCtx?: unknown) =>
+  mount(ArtifactPreviewHost, {
+    global: previewCtx ? { provide: { [ARTIFACT_PREVIEW_TOKEN]: previewCtx } } : {},
+    props: { file },
+  });
+
+describe('ArtifactPreviewHost', () => {
+  let wrapper: VueWrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.unstubAllGlobals();
+  });
+
+  it('未传文件时应展示空态', async () => {
+    wrapper = mountHost();
+    await flushPromises();
+
+    expect(wrapper.find('.ai-artifact-preview-host-empty').exists()).toBe(true);
+  });
+
+  it('pdf 文件应使用 iframe src 展示预览地址', async () => {
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      preview_url: 'https://example.com/file.pdf',
+    });
+    wrapper = mountHost(createFile(), createPreviewContext({ resolveArtifactUrls }));
+    await flushPromises();
+
+    expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/file.pdf');
+  });
+
+  it('切换相同 outputId 和类型但 artifactId 不同的文件时应重新加载预览', async () => {
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      preview_url: 'https://example.com/file.pdf',
+    });
+    const firstFile = createSessionArtifact();
+    const secondFile = createSessionArtifact({
+      artifactId: 'message-2#0#output-1',
+      messageUid: 'message-2',
+    });
+    wrapper = mountHost(firstFile, createPreviewContext({ resolveArtifactUrls }));
+    await flushPromises();
+
+    await wrapper.setProps({ file: secondFile });
+    await flushPromises();
+
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
+    expect(resolveArtifactUrls).toHaveBeenLastCalledWith(secondFile);
+  });
+
+  it('html 文件应使用 iframe srcdoc 展示下载内容', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('<h1>预览</h1>') });
+    vi.stubGlobal('fetch', fetchSpy);
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/file.html',
+    });
+    wrapper = mountHost(
+      createFile({ name: 'file.html', type: AIFileType.Html }),
+      createPreviewContext({ resolveArtifactUrls }),
+    );
+    await flushPromises();
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/file.html', expect.any(Object));
+    expect(wrapper.find('.ai-artifact-html-preview').attributes('srcdoc')).toBe('<h1>预览</h1>');
+  });
+
+  it('txt 文件应获取下载内容并渲染文本', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('文本预览内容') });
+    vi.stubGlobal('fetch', fetchSpy);
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/file.txt',
+    });
+    wrapper = mountHost(
+      createFile({ name: 'file.txt', type: AIFileType.Txt }),
+      createPreviewContext({ resolveArtifactUrls }),
+    );
+    await flushPromises();
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/file.txt', expect.any(Object));
+    expect(wrapper.find('.ai-artifact-txt-preview').text()).toBe('文本预览内容');
+  });
+
+  it('markdown 文件应将下载内容传给 MarkdownContent', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('# 标题') }));
+    wrapper = mountHost(
+      createFile({ name: 'file.md', type: AIFileType.Markdown }),
+      createPreviewContext({ resolveArtifactUrls: vi.fn().mockResolvedValue({ download_url: 'https://example.com/file.md' }) }),
+    );
+    await flushPromises();
+
+    expect(wrapper.find('.mock-markdown-content').text()).toBe('# 标题');
+  });
+
+  it('加载失败时应展示错误态，点击重试后再次加载', async () => {
+    const resolveArtifactUrls = vi.fn()
+      .mockRejectedValueOnce(new Error('请求失败'))
+      .mockResolvedValueOnce({ preview_url: 'https://example.com/retry.pdf' });
+    wrapper = mountHost(createFile(), createPreviewContext({ resolveArtifactUrls }));
+    await flushPromises();
+
+    expect(wrapper.find('.ai-artifact-preview-host-error').exists()).toBe(true);
+
+    await wrapper.find('.mock-btn').trigger('click');
+    await flushPromises();
+
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
+    expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/retry.pdf');
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -1,0 +1,118 @@
+<template>
+  <div class="ai-artifact-preview-host">
+    <div
+      v-if="status === 'loading'"
+      class="ai-artifact-preview-host-loading"
+    >
+      <MessageLoading />
+    </div>
+    <div
+      v-else-if="status === 'error'"
+      class="ai-artifact-preview-host-error"
+    >
+      <span>{{ t('预览加载失败') }}</span>
+      <Button
+        size="small"
+        text
+        theme="primary"
+        @click="load"
+      >
+        {{ t('重试') }}
+      </Button>
+    </div>
+    <div
+      v-else-if="status === 'empty' || !file"
+      class="ai-artifact-preview-host-empty"
+    >
+      {{ t('暂无可预览的文件') }}
+    </div>
+    <HtmlPreview
+      v-else-if="renderer === 'html'"
+      :content="content"
+    />
+    <TxtPreview
+      v-else-if="renderer === 'txt'"
+      :content="content"
+    />
+    <MarkdownPreview
+      v-else-if="renderer === 'markdown'"
+      :content="content"
+    />
+    <UrlIframePreview
+      v-else
+      :url="previewUrl"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+  import { watch } from 'vue';
+
+  import { Button } from 'bkui-vue';
+
+  import { useArtifactPreviewConsumer } from '../../../../../composables/use-artifact-preview';
+  import { t } from '../../../../../lang/lang';
+  import MessageLoading from '../../../../message-loading/message-loading.vue';
+  import HtmlPreview from './renderers/html-preview.vue';
+  import MarkdownPreview from './renderers/markdown-preview.vue';
+  import TxtPreview from './renderers/txt-preview.vue';
+  import UrlIframePreview from './renderers/url-iframe-preview.vue';
+  import { useArtifactPreviewLoader } from './use-artifact-preview-loader';
+
+  import type { AIFileInfo } from '../../../../../ag-ui/types/file';
+  import type { SessionArtifact } from '../../../../../composables/use-artifact-preview';
+
+  const props = defineProps<{ file?: AIFileInfo | SessionArtifact }>();
+  const artifactPreview = useArtifactPreviewConsumer();
+
+  const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
+    canResolve: () => !!artifactPreview?.canResolveArtifactUrl.value,
+    getFile: () => props.file,
+    resolveUrls: file => artifactPreview?.resolveArtifactUrls(file) ?? Promise.resolve({}),
+  });
+
+  watch(
+    () => {
+      if (!props.file) {
+        return '';
+      }
+      return 'artifactId' in props.file ? props.file.artifactId : `${props.file.outputId}:${props.file.type}`;
+    },
+    () => {
+      load();
+    },
+    { immediate: true },
+  );
+</script>
+<style lang="scss">
+  @use '../../../../../styles/variables.scss' as variables;
+
+  .ai-artifact-preview-host {
+    width: 100%;
+    height: 100%;
+    font-size: var(--ai-font-size, 12px);
+
+    &-loading {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+    }
+
+    &-error {
+      display: flex;
+      gap: 8px;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: variables.$color-text-secondary;
+    }
+
+    &-empty {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      height: 100%;
+      color: variables.$color-text-secondary;
+    }
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/preview-strategy.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/preview-strategy.spec.ts
@@ -1,0 +1,62 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { AIFileType } from '../../../../../ag-ui/types/file';
+import { getArtifactPreviewStrategy } from './preview-strategy';
+
+describe('preview-strategy', () => {
+  it('Html/Txt/Markdown/Json 应走 text_from_download 且 renderer 对应类型', () => {
+    expect(getArtifactPreviewStrategy(AIFileType.Html)).toEqual({
+      load: 'text_from_download',
+      renderer: 'html',
+    });
+    expect(getArtifactPreviewStrategy(AIFileType.Txt)).toEqual({
+      load: 'text_from_download',
+      renderer: 'txt',
+    });
+    expect(getArtifactPreviewStrategy(AIFileType.Markdown)).toEqual({
+      load: 'text_from_download',
+      renderer: 'markdown',
+    });
+    // Json 与 Txt 相同：纯文本预览
+    expect(getArtifactPreviewStrategy(AIFileType.Json)).toEqual({
+      load: 'text_from_download',
+      renderer: 'txt',
+    });
+  });
+
+  it('Pdf/Jpg 应走 preview_url_iframe', () => {
+    expect(getArtifactPreviewStrategy(AIFileType.Pdf)).toEqual({
+      load: 'preview_url_iframe',
+      renderer: 'urlIframe',
+    });
+    expect(getArtifactPreviewStrategy(AIFileType.Jpg)).toEqual({
+      load: 'preview_url_iframe',
+      renderer: 'urlIframe',
+    });
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/preview-strategy.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/preview-strategy.ts
@@ -1,0 +1,51 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { AIFileType } from '../../../../../ag-ui/types/file';
+
+export type ArtifactPreviewLoadStrategy = 'preview_url_iframe' | 'text_from_download';
+
+export type ArtifactPreviewRendererKind = 'html' | 'markdown' | 'txt' | 'urlIframe';
+
+export type ArtifactPreviewStrategy = {
+  load: ArtifactPreviewLoadStrategy;
+  renderer: ArtifactPreviewRendererKind;
+};
+
+const TEXT_RENDERER_MAP: Partial<Record<AIFileType, ArtifactPreviewRendererKind>> = {
+  [AIFileType.Html]: 'html',
+  [AIFileType.Json]: 'txt',
+  [AIFileType.Markdown]: 'markdown',
+  [AIFileType.Txt]: 'txt',
+};
+
+/** 按文件类型解析预览加载策略与渲染器；未单独注册的类型默认 preview_url iframe */
+export const getArtifactPreviewStrategy = (type: AIFileType): ArtifactPreviewStrategy => {
+  const textRenderer = TEXT_RENDERER_MAP[type];
+  if (textRenderer) {
+    return { load: 'text_from_download', renderer: textRenderer };
+  }
+  return { load: 'preview_url_iframe', renderer: 'urlIframe' };
+};

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/html-preview.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/html-preview.vue
@@ -1,0 +1,16 @@
+<template>
+  <iframe
+    class="ai-artifact-html-preview"
+    :srcdoc="content"
+  />
+</template>
+<script setup lang="ts">
+  defineProps<{ content: string }>();
+</script>
+<style lang="scss">
+  .ai-artifact-html-preview {
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/markdown-preview.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/markdown-preview.vue
@@ -1,0 +1,28 @@
+<template>
+  <div class="ai-artifact-markdown-preview">
+    <MarkdownContent
+      :content="content"
+      :status="MessageStatus.Success"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+  import { MessageStatus } from '../../../../../../ag-ui/types/constants';
+  import MarkdownContent from '../../../../../chat-content/markdown-content/markdown-content.vue';
+
+  defineProps<{ content: string }>();
+</script>
+<style lang="scss">
+  @import 'highlight.js/styles/github-dark.css';
+
+  .ai-artifact-markdown-preview {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+
+    .ai-markdown-content {
+      height: fit-content;
+      min-height: 100%;
+    }
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/txt-preview.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/txt-preview.vue
@@ -1,0 +1,22 @@
+<template>
+  <pre class="ai-artifact-txt-preview">{{ content }}</pre>
+</template>
+<script setup lang="ts">
+  defineProps<{ content: string }>();
+</script>
+<style lang="scss">
+  @use '../../../../../../styles/variables.scss' as variables;
+
+  .ai-artifact-txt-preview {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    overflow: auto;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+    font-size: var(--ai-font-size, 12px);
+    line-height: var(--ai-line-height, 20px);
+    color: variables.$color-title;
+    word-break: break-all;
+    white-space: pre-wrap;
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/url-iframe-preview.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/renderers/url-iframe-preview.vue
@@ -1,0 +1,16 @@
+<template>
+  <iframe
+    class="ai-artifact-url-iframe-preview"
+    :src="url"
+  />
+</template>
+<script setup lang="ts">
+  defineProps<{ url: string }>();
+</script>
+<style lang="scss">
+  .ai-artifact-url-iframe-preview {
+    width: 100%;
+    height: 100%;
+    border: none;
+  }
+</style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
@@ -1,0 +1,211 @@
+import { defineComponent, h, shallowRef } from 'vue';
+
+import { flushPromises, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { AIFileType } from '../../../../../ag-ui/types/file';
+import { useArtifactPreviewLoader } from './use-artifact-preview-loader';
+
+import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
+
+const createFile = (type: AIFileType, name = `a.${type}`): AIFileInfo => ({
+  name,
+  outputId: '1',
+  size: 1,
+  type,
+});
+
+const createDeferred = <T,>() => {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  if (!resolve) {
+    throw new Error('延迟 Promise 未初始化');
+  }
+  return { promise, resolve };
+};
+
+describe('use-artifact-preview-loader', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  const mountLoader = (opts: {
+    canResolve?: boolean;
+    file: AIFileInfo | undefined;
+    resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+  }) => {
+    let api: ReturnType<typeof useArtifactPreviewLoader> | undefined;
+    const fileRef = shallowRef(opts.file);
+    const Comp = defineComponent({
+      setup() {
+        api = useArtifactPreviewLoader({
+          canResolve: () => opts.canResolve !== false,
+          getFile: () => fileRef.value,
+          resolveUrls: opts.resolveUrls,
+        });
+        return () => h('div');
+      },
+    });
+    const wrapper = mount(Comp);
+    if (!api) {
+      throw new Error('加载器未初始化');
+    }
+    return {
+      api,
+      setFile: (file: AIFileInfo | undefined) => {
+        fileRef.value = file;
+      },
+      wrapper,
+    };
+  };
+
+  it('无取链能力时应为 empty', async () => {
+    const { api, wrapper } = mountLoader({
+      canResolve: false,
+      file: createFile(AIFileType.Pdf),
+      resolveUrls: vi.fn(),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('empty');
+    wrapper.unmount();
+  });
+
+  it('pdf 应使用 preview_url 且不 fetch', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Pdf),
+      resolveUrls: vi.fn().mockResolvedValue({ preview_url: 'https://example.com/a.pdf' }),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('ready');
+    expect(api.previewUrl.value).toBe('https://example.com/a.pdf');
+    expect(api.renderer.value).toBe('urlIframe');
+    expect(fetchSpy).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('txt 应 fetch download_url 得到 content', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('hello txt') }),
+    );
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Txt),
+      resolveUrls: vi.fn().mockResolvedValue({
+        download_url: 'https://example.com/a.txt',
+        preview_url: 'https://example.com/a.pdf',
+      }),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('ready');
+    expect(api.content.value).toBe('hello txt');
+    expect(api.renderer.value).toBe('txt');
+    expect(api.previewUrl.value).toBe('');
+    wrapper.unmount();
+  });
+
+  it('markdown 应使用下载内容及 markdown 渲染器', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('# 标题') }),
+    );
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Markdown),
+      resolveUrls: vi.fn().mockResolvedValue({ download_url: 'https://example.com/a.md' }),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('ready');
+    expect(api.content.value).toBe('# 标题');
+    expect(api.renderer.value).toBe('markdown');
+    wrapper.unmount();
+  });
+
+  it('加载失败时应为 error', async () => {
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Pdf),
+      resolveUrls: vi.fn().mockRejectedValue(new Error('resolve failed')),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('error');
+    wrapper.unmount();
+  });
+
+  it('dispose 后 abort 不应置为 error', async () => {
+    const fetchMock = vi.fn(
+      (_url: string, options: { signal: AbortSignal }) => new Promise((_resolve, reject) => {
+        options.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+      }),
+    );
+    vi.stubGlobal('fetch', fetchMock);
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Txt),
+      resolveUrls: vi.fn().mockResolvedValue({ download_url: 'https://example.com/a.txt' }),
+    });
+
+    const loading = api.load();
+    await flushPromises();
+    api.dispose();
+    await loading;
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(api.status.value).not.toBe('error');
+    wrapper.unmount();
+  });
+
+  it('切换文件后过期结果不应覆盖最新内容', async () => {
+    const first = createDeferred<ArtifactUrlResult>();
+    const resolveUrls = vi.fn()
+      .mockReturnValueOnce(first.promise)
+      .mockResolvedValueOnce({ download_url: 'https://example.com/b.txt' });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('new content') }),
+    );
+    const { api, setFile, wrapper } = mountLoader({
+      file: createFile(AIFileType.Txt, 'a.txt'),
+      resolveUrls,
+    });
+
+    const firstLoad = api.load();
+    setFile(createFile(AIFileType.Txt, 'b.txt'));
+    await api.load();
+    first.resolve({ download_url: 'https://example.com/a.txt' });
+    await firstLoad;
+
+    expect(api.content.value).toBe('new content');
+    expect(api.status.value).toBe('ready');
+    wrapper.unmount();
+  });
+
+  it('清空文件后过期结果不应覆盖 empty 状态', async () => {
+    const first = createDeferred<ArtifactUrlResult>();
+    const { api, setFile, wrapper } = mountLoader({
+      file: createFile(AIFileType.Pdf),
+      resolveUrls: vi.fn().mockReturnValue(first.promise),
+    });
+
+    const firstLoad = api.load();
+    setFile(undefined);
+    await api.load();
+    first.resolve({ preview_url: 'https://example.com/a.pdf' });
+    await firstLoad;
+
+    expect(api.status.value).toBe('empty');
+    expect(api.previewUrl.value).toBe('');
+    wrapper.unmount();
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
@@ -1,0 +1,127 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+import { onBeforeUnmount, shallowRef } from 'vue';
+
+import { getArtifactPreviewStrategy } from './preview-strategy';
+
+import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
+import type { ArtifactPreviewRendererKind } from './preview-strategy';
+
+export type ArtifactPreviewPayload = {
+  content: string;
+  previewUrl: string;
+  renderer: ArtifactPreviewRendererKind;
+  status: ArtifactPreviewStatus;
+};
+
+export type ArtifactPreviewStatus = 'empty' | 'error' | 'idle' | 'loading' | 'ready';
+
+export const useArtifactPreviewLoader = (options: {
+  canResolve: () => boolean;
+  getFile: () => AIFileInfo | undefined;
+  resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+}) => {
+  const status = shallowRef<ArtifactPreviewStatus>('idle');
+  const content = shallowRef('');
+  const previewUrl = shallowRef('');
+  const renderer = shallowRef<ArtifactPreviewRendererKind>('urlIframe');
+
+  let abortController: AbortController | undefined;
+  let loadSeq = 0;
+
+  const resetPayload = () => {
+    content.value = '';
+    previewUrl.value = '';
+  };
+
+  const load = async () => {
+    const seq = ++loadSeq;
+    abortController?.abort();
+    abortController = undefined;
+
+    const file = options.getFile();
+    if (!file || !options.canResolve()) {
+      status.value = 'empty';
+      resetPayload();
+      return;
+    }
+
+    status.value = 'loading';
+    resetPayload();
+
+    const strategy = getArtifactPreviewStrategy(file.type);
+    renderer.value = strategy.renderer;
+
+    try {
+      const urls = await options.resolveUrls(file);
+      if (seq !== loadSeq) {
+        return;
+      }
+
+      if (strategy.load === 'text_from_download') {
+        if (!urls.download_url) {
+          status.value = 'empty';
+          return;
+        }
+
+        const controller = new AbortController();
+        abortController = controller;
+        const response = await fetch(urls.download_url, { signal: controller.signal });
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        const text = await response.text();
+        if (controller.signal.aborted || seq !== loadSeq) {
+          return;
+        }
+        content.value = text;
+        status.value = 'ready';
+        return;
+      }
+
+      if (!urls.preview_url) {
+        status.value = 'empty';
+        return;
+      }
+      previewUrl.value = urls.preview_url;
+      status.value = 'ready';
+    } catch {
+      if (seq !== loadSeq || abortController?.signal.aborted) {
+        return;
+      }
+      status.value = 'error';
+    }
+  };
+
+  const dispose = () => {
+    loadSeq += 1;
+    abortController?.abort();
+  };
+
+  onBeforeUnmount(dispose);
+
+  return { content, dispose, load, previewUrl, renderer, status };
+};

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
@@ -163,8 +163,8 @@ describe('FileArtifactPanel', () => {
     wrapper = mountPanel({ activeId: artifact.artifactId, artifacts: [artifact] });
     await flushPromises();
 
-    expect(wrapper.find('.ai-file-artifact-panel-preview-empty').exists()).toBe(true);
-    expect(wrapper.find('.ai-file-artifact-panel-preview-iframe').exists()).toBe(false);
+    expect(wrapper.find('.ai-artifact-preview-host-empty').exists()).toBe(true);
+    expect(wrapper.find('.ai-artifact-url-iframe-preview').exists()).toBe(false);
   });
 
   it('pdf 文件应异步取链后用 iframe src 展示 preview_url', async () => {
@@ -181,7 +181,7 @@ describe('FileArtifactPanel', () => {
     );
     await flushPromises();
 
-    const iframe = wrapper.find('.ai-file-artifact-panel-preview-iframe');
+    const iframe = wrapper.find('.ai-artifact-url-iframe-preview');
     expect(iframe.attributes('src')).toBe('https://example.com/x.pdf');
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
@@ -206,7 +206,7 @@ describe('FileArtifactPanel', () => {
     await flushPromises();
 
     expect(fetchSpy).toHaveBeenCalledWith('https://example.com/page.html', expect.any(Object));
-    const iframe = wrapper.find('.ai-file-artifact-panel-preview-iframe');
+    const iframe = wrapper.find('.ai-artifact-html-preview');
     expect(iframe.attributes('srcdoc')).toBe('<h1>hi</h1>');
     vi.unstubAllGlobals();
   });
@@ -224,7 +224,7 @@ describe('FileArtifactPanel', () => {
     );
     await flushPromises();
 
-    expect(wrapper.find('.ai-file-artifact-panel-preview-error').exists()).toBe(true);
+    expect(wrapper.find('.ai-artifact-preview-host-error').exists()).toBe(true);
     vi.unstubAllGlobals();
   });
 
@@ -248,12 +248,12 @@ describe('FileArtifactPanel', () => {
     await flushPromises();
 
     expect(wrapper.find('.mock-message-loading').exists()).toBe(false);
-    expect(wrapper.find('.ai-file-artifact-panel-preview-iframe').exists()).toBe(true);
+    expect(wrapper.find('.ai-artifact-url-iframe-preview').exists()).toBe(true);
   });
 
   it('无命中文件时应展示空态', () => {
     wrapper = mountPanel({ activeId: 'not-exist', artifacts: [createArtifact()] });
 
-    expect(wrapper.find('.ai-file-artifact-panel-preview-empty').exists()).toBe(true);
+    expect(wrapper.find('.ai-artifact-preview-host-empty').exists()).toBe(true);
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
@@ -62,69 +62,24 @@
             />
           </span>
         </div>
-        <div class="ai-file-artifact-panel-preview-body">
-          <!-- 异步取链 / HTML 拉取中：统一 MessageLoading -->
-          <div
-            v-if="previewStatus === 'loading'"
-            class="ai-file-artifact-panel-preview-loading"
-          >
-            <MessageLoading />
-          </div>
-          <div
-            v-else-if="previewStatus === 'error'"
-            class="ai-file-artifact-panel-preview-error"
-          >
-            <span>{{ t('预览加载失败') }}</span>
-            <Button
-              size="small"
-              text
-              theme="primary"
-              @click="loadPreview"
-            >
-              {{ t('重试') }}
-            </Button>
-          </div>
-          <div
-            v-else-if="previewStatus === 'empty'"
-            class="ai-file-artifact-panel-preview-empty"
-          >
-            {{ t('暂无可预览的文件') }}
-          </div>
-          <!-- HTML：用 download_url 拉取 html 后 iframe srcdoc -->
-          <iframe
-            v-else-if="isHtml"
-            class="ai-file-artifact-panel-preview-iframe"
-            :srcdoc="htmlContent"
-          />
-          <!-- 其余类型：preview_url 为后台转换好的 pdf -->
-          <iframe
-            v-else
-            class="ai-file-artifact-panel-preview-iframe"
-            :src="previewUrl"
-          />
-        </div>
       </template>
-      <div
-        v-else
-        class="ai-file-artifact-panel-preview-empty"
-      >
-        {{ t('暂无可预览的文件') }}
+      <div class="ai-file-artifact-panel-preview-body">
+        <ArtifactPreviewHost :file="activeArtifact" />
       </div>
     </div>
   </div>
 </template>
 <script setup lang="ts">
-  import { cloneVNode, computed, onBeforeUnmount, shallowRef, watch } from 'vue';
+  import { cloneVNode, computed, shallowRef, watch } from 'vue';
 
-  import { Button, Input, Loading } from 'bkui-vue';
+  import { Input, Loading } from 'bkui-vue';
 
-  import { AIFileType } from '../../../../ag-ui/types/file';
   import { triggerArtifactDownload, useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
   import { DownloadFileIcon } from '../../../../icons/file';
   import { t } from '../../../../lang/lang';
-  import MessageLoading from '../../../message-loading/message-loading.vue';
   import ArtifactFileCard from './artifact-file-card.vue';
+  import ArtifactPreviewHost from './artifact-preview/artifact-preview-host.vue';
   import { getFileIcon } from './file-icon';
 
   import type { SessionArtifact } from '../../../../composables/use-artifact-preview';
@@ -148,13 +103,6 @@
 
   const keyword = shallowRef('');
   const downloadLoading = shallowRef(false);
-  const previewStatus = shallowRef<'empty' | 'error' | 'idle' | 'loading' | 'ready'>('idle');
-  const previewUrl = shallowRef('');
-  const htmlContent = shallowRef('');
-  // 记录当前进行中的请求，切换文件时中断旧请求，避免竞态覆盖
-  let htmlAbortController: AbortController | undefined;
-  // 用于丢弃过期的 URL 解析结果
-  let loadSeq = 0;
 
   const filteredArtifacts = computed(() => {
     const kw = keyword.value.trim().toLowerCase();
@@ -165,74 +113,6 @@
   });
 
   const activeArtifact = computed(() => props.artifacts.find(item => item.artifactId === props.activeId));
-
-  const isHtml = computed(() => activeArtifact.value?.type === AIFileType.Html);
-
-  const loadPreview = async () => {
-    const file = activeArtifact.value;
-    if (!file) {
-      previewStatus.value = 'empty';
-      return;
-    }
-
-    // 未传 onArtifactClick：预览区展示无数据
-    if (!artifactPreview?.canResolveArtifactUrl.value) {
-      previewStatus.value = 'empty';
-      previewUrl.value = '';
-      htmlContent.value = '';
-      return;
-    }
-
-    const seq = ++loadSeq;
-    htmlAbortController?.abort();
-    previewStatus.value = 'loading';
-    previewUrl.value = '';
-    htmlContent.value = '';
-
-    try {
-      const urls = await artifactPreview.resolveArtifactUrls(file);
-      if (seq !== loadSeq) {
-        return;
-      }
-
-      if (file.type === AIFileType.Html) {
-        const downloadUrl = urls.download_url;
-        if (!downloadUrl) {
-          previewStatus.value = 'empty';
-          return;
-        }
-        const controller = new AbortController();
-        htmlAbortController = controller;
-        const res = await fetch(downloadUrl, { signal: controller.signal });
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}`);
-        }
-        const text = await res.text();
-        if (controller.signal.aborted || seq !== loadSeq) {
-          return;
-        }
-        htmlContent.value = text;
-        previewStatus.value = 'ready';
-        return;
-      }
-
-      if (!urls.preview_url) {
-        previewStatus.value = 'empty';
-        return;
-      }
-      previewUrl.value = urls.preview_url;
-      previewStatus.value = 'ready';
-    } catch {
-      if (seq !== loadSeq) {
-        return;
-      }
-      // abort 不算失败
-      if (htmlAbortController?.signal.aborted) {
-        return;
-      }
-      previewStatus.value = 'error';
-    }
-  };
 
   const handleSelect = (item: SessionArtifact) => {
     if (item.artifactId === props.activeId) {
@@ -256,20 +136,12 @@
     }
   };
 
-  // 命中文件变化时重新异步取链并加载预览
   watch(
     () => activeArtifact.value?.artifactId,
     () => {
       downloadLoading.value = false;
-      loadPreview();
     },
-    { immediate: true },
   );
-
-  onBeforeUnmount(() => {
-    loadSeq += 1;
-    htmlAbortController?.abort();
-  });
 </script>
 <style lang="scss">
   @use '../../../../styles/variables.scss' as variables;
@@ -380,37 +252,6 @@
         flex: 1;
         min-height: 0;
         margin-top: 10px;
-      }
-
-      &-iframe {
-        width: 100%;
-        height: 100%;
-        border: none;
-      }
-
-      &-loading {
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-      }
-
-      &-error {
-        display: flex;
-        gap: 8px;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-        color: variables.$color-text-secondary;
-      }
-
-      &-empty {
-        display: flex;
-        flex: 1;
-        align-items: center;
-        justify-content: center;
-        height: 100%;
-        color: variables.$color-text-secondary;
       }
     }
   }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
@@ -125,20 +125,15 @@ const doubled = computed(() => count.value * 2);
   ];
 
   // 文件产物（AIFileInfo 元信息；下载/预览链路由 ChatContainer.onArtifactClick 异步获取）
+  // 侧栏按类型分派：html / markdown / txt / json → download_url 正文；pdf / jpg → preview_url iframe
   const artifactsProperty = {
     artifacts: [
-      {
-        name: 'report.html',
-        outputId: 'output-1',
-        size: 10240,
-        type: 'html',
-      },
-      {
-        name: 'summary.pdf',
-        outputId: 'output-2',
-        size: 204800,
-        type: 'pdf',
-      },
+      { name: '监控大盘周报.html', outputId: 'output-html', size: 10240, type: 'html' },
+      { name: '系统配置说明.md', outputId: 'output-md', size: 8192, type: 'markdown' },
+      { name: '周例会纪要.txt', outputId: 'output-txt', size: 4096, type: 'txt' },
+      { name: '告警策略配置.json', outputId: 'output-json', size: 2048, type: 'json' },
+      { name: '立项说明书.pdf', outputId: 'output-pdf', size: 204800, type: 'pdf' },
+      { name: '巡检现场照片.jpg', outputId: 'output-jpg', size: 1048576, type: 'jpg' },
     ],
   };
 </script>
@@ -163,7 +158,7 @@ AssistantMessage（根类名：ai-assistant-message）
 │   └── [default slot { content }] 或 ContentRender → MarkdownContent
 ├── ToolCallRender × N（toolCalls，不受 slot 影响）
 └── MessageArtifacts（v-if property.artifacts 非空）
-      └── ArtifactFileCard × N（点击 → useArtifactPreview → 侧栏 FileArtifactPanel）
+      └── ArtifactFileCard × N（点击 → useArtifactPreview → 侧栏 FileArtifactPanel → ArtifactPreviewHost）
 ```
 
 - **内容区**：`content` 经 `ContentRender`（`MessageContentType.Text`）由 `MarkdownContent` 渲染；default slot 仅收到 `{ content }`
@@ -627,6 +622,13 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 
 `AIFileInfo` 仅含元信息（`name` / `outputId` / `size` / `type`）；`download_url` / `preview_url` 由容器 `onArtifactClick` 异步获取。命中唯一文件依赖 `messageUid = uid ?? String(id)` + 卡片下标 + `outputId`。
 
+侧栏预览由面板内 `ArtifactPreviewHost` 按类型分派（详见面板文档「预览机制」）：
+
+| type | 预览依赖 | 渲染 |
+| ---- | -------- | ---- |
+| `html` / `markdown` / `txt` / `json` | `download_url` | 正文直渲染（srcdoc / MarkdownContent / `<pre>`） |
+| `pdf` / `jpg` 等 | `preview_url` | iframe（一般为后台转好的 PDF） |
+
 ```vue
 <template>
   <MessageRender :message="message" />
@@ -637,8 +639,12 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
   import type { AIFileInfo } from '@blueking/chat-x';
 
   const artifacts: AIFileInfo[] = [
-    { name: 'report.html', outputId: 'output-1', size: 10240, type: 'html' },
-    { name: 'summary.pdf', outputId: 'output-2', size: 204800, type: 'pdf' },
+    { name: '监控大盘周报.html', outputId: 'output-html', size: 10240, type: 'html' },
+    { name: '系统配置说明.md', outputId: 'output-md', size: 8192, type: 'markdown' },
+    { name: '周例会纪要.txt', outputId: 'output-txt', size: 4096, type: 'txt' },
+    { name: '告警策略配置.json', outputId: 'output-json', size: 2048, type: 'json' },
+    { name: '立项说明书.pdf', outputId: 'output-pdf', size: 204800, type: 'pdf' },
+    { name: '巡检现场照片.jpg', outputId: 'output-jpg', size: 1048576, type: 'jpg' },
   ];
 
   const message = {
@@ -647,7 +653,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
     uid: 'assistant-uid-1',
     role: MessageRole.Assistant,
     status: MessageStatus.Complete,
-    content: '已为你生成分析报告：',
+    content: '已为你生成一组评审材料，可点击卡片在侧栏预览或下载：',
     property: { artifacts },
   };
 </script>
@@ -658,7 +664,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 <div class="demo">
   <AssistantMessageComp
     uid="assistant-uid-1"
-    content="已为你生成分析报告："
+    content="已为你生成一组评审材料，可点击卡片在侧栏预览或下载："
     status="complete"
     :property="artifactsProperty"
   />
@@ -738,4 +744,4 @@ interface ToolMessage extends BaseMessage<MessageRole.Tool, string> {
 - [MessageRender](/components/message/message-render) — assistant 角色由其实例化
 - [ToolMessage](/components/message/tool-message) — 工具执行结果可通过 toolCall.toolMessage 内联
 - [ToolcallRender](/components/agent/toolcall-render) — 工具调用列表渲染
-- [FileArtifactPanel](/components/message/file-artifact-panel) — 文件产物侧栏预览
+- [FileArtifactPanel](/components/message/file-artifact-panel) — 文件产物侧栏列表与分类型预览 Host

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -3,11 +3,11 @@ name: FileArtifactPanel 文件产物预览
 slug: file-artifact-panel
 kind: component
 domain: message
-description: 汇总当前会话全部文件产物，支持搜索、选中与 HTML / PDF 预览，挂载在 ChatContainer 侧栏「文件产物」Tab。
+description: 汇总当前会话全部文件产物，支持搜索、选中与分类型预览，挂载在 ChatContainer 侧栏「文件产物」Tab。
 aiSummary: >
-  汇总当前会话所有 AssistantMessage 的 artifacts，支持关键词搜索、列表选中与预览；
-  download_url / preview_url 通过 onArtifactClick 异步获取；HTML 用 download_url fetch + iframe srcdoc，
-  其余类型用 preview_url（后台转好的 PDF）iframe 展示；取链过程展示 MessageLoading。
+  汇总当前会话所有 AssistantMessage 的 artifacts，支持关键词搜索、列表选中与下载；
+  预览区委托 ArtifactPreviewHost：按类型走 text_from_download（html / markdown / txt / json）
+  或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 异步获取。
   源码位置：src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue。
 relatedComponents:
   - slug: assistant-message
@@ -17,9 +17,37 @@ relatedComponents:
   - slug: execution-summary
     relation: 同为 ChatContainer 侧栏 Tab 面板，交互形态一致
   - slug: message-loading
-    relation: 异步取链 / HTML 拉取过程使用 MessageLoading
+    relation: ArtifactPreviewHost 取链 / 拉取正文过程使用 MessageLoading
 sinceVersion: 0.0.20
 ---
+
+<script lang="ts" setup>
+  import { shallowRef } from 'vue'
+
+  import { MOCK_FILE_ARTIFACTS, mockArtifactClick } from '../../../playground/mock'
+  import FileArtifactPanelComp from '../../../src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue'
+  import { buildArtifactId, useArtifactPreviewProvider } from '../../../src/composables/use-artifact-preview'
+
+  const DEMO_MESSAGE_UID = 'wiki-artifact-msg'
+
+  const demoArtifacts = MOCK_FILE_ARTIFACTS.map((file, index) => ({
+    ...file,
+    artifactId: buildArtifactId(DEMO_MESSAGE_UID, index, file.outputId),
+    messageUid: DEMO_MESSAGE_UID,
+  }))
+
+  const activeArtifactId = shallowRef(demoArtifacts[0]?.artifactId ?? '')
+
+  // 文档站单独挂载面板时需自行提供 Provider；业务侧由 ChatContainer 注入
+  useArtifactPreviewProvider({
+    getOnArtifactClick: () => mockArtifactClick,
+    onOpen: () => {},
+  })
+
+  const handleSelectArtifact = (id: string) => {
+    activeArtifactId.value = id
+  }
+</script>
 
 # FileArtifactPanel 文件产物预览
 
@@ -27,9 +55,9 @@ sinceVersion: 0.0.20
 
 - **源码位置**：`src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue`
 - **能力域**：消息系统
-- **能力说明**：汇总当前会话全部文件产物，支持搜索、选中与 HTML / PDF 预览。
+- **能力说明**：汇总当前会话全部文件产物；左侧列表搜索与选中，右侧预览委托内部 `ArtifactPreviewHost`。
 
-> **导出说明**：内部侧栏面板组件，**通常不直接使用**；由 `ChatContainer` 在「文件产物」Tab 内自动挂载。
+> **导出说明**：内部侧栏面板组件，**通常不直接使用**；由 `ChatContainer` 在「文件产物」Tab 内自动挂载。预览加载与渲染为同目录下 `artifact-preview/` 内部实现，不单独导出。
 
 点击 AI 回复中的[文件卡片](/components/message/assistant-message)后，`ChatContainer` 侧栏会弹出固定的「文件产物」Tab，聚合展示当前会话**所有** `AssistantMessage` 的文件产物，并命中被点击的文件进行预览。
 
@@ -41,11 +69,139 @@ sinceVersion: 0.0.20
 - **唯一命中**：同一会话可能出现多个消息 + 同名文件，文件名不可作唯一键，统一用 `messageUid#消息内下标#outputId` 生成全局唯一 id
 - **关键词搜索**：按文件名实时过滤列表
 - **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 缓存获取 `download_url` / `preview_url`
-- **分类型预览**：
-  - **HTML**：`fetch(download_url)` 拉取 HTML 字符串，用 `<iframe srcdoc>` 渲染
-  - **其余类型**：`preview_url` 是后台转换好的 PDF 链接，直接作为 `<iframe src>` 展示
-- **Loading**：取链 / HTML 拉取过程在预览区展示 [MessageLoading](/components/helper/message-loading)；下载图标展示 bkui `Loading` spin
+- **职责拆分**：
+  - **面板本身**：列表、搜索、预览头（文件名 / 图标 / 下载）
+  - **`ArtifactPreviewHost`**：按策略加载正文或预览 URL，分派到对应 renderer；展示 loading / empty / error（含重试）
 - **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
+
+## 基础用法
+
+面板**未从包入口导出**，业务侧请走下方「业务接入」；下列示例仅用于文档站 / 本地调试（与 `ExecutionSummary` 文档站写法一致：相对路径引入 + 自行挂 Provider）。
+
+```vue
+<template>
+  <div style="height: 480px; border: 1px solid #dcdee5; border-radius: 8px; overflow: hidden;">
+    <FileArtifactPanel
+      :active-id="activeArtifactId"
+      :artifacts="sessionArtifacts"
+      @select="handleSelect"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+  import { shallowRef } from 'vue'
+  import { buildArtifactId, useArtifactPreviewProvider } from '@blueking/chat-x'
+  import type { AIFileInfo, SessionArtifact } from '@blueking/chat-x'
+  // 内部组件：仅文档 / 调试；业务请用 ChatContainer 自动挂载
+  import FileArtifactPanel from './message-artifacts/file-artifact-panel.vue'
+
+  const files: AIFileInfo[] = [
+    { name: '周报.html', outputId: 'a-html', size: 10240, type: 'html' },
+    { name: '说明.md', outputId: 'a-md', size: 8192, type: 'markdown' },
+    { name: '纪要.txt', outputId: 'a-txt', size: 4096, type: 'txt' },
+    { name: '配置.json', outputId: 'a-json', size: 2048, type: 'json' },
+    { name: '立项.pdf', outputId: 'a-pdf', size: 204800, type: 'pdf' },
+  ]
+
+  const sessionArtifacts: SessionArtifact[] = files.map((file, index) => ({
+    ...file,
+    artifactId: buildArtifactId('msg-1', index, file.outputId),
+    messageUid: 'msg-1',
+  }))
+
+  useArtifactPreviewProvider({
+    getOnArtifactClick: () => async file => {
+      // 文本类返回可 fetch 的 download_url；iframe 类返回 preview_url
+      const res = await api.getArtifactUrls(file.outputId)
+      return { download_url: res.download_url, preview_url: res.preview_url }
+    },
+    onOpen: () => {},
+  })
+
+  const activeArtifactId = shallowRef(sessionArtifacts[0].artifactId)
+  const handleSelect = (id: string) => {
+    activeArtifactId.value = id
+  }
+</script>
+```
+
+**渲染效果**（点击左侧列表切换类型；文本类直渲染，PDF 走 iframe。Mock 取链约 600ms）
+
+<div class="demo">
+  <div style="height: 480px; border: 1px solid #dcdee5; border-radius: 8px; overflow: hidden;">
+    <FileArtifactPanelComp
+      :active-id="activeArtifactId"
+      :artifacts="demoArtifacts"
+      @select="handleSelectArtifact"
+    />
+  </div>
+</div>
+
+## 业务接入（ChatContainer）
+
+日常用法是给容器传 `messages`（含 `property.artifacts`）与 `onArtifactClick`，点击文件卡片即可打开侧栏面板：
+
+```vue
+<template>
+  <ChatContainer
+    v-model="input"
+    :messages="messages"
+    :on-artifact-click="onArtifactClick"
+    @send-message="handleSend"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref, shallowRef } from 'vue'
+  import {
+    ChatContainer,
+    MessageRole,
+    MessageStatus,
+    type AIFileInfo,
+    type Message,
+  } from '@blueking/chat-x'
+
+  const input = ref('')
+  const messages = shallowRef<Message[]>([
+    {
+      id: 'u1',
+      messageId: 'u1',
+      role: MessageRole.User,
+      status: MessageStatus.Complete,
+      content: '整理本周评审材料',
+    },
+    {
+      id: 'a1',
+      messageId: 'a1',
+      uid: 'assistant-uid-1',
+      role: MessageRole.Assistant,
+      status: MessageStatus.Complete,
+      content: '已生成评审材料，点击卡片可在侧栏预览：',
+      property: {
+        artifacts: [
+          { name: '周报.html', outputId: 'a-html', size: 10240, type: 'html' },
+          { name: '说明.md', outputId: 'a-md', size: 8192, type: 'markdown' },
+          { name: '配置.json', outputId: 'a-json', size: 2048, type: 'json' },
+          { name: '立项.pdf', outputId: 'a-pdf', size: 204800, type: 'pdf' },
+        ] satisfies AIFileInfo[],
+      },
+    },
+  ])
+
+  const onArtifactClick = async (file: AIFileInfo) => {
+    const res = await api.getArtifactUrls(file.outputId)
+    return {
+      download_url: res.download_url,
+      preview_url: res.preview_url,
+    }
+  }
+
+  const handleSend = () => {
+    /* ... */
+  }
+</script>
+```
 
 ## 触发链路
 
@@ -56,8 +212,11 @@ ArtifactFileCard（点击文件卡片）
             ├─ 记录命中文件 activeArtifactId
             └─ onOpen → addCustomTab('file-artifact') 展开并选中侧栏 Tab
                  └─ FileArtifactPanel
-                      ├─ resolveArtifactUrls(file) → onArtifactClick（带 outputId 缓存）
-                      └─ MessageLoading → 渲染预览 / 下载
+                      ├─ 列表 @select → setActiveArtifactId
+                      ├─ 下载 → resolveArtifactUrls + triggerArtifactDownload
+                      └─ ArtifactPreviewHost
+                           ├─ useArtifactPreviewLoader（策略 + fetch / 取链，防竞态）
+                           └─ HtmlPreview | MarkdownPreview | TxtPreview | UrlIframePreview
 ```
 
 - 文件卡片通过 `useArtifactPreviewConsumer` 注入预览上下文，无 Provider 时卡片不可点击（兜底 `undefined`）
@@ -79,10 +238,41 @@ Provider 侧聚合与文件卡片侧透传必须使用同一规则，保证命�
 
 ## 预览机制
 
-| 文件类型 | 预览字段 | 渲染方式 |
-| -------- | -------- | -------- |
-| `html`   | `download_url`（`onArtifactClick` 返回） | `fetch(download_url)` 拿到 HTML 字符串 → `<iframe srcdoc>` 渲染，切换文件会中断上一次请求避免竞态 |
-| 其余     | `preview_url`（`onArtifactClick` 返回） | 后台已转换为 PDF，直接 `<iframe src="preview_url">` 展示 |
+预览由内部 `getArtifactPreviewStrategy(type)` 决定 **加载方式** 与 **渲染器**；面板不直接写死类型分支。
+
+| 文件类型 | load | 取链字段 | renderer |
+| -------- | ---- | -------- | -------- |
+| `html` | `text_from_download` | `download_url` → `fetch` 正文 | `HtmlPreview`（`<iframe srcdoc>`） |
+| `markdown` | `text_from_download` | 同上 | `MarkdownPreview`（`MarkdownContent`） |
+| `txt` / `json` | `text_from_download` | 同上 | `TxtPreview`（`<pre>`） |
+| 其余（如 `pdf` / `jpg`） | `preview_url_iframe` | `preview_url` | `UrlIframePreview`（`<iframe src>`，一般为后台转好的 PDF） |
+
+### 加载态
+
+| status | 表现 |
+| ------ | ---- |
+| `loading` | 预览区 [MessageLoading](/components/helper/message-loading) |
+| `ready` | 对应 renderer 渲染 |
+| `empty` | 「暂无可预览的文件」（无文件 / 未传 `onArtifactClick` / 缺所需 URL） |
+| `error` | 「预览加载失败」+ 重试按钮 |
+
+切换文件时 `useArtifactPreviewLoader` 用 `loadSeq` + `AbortController` 中断上一次 `fetch`，避免竞态覆盖。下载图标仍由面板用 bkui `Loading` spin 单独表达。
+
+## 内部结构（不导出）
+
+```
+message-artifacts/
+├── file-artifact-panel.vue          # 列表 + 下载头 + 挂载 Host
+└── artifact-preview/
+    ├── artifact-preview-host.vue    # 状态机 UI + 分派 renderer
+    ├── preview-strategy.ts          # getArtifactPreviewStrategy
+    ├── use-artifact-preview-loader.ts
+    └── renderers/
+        ├── html-preview.vue
+        ├── markdown-preview.vue
+        ├── txt-preview.vue
+        └── url-iframe-preview.vue
+```
 
 ## API
 
@@ -124,11 +314,11 @@ type AIFileInfo = {
 
 ## 关联 Composable
 
-预览状态由 [useArtifactPreview](/composables/use-artifact-preview) 提供，Provider / Consumer 通过 `ARTIFACT_PREVIEW_TOKEN` 通信。容器侧 `useArtifactPreviewProvider` 维护 `activeArtifactId`、封装 `resolveArtifactUrls`（含缓存），并通过 `onOpen` 打开侧栏 Tab；文件卡片 / 面板侧 `useArtifactPreviewConsumer` 触发预览与取链。
+预览**命中与取链**由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider / Consumer + `ARTIFACT_PREVIEW_TOKEN`）。**正文加载与渲染**由内部 `useArtifactPreviewLoader` + `ArtifactPreviewHost` 完成，不在该 composable 内。
 
 ## 关联组件
 
 - [AssistantMessage](/components/message/assistant-message) — 文件产物来源（`property.artifacts`）
 - [ChatContainer](/components/setup/chat-container) — 侧栏「文件产物」Tab 挂载场景，提供 `onArtifactClick`
-- [MessageLoading](/components/helper/message-loading) — 预览区异步加载态
+- [MessageLoading](/components/helper/message-loading) — Host 预览区异步加载态
 - [ExecutionSummary](/components/agent/execution-summary) — 同为侧栏 Tab 面板

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -566,11 +566,75 @@ ai-chat-container（:data-ai-size="size"）
 - **触发**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 命中该文件并 `addCustomTab` 弹出侧栏
 - **排序 / 关闭**：`order: -1` 排在「执行情况」之前，`closable: false` 不可关闭
 - **显隐解耦**：该 Tab 存在时，侧栏展示不再受「`executionGroups` 为空」约束（即使当前会话没有执行类消息，也能独立展示文件产物侧栏）；会话切换或无文件产物时自动移除并重置命中态
-- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染文件列表与预览；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取（HTML 用 `download_url` fetch + `iframe srcdoc`，其余类型用 `preview_url` 的 PDF）
-- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）
+- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取。文本类（`html` / `markdown` / `txt` / `json`）拉 `download_url` 正文直渲染；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）
+- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）；正文加载与分类型渲染由 Host 内部完成
 - **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
 
 详见 [FileArtifactPanel 文件产物预览](/components/message/file-artifact-panel) 与 [useArtifactPreview 文件产物预览](/composables/use-artifact-preview)。
+
+#### 接入示例
+
+```vue
+<template>
+  <ChatContainer
+    v-model="input"
+    :messages="messages"
+    :on-artifact-click="onArtifactClick"
+    @send-message="handleSend"
+  />
+</template>
+
+<script setup lang="ts">
+  import { ref, shallowRef } from 'vue'
+  import {
+    ChatContainer,
+    MessageRole,
+    MessageStatus,
+    type AIFileInfo,
+    type Message,
+  } from '@blueking/chat-x'
+
+  const input = ref('')
+  const messages = shallowRef<Message[]>([
+    {
+      id: 'u1',
+      messageId: 'u1',
+      role: MessageRole.User,
+      status: MessageStatus.Complete,
+      content: '整理本周评审材料',
+    },
+    {
+      id: 'a1',
+      messageId: 'a1',
+      uid: 'assistant-uid-1',
+      role: MessageRole.Assistant,
+      status: MessageStatus.Complete,
+      content: '已生成评审材料，点击卡片可在侧栏预览：',
+      property: {
+        artifacts: [
+          { name: '周报.html', outputId: 'a-html', size: 10240, type: 'html' },
+          { name: '说明.md', outputId: 'a-md', size: 8192, type: 'markdown' },
+          { name: '配置.json', outputId: 'a-json', size: 2048, type: 'json' },
+          { name: '立项.pdf', outputId: 'a-pdf', size: 204800, type: 'pdf' },
+        ] satisfies AIFileInfo[],
+      },
+    },
+  ])
+
+  /** 文本类预览依赖 download_url；iframe 类依赖 preview_url */
+  const onArtifactClick = async (file: AIFileInfo) => {
+    const res = await api.getArtifactUrls(file.outputId)
+    return {
+      download_url: res.download_url,
+      preview_url: res.preview_url,
+    }
+  }
+
+  const handleSend = () => {
+    /* ... */
+  }
+</script>
+```
 
 ### 自定义 Tab 与「在对话中定位」
 
@@ -977,7 +1041,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | size               | `'normal' \| 'small'`                                                        | `'small'` | 字号主题档位：`small` 为 12px 基准，`normal` 为 14px 基准；根节点设置 `data-ai-size` 并注入 `useGlobalConfig`                                |
 | resizeProps        | `{ disabled?: boolean; initialDivide?: number \| string; max?: number; min?: number }` | —        | 透传给内部 `ResizeLayout` 的可选配置，与默认 `collapsible: false`、`immediate: true`、`min: 400` 合并；`placement` 始终取自本组件 `placement`；`initialDivide` 可为像素数字或百分比等字符串（与 bkui ResizeLayout 一致）。**数字型** `initialDivide` 还会作为内部侧栏宽度初值（驱动 `--resize-main-width`，并在展开时作为 `collapseChange` 的 `width`）；百分比等字符串则回退为 `400` |
 | onCustomTabChange  | `(tab: CustomTab) => Promise<any>`                                           | —        | 自定义 Tab 切换回调，返回值作为 Tab 组件 props                                                                                                |
-| onArtifactClick    | `(file: AIFileInfo) => Promise<{ download_url?: string; preview_url?: string }>` | —        | 点击文件产物时异步获取下载 / 预览链接（按 `outputId` 缓存）；未传则隐藏下载、预览无数据 |
+| onArtifactClick    | `(file: AIFileInfo) => Promise<{ download_url?: string; preview_url?: string }>` | —        | 异步获取下载 / 预览链接（按 `outputId` 缓存）。文本类预览依赖 `download_url`，iframe 类依赖 `preview_url`；未传则隐藏下载、预览无数据 |
 
 > 完整 Props 列表请参考 [ChatInput](/components/input/chat-input) 和 [MessageContainer](/components/setup/message-container) 文档。
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -9,12 +9,13 @@ aiSummary: >
   useArtifactPreviewProvider 维护 activeArtifactId，openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
   并通过 getOnArtifactClick 封装 resolveArtifactUrls（按 outputId 缓存 download_url / preview_url）；
   useArtifactPreviewConsumer 在后代注入同一套 API。buildArtifactId 用 messageUid#index#outputId 生成唯一 id。
+  正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
 relatedComponents:
   - slug: chat-container
     relation: Provider 主场景，聚合 sessionArtifacts 并挂载 FileArtifactPanel
   - slug: file-artifact-panel
-    relation: 侧栏面板消费 activeArtifactId 与 setActiveArtifactId
+    relation: 侧栏面板消费 activeArtifactId 与 setActiveArtifactId；预览加载在面板内 Host
   - slug: assistant-message
     relation: 文件产物来源 property.artifacts
 sinceVersion: 0.0.20
@@ -26,7 +27,10 @@ sinceVersion: 0.0.20
 
 Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatContainer` 中创建，负责维护当前命中的文件 id；Consumer 在深层 `ArtifactFileCard` 中注入，用于点击卡片触发预览。
 
-**职责边界**：composable 维护「命中文件」与「URL 解析缓存」；打开侧栏 Tab（`addCustomTab`）、聚合会话文件列表、渲染预览面板等副作用由 `ChatContainer` 承担，通过 `onOpen` / `getOnArtifactClick` 回调注入，避免直接依赖 `useCustomTab`。
+**职责边界**：
+
+- **本 composable**：维护「命中文件」与「URL 解析缓存」；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
+- **不在本 composable**：聚合会话文件列表、渲染预览面板、按类型 fetch 正文 / iframe 展示 —— 分别由 `useMessageGroup.sessionArtifacts`、`FileArtifactPanel`、内部 `ArtifactPreviewHost` + `useArtifactPreviewLoader` 承担
 
 ## 函数签名
 
@@ -136,11 +140,26 @@ const handleCardClick = () => {
 
 ```typescript
 // FileArtifactPanel 列表点击 → emit select → 容器调用 setActiveArtifactId
+// 右侧预览由面板内 ArtifactPreviewHost 消费 activeArtifact，自行取链并按类型渲染
 <FileArtifactPanel
   :active-id="activeArtifactId"
   :artifacts="sessionArtifacts"
   @select="setActiveArtifactId"
 />
+```
+
+### 业务侧取链（ChatContainer `onArtifactClick`）
+
+文本类预览需要可 `fetch` 的 `download_url`；iframe 类需要 `preview_url`（一般为后台转好的 PDF）：
+
+```typescript
+const onArtifactClick = async (file: AIFileInfo) => {
+  const res = await api.getArtifactUrls(file.outputId);
+  return {
+    download_url: res.download_url,
+    preview_url: res.preview_url,
+  };
+};
 ```
 
 ## 内置常量
@@ -208,12 +227,15 @@ ArtifactFileCard（点击）
        └─ useArtifactPreviewProvider（ChatContainer）
             ├─ activeArtifactId = buildArtifactId(...)
             └─ onOpen(artifactId) → addCustomTab(FILE_ARTIFACT_TAB_NAME)
-                 └─ FileArtifactPanel（列表 + 预览，@select → setActiveArtifactId）
+                 └─ FileArtifactPanel（列表 + 下载头，@select → setActiveArtifactId）
+                      └─ ArtifactPreviewHost（loader + 分类型 renderer）
 ```
+
+分类型预览策略见 [FileArtifactPanel 预览机制](../components/message/file-artifact-panel#预览机制)。
 
 ## 设计特点
 
-- **职责单一**：composable 不直接调用 `useCustomTab`，侧栏 Tab 打开逻辑由 `onOpen` 注入
+- **职责单一**：composable 不直接调用 `useCustomTab`，侧栏 Tab 打开逻辑由 `onOpen` 注入；也不做正文 fetch / iframe 渲染
 - **ShallowRef 优先**：`activeArtifactId` 使用 `shallowRef`，避免不必要的深层响应式开销
 - **Consumer 兜底**：`useArtifactPreviewConsumer` 无 Provider 时返回 `undefined`，文件卡片在无容器上下文时自动不可点击
 - **与 useCustomTab 协作**：「文件产物」Tab 通过 `addCustomTab` 按需添加（`order: -1`、`closable: false`），会话无文件产物时由容器 `removeCustomTab` 清理
@@ -221,5 +243,5 @@ ArtifactFileCard（点击）
 ## 关联组件
 
 - [ChatContainer](../components/setup/chat-container) — Provider 主场景，内置「文件产物」Tab
-- [FileArtifactPanel](../components/message/file-artifact-panel) — 侧栏预览面板
+- [FileArtifactPanel](../components/message/file-artifact-panel) — 侧栏列表与预览 Host 挂载
 - [AssistantMessage](../components/message/assistant-message) — 文件产物来源（`property.artifacts`）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -145,7 +145,7 @@ const sessionArtifacts = computed(() => {
 });
 ```
 
-预览命中与侧栏交互见 [useArtifactPreview](./use-artifact-preview) 与 [FileArtifactPanel](../components/message/file-artifact-panel)。
+预览命中与取链见 [useArtifactPreview](./use-artifact-preview)；侧栏列表与分类型预览（`ArtifactPreviewHost`）见 [FileArtifactPanel](../components/message/file-artifact-panel)。
 
 ## 待审批统计
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物预览按类型策略化并支持 txt/md/html 直渲染
ID: 1070093903136559114

## 改动
- artifact-preview: 新增策略/加载器/Host 与 html、txt、markdown、url-iframe 渲染器
- file-artifact-panel: 预览逻辑下沉到 ArtifactPreviewHost
- playground/mock + wikis: 补齐多类型产物 mock 与文档

## 影响面
- 影响文件产物侧栏预览加载与渲染路径；html/txt/md/json 改为 download_url 直渲染，pdf/jpg 仍走 preview_url

## 测试
- [ ] html / txt / markdown / json 可通过 download_url 正确预览
- [ ] pdf / jpg 仍走 preview_url iframe，且不对其 fetch 正文
- [ ] 切换文件时旧请求不覆盖新内容；dispose/abort 不误报 error
- [ ] loading / error 可重试 / empty 状态正确
- [ ] 相关 vitest 通过（含 pre-commit）

Made with [Cursor](https://cursor.com)