### PR TITLE
fix: 收敛后台流式会话终态写入 --story=136206810

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -2,6 +2,7 @@ import json
 import re
 import uuid
 import warnings
+from functools import partial
 from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
@@ -537,7 +538,7 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(
             remaining_producer,
-            on_complete=self._on_complete,
+            on_complete=partial(self._on_complete, finalize_session=not background_only),
             event_handler=self.event_handler,
         )
 
@@ -726,8 +727,8 @@ class ChatCompletionAgent(BaseModel):
             )
         )
 
-    def _on_complete(self):
-        if self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
+    def _on_complete(self, *, finalize_session: bool = True):
+        if finalize_session and self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
             self.event_handler.set_streaming_finished()
         # 流式执行结束后释放资源
         self.release_resources()

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1185,21 +1185,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     # replay offset 只描述 RabbitMQ 已提交队列，不能包含本地未发布 buffer。
                     # flush_peek_lock 避免读取到本进程尚未完整发布的 flush 批次。
                     with flush_peek_lock:
-                        all_messages = self._peek_queue_messages(channel, main_queue_name)
+                        queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                        committed_count = queue_info.method.message_count
 
                         # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if not all_messages and self._get_dlq_count(thread_id) > 0:
+                        if committed_count == 0 and self._get_dlq_count(thread_id) > 0:
                             restored = self._restore_from_dlq(thread_id)
                             logger.info(
                                 "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
                                 thread_id,
                                 restored,
                             )
-                            all_messages = self._peek_queue_messages(channel, main_queue_name)
+                            queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                            committed_count = queue_info.method.message_count
 
-                next_offset = len(all_messages)
-                if next_offset > offset:
-                    return all_messages[offset:], next_offset
+                        # 没有新消息时避免反复 basic_get/basic_nack 全量扫描历史队列。
+                        all_messages = (
+                            self._peek_queue_messages(channel, main_queue_name) if committed_count > offset else None
+                        )
+
+                if all_messages is not None:
+                    next_offset = len(all_messages)
+                    if next_offset > offset:
+                        return all_messages[offset:], next_offset
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
 

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -745,6 +745,20 @@ class TestOnComplete:
         agent._on_complete()
         mock_handler.set_streaming_finished.assert_called_once()
 
+    def test_background_stream_defers_set_streaming_finished(self):
+        """后台 drain 的 producer 完成回调不写会话终态。"""
+        mock_handler = MagicMock(spec=BaseSessionWriter)
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"], stream_chunk_size=2),
+            checkpointer=MemorySaver(),
+            chat_history=[ChatPrompt(role="user", content="hi")],
+            event_handler=mock_handler,
+        )
+
+        list(agent.execute(ExecuteKwargs(stream=True, background_only=True)))
+
+        mock_handler.set_streaming_finished.assert_not_called()
+
     def test_on_complete_invoked_during_stream(self):
         """端到端验证：流式执行结束后 on_complete 被触发"""
         mock_handler = MagicMock(spec=BaseSessionWriter)

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -1,0 +1,58 @@
+import contextlib
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler(message_count: int, messages: list[str]) -> tuple[RabbitMQMessageHandler, MagicMock]:
+    handler = object.__new__(RabbitMQMessageHandler)
+    channel = MagicMock()
+    channel.queue_declare.return_value.method.message_count = message_count
+
+    handler._get_flush_peek_lock = MagicMock(return_value=threading.Lock())
+    handler._with_replay_lock = MagicMock(return_value=contextlib.nullcontext(channel))
+    handler._ensure_queue = MagicMock(return_value="replay-queue")
+    handler._peek_queue_messages = MagicMock(return_value=messages)
+    handler._get_dlq_count = MagicMock(return_value=0)
+    handler._restore_from_dlq = MagicMock(return_value=0)
+    return handler, channel
+
+
+def test_get_messages_since_skips_full_peek_without_new_messages():
+    handler, channel = _make_handler(message_count=835, messages=[])
+
+    with pytest.raises(TimeoutError, match="No message available within timeout"):
+        handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    channel.queue_declare.assert_called_once_with(queue="replay-queue", durable=True, passive=True)
+    handler._peek_queue_messages.assert_not_called()
+
+
+def test_get_messages_since_peeks_when_queue_has_new_messages():
+    messages = [f"message-{index}" for index in range(836)]
+    handler, channel = _make_handler(message_count=836, messages=messages)
+
+    new_messages, next_offset = handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    assert new_messages == ["message-835"]
+    assert next_offset == 836
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+
+
+def test_get_messages_since_preserves_legacy_dlq_restore():
+    handler, channel = _make_handler(message_count=0, messages=["restored-message"])
+    channel.queue_declare.side_effect = [
+        MagicMock(method=MagicMock(message_count=0)),
+        MagicMock(method=MagicMock(message_count=1)),
+    ]
+    handler._get_dlq_count.return_value = 1
+    handler._restore_from_dlq.return_value = 1
+
+    messages, next_offset = handler.get_messages_since("thread-id", offset=0, timeout=0)
+
+    assert messages == ["restored-message"]
+    assert next_offset == 1
+    handler._restore_from_dlq.assert_called_once_with("thread-id")
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -89,7 +89,7 @@ class AgentExecutor:
         *,
         turn_id: str = "",
     ):
-        """执行 agent 直至结束；AG-UI 流式负责事件落库并收尾会话状态。"""
+        """执行 agent 直至结束；后台消费者完整 drain 后统一收尾会话状态。"""
         # 后台 drain（for _ in out: pass，无 SSE 下游）：标记为 background_only，
         # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
         execute_kwargs.background_only = True
@@ -99,24 +99,18 @@ class AgentExecutor:
                 handler.turn_id = turn_id
             if hasattr(handler, "set_streaming_started"):
                 handler.set_streaming_started()
-        try:
-            out = cls(session_manager).execute_with_save(
-                agent_instance,
-                execute_kwargs,
-                session_code,
-                turn_id=turn_id,
-            )
-            if execute_kwargs.stream:
-                for _ in out:
-                    pass
-            return out
-        finally:
-            if (
-                execute_kwargs.stream
-                and isinstance(handler, BaseSessionWriter)
-                and hasattr(handler, "set_streaming_finished")
-            ):
+        out = cls(session_manager).execute_with_save(
+            agent_instance,
+            execute_kwargs,
+            session_code,
+            turn_id=turn_id,
+        )
+        if execute_kwargs.stream:
+            for _ in out:
+                pass
+            if isinstance(handler, BaseSessionWriter) and hasattr(handler, "set_streaming_finished"):
                 handler.set_streaming_finished()
+        return out
 
     def wrap_generator(self, generator, session_code: str, *, turn_id: str = ""):
         """SSE 数据格式约定：

--- a/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""后台 Agent 流式终态写入回归测试。"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if "pkg_resources" not in sys.modules:
+    sys.modules["pkg_resources"] = MagicMock()
+
+sys.modules.setdefault("aidev_bkplugin.models", MagicMock())
+_bk_plugin_framework = MagicMock()
+_bk_plugin_framework.kit.decorators.inject_user_token = lambda func: func
+sys.modules.setdefault("bk_plugin_framework", _bk_plugin_framework)
+sys.modules.setdefault("bk_plugin_framework.kit", _bk_plugin_framework.kit)
+sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framework.kit.decorators)
+
+
+class TestAgentExecutorCompletion:
+    def test_sets_finished_after_stream_is_drained(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        lifecycle = []
+
+        def stream():
+            yield "chunk"
+            lifecycle.append("drained")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        handler.set_streaming_finished.side_effect = lambda: lifecycle.append("finished")
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with patch.object(AgentExecutor, "execute_with_save", return_value=stream()):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        assert execute_kwargs.background_only is True
+        assert lifecycle == ["drained", "finished"]
+
+    def test_does_not_set_finished_when_stream_drain_fails(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        def failing_stream():
+            yield "chunk"
+            raise RuntimeError("producer heartbeat timeout")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with (
+            patch.object(AgentExecutor, "execute_with_save", return_value=failing_stream()),
+            pytest.raises(RuntimeError, match="heartbeat timeout"),
+        ):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        handler.set_streaming_finished.assert_not_called()


### PR DESCRIPTION
## 背景

后台流式执行可能在消息消费者尚未完整读取时提前结束会话；在等待新消息期间，replay 消费者还会重复扫描已经读取的历史消息。

## 原因

- 生产端完成回调和后台消费者都写入会话终态；同时后台消费者的 `finally` 会在消费异常时误写成功终态。
- replay 轮询未先比较队列消息数与消费 offset，无新消息时仍会对完整历史队列执行 `basic_get/basic_nack`。

## 改动内容

- 后台模式下，生产端完成回调仅释放资源，不写会话终态。
- 仅在后台消费者完整读取流后写入结束状态。
- 消费异常保持向上传播，由 worker 记录失败状态。
- replay 读取先轻量检查队列消息数；没有超过当前 offset 时跳过全量历史扫描。
- 保留新消息回放和旧 DLQ 消息恢复逻辑。
- 补充正常完成、消费异常、replay 空轮询及 DLQ 恢复回归测试。

## 收益

避免会话提前结束和异常被成功终态掩盖；同时降低长会话等待阶段的 RabbitMQ 读写及 requeue 压力。

## 测试验证

- Agent 相关测试：83 passed，5 skipped。
- bkplugin 后台完成状态测试：2 passed。
- 提交钩子中的 Ruff、格式化与冲突检查通过。
