### PR TITLE
fix: 修复 RabbitMQ snapshot replay 重复 --story=1070093903135579259

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -809,9 +809,11 @@ class ChatCompletionAgent(BaseModel):
         """使用队列处理器缓存流式请求，支持断点续传。
 
         两阶段输出：
-        1. 同步直传头部帧到RUN_STARTED，
-           绕过 RabbitMQ buffer 避免 gevent 环境下的顺序竞态。
-        2. 后续运行时事件交给队列管理，支持断点续传。
+        1. 新 producer 提取到 RUN_STARTED 的头部帧，固化为本段 replay baseline。
+        2. 后续运行时事件写入队列 tail；重连读取同一 baseline + tail。
+
+        InMemory 仍同步直传头部帧；RabbitMQ 先完成 producer/replay 决策，
+        避免为 replay 连接推进一个不会执行的本地 producer。
         """
         helper = GeneratorStreamingHelper(
             thread_id=queue_thread_id or agent_input.thread_id,
@@ -819,26 +821,26 @@ class ChatCompletionAgent(BaseModel):
         )
         producer = self._build_resume_aware_producer(agui_entry, agent_input, agent_e=agent_e, cfg=cfg, resume=resume)
 
-        # ---- 阶段 1：同步拉取头部帧并直接 yield ----
-        head_frames = []
-        remaining_producer = self._extract_head_frames(producer, head_frames)
-        for frame in head_frames:
-            yield frame
-
-        # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+        # 先由 helper 确定本连接是新 producer 还是 replay，再决定是否拉取本地头部。
+        # RabbitMQ producer 会把唯一一份头部基线与后续 runtime 日志绑定；replay 连接
+        # 直接复用该基线，避免 DB snapshot 与 RabbitMQ 日志重叠。
+        yield from helper.stream(
+            producer,
+            on_complete=self._on_complete,
+            prelude_extractor=self._extract_head_frames,
+        )
 
     @staticmethod
     def _extract_head_frames(
         producer: Generator[Any, None, None],
-        head_frames: list,
-    ) -> Generator[Any, None, None]:
-        """从 producer 中同步提取头部帧（到 RUN_STARTED 为止），返回剩余帧 generator。
+    ) -> tuple[list[Any], Generator[Any, None, None]]:
+        """从 producer 中同步提取头部帧，返回 ``(头部帧, 剩余 generator)``。
 
         事件流结构：MESSAGES_SNAPSHOT → [RUN_FINISHED] → RUN_STARTED → STEP_* ...
         RUN_STARTED 是 Agent 图执行的起点，之前的帧为初始化/回放事件。
         """
         RUN_STARTED_MARKER = '"type":"RUN_STARTED"'
+        head_frames: list[Any] = []
 
         def _remaining() -> Generator[Any, None, None]:
             yield from producer
@@ -848,7 +850,7 @@ class ChatCompletionAgent(BaseModel):
             if isinstance(frame, str) and RUN_STARTED_MARKER in frame:
                 break
 
-        return _remaining()
+        return head_frames, _remaining()
 
     def _build_resume_aware_producer(
         self,

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -288,6 +288,23 @@ class BaseMessageQueueHandler(ABC):
         """
         raise NotImplementedError("get_messages_since is only available for replay-from-start handlers")
 
+    def publish_replay_segment_start(
+        self,
+        thread_id: str,
+        segment_id: str,
+        head_frames: list[Any],
+        segment_marker: Any,
+    ) -> None:
+        """提交生产 segment 的不可变 replay 基线与日志边界。"""
+        raise NotImplementedError("publish_replay_segment_start requires replay-from-start support")
+
+    def get_replay_baseline(self, thread_id: str, segment_id: str) -> list[Any] | None:
+        """读取指定生产 segment 的 replay 基线。
+
+        默认返回 None；返回值必须是非破坏性读取的独立列表。
+        """
+        return None
+
     def acquire_producer(self, thread_id: str) -> bool:
         """尝试获取会话级生产者写入权。
 

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -300,6 +300,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     CANCEL_QUEUE_PREFIX: ClassVar[str] = QueueNamePrefixes.CANCEL_REQUEST
     PRODUCER_LOCK_PREFIX: ClassVar[str] = "aidev_agent.producer_lock."
     REPLAY_LOCK_PREFIX: ClassVar[str] = "aidev_agent.replay_lock."
+    REPLAY_BASELINE_PREFIX: ClassVar[str] = "aidev_agent.replay_baseline."
     ACTIVE_CONSUMER_PREFIX: ClassVar[str] = "aidev_agent.consumer_active."
     QUEUE_TTL_MS: ClassVar[int] = QueueTTLConfig.QUEUE_EXPIRE_MS
     REPLAY_LOCK_RETRY_INTERVAL: ClassVar[float] = 0.05
@@ -395,6 +396,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     def _get_replay_lock_queue_name(self, thread_id: str) -> str:
         """获取会话日志 replay 互斥队列名。"""
         return f"{self.REPLAY_LOCK_PREFIX}{thread_id}"
+
+    def _get_replay_baseline_queue_name(self, thread_id: str) -> str:
+        """获取生产 segment replay 基线队列名。"""
+        return f"{self.REPLAY_BASELINE_PREFIX}{thread_id}"
 
     def _get_active_consumer_queue_name(self, thread_id: str) -> str:
         """获取多消费者活跃状态队列名。"""
@@ -599,6 +604,90 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         旧的 in-memory/默认 handler 返回 False，继续使用竞争消费 + DLQ 恢复语义。
         """
         return True
+
+    def _ensure_replay_baseline_queue(self, channel: Any, thread_id: str) -> str:
+        """声明只保留最新一条持久化 replay 基线的队列。"""
+        queue_name = self._get_replay_baseline_queue_name(thread_id)
+        channel.queue_declare(
+            queue=queue_name,
+            durable=True,
+            arguments={
+                "x-expires": self.QUEUE_TTL_MS,
+                "x-max-length": 1,
+                "x-overflow": "drop-head",
+            },
+        )
+        return queue_name
+
+    def publish_replay_segment_start(
+        self,
+        thread_id: str,
+        segment_id: str,
+        head_frames: list[Any],
+        segment_marker: Any,
+    ) -> None:
+        """确认 baseline 已持久化后，再确认提交主日志 segment marker。"""
+        baseline_payload = pickle.dumps(
+            {
+                "segment_id": segment_id,
+                "head_frames": list(head_frames),
+            }
+        )
+        with self._with_replay_lock(thread_id) as channel:
+            baseline_queue = self._ensure_replay_baseline_queue(channel, thread_id)
+            main_queue = self._ensure_queue(channel, thread_id)
+            channel.confirm_delivery()
+            baseline_published = channel.basic_publish(
+                exchange="",
+                routing_key=baseline_queue,
+                body=baseline_payload,
+                properties=pika.BasicProperties(delivery_mode=2),
+            )
+            if baseline_published is False:
+                raise RuntimeError(
+                    f"RabbitMQ replay baseline was not confirmed for thread_id={thread_id}, segment_id={segment_id}"
+                )
+            marker_published = channel.basic_publish(
+                exchange="",
+                routing_key=main_queue,
+                body=pickle.dumps(segment_marker),
+                properties=pika.BasicProperties(delivery_mode=2),
+            )
+            if marker_published is False:
+                raise RuntimeError(
+                    f"RabbitMQ replay marker was not confirmed for thread_id={thread_id}, segment_id={segment_id}"
+                )
+
+    def get_replay_baseline(self, thread_id: str, segment_id: str) -> list[Any] | None:
+        """非破坏性读取并校验指定生产 segment 的 replay 基线。"""
+        queue_name = self._get_replay_baseline_queue_name(thread_id)
+        with self._with_replay_lock(thread_id) as channel:
+            try:
+                channel.queue_declare(queue=queue_name, durable=True, passive=True)
+            except pika.exceptions.ChannelClosedByBroker as e:
+                if e.reply_code == 404:
+                    return None
+                raise
+
+            method_frame, _, body = channel.basic_get(queue=queue_name, auto_ack=False)
+            if not method_frame:
+                return None
+
+            try:
+                payload = pickle.loads(body)
+                if not isinstance(payload, dict) or payload.get("segment_id") != segment_id:
+                    return None
+                head_frames = payload.get("head_frames")
+                if not isinstance(head_frames, list):
+                    logger.warning(
+                        "[RabbitMQ] invalid replay baseline thread_id=%s segment_id=%s",
+                        thread_id,
+                        segment_id,
+                    )
+                    return None
+                return list(head_frames)
+            finally:
+                channel.basic_nack(delivery_tag=method_frame.delivery_tag, requeue=True)
 
     def acquire_producer(self, thread_id: str) -> bool:
         """使用 RabbitMQ exclusive queue 获取会话级生产者写入权。"""
@@ -1307,6 +1396,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 # 每个 purge 操作使用独立 channel，避免 404 channel error 影响后续操作
                 self._safe_purge_queue(connection, self._get_queue_name(thread_id))
                 self._safe_purge_queue(connection, self._get_dlq_name(thread_id))
+                self._safe_purge_queue(
+                    connection,
+                    self._get_replay_baseline_queue_name(thread_id),
+                    passive_check=True,
+                )
 
                 # 清空取消请求队列（如果需要，先检查是否存在）
                 if include_cancel_queue:
@@ -1326,6 +1420,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     self._get_queue_name(thread_id),
                     self._get_dlq_name(thread_id),
                     self._get_cancel_queue_name(thread_id),
+                    self._get_replay_baseline_queue_name(thread_id),
                     self._get_active_consumer_queue_name(thread_id),
                 ]
                 # 追加 MultiProcessMixin 管理的信号队列

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -1,6 +1,7 @@
 import threading
 import time
 import uuid
+from dataclasses import dataclass
 from logging import getLogger
 from typing import Any, Callable, Generator
 
@@ -25,6 +26,25 @@ logger = getLogger(__name__)
 # 断点续传时需要过滤的事件类型
 # flow_agent_start 事件在续聊时不应该重复发送，避免前端重新渲染
 _RESUME_FILTER_EVENT_TYPES: frozenset[str] = frozenset({"flow_agent_start"})
+
+# 新版 RabbitMQ 日志的首帧标记。SSE comment 在滚动发布期间会被旧客户端按协议忽略。
+_REPLAY_SEGMENT_PREFIX = ": aidev-replay-segment "
+_SSE_FRAME_SUFFIX = "\n\n"
+
+_PreludeExtractor = Callable[
+    [Generator[Any, None, None]],
+    tuple[list[Any], Generator[Any, None, None]],
+]
+_ReplayPreludeSource = tuple[Generator[Any, None, None], _PreludeExtractor]
+
+
+@dataclass(frozen=True)
+class _ReplayStreamContext:
+    replay_source: _ReplayPreludeSource
+    cancel_event: threading.Event
+    consumer_id: str
+    has_pending: bool
+    on_complete: Callable[[], None] | None
 
 
 class GeneratorStreamingHelper:
@@ -246,6 +266,58 @@ class GeneratorStreamingHelper:
         """判断 chunk 是否为 SSE 的业务完成标记。"""
         return isinstance(chunk, str) and chunk.strip() == "data: [DONE]"
 
+    @staticmethod
+    def _build_replay_segment_marker(segment_id: str) -> str:
+        """构造连接 baseline 与 runtime 日志的 SSE comment 边界帧。"""
+        return f"{_REPLAY_SEGMENT_PREFIX}{segment_id}{_SSE_FRAME_SUFFIX}"
+
+    @staticmethod
+    def _parse_replay_segment_marker(message: Any) -> str | None:
+        """解析 segment marker，普通业务帧或非法帧返回 ``None``。"""
+        if not isinstance(message, str) or not message.startswith(_REPLAY_SEGMENT_PREFIX):
+            return None
+        segment_id = message[len(_REPLAY_SEGMENT_PREFIX) :].partition("\n")[0].strip()
+        return segment_id or None
+
+    def _resolve_replay_prelude(
+        self,
+        first_message: Any,
+        replay_source: _ReplayPreludeSource,
+    ) -> tuple[list[Any], bool]:
+        """按日志格式解析 producer baseline；返回 (帧, 是否为新 segment)。"""
+        replay_generator, prelude_extractor = replay_source
+        segment_id = self._parse_replay_segment_marker(first_message)
+        if not segment_id:
+            local_head_frames, _ = prelude_extractor(replay_generator)
+            return local_head_frames, False
+
+        baseline = self.message_handler.get_replay_baseline(self.thread_id, segment_id)
+        if baseline is None:
+            raise RuntimeError(
+                f"RabbitMQ replay baseline missing for thread_id={self.thread_id}, segment_id={segment_id}"
+            )
+        return baseline, True
+
+    def _strip_replay_segment_markers(
+        self,
+        messages: list[Any],
+        segment_replay_started: bool,
+    ) -> tuple[list[Any], bool]:
+        """移除内部 segment marker，并记录当前流已进入新格式 segment。"""
+        segment_ids = [self._parse_replay_segment_marker(message) for message in messages]
+        if not any(segment_ids):
+            return messages, segment_replay_started
+        return [message for message, segment_id in zip(messages, segment_ids) if not segment_id], True
+
+    def _should_filter_replayed_message(
+        self,
+        message: Any,
+        is_resuming: bool,
+        segment_replay_started: bool,
+    ) -> bool:
+        """新 segment 必须精确 replay；仅 legacy resume 沿用旧的事件过滤。"""
+        return is_resuming and not segment_replay_started and self._should_filter_on_resume(message)
+
     def _is_cancelled(self, cancel_event: threading.Event) -> bool:
         """检查是否被取消（同时检查进程内事件和跨进程信号）
 
@@ -289,6 +361,7 @@ class GeneratorStreamingHelper:
     def _consume_stopped_session(
         self,
         consumer_id: str,
+        replay_source: _ReplayPreludeSource | None = None,
     ) -> Generator[Any, None, None]:
         """消费已停止会话的消息（内部方法）
 
@@ -304,6 +377,7 @@ class GeneratorStreamingHelper:
         empty_rounds = 0
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        segment_baseline_replay = False
 
         while True:
             try:
@@ -325,11 +399,20 @@ class GeneratorStreamingHelper:
                     continue
 
                 empty_rounds = 0  # 重置空轮询计数
+                if messages and replay_source is not None:
+                    head_frames, segment_baseline_replay = self._resolve_replay_prelude(messages[0], replay_source)
+                    yield from head_frames
+                    replay_source = None
+
+                messages, segment_baseline_replay = self._strip_replay_segment_markers(
+                    messages,
+                    segment_baseline_replay,
+                )
                 for item in messages:
                     if item in (HEARTBEAT_CHUNK, EOD_CHUNK, CANCELLED_CHUNK):
                         continue  # 跳过控制消息
                     # 已停止会话也是恢复模式，过滤 thinking 事件避免重复显示
-                    if self._should_filter_on_resume(item):
+                    if self._should_filter_replayed_message(item, True, segment_baseline_replay):
                         logger.debug(f"Filtered thinking event in stopped session for thread_id={self.thread_id}")
                         continue
                     yield item
@@ -423,6 +506,22 @@ class GeneratorStreamingHelper:
             )
         return has_pending
 
+    def _start_producer_thread(
+        self,
+        generator: Generator[Any, None, None],
+        cancel_event: threading.Event,
+        on_complete: Callable[[], None] | None,
+    ) -> threading.Thread:
+        """启动已取得会话写入权的 producer，并把写入权交给 producer 释放。"""
+        producer_thread = threading.Thread(
+            target=self._producer,
+            args=(generator, cancel_event, on_complete, True),
+            daemon=True,
+        )
+        producer_thread.start()
+        logger.info(f"Started producer for thread_id={self.thread_id}")
+        return producer_thread
+
     def _start_or_resume_stream(
         self,
         generator: Generator[Any, None, None],
@@ -451,13 +550,7 @@ class GeneratorStreamingHelper:
                 self.message_handler.release_producer(self.thread_id)
                 raise
 
-            producer_thread = threading.Thread(
-                target=self._producer,
-                args=(generator, cancel_event, on_complete, True),
-                daemon=True,
-            )
-            producer_thread.start()
-            logger.info(f"Started producer for thread_id={self.thread_id}")
+            producer_thread = self._start_producer_thread(generator, cancel_event, on_complete)
             enable_heartbeat_check = True
             return producer_thread, is_resuming, enable_heartbeat_check
 
@@ -493,8 +586,13 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        replay_source: _ReplayPreludeSource | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
+
+        新格式 replay 的主日志以 segment marker 开头。消费者先按 marker 读取
+        producer 保存的不可变 baseline，再消费 runtime tail；没有 marker 的旧日志
+        才从 ``replay_generator`` 提取本连接头部，保持滚动升级兼容。
 
         纯观测日志（零行为改动）：
         - 入口 / 出口 INFO，`finally` 带 reason / consumed / iter；
@@ -513,6 +611,7 @@ class GeneratorStreamingHelper:
         last_progress_ts = time.time()
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        segment_baseline_replay = False
 
         logger.info(
             "[RabbitMQ] consumer loop enter thread_id=%s consumer_id=%s is_resuming=%s heartbeat_check=%s",
@@ -590,6 +689,32 @@ class GeneratorStreamingHelper:
                     if messages:
                         last_message_time = time.time()
 
+                    if messages and replay_source is not None:
+                        head_frames, segment_baseline_replay = self._resolve_replay_prelude(
+                            messages[0],
+                            replay_source,
+                        )
+                        yield from head_frames
+                        segment_id = self._parse_replay_segment_marker(messages[0])
+                        if segment_baseline_replay:
+                            logger.info(
+                                "Replaying producer baseline thread_id=%s segment_id=%s frames=%d",
+                                self.thread_id,
+                                segment_id,
+                                len(head_frames),
+                            )
+                        else:
+                            logger.info(
+                                "Legacy replay log detected; using local head frames thread_id=%s frames=%d",
+                                self.thread_id,
+                                len(head_frames),
+                            )
+                        replay_source = None
+
+                    messages, segment_baseline_replay = self._strip_replay_segment_markers(
+                        messages,
+                        segment_baseline_replay,
+                    )
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
                             logger.debug(f"Received heartbeat for thread_id={self.thread_id}")
@@ -629,7 +754,7 @@ class GeneratorStreamingHelper:
                             yielded_total += 1
                             exit_reason = "cancelled"
                             return exit_reason
-                        if is_resuming and self._should_filter_on_resume(item):
+                        if self._should_filter_replayed_message(item, is_resuming, segment_baseline_replay):
                             logger.debug(f"Filtered thinking event in resume mode for thread_id={self.thread_id}")
                             continue
                         t_yield = time.time()
@@ -700,20 +825,111 @@ class GeneratorStreamingHelper:
         except Exception:
             logger.exception("Error cleaning completed replay session for thread_id=%s", self.thread_id)
 
+    def _stream_replay_segment(
+        self,
+        context: _ReplayStreamContext,
+    ) -> Generator[Any, None, str]:
+        """执行 RabbitMQ replay 的单一状态机：复用旧 segment，或提交并运行新 segment。"""
+        replay_generator, prelude_extractor = context.replay_source
+        has_pending = context.has_pending
+        producer_acquired = False
+        producer_thread: threading.Thread | None = None
+
+        try:
+            if not has_pending:
+                producer_acquired = self.message_handler.acquire_producer(self.thread_id)
+                if producer_acquired and self.message_handler.has_pending_messages(self.thread_id):
+                    self.message_handler.release_producer(self.thread_id)
+                    producer_acquired = False
+                    has_pending = True
+                    logger.info(
+                        "Messages appeared after producer lock acquisition, replaying instead of clearing thread_id=%s",
+                        self.thread_id,
+                    )
+
+            if not producer_acquired:
+                logger.info(
+                    "Existing producer or cached messages found for thread_id=%s, replaying segment",
+                    self.thread_id,
+                )
+                return (
+                    yield from self._consume_stream_messages(
+                        consumer_id=context.consumer_id,
+                        cancel_event=context.cancel_event,
+                        is_resuming=True,
+                        enable_heartbeat_check=not has_pending,
+                        on_complete=context.on_complete,
+                        replay_source=context.replay_source,
+                    )
+                )
+
+            try:
+                self.message_handler.clear(self.thread_id)
+                self.message_handler.clear_stopped(self.thread_id)
+                head_frames, remaining_generator = prelude_extractor(replay_generator)
+                segment_id = uuid.uuid4().hex
+                self.message_handler.publish_replay_segment_start(
+                    self.thread_id,
+                    segment_id,
+                    head_frames,
+                    self._build_replay_segment_marker(segment_id),
+                )
+                producer_thread = self._start_producer_thread(
+                    remaining_generator,
+                    context.cancel_event,
+                    context.on_complete,
+                )
+            except Exception:
+                try:
+                    self.message_handler.clear(self.thread_id)
+                except Exception:
+                    logger.exception(
+                        "Error cleaning failed replay segment initialization thread_id=%s",
+                        self.thread_id,
+                    )
+                raise
+
+            producer_acquired = False
+            yield from head_frames
+            return (
+                yield from self._consume_stream_messages(
+                    consumer_id=context.consumer_id,
+                    cancel_event=context.cancel_event,
+                    is_resuming=False,
+                    enable_heartbeat_check=True,
+                    on_complete=context.on_complete,
+                )
+            )
+        finally:
+            if producer_acquired:
+                self.message_handler.release_producer(self.thread_id)
+            if producer_thread is not None:
+                try:
+                    producer_thread.join(timeout=self.CANCEL_DRAIN_TIMEOUT + 2.0)
+                except Exception as e:
+                    logger.exception(f"Error joining producer thread for thread_id={self.thread_id}: {e}")
+
     def stream(
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        prelude_extractor: _PreludeExtractor | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
         replay-from-start handler 支持多个消费者各自从会话日志开头 replay；
         旧 handler 仍使用竞争消费语义，新消费者会抢占旧消费者。
 
+        ``prelude_extractor`` 用于两阶段 SSE：新 RabbitMQ producer 把提取出的
+        baseline 与 runtime 日志绑定；replay 连接读取 producer baseline，不再把
+        本连接的 DB snapshot 和旧 producer 的 RabbitMQ tail 混在一起。旧 handler
+        仍在进入队列流程前直传本地 prelude，行为不变。
+
         Args:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+            prelude_extractor: 从惰性 generator 提取 ``(head_frames, remaining_generator)`` 的回调。
 
         Yields:
             生成器产生的数据
@@ -721,6 +937,14 @@ class GeneratorStreamingHelper:
         Raises:
             RuntimeError: 当心跳超时时抛出，表示生产者可能已异常结束
         """
+        supports_replay_from_start = self._supports_replay_from_start()
+
+        # InMemory/旧 handler 保持原来的两阶段时序：先直传 head，再注册队列 consumer。
+        if prelude_extractor is not None and not supports_replay_from_start:
+            head_frames, generator = prelude_extractor(generator)
+            yield from head_frames
+            prelude_extractor = None
+
         # 注册取消事件（让 cancel() 可以通知生产者和消费者停止）
         cancel_event = self._register_cancel_event()
 
@@ -738,10 +962,26 @@ class GeneratorStreamingHelper:
 
         try:
             if should_consume_stopped:
-                yield from self._consume_stopped_session(consumer_id)
+                yield from self._consume_stopped_session(
+                    consumer_id,
+                    replay_source=(generator, prelude_extractor) if prelude_extractor is not None else None,
+                )
                 return
 
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
+
+            if supports_replay_from_start and prelude_extractor is not None:
+                consumer_exit_reason = yield from self._stream_replay_segment(
+                    _ReplayStreamContext(
+                        replay_source=(generator, prelude_extractor),
+                        cancel_event=cancel_event,
+                        consumer_id=consumer_id,
+                        has_pending=has_pending,
+                        on_complete=on_complete,
+                    )
+                )
+                return
+
             producer_thread, is_resuming, enable_heartbeat_check = self._start_or_resume_stream(
                 generator=generator,
                 cancel_event=cancel_event,

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -1,11 +1,13 @@
 """测试 InMemoryQueueMessageHandler 的基本功能"""
 
 import contextlib
+import json
 import threading
 import time
 
-import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
+
+import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
     CANCELLED_CHUNK,
@@ -25,14 +27,55 @@ def _make_run_finished_chunk(thread_id: str, run_id: str) -> str:
     return emit_run_finished_event(thread_id=thread_id, run_id=run_id)
 
 
+def _make_replay_segment_marker(segment_id: str) -> str:
+    return f": aidev-replay-segment {segment_id}\n\n"
+
+
+def _make_mixed_runtime_frames(count: int) -> list[str]:
+    event_types = ("TEXT_MESSAGE_CONTENT", "TOOL_CALL_ARGS", "STATE_DELTA")
+    return [
+        f"data: {json.dumps({'type': event_types[index % len(event_types)], 'sequence': index})}\n\n"
+        for index in range(count)
+    ]
+
+
+def _consume_replay_concurrently(handler, thread_id, prelude_extractor):
+    results = []
+    errors = []
+
+    def consume():
+        try:
+            helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+            results.append(list(helper.stream(iter(()), prelude_extractor=prelude_extractor)))
+        except Exception as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=consume) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+    return results, errors, threads
+
+
 class ReplayFromStartHandler:
     """测试用 replay handler：模拟 RabbitMQ 的非破坏性会话日志读取。"""
 
     def __init__(self):
         self.messages: dict[str, list] = {}
+        self.baselines: dict[tuple[str, str], list] = {}
         self.active_consumers: set[tuple[str, str]] = set()
         self.producer_locks: set[str] = set()
         self.completed_threads: list[str] = []
+        self.saved_baselines: list[tuple[str, str, list]] = []
+        self.put_calls: list[tuple[str, object]] = []
+        self.operations: list[tuple[str, object]] = []
+        self.fail_publish_baseline = False
+        self.fail_publish_marker = False
+        self.fail_flush = False
+        self.on_producer_acquired = None
+        self.message_wait_started = threading.Event()
+        self.stopped_threads: set[str] = set()
         self._consumer_seq = 0
         self._lock = threading.Lock()
         self._condition = threading.Condition(self._lock)
@@ -43,10 +86,31 @@ class ReplayFromStartHandler:
     def put(self, thread_id, message):
         with self._condition:
             self.messages.setdefault(thread_id, []).append(message)
+            self.put_calls.append((thread_id, message))
+            self.operations.append(("put", message))
             self._condition.notify_all()
 
     def flush(self, thread_id):
-        pass
+        if self.fail_flush:
+            raise RuntimeError("marker flush failed")
+
+    def publish_replay_segment_start(self, thread_id, segment_id, head_frames, segment_marker):
+        self.operations.append(("publish_baseline", segment_id))
+        if self.fail_publish_baseline:
+            raise RuntimeError("baseline publish failed")
+        frames = list(head_frames)
+        with self._lock:
+            self.baselines[(thread_id, segment_id)] = frames
+            self.saved_baselines.append((thread_id, segment_id, frames))
+        if self.fail_publish_marker:
+            raise RuntimeError("marker publish failed")
+        self.put(thread_id, segment_marker)
+        self.operations.append(("publish_segment", segment_id))
+
+    def get_replay_baseline(self, thread_id, segment_id):
+        with self._lock:
+            frames = self.baselines.get((thread_id, segment_id))
+            return list(frames) if frames is not None else None
 
     def get_messages_since(self, thread_id, offset, timeout=None):
         start = time.time()
@@ -59,6 +123,7 @@ class ReplayFromStartHandler:
                     remaining = timeout - (time.time() - start)
                     if remaining <= 0:
                         raise TimeoutError("No message available within timeout")
+                    self.message_wait_started.set()
                     self._condition.wait(timeout=remaining)
                 else:
                     self._condition.wait()
@@ -72,7 +137,9 @@ class ReplayFromStartHandler:
             if thread_id in self.producer_locks:
                 return False
             self.producer_locks.add(thread_id)
-            return True
+        if self.on_producer_acquired:
+            self.on_producer_acquired()
+        return True
 
     def release_producer(self, thread_id):
         with self._lock:
@@ -100,20 +167,24 @@ class ReplayFromStartHandler:
             return any(tid == thread_id for tid, _ in self.active_consumers)
 
     def is_stopped(self, thread_id):
-        return False
+        with self._lock:
+            return thread_id in self.stopped_threads
 
     def clear_stopped(self, thread_id):
-        pass
+        with self._lock:
+            self.stopped_threads.discard(thread_id)
 
     def mark_completed(self, thread_id):
         with self._condition:
             self.completed_threads.append(thread_id)
             self.messages.pop(thread_id, None)
+            self.baselines = {key: frames for key, frames in self.baselines.items() if key[0] != thread_id}
             self._condition.notify_all()
 
     def clear(self, thread_id):
         with self._condition:
             self.messages.pop(thread_id, None)
+            self.baselines = {key: frames for key, frames in self.baselines.items() if key[0] != thread_id}
             self._condition.notify_all()
 
     def clear_cancel_signal(self, thread_id):
@@ -146,6 +217,249 @@ class BarrierReplayFromStartHandler(ReplayFromStartHandler):
 
 
 class TestReplayFromStartStreamingHelper:
+    def test_new_producer_persists_segment_baseline_before_starting_runtime(self):
+        thread_id = "test_new_segment_baseline"
+        handler = ReplayFromStartHandler()
+
+        def runtime():
+            handler.operations.append(("generator_started", thread_id))
+            yield "runtime"
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                runtime(),
+                prelude_extractor=lambda generator: (["head"], generator),
+            )
+        )
+
+        saved_thread_id, segment_id, baseline = handler.saved_baselines[0]
+        marker = _make_replay_segment_marker(segment_id)
+        operation_names = [name for name, _ in handler.operations]
+        assert (saved_thread_id, baseline) == (thread_id, ["head"])
+        assert result == ["head", "runtime"]
+        assert (thread_id, marker) in handler.put_calls
+        marker_index = handler.operations.index(("put", marker))
+        assert operation_names.index("publish_baseline") < marker_index
+        assert marker_index < operation_names.index("publish_segment") < operation_names.index("generator_started")
+
+    def test_cached_segment_replays_saved_baseline_without_local_extraction(self):
+        thread_id = "test_cached_segment_baseline"
+        segment_id = "segment-cached"
+        handler = ReplayFromStartHandler()
+        handler.publish_replay_segment_start(
+            thread_id,
+            segment_id,
+            ["saved-head"],
+            _make_replay_segment_marker(segment_id),
+        )
+        handler.put(thread_id, "runtime")
+        handler.put(thread_id, EOD_CHUNK)
+
+        def reject_local_extraction(_generator):
+            pytest.fail("cached segment must not extract a connection-local baseline")
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=reject_local_extraction,
+            )
+        )
+
+        assert result == ["saved-head", "runtime"]
+
+    def test_large_mixed_segment_replays_identically_to_two_concurrent_consumers(self):
+        thread_id = "test_large_mixed_segment"
+        segment_id = "segment-large"
+        handler = BarrierReplayFromStartHandler(parties=2)
+        baseline = ["snapshot-head-0", "snapshot-head-1"]
+        runtime_frames = _make_mixed_runtime_frames(1537)
+        handler.publish_replay_segment_start(
+            thread_id,
+            segment_id,
+            baseline,
+            _make_replay_segment_marker(segment_id),
+        )
+        for frame in runtime_frames:
+            handler.put(thread_id, frame)
+        handler.put(thread_id, EOD_CHUNK)
+
+        def reject_local_extraction(_generator):
+            pytest.fail("new-format replay must use the producer baseline")
+
+        results, errors, threads = _consume_replay_concurrently(handler, thread_id, reject_local_extraction)
+        expected = baseline + runtime_frames
+        assert errors == []
+        assert all(not thread.is_alive() for thread in threads)
+        assert results == [expected, expected]
+
+    def test_active_producer_without_marker_waits_for_saved_segment_baseline(self):
+        thread_id = "test_wait_for_active_producer_marker"
+        segment_id = "segment-delayed"
+        handler = ReplayFromStartHandler()
+        handler.producer_locks.add(thread_id)
+
+        def publish_segment():
+            handler.message_wait_started.wait(timeout=1)
+            handler.publish_replay_segment_start(
+                thread_id,
+                segment_id,
+                ["saved-head"],
+                _make_replay_segment_marker(segment_id),
+            )
+            handler.put(thread_id, "runtime")
+            handler.put(thread_id, EOD_CHUNK)
+            handler.release_producer(thread_id)
+
+        publisher = threading.Thread(target=publish_segment)
+        publisher.start()
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=lambda _generator: pytest.fail("must wait for the producer marker"),
+            )
+        )
+        publisher.join(timeout=2)
+        assert handler.message_wait_started.is_set()
+        assert not publisher.is_alive()
+        assert result == ["saved-head", "runtime"]
+
+    def test_segment_marker_without_baseline_fails_instead_of_local_fallback(self):
+        thread_id = "test_missing_segment_baseline"
+        segment_id = "segment-missing"
+        handler = ReplayFromStartHandler()
+        handler.put(thread_id, _make_replay_segment_marker(segment_id))
+        handler.put(thread_id, EOD_CHUNK)
+
+        stream = GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+            iter(()),
+            prelude_extractor=lambda _generator: pytest.fail("missing baseline must not use local state"),
+        )
+
+        with pytest.raises(RuntimeError, match="replay baseline missing"):
+            list(stream)
+
+    def test_legacy_replay_without_segment_marker_uses_local_baseline(self):
+        thread_id = "test_legacy_replay_baseline"
+        handler = ReplayFromStartHandler()
+        handler.put(thread_id, "legacy-runtime")
+        handler.put(thread_id, EOD_CHUNK)
+        extracted = []
+
+        def extract_local_baseline(generator):
+            extracted.append(True)
+            return ["local-head"], generator
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=extract_local_baseline,
+            )
+        )
+
+        assert extracted == [True]
+        assert result == ["local-head", "legacy-runtime"]
+
+    def test_pending_segment_after_producer_lock_is_replayed_without_clear(self):
+        thread_id = "test_pending_after_producer_lock"
+        segment_id = "segment-raced"
+        handler = ReplayFromStartHandler()
+
+        def publish_previous_segment():
+            handler.publish_replay_segment_start(
+                thread_id,
+                segment_id,
+                ["saved-head"],
+                _make_replay_segment_marker(segment_id),
+            )
+            handler.put(thread_id, "runtime")
+            handler.put(thread_id, EOD_CHUNK)
+
+        handler.on_producer_acquired = publish_previous_segment
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=lambda _generator: pytest.fail("must replay the raced segment"),
+            )
+        )
+
+        assert result == ["saved-head", "runtime"]
+
+    def test_stopped_new_segment_replays_saved_baseline_then_one_stopped_terminal(self):
+        thread_id = "test_stopped_segment_baseline"
+        segment_id = "segment-stopped"
+        handler = ReplayFromStartHandler()
+        handler.stopped_threads.add(thread_id)
+        handler.publish_replay_segment_start(
+            thread_id,
+            segment_id,
+            ["saved-head"],
+            _make_replay_segment_marker(segment_id),
+        )
+        handler.put(thread_id, "runtime")
+        handler.put(thread_id, EOD_CHUNK)
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=lambda _generator: pytest.fail("stopped segment must use saved baseline"),
+            )
+        )
+
+        stopped_terminal = _make_run_finished_chunk(thread_id, RunId.STOPPED)
+        assert result == ["saved-head", "runtime", stopped_terminal]
+        assert result.count(stopped_terminal) == 1
+        assert thread_id not in handler.stopped_threads
+
+    def test_new_segment_replay_preserves_flow_agent_start(self):
+        thread_id = "test_segment_flow_agent_start"
+        segment_id = "segment-flow-agent"
+        flow_agent_start = 'data: {"type":"CUSTOM","name":"flow_agent_start","value":{}}\n\n'
+        handler = ReplayFromStartHandler()
+        handler.publish_replay_segment_start(
+            thread_id,
+            segment_id,
+            ["saved-head"],
+            _make_replay_segment_marker(segment_id),
+        )
+        handler.put(thread_id, flow_agent_start)
+        handler.put(thread_id, EOD_CHUNK)
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=lambda _generator: pytest.fail("new segment must use saved baseline"),
+            )
+        )
+
+        assert result == ["saved-head", flow_agent_start]
+
+    @pytest.mark.parametrize(
+        ("failure_attribute", "error_message"),
+        [
+            ("fail_publish_baseline", "baseline publish failed"),
+            ("fail_publish_marker", "marker publish failed"),
+        ],
+    )
+    def test_segment_initialization_failure_does_not_start_runtime(self, failure_attribute, error_message):
+        thread_id = f"test_segment_init_{failure_attribute}"
+        handler = ReplayFromStartHandler()
+        setattr(handler, failure_attribute, True)
+        runtime_started = threading.Event()
+
+        def runtime():
+            runtime_started.set()
+            yield "runtime"
+
+        stream = GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+            runtime(),
+            prelude_extractor=lambda generator: (["head"], generator),
+        )
+
+        with pytest.raises(RuntimeError, match=error_message):
+            list(stream)
+        assert not runtime_started.is_set()
+        assert thread_id not in handler.producer_locks
+
     def test_concurrent_consumers_replay_same_cached_stream_without_draining_each_other(self):
         thread_id = "test_replay_multi_consumer"
         handler = BarrierReplayFromStartHandler(parties=2)

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -1,5 +1,6 @@
 import asyncio
 import contextlib
+import json
 import os
 import threading
 import time
@@ -63,6 +64,84 @@ class TestRabbitMQMessageHandler:
             assert handler.get_cached_count(thread_id) == 1
 
         assert self._get_open_channel_count(handler) <= 1
+
+    def test_replay_baseline_is_non_destructive_and_segment_scoped(self, handler, thread_id):
+        """Replay 基线只能由匹配的 segment 读取，且读取不会消费它。"""
+        head_frames = [{"event": "snapshot", "content": "answer"}, ["nested", 1]]
+
+        handler.publish_replay_segment_start(thread_id, "segment-1", head_frames, "marker-1")
+
+        assert handler.get_replay_baseline(thread_id, "segment-other") is None
+        assert handler.get_replay_baseline(thread_id, "segment-1") == head_frames
+        assert handler.get_replay_baseline(thread_id, "segment-1") == head_frames
+        assert handler.get_messages_since(thread_id, 0, timeout=1) == (["marker-1"], 1)
+
+    def test_replay_baseline_keeps_latest_segment(self, handler, thread_id):
+        """连续保存基线时队列只保留最新 segment 的单条消息。"""
+        handler.publish_replay_segment_start(thread_id, "segment-old", ["old"], "marker-old")
+        handler.publish_replay_segment_start(thread_id, "segment-new", ["new"], "marker-new")
+
+        queue_name = handler._get_replay_baseline_queue_name(thread_id)
+        with handler._with_channel() as channel:
+            queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
+            assert queue_info.method.message_count == 1
+
+        assert handler.get_replay_baseline(thread_id, "segment-old") is None
+        assert handler.get_replay_baseline(thread_id, "segment-new") == ["new"]
+
+    def test_clear_purges_replay_baseline(self, handler, thread_id):
+        """clear 会清空 replay 基线，但保留可复用队列。"""
+        handler.publish_replay_segment_start(thread_id, "segment-1", ["head"], "marker-1")
+        queue_name = handler._get_replay_baseline_queue_name(thread_id)
+
+        handler.clear(thread_id)
+
+        assert handler.get_replay_baseline(thread_id, "segment-1") is None
+        with handler._with_channel() as channel:
+            queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
+            assert queue_info.method.message_count == 0
+
+    def test_reconnect_replays_same_baseline_and_long_mixed_tail(self, handler, thread_id):
+        """首连接断开后，真实 RabbitMQ 从同一 baseline 完整重放 1500 条混合事件。"""
+        head_frames = ["snapshot-head", "run-started-head"]
+        event_types = [
+            "TEXT_MESSAGE_CONTENT",
+            "THINKING_TEXT_MESSAGE_CONTENT",
+            "TOOL_CALL_ARGS",
+            "TOOL_CALL_RESULT",
+            "CUSTOM",
+        ]
+        runtime_frames = [
+            f"data: {json.dumps({'type': event_types[index % len(event_types)], 'index': index})}\n\n"
+            for index in range(1500)
+        ]
+        runtime_finished = threading.Event()
+
+        def runtime_generator():
+            try:
+                yield from runtime_frames
+            finally:
+                runtime_finished.set()
+
+        first_stream = GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+            runtime_generator(),
+            prelude_extractor=lambda generator: (head_frames, generator),
+        )
+        assert next(first_stream) == head_frames[0]
+        first_stream.close()
+        assert runtime_finished.wait(timeout=3.0)
+
+        def reject_local_extraction(_generator):
+            pytest.fail("segment replay must reuse the producer baseline")
+
+        replayed = list(
+            GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
+                iter(()),
+                prelude_extractor=reject_local_extraction,
+            )
+        )
+
+        assert replayed == head_frames + runtime_frames
 
     def test_live_test(self, handler, thread_id):
         """实际连接 RabbitMQ 进行测试"""
@@ -400,6 +479,7 @@ class TestResourceCleanup:
         handler.put(thread_id, "msg_1")
         handler.put(thread_id, "msg_2")
         handler.flush(thread_id)
+        handler.publish_replay_segment_start(thread_id, "segment-1", ["head"], "marker-1")
 
         # 消费消息使其进入死信队列
         handler.get(thread_id, timeout=1)
@@ -407,10 +487,12 @@ class TestResourceCleanup:
         # 确认队列和交换机存在
         main_queue = handler._get_queue_name(thread_id)
         dlq_name = handler._get_dlq_name(thread_id)
+        replay_baseline_queue = handler._get_replay_baseline_queue_name(thread_id)
         dlx_exchange = handler._get_dlx_exchange_name(thread_id)
 
         assert self._queue_exists(handler, main_queue), "主队列应该存在"
         assert self._queue_exists(handler, dlq_name), "死信队列应该存在"
+        assert self._queue_exists(handler, replay_baseline_queue), "replay 基线队列应该存在"
         assert self._exchange_exists(handler, dlx_exchange), "死信交换机应该存在"
 
         # 执行 mark_completed
@@ -419,6 +501,7 @@ class TestResourceCleanup:
         # 验证队列和交换机已被删除
         assert not self._queue_exists(handler, main_queue), "主队列应该被删除"
         assert not self._queue_exists(handler, dlq_name), "死信队列应该被删除"
+        assert not self._queue_exists(handler, replay_baseline_queue), "replay 基线队列应该被删除"
         assert not self._exchange_exists(handler, dlx_exchange), "死信交换机应该被删除"
 
     @pytest.mark.skipif(not os.getenv("RABBITMQ_HOST"), reason="Live test requires RABBITMQ_HOST")


### PR DESCRIPTION
## 背景

#712 已把 runtime 消费收敛到 RabbitMQ，解决本地 buffer 与队列混读造成的乱序。本 PR 只处理剩余的重复边界：连接本地生成的 `MESSAGES_SNAPSHOT` 可能已经覆盖 RabbitMQ replay tail 中的同一批历史事件，刷新或 Stop 后重进时会重复输出。

## 顶层不变量

每个 RabbitMQ producer segment 只有一个不可变回放基线：

1. producer 从自身生成器提取 `MESSAGES_SNAPSHOT` 到 `RUN_STARTED` 作为 baseline；
2. RabbitMQ 先确认持久化 baseline，再确认向主日志写入该 segment 的 SSE comment marker；
3. marker 提交成功后才启动 runtime producer；
4. 首连接、刷新重连和 Stop 后重进都使用同一个 baseline，再消费 RabbitMQ tail。

这样 snapshot 与 tail 属于同一 producer segment，不再把“当前连接的 DB snapshot”和“另一个 producer 的 RabbitMQ tail”拼接。

## 改动

- `ChatCompletionAgent` 把 head 提取时机交给 streaming helper；InMemory 仍按原时序同步直传 head。
- RabbitMQ 新增一个每会话只保留 1 条、带 TTL 的 durable baseline queue；`clear` 时 purge，`mark_completed` 时删除。
- baseline 与主日志 marker 在同一 replay lock/channel 中按顺序 publisher-confirm；任一步失败都不启动 runtime。
- 主日志 marker 使用标准 SSE comment，旧 worker / SSE client 会忽略，支持滚动发布。
- replay 看到 marker 后必须读取对应 producer baseline；marker 存在但 baseline 缺失时硬失败，不静默退回本地 snapshot。
- 没有 marker 的旧日志保留 legacy fallback，继续从本地 generator 提取 head。
- Stop replay 同样输出 producer baseline + tail + 既有 STOPPED 终态。

## 最小范围说明

- 只修复 `MESSAGES_SNAPSHOT + RabbitMQ replay tail` 的重复问题。
- 不改 InMemory handler 的生产实现；仅通用 helper 接口适配并用测试确认原流程不变。
- 不包含 `last_message_id` 触发的新 graph execution 去重。
- 不改 cancel generation、consumer fencing、prune、水位或消息落库生命周期。
- 额外运行资源只有一个单消息 TTL baseline queue。

## 验证

- InMemory / streaming helper：`42 passed`
- chat 与属性相关回归：`89 passed, 1 skipped`
- Stop / 标准 stream 专项：`29 passed`
- RabbitMQ baseline、清理与真实 broker 长重连专项通过；1500 条混合 text/thinking/tool/custom tail 精确回放。
- 排除 #712 已记录的 RabbitMQ consumer-mixin / observability 基线问题及 `live_chat`、旧 signal queue 断言后：`1835 passed, 24 skipped, 63 deselected, 3 xfailed`
- Ruff format/check、`py_compile`、`git diff --check` 通过。
- 本地模板应用加载当前 worktree，`http://local.woa.com:8000/` 返回 302 并正常进入聊天页：
  - 50 次串行工具调用，中途刷新并重进，`ROUND 1/50` 到 `ROUND 50/50` 各出现一次；
  - 第 4 次工具执行中点击 Stop，刷新重进后只保留 `STOPTEST 1/80` 到 `STOPTEST 3/80`，无重复且不再继续生成。

## 已知基线

仓库原始全量仍会命中 #712 已记录的 RabbitMQ consumer-mixin / observability 测试问题，以及依赖真实 LLM 的 `test_live_chat` 和旧 signal queue 模型断言；本 PR 没有扩大或掩盖这些问题。