### PR TITLE
feat: 支持市场入口 URL 子路径 --story=1070093903133517236

### DIFF
--- a/src/plugins/aidev_ai_blueking/aidev_ai_blueking/settings.py
+++ b/src/plugins/aidev_ai_blueking/aidev_ai_blueking/settings.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+from urllib.parse import urlparse
 
 # 应用模块
 INSTALLED_APPS = ("aidev_ai_blueking",)
@@ -8,4 +9,12 @@ INSTALLED_APPS = ("aidev_ai_blueking",)
 RUN_VER = "ieod" if os.environ.get("BKPAAS_ENGINE_REGION", "default") == "ieod" else "open"
 
 BKPAAS_APP_CODE = os.getenv("BKPAAS_APP_ID")
-BKAPP_SAAS_PATH = os.getenv("BKAPP_SAAS_PATH") or ("" if RUN_VER == "ieod" else f"/{BKPAAS_APP_CODE}")
+
+
+def _get_bkapp_saas_path(run_ver: str, app_code: str | None) -> str:
+    if market_entrance_url := os.getenv("BKPAAS_MARKET_ENTRANCE_URL"):
+        return urlparse(market_entrance_url).path.rstrip("/")
+    return os.getenv("BKAPP_SAAS_PATH") or ("" if run_ver == "ieod" else f"/{app_code}")
+
+
+BKAPP_SAAS_PATH = _get_bkapp_saas_path(RUN_VER, BKPAAS_APP_CODE)

--- a/src/plugins/aidev_ai_blueking/tests/test_settings.py
+++ b/src/plugins/aidev_ai_blueking/tests/test_settings.py
@@ -1,0 +1,28 @@
+import pytest
+from aidev_ai_blueking.settings import _get_bkapp_saas_path
+
+
+@pytest.mark.parametrize(
+    ("environment", "run_ver", "app_code", "expected"),
+    [
+        (
+            {
+                "BKPAAS_MARKET_ENTRANCE_URL": "https://example.com/market/agent/?from=market#chat",
+                "BKAPP_SAAS_PATH": "/legacy-path",
+            },
+            "open",
+            "agent-app",
+            "/market/agent",
+        ),
+        ({"BKAPP_SAAS_PATH": "/legacy-path"}, "open", "agent-app", "/legacy-path"),
+        ({}, "ieod", "agent-app", ""),
+        ({}, "open", "agent-app", "/agent-app"),
+    ],
+)
+def test_get_bkapp_saas_path(monkeypatch, environment, run_ver, app_code, expected):
+    monkeypatch.delenv("BKPAAS_MARKET_ENTRANCE_URL", raising=False)
+    monkeypatch.delenv("BKAPP_SAAS_PATH", raising=False)
+    for key, value in environment.items():
+        monkeypatch.setenv(key, value)
+
+    assert _get_bkapp_saas_path(run_ver, app_code) == expected


### PR DESCRIPTION
## 背景

AI 智能体独立集群需要通过统一入口的子路径访问，页面静态资源与插件 API 应共享该路径前缀。

## 原因

现有路径仅从旧的显式配置或应用代码推导，无法感知平台提供的市场入口 URL。

## 改动内容

- 优先解析市场入口 URL 的 path，并移除末尾斜杠，避免拼接插件 API 时产生重复分隔符。
- 市场入口 URL 为空时，保留旧路径、IEOD 空路径及应用代码路径的兼容逻辑。
- 增加参数化单元测试覆盖新路径与三类兜底行为。

## 收益

独立集群可复用统一主域名下的子路径，同时不影响既有部署方式。

## 测试验证

- 参数化单元测试：4 passed。
- 变更文件完整 pre-commit hooks：通过。
- 暂存提交完整 pre-commit hooks：通过。
