### PR TITLE
fix: keep RabbitMQ replay on committed queue log --story=107009390313…

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -338,8 +338,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         self._producer_lock_connections: dict[str, pika.BlockingConnection] = {}
         self._producer_lock_guard = threading.Lock()
 
-        # flush 与 peek+buffer 合并的互斥锁（per thread_id，进程内）
-        # 防止 flush 在 peek 和 buffer 合并之间清空 buffer 导致消息丢失/重复
+        # flush 与 replay peek 的互斥锁（per thread_id，进程内）
+        # 避免 replay 读取到本进程尚未完整发布的 flush 批次
         self._flush_peek_locks: dict[str, threading.Lock] = {}
         self._flush_peek_locks_guard = threading.Lock()
 
@@ -834,7 +834,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """批量推送缓冲区中的所有消息到 RabbitMQ
 
         对每个 thread_id，在 _flush_peek_lock 内完成"取出 buffer + publish"的原子操作，
-        确保与 get_messages_since（peek + buffer 合并）互斥，避免消息丢失/重复。
+        确保与 get_messages_since 的 queue peek 互斥，避免 replay 观察到未完整发布的 flush 批次。
         """
         # 快速检查是否有消息需要 flush
         with self._buffer_lock:
@@ -1124,8 +1124,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 with self._with_replay_lock(thread_id) as channel:
                     main_queue_name = self._ensure_queue(channel=channel, thread_id=thread_id)
 
-                    # flush_peek_lock 保护 peek + buffer 合并这两步的原子性，
-                    # 防止 flush 在 peek 之后、buffer 合并之前清空 buffer 导致消息丢失。
+                    # replay offset 只描述 RabbitMQ 已提交队列，不能包含本地未发布 buffer。
+                    # flush_peek_lock 避免读取到本进程尚未完整发布的 flush 批次。
                     with flush_peek_lock:
                         all_messages = self._peek_queue_messages(channel, main_queue_name)
 
@@ -1138,9 +1138,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 restored,
                             )
                             all_messages = self._peek_queue_messages(channel, main_queue_name)
-
-                        with self._buffer_lock:
-                            all_messages.extend(self._message_buffer.get(thread_id, []))
 
                 next_offset = len(all_messages)
                 if next_offset > offset:

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -211,6 +211,34 @@ class TestRabbitMQMessageHandler:
 
         self._wait_until_empty(handler, thread_id)
 
+    def test_replay_waits_until_a_long_buffer_is_committed(self, handler, thread_id, monkeypatch):
+        """Replay offset 只推进到 RabbitMQ 已提交日志，不包含本地未发布 buffer。"""
+        committed_messages = [f"committed-{index}" for index in range(1_000)]
+        buffered_messages = [f"buffered-{index}" for index in range(1_000)]
+
+        handler._stop_daemon()
+        monkeypatch.setattr(handler, "_ensure_daemon_alive", lambda: None)
+
+        for message in committed_messages:
+            handler.put(thread_id, message)
+        handler.flush(thread_id)
+
+        messages, offset = handler.get_messages_since(thread_id, offset=0, timeout=5)
+        assert messages == committed_messages
+        assert offset == 1_000
+
+        for message in buffered_messages:
+            handler.put(thread_id, message)
+
+        with pytest.raises(TimeoutError):
+            handler.get_messages_since(thread_id, offset=offset, timeout=0.1)
+
+        handler.flush(thread_id)
+        messages, next_offset = handler.get_messages_since(thread_id, offset=offset, timeout=5)
+
+        assert messages == buffered_messages
+        assert next_offset == 2_000
+
     def test_consumer_reconnect_with_dlq(self, handler, thread_id):
         """测试消费者断开后重连可以从死信队列恢复消息
 


### PR DESCRIPTION
…5579259 (#712)