### PR TITLE
feat: 支持知识查询会话历史 --story=1070093903136549947

### DIFF
--- a/src/agent/aidev_agent/core/nodes/knowledge.py
+++ b/src/agent/aidev_agent/core/nodes/knowledge.py
@@ -260,6 +260,7 @@ class AidevKnowledgeNode(BaseKnowledgeNode):
         kb_retriever: BkRetriever | None = None,
         score_threshold: float | None = None,
         topk: int = 20,
+        chat_history: list[BaseMessage] | None = None,
         **kwargs,
     ):
         """初始化 AIDev 产品页面检索测试节点。
@@ -270,6 +271,7 @@ class AidevKnowledgeNode(BaseKnowledgeNode):
             kb_retriever: 可选的知识库检索器
             score_threshold: 分数阈值，用于过滤 retrieved_docs
             topk: 返回的最大文档数量
+            chat_history: 查询预处理使用的会话历史
         其他：
             with_scalar_data 参数应该由 knowledge_query_options.with_scalar_data 进行调整
         """
@@ -279,7 +281,7 @@ class AidevKnowledgeNode(BaseKnowledgeNode):
                 raise ValueError("knowledge_query_options is required when agent_options is not provided")
             knowledge_query_options = migration_knowledge_query_options_from_agent_options_v1(agent_options)
 
-        super().__init__(llm, knowledge_query_options, [], kb_retriever)
+        super().__init__(llm, knowledge_query_options, chat_history or [], kb_retriever)
         self.score_threshold = score_threshold
         self.topk = topk
 

--- a/src/agent/tests/core/nodes/test_knowledge.py
+++ b/src/agent/tests/core/nodes/test_knowledge.py
@@ -6,11 +6,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-from langchain_core.messages import HumanMessage
-from langgraph.graph import END, START, StateGraph
-from langgraph.store.memory import InMemoryStore
-from typing_extensions import TypedDict
-
 from aidev_agent.core.nodes.knowledge import (
     AgentKnowledgeNode,
     AidevKnowledgeNode,
@@ -20,6 +15,10 @@ from aidev_agent.core.nodes.knowledge import (
 )
 from aidev_agent.enums import Decision
 from aidev_agent.pydantic_models import AgentOptions, KnowledgebaseSettings, KnowledgeSettings
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, StateGraph
+from langgraph.store.memory import InMemoryStore
+from typing_extensions import TypedDict
 
 # ============================================================================
 # 测试状态定义
@@ -364,6 +363,27 @@ class TestAidevKnowledgeNode:
         assert len(result["retrieved_docs"]) == 2
         assert result["retrieved_docs"][0]["metadata"]["fine_grained_score"] == 0.9
         assert result["retrieved_docs"][1]["metadata"]["fine_grained_score"] == 0.7
+
+    @patch("aidev_agent.core.nodes.knowledge.KnowledgeRag")
+    def test_call_forwards_chat_history_to_retriever(self, mock_rag_class, mock_llm, mock_knowledge_settings):
+        """查询节点应把调用方提供的历史消息传给查询预处理链路。"""
+        mock_rag_instance = MagicMock()
+        mock_rag_instance.retrieve.return_value = create_mock_retrieve_result()
+        mock_rag_class.return_value = mock_rag_instance
+        chat_history = [
+            HumanMessage(content="Redis 为什么会超时？"),
+            AIMessage(content="先确认连接池和慢查询。"),
+        ]
+        node = AidevKnowledgeNode(
+            llm=mock_llm,
+            knowledge_query_options=mock_knowledge_settings,
+            chat_history=chat_history,
+        )
+
+        run_knowledge_node_in_graph(node, {"query": "那网络抖动呢？"})
+
+        call_args = mock_rag_instance.retrieve.call_args
+        assert call_args.args[2] == chat_history
 
     @patch("aidev_agent.core.nodes.knowledge.KnowledgeRag")
     def test_call_with_topk_limit(self, mock_rag_class, mock_llm, mock_knowledge_settings):


### PR DESCRIPTION
## 背景

平台知识查询接口已经开放 independent_query_mode，但 AidevKnowledgeNode 构造时固定向 BaseKnowledgeNode 传入空会话历史，导致 REWRITE 和 SUM_AND_CONCATE 无法利用 HTTP 调用方提供的历史消息。

## 改动

- 为 AidevKnowledgeNode 增加可选 chat_history 参数
- 将调用方提供的历史消息透传给 BaseKnowledgeNode 和 KnowledgeRag.retrieve
- 参数放在现有位置参数之后，保留旧调用方式兼容性
- 增加节点级回归测试，验证历史消息进入查询预处理链路

## 兼容性

未传 chat_history 时仍使用空列表，行为与修改前一致；现有调用方无需调整。配套平台改动见 TencentBlueKing/bk-aidev#1770。

## 验证

- make test path=./tests/core/nodes/test_knowledge.py：19 passed
- ruff、ruff-format：通过
