### PR TITLE
fix: 隔离跨线程异步模型客户端 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -29,7 +29,7 @@ from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, PrivateAttr, model_validator
 
 from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
@@ -39,11 +39,15 @@ from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
 
 class ApiGwMixin(BaseModel):
     @classmethod
-    def get_setup_instance(cls, **kwargs):
+    def _resolve_base_url(cls, kwargs: dict) -> str:
         base_url = kwargs.get("base_url", "") or settings.LLM_GW_ENDPOINT
         if not base_url:
             base_url = f"{BKAIDEV_URL}/openapi/aidev/gateway/llm/v1"
-        kwargs["base_url"] = base_url
+        return base_url
+
+    @classmethod
+    def get_setup_instance(cls, **kwargs):
+        kwargs["base_url"] = cls._resolve_base_url(kwargs)
         auth_headers = kwargs.pop("auth_headers", {})
         session_code = kwargs.pop("session_code", None)
         if not auth_headers:
@@ -65,11 +69,29 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
+    _owns_http_async_client: bool = PrivateAttr(default=False)
 
     @classmethod
     def get_setup_instance(cls, **kwargs) -> "ChatModel | RunnableWithFallbacks":
-        """创建网关模型；配置备用模型时返回 LangChain fallback Runnable。"""
+        """创建网关模型，并为每个调用链隔离异步 HTTP 连接池。"""
+        owns_http_async_client = False
+        if kwargs.get("http_async_client") is None and kwargs.get("async_client") is None:
+            base_url = cls._resolve_base_url(kwargs)
+            client_kwargs = {
+                "base_url": base_url,
+                "timeout": kwargs.get("timeout"),
+            }
+            openai_proxy = kwargs.get("openai_proxy") or os.getenv("OPENAI_PROXY")
+            if openai_proxy:
+                client_kwargs["proxy"] = openai_proxy
+                # LangChain rejects openai_proxy together with an explicit
+                # client. The client above already owns the proxy setting.
+                kwargs["openai_proxy"] = None
+            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient(**client_kwargs)
+            owns_http_async_client = True
+
         model = super().get_setup_instance(**kwargs)
+        model._owns_http_async_client = owns_http_async_client
         fallback = model._get_fallback_model()
         if fallback is None:
             return model

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -39,15 +39,11 @@ from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
 
 class ApiGwMixin(BaseModel):
     @classmethod
-    def _resolve_base_url(cls, kwargs: dict) -> str:
+    def get_setup_instance(cls, **kwargs):
         base_url = kwargs.get("base_url", "") or settings.LLM_GW_ENDPOINT
         if not base_url:
             base_url = f"{BKAIDEV_URL}/openapi/aidev/gateway/llm/v1"
-        return base_url
-
-    @classmethod
-    def get_setup_instance(cls, **kwargs):
-        kwargs["base_url"] = cls._resolve_base_url(kwargs)
+        kwargs["base_url"] = base_url
         auth_headers = kwargs.pop("auth_headers", {})
         session_code = kwargs.pop("session_code", None)
         if not auth_headers:
@@ -76,18 +72,7 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         """创建网关模型，并为每个调用链隔离异步 HTTP 连接池。"""
         owns_http_async_client = False
         if kwargs.get("http_async_client") is None and kwargs.get("async_client") is None:
-            base_url = cls._resolve_base_url(kwargs)
-            client_kwargs = {
-                "base_url": base_url,
-                "timeout": kwargs.get("timeout"),
-            }
-            openai_proxy = kwargs.get("openai_proxy") or os.getenv("OPENAI_PROXY")
-            if openai_proxy:
-                client_kwargs["proxy"] = openai_proxy
-                # LangChain rejects openai_proxy together with an explicit
-                # client. The client above already owns the proxy setting.
-                kwargs["openai_proxy"] = None
-            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient(**client_kwargs)
+            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient()
             owns_http_async_client = True
 
         model = super().get_setup_instance(**kwargs)

--- a/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
+++ b/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
@@ -738,7 +738,15 @@ class AgentStreamAdapter:
         )
 
     # 流协议处理
-    def stream_standard_event(self, agent_e, cfg, input_state, skip_thought=False, timeout: int = 30):
+    def stream_standard_event(
+        self,
+        agent_e,
+        cfg,
+        input_state,
+        skip_thought=False,
+        timeout: int = 30,
+        async_finalizer=None,
+    ):
         try:
             protocol = BkAiStreamingProtocol(
                 skip_thought=skip_thought,
@@ -755,7 +763,7 @@ class AgentStreamAdapter:
                 durability="exit",
             )
             _aiter = async_generator_with_timeout(_aiter, timeout=timeout)
-            g = async_to_sync_generator(_aiter)
+            g = async_to_sync_generator(_aiter, async_finalizer=async_finalizer)
             yield from protocol.stream_standard_event(g)
         except Exception:
             logger.error(traceback.format_exc())

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -242,6 +242,39 @@ class ChatCompletionAgent(BaseModel):
             finally:
                 self.runtime_backend_resolver = None
 
+    def _managed_chat_models(self) -> list[BaseChatModel]:
+        """Return concrete chat models whose async clients belong to this agent."""
+        models: list[BaseChatModel] = []
+        for candidate in (self.chat_model, self.chat_model_non_thinking, self.chat_model_fast):
+            if candidate is None:
+                continue
+            if isinstance(candidate, RunnableWithFallbacks):
+                models.extend([candidate.runnable, *candidate.fallbacks])
+            else:
+                models.append(candidate)
+        return models
+
+    async def _aclose_chat_models(self) -> None:
+        """Close owned async HTTP clients on the model execution event loop."""
+        client_models: dict[int, tuple[Any, list[BaseChatModel]]] = {}
+        for model in self._managed_chat_models():
+            if not getattr(model, "_owns_http_async_client", False):
+                continue
+            client = getattr(model, "http_async_client", None)
+            if client is None:
+                continue
+            _, owners = client_models.setdefault(id(client), (client, []))
+            owners.append(model)
+
+        for client, owners in client_models.values():
+            try:
+                await client.aclose()
+            except Exception:
+                logger.warning("ChatCompletionAgent: 关闭模型异步 HTTP client 失败", exc_info=True)
+            else:
+                for model in owners:
+                    model._owns_http_async_client = False
+
     def _query_approval_status(self, session_code: str) -> dict | None:
         """查询 gongfeng 后端判断是否需要续流，并从 interrupt 记录获取审批结果及 interrupts。
 
@@ -642,8 +675,15 @@ class ChatCompletionAgent(BaseModel):
         """
         try:
             input_state: dict[str, Any] = {"messages": messages, "execute_kwargs": execute_kwargs, **state}
+
+            async def _ainvoke_with_cleanup():
+                try:
+                    return await agent_e.ainvoke(input_state, cfg)
+                finally:
+                    await self._aclose_chat_models()
+
             result = run_coro_sync(
-                agent_e.ainvoke(input_state, cfg),
+                _ainvoke_with_cleanup(),
                 timeout=execute_kwargs.invoke_timeout,
             )
             result_output = result.get("messages")[-1]
@@ -671,7 +711,7 @@ class ChatCompletionAgent(BaseModel):
         _input: dict[str, Any] = {"messages": messages, **state}
         agent_type = self.model_context_options.llm_code_agent_type if self.model_context_options else None
         adapter = AgentStreamAdapter(agent_type=agent_type)
-        return adapter.stream_standard_event(agent_e, cfg, _input)
+        return adapter.stream_standard_event(agent_e, cfg, _input, async_finalizer=self._aclose_chat_models)
 
     def _stream(
         self,
@@ -878,9 +918,15 @@ class ChatCompletionAgent(BaseModel):
                         "(scheme B fallback), thread_id=%s",
                         agent_input.thread_id,
                     )
-                    yield from replay
+                    try:
+                        yield from replay
+                    finally:
+                        run_coro_sync(self._aclose_chat_models())
                     return
-            yield from async_to_sync_generator(agui_entry.run(agent_input))
+            yield from async_to_sync_generator(
+                agui_entry.run(agent_input),
+                async_finalizer=self._aclose_chat_models,
+            )
 
         return _gen()
 

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,10 +10,14 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
-from typing import AsyncGenerator
+import threading
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from contextlib import suppress
+from typing import AsyncGenerator, Awaitable, Callable
 
 from aidev_agent.utils import Empty
-from aidev_agent.utils.loop import get_event_loop
+
+_QUEUE_GET_TIMEOUT = 300
 
 
 async def async_generator_with_timeout(
@@ -21,29 +25,43 @@ async def async_generator_with_timeout(
 ) -> AsyncGenerator:
     try:
         while True:
-            tasks = [asyncio.create_task(gen.__anext__()), asyncio.create_task(asyncio.sleep(timeout))]
-            for _ in range(max_wait_rounds):
-                done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-                if tasks[0] in done:
-                    result = tasks[0].result()
-                    yield result
-                    break
+            next_item = asyncio.create_task(gen.__anext__())
+            try:
+                for _ in range(max_wait_rounds):
+                    try:
+                        result = await asyncio.wait_for(asyncio.shield(next_item), timeout=timeout)
+                    except TimeoutError:
+                        yield Empty
+                    else:
+                        yield result
+                        break
                 else:
-                    tasks[1] = asyncio.create_task(asyncio.sleep(timeout))
-                    yield Empty
-            else:
-                raise TimeoutError("生成器超时")
+                    raise TimeoutError("生成器超时")
+            finally:
+                if not next_item.done():
+                    next_item.cancel()
+                    await asyncio.gather(next_item, return_exceptions=True)
     except StopAsyncIteration:
         return
 
 
-def async_to_sync_generator(async_gen):
+def async_to_sync_generator(
+    async_gen: AsyncGenerator,
+    async_finalizer: Callable[[], Awaitable[None]] | None = None,
+):
+    """Consume an async generator from synchronous code on an isolated loop.
+
+    The async generator and its optional finalizer always execute on the same
+    helper loop. This keeps loop-bound resources out of the caller thread and
+    also works when the caller already has a running event loop.
+    """
     data_queue = asyncio.Queue()
     error = None
 
-    loop = get_event_loop()
+    loop = asyncio.new_event_loop()
+    loop_thread = threading.Thread(target=loop.run_forever, name="aidev-async-generator", daemon=True)
+    loop_thread.start()
 
-    # 定义异步消费任务
     async def consume_async():
         nonlocal error
         try:
@@ -52,16 +70,46 @@ def async_to_sync_generator(async_gen):
         except Exception as e:
             error = e
         finally:
-            await data_queue.put(None)  # 结束信号
+            if async_finalizer is not None:
+                try:
+                    await async_finalizer()
+                except Exception as e:
+                    if error is None:
+                        error = e
+            await data_queue.put(None)
 
-    # 线程运行函数（仅当需要新线程时启动）
-    # 提交异步任务到指定循环
+    async def cancel_pending_tasks():
+        async def cancel_all():
+            current_task = asyncio.current_task()
+            pending_tasks = [task for task in asyncio.all_tasks() if task is not current_task]
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        await cancel_all()
+        await loop.shutdown_asyncgens()
+        await cancel_all()
+
     asyncio.run_coroutine_threadsafe(consume_async(), loop)
 
-    while True:
-        item = loop.run_until_complete(data_queue.get())
-        if item is None:
-            if error is not None:
-                raise error
-            break
-        yield item
+    try:
+        while True:
+            get_future = asyncio.run_coroutine_threadsafe(data_queue.get(), loop)
+            try:
+                item = get_future.result(timeout=_QUEUE_GET_TIMEOUT)
+            except FutureTimeoutError:
+                get_future.cancel()
+                raise
+
+            if item is None:
+                if error is not None:
+                    raise error
+                break
+            yield item
+    finally:
+        with suppress(FutureTimeoutError):
+            asyncio.run_coroutine_threadsafe(cancel_pending_tasks(), loop).result(timeout=1)
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join()
+        loop.close()

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,14 +10,13 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
+import queue
 import threading
-from concurrent.futures import TimeoutError as FutureTimeoutError
 from contextlib import suppress
+from contextvars import copy_context
 from typing import AsyncGenerator, Awaitable, Callable
 
 from aidev_agent.utils import Empty
-
-_QUEUE_GET_TIMEOUT = 300
 
 
 async def async_generator_with_timeout(
@@ -25,22 +24,18 @@ async def async_generator_with_timeout(
 ) -> AsyncGenerator:
     try:
         while True:
-            next_item = asyncio.create_task(gen.__anext__())
-            try:
-                for _ in range(max_wait_rounds):
-                    try:
-                        result = await asyncio.wait_for(asyncio.shield(next_item), timeout=timeout)
-                    except TimeoutError:
-                        yield Empty
-                    else:
-                        yield result
-                        break
+            tasks = [asyncio.create_task(gen.__anext__()), asyncio.create_task(asyncio.sleep(timeout))]
+            for _ in range(max_wait_rounds):
+                done, _ = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                if tasks[0] in done:
+                    result = tasks[0].result()
+                    yield result
+                    break
                 else:
-                    raise TimeoutError("生成器超时")
-            finally:
-                if not next_item.done():
-                    next_item.cancel()
-                    await asyncio.gather(next_item, return_exceptions=True)
+                    tasks[1] = asyncio.create_task(asyncio.sleep(timeout))
+                    yield Empty
+            else:
+                raise TimeoutError("生成器超时")
     except StopAsyncIteration:
         return
 
@@ -55,18 +50,20 @@ def async_to_sync_generator(
     helper loop. This keeps loop-bound resources out of the caller thread and
     also works when the caller already has a running event loop.
     """
-    data_queue = asyncio.Queue()
+    data_queue = queue.Queue()
+    end = object()
     error = None
 
     loop = asyncio.new_event_loop()
-    loop_thread = threading.Thread(target=loop.run_forever, name="aidev-async-generator", daemon=True)
-    loop_thread.start()
+    context = copy_context()
+    task_ready = threading.Event()
+    consumer_task = None
 
     async def consume_async():
         nonlocal error
         try:
             async for item in async_gen:
-                await data_queue.put(item)
+                data_queue.put(item)
         except Exception as e:
             error = e
         finally:
@@ -76,40 +73,39 @@ def async_to_sync_generator(
                 except Exception as e:
                     if error is None:
                         error = e
-            await data_queue.put(None)
+            data_queue.put(end)
 
-    async def cancel_pending_tasks():
-        async def cancel_all():
-            current_task = asyncio.current_task()
-            pending_tasks = [task for task in asyncio.all_tasks() if task is not current_task]
+    def run_loop():
+        nonlocal consumer_task
+        asyncio.set_event_loop(loop)
+        consumer_task = context.run(loop.create_task, consume_async())
+        task_ready.set()
+        try:
+            loop.run_until_complete(consumer_task)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            pending_tasks = asyncio.all_tasks(loop)
             for task in pending_tasks:
                 task.cancel()
             if pending_tasks:
-                await asyncio.gather(*pending_tasks, return_exceptions=True)
+                loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
+            with suppress(RuntimeError):
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
 
-        await cancel_all()
-        await loop.shutdown_asyncgens()
-        await cancel_all()
-
-    asyncio.run_coroutine_threadsafe(consume_async(), loop)
-
+    loop_thread = threading.Thread(target=run_loop, name="aidev-async-generator", daemon=True)
+    loop_thread.start()
+    task_ready.wait()
     try:
         while True:
-            get_future = asyncio.run_coroutine_threadsafe(data_queue.get(), loop)
-            try:
-                item = get_future.result(timeout=_QUEUE_GET_TIMEOUT)
-            except FutureTimeoutError:
-                get_future.cancel()
-                raise
-
-            if item is None:
+            item = data_queue.get()
+            if item is end:
                 if error is not None:
                     raise error
                 break
             yield item
     finally:
-        with suppress(FutureTimeoutError):
-            asyncio.run_coroutine_threadsafe(cancel_pending_tasks(), loop).result(timeout=1)
-        loop.call_soon_threadsafe(loop.stop)
+        if not consumer_task.done():
+            loop.call_soon_threadsafe(consumer_task.cancel)
         loop_thread.join()
-        loop.close()

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,7 +20,6 @@ import asyncio
 import atexit
 import contextlib
 import threading
-from concurrent.futures import Future
 from contextvars import copy_context
 
 # Thread-local storage for event loops
@@ -102,27 +101,21 @@ async def _await_with_timeout(coro, timeout=None):
 
 def _run_coro_in_helper_thread(coro, timeout=None):
     """Run a coroutine on a short-lived loop when the caller loop is running."""
-    result_future = Future()
+    result = {}
     context = copy_context()
 
     def _runner():
-        loop = asyncio.new_event_loop()
         try:
-            asyncio.set_event_loop(loop)
-            result = context.run(loop.run_until_complete, _await_with_timeout(coro, timeout))
+            result["value"] = context.run(asyncio.run, _await_with_timeout(coro, timeout))
         except BaseException as exc:
-            result_future.set_exception(exc)
-        else:
-            result_future.set_result(result)
-        finally:
-            _cleanup_thread_loop(loop)
-            with contextlib.suppress(Exception):
-                asyncio.set_event_loop(None)
+            result["error"] = exc
 
     thread = threading.Thread(target=_runner, name="aidev-run-coro-sync", daemon=True)
     thread.start()
     thread.join()
-    return result_future.result()
+    if "error" in result:
+        raise result["error"]
+    return result["value"]
 
 
 def run_coro_sync(coro, timeout=None):

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,6 +20,8 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from concurrent.futures import Future
+from contextvars import copy_context
 
 # Thread-local storage for event loops
 _thread_local = threading.local()
@@ -92,18 +94,53 @@ def close_thread_loop() -> None:
     _thread_local.loop = None
 
 
+async def _await_with_timeout(coro, timeout=None):
+    if timeout is None:
+        return await coro
+    return await asyncio.wait_for(coro, timeout=timeout)
+
+
+def _run_coro_in_helper_thread(coro, timeout=None):
+    """Run a coroutine on a short-lived loop when the caller loop is running."""
+    result_future = Future()
+    context = copy_context()
+
+    def _runner():
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            result = context.run(loop.run_until_complete, _await_with_timeout(coro, timeout))
+        except BaseException as exc:
+            result_future.set_exception(exc)
+        else:
+            result_future.set_result(result)
+        finally:
+            _cleanup_thread_loop(loop)
+            with contextlib.suppress(Exception):
+                asyncio.set_event_loop(None)
+
+    thread = threading.Thread(target=_runner, name="aidev-run-coro-sync", daemon=True)
+    thread.start()
+    thread.join()
+    return result_future.result()
+
+
 def run_coro_sync(coro, timeout=None):
     """Run a coroutine synchronously in the current thread's event loop.
 
-    Note: The event loop is intentionally kept open after execution, so that
-    long-lived async clients (e.g. httpx.AsyncClient) can safely reuse their
-    connections across multiple calls on the same thread. Cleanup is handled by
-    atexit registration and by async_to_sync_generator's finally block.
+    A thread-local loop is reused for normal synchronous callers. If the caller
+    already owns a running loop, the coroutine is executed on a helper thread so
+    we never call ``run_until_complete`` on that running loop.
     """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        pass
+    else:
+        return _run_coro_in_helper_thread(coro, timeout)
+
     loop = get_event_loop()
-    if timeout is not None:
-        coro = asyncio.wait_for(coro, timeout=timeout)
-    return loop.run_until_complete(coro)
+    return loop.run_until_complete(_await_with_timeout(coro, timeout))
 
 
 def _cleanup_thread_loop(loop):

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -16,13 +16,17 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import asyncio
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import openai
 import pytest
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from langchain_core.messages import HumanMessage
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 
 # 测试模型列表
 TEST_MODELS = ["hunyuan-turbo", "qwen3", "deepseek-v3", "deepseek-r1"]
@@ -38,12 +42,77 @@ TEST_VISION_MODELS = ["qwen3-vl-32B"]
 
 # 测试图片路径
 TEST_IMAGE_PATH = Path(__file__).parent.parent.parent.parent / "mock_data" / "bkaidev.png"
+TEST_BASE_URL = "https://llm-gateway.example.com/v1"
 
 
 def get_test_image_base64() -> str:
     """读取测试图片并返回 base64 编码"""
     with open(TEST_IMAGE_PATH, "rb") as f:
         return base64.b64encode(f.read()).decode("utf-8")
+
+
+def test_chat_model_owns_an_isolated_async_http_client():
+    first = ChatModel.get_setup_instance(model="first", base_url=TEST_BASE_URL)
+    second = ChatModel.get_setup_instance(model="second", base_url=TEST_BASE_URL)
+
+    try:
+        assert isinstance(first, ChatModel)
+        assert isinstance(second, ChatModel)
+        assert first.http_async_client is not second.http_async_client
+        assert first._owns_http_async_client is True
+        assert second._owns_http_async_client is True
+    finally:
+        asyncio.run(first.http_async_client.aclose())
+        asyncio.run(second.http_async_client.aclose())
+
+
+def test_chat_model_preserves_caller_owned_async_http_client():
+    client = openai.DefaultAsyncHttpxClient(base_url=TEST_BASE_URL)
+    model = ChatModel.get_setup_instance(
+        model="explicit-client",
+        base_url=TEST_BASE_URL,
+        http_async_client=client,
+    )
+
+    try:
+        assert isinstance(model, ChatModel)
+        assert model.http_async_client is client
+        assert model._owns_http_async_client is False
+    finally:
+        asyncio.run(client.aclose())
+
+
+def test_fallback_models_share_only_their_request_local_async_client():
+    runnable = ChatModel.get_setup_instance(
+        model="primary",
+        fallback_model="fallback",
+        base_url=TEST_BASE_URL,
+    )
+
+    assert isinstance(runnable, RunnableWithFallbacks)
+    primary = runnable.runnable
+    fallback = runnable.fallbacks[0]
+    try:
+        assert primary.http_async_client is fallback.http_async_client
+        assert primary._owns_http_async_client is True
+        assert fallback._owns_http_async_client is True
+    finally:
+        asyncio.run(primary.http_async_client.aclose())
+
+
+def test_chat_model_async_clients_are_isolated_across_worker_threads():
+    def _build(index: int):
+        return ChatModel.get_setup_instance(model=f"model-{index}", base_url=TEST_BASE_URL)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        models = list(pool.map(_build, range(32)))
+
+    try:
+        clients = [model.http_async_client for model in models]
+        assert len({id(client) for client in clients}) == len(clients)
+    finally:
+        for model in models:
+            asyncio.run(model.http_async_client.aclose())
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
@@ -11,6 +11,7 @@ from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
 from aidev_agent.core.ag_ui.types import CustomMessageType
 from aidev_agent.core.nodes.tool.approval_wrapper import TOOL_APPROVAL_REASON
 from aidev_agent.enums import PromptRole
+from aidev_agent.exceptions import AgentException
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.packages.langchain_core.models.mock import MockChatModel, MockResponse
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
@@ -758,6 +759,77 @@ class TestOnComplete:
         )
         list(agent.execute(ExecuteKwargs(stream=True)))
         mock_handler.set_streaming_finished.assert_called_once()
+
+
+class TestChatModelClientCleanup:
+    @pytest.mark.asyncio
+    async def test_owned_fallback_client_is_closed_once(self):
+        runnable = ChatModel.get_setup_instance(
+            model="primary",
+            fallback_model="fallback",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = runnable.runnable.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=runnable)
+
+        with patch.object(client, "aclose", close_spy):
+            await agent._aclose_chat_models()
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+        assert runnable.runnable._owns_http_async_client is False
+        assert runnable.fallbacks[0]._owns_http_async_client is False
+
+    def test_non_streaming_invoke_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="done", id="message-id")]})
+
+        with patch.object(client, "aclose", close_spy):
+            result = agent._invoke(
+                agent_e,
+                {},
+                {},
+                [HumanMessage(content="hello")],
+                SimpleNamespace(invoke_timeout=1),
+            )
+
+        assert result["choices"][0]["delta"]["content"] == "done"
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+
+    def test_non_streaming_invoke_error_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(side_effect=RuntimeError("model failed"))
+
+        with (
+            patch.object(client, "aclose", close_spy),
+            pytest.raises(AgentException, match="model failed"),
+        ):
+            agent._invoke(
+                agent_e,
+                {},
+                {},
+                [HumanMessage(content="hello")],
+                SimpleNamespace(invoke_timeout=1),
+            )
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/utils/test_async_utils.py
+++ b/src/agent/tests/utils/test_async_utils.py
@@ -47,6 +47,64 @@ def test_async_to_sync_generator():
     assert result == ["run_id-0", "run_id-1", "run_id-2"]
 
 
+@pytest.mark.asyncio
+async def test_async_to_sync_generator_in_running_loop():
+    request_local.run_id = "async"
+
+    result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
+
+    assert result == ["async-0", "async-1", "async-2"]
+
+
+def test_async_to_sync_generator_runs_finalizer_on_consumer_loop():
+    loop_ids: list[int] = []
+
+    async def _gen():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        yield "value"
+
+    async def _finalize():
+        loop_ids.append(id(asyncio.get_running_loop()))
+
+    assert list(async_to_sync_generator(_gen(), async_finalizer=_finalize)) == ["value"]
+    assert len(set(loop_ids)) == 1
+
+
+def test_async_to_sync_generator_runs_finalizer_on_error():
+    finalized = False
+
+    async def _gen():
+        yield "value"
+        raise RuntimeError("stream failed")
+
+    async def _finalize():
+        nonlocal finalized
+        finalized = True
+
+    with pytest.raises(RuntimeError, match="stream failed"):
+        list(async_to_sync_generator(_gen(), async_finalizer=_finalize))
+
+    assert finalized is True
+
+
+def test_async_to_sync_generator_runs_finalizer_when_consumer_closes():
+    finalized = False
+
+    async def _gen():
+        yield "value"
+        await asyncio.Event().wait()
+
+    async def _finalize():
+        nonlocal finalized
+        finalized = True
+
+    generator = async_to_sync_generator(_gen(), async_finalizer=_finalize)
+    assert next(generator) == "value"
+    generator.close()
+
+    assert finalized is True
+
+
 async def test_async_gen_with_timeout():
     request_local.run_id = "run_id"
     result = [each async for each in async_generator_with_timeout(gen(), timeout=0.18)]
@@ -63,7 +121,6 @@ def test_async_to_sync_generator_in_worker_thread():
     def _consume():
         request_local.run_id = "worker"
         result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
-        # get_event_loop() 会在 worker 线程缓存事件循环用于复用，has_loop 为 True 是预期行为
         has_loop = hasattr(_thread_local, "loop") and _thread_local.loop is not None
         return result, has_loop
 
@@ -71,4 +128,4 @@ def test_async_to_sync_generator_in_worker_thread():
         result, has_loop = pool.submit(_consume).result()
 
     assert result == ["worker-0", "worker-1", "worker-2"]
-    assert has_loop is True
+    assert has_loop is False

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -1,5 +1,7 @@
 import asyncio
+import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 
 import pytest
 
@@ -133,3 +135,28 @@ def test_run_coro_sync_preserves_worker_thread_loop():
 
     assert result == 10
     assert has_loop is True
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_from_running_loop_uses_helper_thread():
+    marker = ContextVar("marker", default="")
+    token = marker.set("request-context")
+    caller_thread_id = threading.get_ident()
+
+    async def _probe():
+        await asyncio.sleep(0)
+        return threading.get_ident(), marker.get()
+
+    try:
+        worker_thread_id, context_value = run_coro_sync(_probe())
+    finally:
+        marker.reset(token)
+
+    assert worker_thread_id != caller_thread_id
+    assert context_value == "request-context"
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_timeout_from_running_loop():
+    with pytest.raises(asyncio.TimeoutError):
+        run_coro_sync(asyncio.sleep(0.05), timeout=0.001)


### PR DESCRIPTION
## 变更说明
- 为每个 ChatModel 调用链显式创建独立 async HTTP client，绕过 langchain-openai 进程级缓存
- 在模型实际执行的 event loop 内关闭 owned client，覆盖非流式、AG-UI、legacy、fallback 与异常路径
- 修复 running loop 下的同步协程/异步生成器桥接，并清理 timeout 遗留 task

## 验证
- 170 passed, 17 skipped, 21 deselected
- Ruff lint/format passed
- 32 worker 并发 client 隔离回归通过