### PR TITLE
feat: 同步 Agent 流式稳定性修复到 develop --story=136206810

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -29,7 +29,7 @@ from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, PrivateAttr, model_validator
 
 from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
@@ -65,11 +65,18 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
+    _owns_http_async_client: bool = PrivateAttr(default=False)
 
     @classmethod
     def get_setup_instance(cls, **kwargs) -> "ChatModel | RunnableWithFallbacks":
-        """创建网关模型；配置备用模型时返回 LangChain fallback Runnable。"""
+        """创建网关模型，并为每个调用链隔离异步 HTTP 连接池。"""
+        owns_http_async_client = False
+        if kwargs.get("http_async_client") is None and kwargs.get("async_client") is None:
+            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient()
+            owns_http_async_client = True
+
         model = super().get_setup_instance(**kwargs)
+        model._owns_http_async_client = owns_http_async_client
         fallback = model._get_fallback_model()
         if fallback is None:
             return model

--- a/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
+++ b/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
@@ -738,7 +738,15 @@ class AgentStreamAdapter:
         )
 
     # 流协议处理
-    def stream_standard_event(self, agent_e, cfg, input_state, skip_thought=False, timeout: int = 30):
+    def stream_standard_event(
+        self,
+        agent_e,
+        cfg,
+        input_state,
+        skip_thought=False,
+        timeout: int = 30,
+        async_finalizer=None,
+    ):
         try:
             protocol = BkAiStreamingProtocol(
                 skip_thought=skip_thought,
@@ -755,7 +763,7 @@ class AgentStreamAdapter:
                 durability="exit",
             )
             _aiter = async_generator_with_timeout(_aiter, timeout=timeout)
-            g = async_to_sync_generator(_aiter)
+            g = async_to_sync_generator(_aiter, async_finalizer=async_finalizer)
             yield from protocol.stream_standard_event(g)
         except Exception:
             logger.error(traceback.format_exc())

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -549,7 +549,7 @@ class BaseResourceManager(abc.ABC):
         async def _load_all_tools():
             return await asyncio.gather(*coros)
 
-        coro_results = run_coro_sync(_load_all_tools())
+        coro_results = run_coro_sync(_load_all_tools)
         tools_list: List[StructuredTool] = []
         failures: List[McpToolFetchFailure] = []
         for tlist, fail in coro_results:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -2,6 +2,7 @@ import json
 import re
 import uuid
 import warnings
+from functools import partial
 from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
@@ -868,7 +869,7 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(
             remaining_producer,
-            on_complete=self._on_complete,
+            on_complete=partial(self._on_complete, finalize_session=not background_only),
             event_handler=self.event_handler,
         )
 
@@ -989,8 +990,8 @@ class ChatCompletionAgent(BaseModel):
 
         return agui_entry.build_terminal_replay_stream(agent_input, non_system)
 
-    def _on_complete(self):
-        if self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
+    def _on_complete(self, *, finalize_session: bool = True):
+        if finalize_session and self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
             self.event_handler.set_streaming_finished()
         # 流式执行结束后释放资源
         self.release_resources()

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -242,6 +242,39 @@ class ChatCompletionAgent(BaseModel):
             finally:
                 self.runtime_backend_resolver = None
 
+    def _managed_chat_models(self) -> list[BaseChatModel]:
+        """Return concrete chat models whose async clients belong to this agent."""
+        models: list[BaseChatModel] = []
+        for candidate in (self.chat_model, self.chat_model_non_thinking, self.chat_model_fast):
+            if candidate is None:
+                continue
+            if isinstance(candidate, RunnableWithFallbacks):
+                models.extend([candidate.runnable, *candidate.fallbacks])
+            else:
+                models.append(candidate)
+        return models
+
+    async def _aclose_chat_models(self) -> None:
+        """Close owned async HTTP clients on the model execution event loop."""
+        client_models: dict[int, tuple[Any, list[BaseChatModel]]] = {}
+        for model in self._managed_chat_models():
+            if not getattr(model, "_owns_http_async_client", False):
+                continue
+            client = getattr(model, "http_async_client", None)
+            if client is None:
+                continue
+            _, owners = client_models.setdefault(id(client), (client, []))
+            owners.append(model)
+
+        for client, owners in client_models.values():
+            try:
+                await client.aclose()
+            except Exception:
+                logger.warning("ChatCompletionAgent: 关闭模型异步 HTTP client 失败", exc_info=True)
+            else:
+                for model in owners:
+                    model._owns_http_async_client = False
+
     def _query_approval_status(self, session_code: str) -> dict | None:
         """查询 gongfeng 后端判断是否需要续流，并从 interrupt 记录获取审批结果及 interrupts。
 
@@ -642,8 +675,15 @@ class ChatCompletionAgent(BaseModel):
         """
         try:
             input_state: dict[str, Any] = {"messages": messages, "execute_kwargs": execute_kwargs, **state}
+
+            async def _ainvoke_with_cleanup():
+                try:
+                    return await agent_e.ainvoke(input_state, cfg)
+                finally:
+                    await self._aclose_chat_models()
+
             result = run_coro_sync(
-                agent_e.ainvoke(input_state, cfg),
+                _ainvoke_with_cleanup,
                 timeout=execute_kwargs.invoke_timeout,
             )
             result_output = result.get("messages")[-1]
@@ -671,7 +711,7 @@ class ChatCompletionAgent(BaseModel):
         _input: dict[str, Any] = {"messages": messages, **state}
         agent_type = self.model_context_options.llm_code_agent_type if self.model_context_options else None
         adapter = AgentStreamAdapter(agent_type=agent_type)
-        return adapter.stream_standard_event(agent_e, cfg, _input)
+        return adapter.stream_standard_event(agent_e, cfg, _input, async_finalizer=self._aclose_chat_models)
 
     def _stream(
         self,
@@ -826,7 +866,11 @@ class ChatCompletionAgent(BaseModel):
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+        yield from helper.stream(
+            remaining_producer,
+            on_complete=self._on_complete,
+            event_handler=self.event_handler,
+        )
 
     @staticmethod
     def _extract_head_frames(
@@ -878,9 +922,15 @@ class ChatCompletionAgent(BaseModel):
                         "(scheme B fallback), thread_id=%s",
                         agent_input.thread_id,
                     )
-                    yield from replay
+                    try:
+                        yield from replay
+                    finally:
+                        run_coro_sync(self._aclose_chat_models)
                     return
-            yield from async_to_sync_generator(agui_entry.run(agent_input))
+            yield from async_to_sync_generator(
+                agui_entry.run(agent_input),
+                async_finalizer=self._aclose_chat_models,
+            )
 
         return _gen()
 

--- a/src/agent/aidev_agent/services/agent/flow.py
+++ b/src/agent/aidev_agent/services/agent/flow.py
@@ -135,7 +135,7 @@ class FlowAgentCompletionAgent(BaseModel):
         """
         stream_thread_id = self.session_code or self.thread_id
         helper = GeneratorStreamingHelper(thread_id=stream_thread_id)
-        return helper.stream(self._run_flow())
+        return helper.stream(self._run_flow(), event_handler=self.event_handler)
 
     def stop(self):
         """停止 Flow Agent"""

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -18,7 +18,7 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import QueueNamePrefixes
+from .constants import EOD_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
@@ -627,14 +627,39 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             connection = self._producer_lock_connections.pop(thread_id, None)
 
         if not connection:
+            logger.info(
+                "[RabbitMQ] producer lock release skipped (no connection) thread_id=%s queue=%s",
+                thread_id,
+                lock_queue,
+            )
             return
 
+        logger.info(
+            "[RabbitMQ] release_producer enter thread_id=%s queue=%s connection_is_open=%s",
+            thread_id,
+            lock_queue,
+            getattr(connection, "is_open", None),
+        )
         channel = None
+        connection_already_closed = False
         try:
             if getattr(connection, "is_open", False):
-                channel = connection.channel()
-                with contextlib.suppress(Exception):
-                    channel.queue_delete(queue=lock_queue)
+                try:
+                    channel = connection.channel()
+                    with contextlib.suppress(Exception):
+                        channel.queue_delete(queue=lock_queue)
+                except Exception as e:
+                    # 连接已被对端重置/关闭：exclusive queue 随连接断开自动删除，
+                    # 无需再 queue_delete，降级走连接清理路径，不让异常冒泡
+                    connection_already_closed = True
+                    channel = None
+                    logger.warning(
+                        "[RabbitMQ] producer lock connection already closed, skip queue_delete "
+                        "thread_id=%s queue=%s error=%s",
+                        thread_id,
+                        lock_queue,
+                        e,
+                    )
         finally:
             if channel and getattr(channel, "is_open", False):
                 with contextlib.suppress(Exception):
@@ -642,7 +667,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if getattr(connection, "is_open", False):
                 with contextlib.suppress(Exception):
                     connection.close()
-            logger.info("[RabbitMQ] producer lock released thread_id=%s queue=%s", thread_id, lock_queue)
+            logger.info(
+                "[RabbitMQ] producer lock released thread_id=%s queue=%s connection_already_closed=%s",
+                thread_id,
+                lock_queue,
+                connection_already_closed,
+            )
 
     def _ensure_active_consumer_queue(self, channel: Any, thread_id: str) -> str:
         queue_name = self._get_active_consumer_queue_name(thread_id)
@@ -867,6 +897,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
                     logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
+                    if EOD_CHUNK in messages:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d (background)",
+                            thread_id,
+                            len(messages),
+                        )
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1034,6 +1070,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                    if EOD_CHUNK in messages_to_flush:
+                        logger.info(
+                            "[EOD] flush thread_id=%s published=%d",
+                            thread_id,
+                            len(messages_to_flush),
+                        )
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1093,9 +1135,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。"""
+        """非破坏性读取队列中的全部消息，仅在读取或 requeue 异常时记录诊断。"""
         messages = []
         delivery_tags = []
+        message_count = 0
+        nack_error = None
 
         try:
             queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
@@ -1105,10 +1149,23 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if not method_frame:
                     break
                 delivery_tags.append(method_frame.delivery_tag)
-                messages.append(pickle.loads(body))
+                msg = pickle.loads(body)
+                messages.append(msg)
         finally:
             for tag in delivery_tags:
-                channel.basic_nack(delivery_tag=tag, requeue=True)
+                try:
+                    channel.basic_nack(delivery_tag=tag, requeue=True)
+                except Exception as e:
+                    nack_error = e
+            if message_count != len(messages) or nack_error is not None:
+                logger.warning(
+                    "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
+                    queue_name,
+                    message_count,
+                    len(messages),
+                    nack_error,
+                    EOD_CHUNK in messages,
+                )
 
         return messages
 

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -1184,21 +1184,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     # replay offset 只描述 RabbitMQ 已提交队列，不能包含本地未发布 buffer。
                     # flush_peek_lock 避免读取到本进程尚未完整发布的 flush 批次。
                     with flush_peek_lock:
-                        all_messages = self._peek_queue_messages(channel, main_queue_name)
+                        queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                        committed_count = queue_info.method.message_count
 
                         # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if not all_messages and self._get_dlq_count(thread_id) > 0:
+                        if committed_count == 0 and self._get_dlq_count(thread_id) > 0:
                             restored = self._restore_from_dlq(thread_id)
                             logger.info(
                                 "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
                                 thread_id,
                                 restored,
                             )
-                            all_messages = self._peek_queue_messages(channel, main_queue_name)
+                            queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                            committed_count = queue_info.method.message_count
 
-                next_offset = len(all_messages)
-                if next_offset > offset:
-                    return all_messages[offset:], next_offset
+                        # 没有新消息时避免反复 basic_get/basic_nack 全量扫描历史队列。
+                        all_messages = (
+                            self._peek_queue_messages(channel, main_queue_name) if committed_count > offset else None
+                        )
+
+                if all_messages is not None:
+                    next_offset = len(all_messages)
+                    if next_offset > offset:
+                        return all_messages[offset:], next_offset
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
 

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -4,7 +4,7 @@ import uuid
 from logging import getLogger
 from typing import Any, Callable, Generator
 
-from ag_ui.core import EventType, RunErrorEvent
+from ag_ui.core import EventType, RawEvent, RunErrorEvent
 from ag_ui.encoder import EventEncoder
 
 from aidev_agent.utils.event import RunId, emit_run_finished_event
@@ -21,6 +21,10 @@ from .constants import (
 from .factory import message_handler_factory
 
 logger = getLogger(__name__)
+
+_SSE_HEARTBEAT_EVENT = EventEncoder().encode(
+    RawEvent(type=EventType.RAW, event={"type": "heartbeat"}),
+)
 
 # 断点续传时需要过滤的事件类型
 # flow_agent_start 事件在续聊时不应该重复发送，避免前端重新渲染
@@ -70,6 +74,7 @@ class GeneratorStreamingHelper:
     # 通过 restore_messages 接管已生产的完整内容；窗口内若有消费者接管则跳过清理。
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
+    _HEARTBEAT_TIMEOUT_GRACE = 5.0
 
     @staticmethod
     def _should_filter_on_resume(item: Any) -> bool:
@@ -429,9 +434,11 @@ class GeneratorStreamingHelper:
         cancel_event: threading.Event,
         has_pending: bool,
         on_complete: Callable[[], None] | None = None,
-    ) -> tuple[threading.Thread | None, bool, bool]:
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> tuple[threading.Thread | None, bool, bool, threading.Event | None]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
         producer_thread: threading.Thread | None = None
+        producer_succeeded_event: threading.Event | None = None
         is_resuming = False
         enable_heartbeat_check = False
         supports_replay_from_start = self._supports_replay_from_start()
@@ -442,7 +449,7 @@ class GeneratorStreamingHelper:
                     "Producer already active for thread_id=%s, consuming existing replay stream",
                     self.thread_id,
                 )
-                return producer_thread, True, True
+                return producer_thread, True, True, producer_succeeded_event
 
             try:
                 self.message_handler.clear(self.thread_id)
@@ -451,15 +458,23 @@ class GeneratorStreamingHelper:
                 self.message_handler.release_producer(self.thread_id)
                 raise
 
+            producer_succeeded_event = threading.Event()
             producer_thread = threading.Thread(
                 target=self._producer,
-                args=(generator, cancel_event, on_complete, True),
+                kwargs={
+                    "generator": generator,
+                    "cancel_event": cancel_event,
+                    "on_complete": on_complete,
+                    "event_handler": event_handler,
+                    "release_producer": True,
+                    "producer_succeeded_event": producer_succeeded_event,
+                },
                 daemon=True,
             )
             producer_thread.start()
             logger.info(f"Started producer for thread_id={self.thread_id}")
             enable_heartbeat_check = True
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
         if supports_replay_from_start:
             is_resuming = True
@@ -467,7 +482,7 @@ class GeneratorStreamingHelper:
                 "Pending messages exist for thread_id=%s, replaying cached stream from start",
                 self.thread_id,
             )
-            return producer_thread, is_resuming, enable_heartbeat_check
+            return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
         self.message_handler.wait_for_previous_consumer(self.thread_id, timeout=3.0)
         restored = self.message_handler.restore_messages(self.thread_id)
@@ -476,7 +491,7 @@ class GeneratorStreamingHelper:
             f"Pending messages exist for thread_id={self.thread_id}, "
             f"restored {restored} messages from DLQ, consuming from start"
         )
-        return producer_thread, is_resuming, enable_heartbeat_check
+        return producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event
 
     # ---- L1 观测：consumer 循环内联耗时 WARNING 阈值（秒），仅日志用途 ----
     _CHECK_CONSUMER_SLOW_SEC = 2.0
@@ -486,6 +501,25 @@ class GeneratorStreamingHelper:
     _CONSUMER_PROGRESS_EVERY_N = 50
     _CONSUMER_PROGRESS_EVERY_SECONDS = 10.0
 
+    def _emit_terminal_error_events(
+        self,
+        message: str,
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> Generator[str, None, None]:
+        """输出 AG-UI 错误与结束事件，并同步通知会话事件处理器。"""
+        error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=message)
+        if event_handler is not None:
+            try:
+                event_handler(error_event)
+            except Exception:
+                logger.exception("Error dispatching RUN_ERROR for thread_id=%s", self.thread_id)
+        yield EventEncoder().encode(error_event)
+        yield emit_run_finished_event(
+            thread_id=self.thread_id,
+            run_id="error",
+            event_handler=event_handler,
+        )
+
     def _consume_stream_messages(
         self,
         consumer_id: str,
@@ -493,6 +527,9 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        producer_thread: threading.Thread | None = None,
+        producer_succeeded_event: threading.Event | None = None,
+        event_handler: Callable[[Any], None] | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -513,6 +550,7 @@ class GeneratorStreamingHelper:
         last_progress_ts = time.time()
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        heartbeat_grace_deadline: float | None = None
 
         logger.info(
             "[RabbitMQ] consumer loop enter thread_id=%s consumer_id=%s is_resuming=%s heartbeat_check=%s",
@@ -589,12 +627,16 @@ class GeneratorStreamingHelper:
 
                     if messages:
                         last_message_time = time.time()
+                        heartbeat_grace_deadline = None
 
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
                             logger.debug(f"Received heartbeat for thread_id={self.thread_id}")
+                            yield _SSE_HEARTBEAT_EVENT
+                            yielded_total += 1
                             continue
                         if item == EOD_CHUNK:
+                            logger.info(f"[EOD] Consumer received EOD_CHUNK for thread_id={self.thread_id}")
                             should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
                             if on_complete and not supports_replay_from_start:
                                 try:
@@ -653,12 +695,40 @@ class GeneratorStreamingHelper:
                     exit_reason = "preempted"
                     raise
                 except TimeoutError:
-                    if enable_heartbeat_check and (time.time() - last_message_time > HEARTBEAT_TIMEOUT):
-                        logger.error(f"心跳超时 thread_id={self.thread_id}，超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息")
-                        exit_reason = "starved"
-                        raise RuntimeError(
-                            f"生产者心跳超时：超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息，生产者可能已崩溃"
+                    time_since_last = time.time() - last_message_time
+                    if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
+                        producer_finished = producer_thread is not None and not producer_thread.is_alive()
+                        producer_succeeded = producer_succeeded_event is not None and producer_succeeded_event.is_set()
+
+                        # 仅在生产者仍可能存活时给予一次短暂宽限；不重新启动 Agent，
+                        # 也不刷新业务执行超时。生产者已结束却未收到 EOD 时直接按链路异常处理。
+                        if not producer_finished and heartbeat_grace_deadline is None:
+                            heartbeat_grace_deadline = time.monotonic() + self._HEARTBEAT_TIMEOUT_GRACE
+                            logger.warning(
+                                "[RabbitMQ] producer heartbeat grace started thread_id=%s grace=%.1fs "
+                                "replay_offset=%d producer_succeeded=%s",
+                                self.thread_id,
+                                self._HEARTBEAT_TIMEOUT_GRACE,
+                                replay_offset,
+                                producer_succeeded,
+                            )
+                            continue
+                        if heartbeat_grace_deadline is not None and time.monotonic() < heartbeat_grace_deadline:
+                            continue
+
+                        logger.error(
+                            f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "
+                            f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
+                            f"replay_offset={replay_offset} producer_finished={producer_finished} "
+                            f"producer_succeeded={producer_succeeded}"
                         )
+                        yield from self._emit_terminal_error_events(
+                            "Agent 执行中断：生产者心跳超时，请稍后重试",
+                            event_handler=event_handler,
+                        )
+                        yielded_total += 2
+                        exit_reason = "heartbeat_timeout"
+                        return exit_reason
                     continue
                 except Exception as exc:
                     # L-5：避免 unexpected 异常被上层 _wrap_streaming_with_status 吞成沉默
@@ -704,6 +774,7 @@ class GeneratorStreamingHelper:
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -714,12 +785,11 @@ class GeneratorStreamingHelper:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+            event_handler: AG-UI 事件处理器，用于同步记录受控错误和结束状态。
 
         Yields:
             生成器产生的数据
 
-        Raises:
-            RuntimeError: 当心跳超时时抛出，表示生产者可能已异常结束
         """
         # 注册取消事件（让 cancel() 可以通知生产者和消费者停止）
         cancel_event = self._register_cancel_event()
@@ -732,6 +802,7 @@ class GeneratorStreamingHelper:
         # 注册为当前活跃消费者
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
+        producer_succeeded_event: threading.Event | None = None
         consumer_exit_reason: str | None = None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
@@ -742,11 +813,14 @@ class GeneratorStreamingHelper:
                 return
 
             has_pending = self._recheck_pending_after_waiting_consumer(has_pending)
-            producer_thread, is_resuming, enable_heartbeat_check = self._start_or_resume_stream(
-                generator=generator,
-                cancel_event=cancel_event,
-                has_pending=has_pending,
-                on_complete=on_complete,
+            producer_thread, is_resuming, enable_heartbeat_check, producer_succeeded_event = (
+                self._start_or_resume_stream(
+                    generator=generator,
+                    cancel_event=cancel_event,
+                    has_pending=has_pending,
+                    on_complete=on_complete,
+                    event_handler=event_handler,
+                )
             )
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
@@ -754,6 +828,9 @@ class GeneratorStreamingHelper:
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
                 on_complete=on_complete,
+                producer_thread=producer_thread,
+                producer_succeeded_event=producer_succeeded_event,
+                event_handler=event_handler,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -848,7 +925,9 @@ class GeneratorStreamingHelper:
         generator: Generator[Any, None, None],
         cancel_event: threading.Event | None = None,
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
         release_producer: bool = False,
+        producer_succeeded_event: threading.Event | None = None,
     ) -> None:
         """生产者线程：将生成器产生的消息推送到队列
 
@@ -858,6 +937,8 @@ class GeneratorStreamingHelper:
         而是继续 drain generator 一段时间，等待 Agent 内部的 cancel_checker 触发
         并 yield RUN_FINISHED 事件，确保前端能收到完整的结束信号。
         """
+        _producer_start = time.monotonic()
+        logger.info(f"[PRODUCER] start thread_id={self.thread_id} thread={threading.current_thread().name}")
         heartbeat_stop_event = threading.Event()
         heartbeat_thread: threading.Thread | None = None
         # 跨进程取消检查计数器（每 N 个 chunk 检查一次，避免频繁访问 RabbitMQ）
@@ -939,14 +1020,21 @@ class GeneratorStreamingHelper:
         except Exception as e:
             producer_error = True
             logger.exception(f"Producer error for thread_id={self.thread_id}: {e}")
-            # 将错误信息作为 SSE error event 推送到队列，让消费者能感知并传播给前端
             try:
-                encoder = EventEncoder()
-                error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=f"Producer error: {e}")
-                self.message_handler.put(self.thread_id, encoder.encode(error_event))
+                for event in self._emit_terminal_error_events(
+                    f"Agent 执行异常：{e}",
+                    event_handler=event_handler,
+                ):
+                    self.message_handler.put(self.thread_id, event)
             except Exception as encode_err:
-                logger.exception(f"Failed to encode/send error event for thread_id={self.thread_id}: {encode_err}")
+                logger.exception(f"Failed to send terminal error events for thread_id={self.thread_id}: {encode_err}")
         finally:
+            logger.info(
+                f"[PRODUCER] finally enter thread_id={self.thread_id} "
+                f"producer_error={producer_error} done_event_seen={done_event_seen} "
+                f"draining={draining} "
+                f"elapsed={time.monotonic() - _producer_start:.1f}s"
+            )
             heartbeat_stop_event.set()
             if heartbeat_thread is not None:
                 try:
@@ -954,19 +1042,33 @@ class GeneratorStreamingHelper:
                 except Exception as e:
                     logger.exception(f"Error joining heartbeat thread for thread_id={self.thread_id}: {e}")
 
-            if on_complete and self._supports_replay_from_start() and not producer_error:
-                try:
-                    on_complete()
-                except Exception as e:
-                    logger.exception(f"on_complete callback error in producer: {e}")
+            try:
+                # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。
+                logger.info(
+                    f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
+                )
+                self.message_handler.put(self.thread_id, EOD_CHUNK)
+                self.message_handler.flush(self.thread_id)
+                if not producer_error and producer_succeeded_event is not None:
+                    producer_succeeded_event.set()
+                logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
-            # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束
-            self.message_handler.put(self.thread_id, EOD_CHUNK)
-            self.message_handler.flush(self.thread_id)
-            logger.debug(f"Producer finished, sent EOD_CHUNK for thread_id={self.thread_id}")
+                if on_complete and self._supports_replay_from_start() and not producer_error:
+                    try:
+                        on_complete()
+                    except Exception as e:
+                        logger.exception(f"on_complete callback error in producer: {e}")
 
-            # 延迟清理：如果消费者已断开且未重连，主动释放队列资源
-            # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争
-            self._schedule_session_cleanup(done_event_seen=done_event_seen)
-            if release_producer:
-                self.message_handler.release_producer(self.thread_id)
+                # 延迟清理：如果消费者已断开且未重连，主动释放队列资源。
+                # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争。
+                self._schedule_session_cleanup(done_event_seen=done_event_seen)
+            finally:
+                if release_producer:
+                    logger.info(
+                        f"[PRODUCER] releasing producer lock thread_id={self.thread_id} "
+                        f"elapsed={time.monotonic() - _producer_start:.1f}s"
+                    )
+                    try:
+                        self.message_handler.release_producer(self.thread_id)
+                    except Exception as e:
+                        logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,10 +10,16 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
-from typing import AsyncGenerator
+import queue
+import threading
+from contextlib import suppress
+from contextvars import copy_context
+from logging import getLogger
+from typing import AsyncGenerator, Awaitable, Callable
 
 from aidev_agent.utils import Empty
-from aidev_agent.utils.loop import get_event_loop
+
+logger = getLogger(__name__)
 
 
 async def async_generator_with_timeout(
@@ -37,31 +43,68 @@ async def async_generator_with_timeout(
         return
 
 
-def async_to_sync_generator(async_gen):
-    data_queue = asyncio.Queue()
+def async_to_sync_generator(
+    async_gen: AsyncGenerator,
+    async_finalizer: Callable[[], Awaitable[None]] | None = None,
+):
+    """在独立 loop 中消费异步生成器，并在同一 loop 执行 finalizer。"""
+    data_queue = queue.Queue()
+    end = object()
     error = None
 
-    loop = get_event_loop()
+    loop = asyncio.new_event_loop()
+    context = copy_context()
+    task_ready = threading.Event()
+    consumer_task = None
 
-    # 定义异步消费任务
     async def consume_async():
         nonlocal error
         try:
             async for item in async_gen:
-                await data_queue.put(item)
+                data_queue.put(item)
         except Exception as e:
+            logger.warning(f"[ASYNC] consume_async error: {e}", exc_info=True)
             error = e
         finally:
-            await data_queue.put(None)  # 结束信号
+            if async_finalizer is not None:
+                try:
+                    await async_finalizer()
+                except Exception as e:
+                    if error is None:
+                        error = e
+            data_queue.put(end)
 
-    # 线程运行函数（仅当需要新线程时启动）
-    # 提交异步任务到指定循环
-    asyncio.run_coroutine_threadsafe(consume_async(), loop)
+    def run_loop():
+        nonlocal consumer_task
+        asyncio.set_event_loop(loop)
+        consumer_task = context.run(loop.create_task, consume_async())
+        task_ready.set()
+        try:
+            loop.run_until_complete(consumer_task)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            pending_tasks = asyncio.all_tasks(loop)
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
+            with suppress(RuntimeError):
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
 
-    while True:
-        item = loop.run_until_complete(data_queue.get())
-        if item is None:
-            if error is not None:
-                raise error
-            break
-        yield item
+    loop_thread = threading.Thread(target=run_loop, name="aidev-async-generator", daemon=True)
+    loop_thread.start()
+    task_ready.wait()
+    try:
+        while True:
+            item = data_queue.get()
+            if item is end:
+                if error is not None:
+                    raise error
+                break
+            yield item
+    finally:
+        if not consumer_task.done():
+            loop.call_soon_threadsafe(consumer_task.cancel)
+        loop_thread.join()

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,6 +20,12 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from collections.abc import Awaitable, Callable
+from contextvars import copy_context
+from logging import getLogger
+from typing import Any
+
+logger = getLogger(__name__)
 
 # Thread-local storage for event loops
 _thread_local = threading.local()
@@ -92,18 +98,78 @@ def close_thread_loop() -> None:
     _thread_local.loop = None
 
 
-def run_coro_sync(coro, timeout=None):
+def run_coro_sync(
+    coro_or_factory: Awaitable[Any] | Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
     """Run a coroutine synchronously in the current thread's event loop.
 
-    Note: The event loop is intentionally kept open after execution, so that
-    long-lived async clients (e.g. httpx.AsyncClient) can safely reuse their
-    connections across multiple calls on the same thread. Cleanup is handled by
-    atexit registration and by async_to_sync_generator's finally block.
+    若当前线程没有 running loop，复用线程局部 loop 跑（保持 loop 开启以便
+    long-lived async client 复用连接）；若当前线程已有 running loop（嵌套调用
+    场景，如 async→sync 桥接、gevent monkey patch），仅接受协程工厂并在独立
+    线程创建、执行协程，避免把已关联当前 loop 的协程对象直接搬到新 loop。
+
+    Note: 正常分支下 event loop 故意保持开启，long-lived async client（如
+    httpx.AsyncClient）可跨多次调用复用连接；清理由 atexit 与
+    async_to_sync_generator 的 finally 块负责。
     """
     loop = get_event_loop()
+    if loop.is_running():
+        if not callable(coro_or_factory):
+            with contextlib.suppress(AttributeError):
+                coro_or_factory.close()
+            raise RuntimeError("run_coro_sync requires a coroutine factory when called from a running event loop")
+        logger.warning(
+            "[LOOP] run_coro_sync: running loop detected, delegate to new thread, thread=%s",
+            threading.current_thread().name,
+        )
+        return _run_coro_in_new_thread(coro_or_factory, timeout)
+
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
     if timeout is not None:
         coro = asyncio.wait_for(coro, timeout=timeout)
-    return loop.run_until_complete(coro)
+    try:
+        return loop.run_until_complete(coro)
+    except RuntimeError as e:
+        if "already running" in str(e):
+            logger.error(
+                "[LOOP] run_coro_sync failed: event loop already running. thread=%s, loop=%s",
+                threading.current_thread().name,
+                loop,
+            )
+        raise
+
+
+def _run_coro_in_new_thread(
+    coro_factory: Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
+    """在独立线程创建并执行协程，返回结果或重新抛出异常。
+
+    用于 run_coro_sync 检测到当前线程已有 running loop 的兜底场景：
+    工厂和协程都在新线程的 Context 与 event loop 内运行。
+    """
+    box: dict = {}
+    context = copy_context()
+
+    async def _execute():
+        coro = coro_factory()
+        if timeout is not None:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        return await coro
+
+    def _runner():
+        try:
+            box["value"] = context.run(asyncio.run, _execute())
+        except BaseException as err:  # noqa: BLE001
+            box["error"] = err
+
+    worker = threading.Thread(target=_runner, name="run-coroutine-sync", daemon=True)
+    worker.start()
+    worker.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
 
 
 def _cleanup_thread_loop(loop):

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -16,9 +16,12 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import asyncio
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import openai
 import pytest
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
@@ -38,12 +41,46 @@ TEST_VISION_MODELS = ["qwen3-vl-32B"]
 
 # 测试图片路径
 TEST_IMAGE_PATH = Path(__file__).parent.parent.parent.parent / "mock_data" / "bkaidev.png"
+TEST_BASE_URL = "https://llm-gateway.example.com/v1"
 
 
 def get_test_image_base64() -> str:
     """读取测试图片并返回 base64 编码"""
     with open(TEST_IMAGE_PATH, "rb") as f:
         return base64.b64encode(f.read()).decode("utf-8")
+
+
+def test_chat_model_async_clients_are_isolated_across_worker_threads():
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        models = list(
+            pool.map(
+                lambda index: ChatModel.get_setup_instance(model=f"model-{index}", base_url=TEST_BASE_URL),
+                range(16),
+            )
+        )
+
+    try:
+        clients = [model.http_async_client for model in models]
+        assert len({id(client) for client in clients}) == len(clients)
+        assert all(model._owns_http_async_client for model in models)
+    finally:
+        for client in clients:
+            asyncio.run(client.aclose())
+
+
+def test_chat_model_preserves_caller_owned_async_http_client():
+    client = openai.DefaultAsyncHttpxClient()
+    model = ChatModel.get_setup_instance(
+        model="explicit-client",
+        base_url=TEST_BASE_URL,
+        http_async_client=client,
+    )
+
+    try:
+        assert model.http_async_client is client
+        assert model._owns_http_async_client is False
+    finally:
+        asyncio.run(client.aclose())
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
@@ -11,6 +11,7 @@ from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
 from aidev_agent.core.ag_ui.types import CustomMessageType
 from aidev_agent.core.nodes.tool.approval_wrapper import TOOL_APPROVAL_REASON
 from aidev_agent.enums import PromptRole
+from aidev_agent.exceptions import AgentException
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.packages.langchain_core.models.mock import MockChatModel, MockResponse
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
@@ -758,6 +759,77 @@ class TestOnComplete:
         )
         list(agent.execute(ExecuteKwargs(stream=True)))
         mock_handler.set_streaming_finished.assert_called_once()
+
+
+class TestChatModelClientCleanup:
+    @pytest.mark.asyncio
+    async def test_owned_fallback_client_is_closed_once(self):
+        runnable = ChatModel.get_setup_instance(
+            model="primary",
+            fallback_model="fallback",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = runnable.runnable.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=runnable)
+
+        with patch.object(client, "aclose", close_spy):
+            await agent._aclose_chat_models()
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+        assert runnable.runnable._owns_http_async_client is False
+        assert runnable.fallbacks[0]._owns_http_async_client is False
+
+    def test_non_streaming_invoke_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="done", id="message-id")]})
+
+        with patch.object(client, "aclose", close_spy):
+            result = agent._invoke(
+                agent_e,
+                {},
+                {},
+                [HumanMessage(content="hello")],
+                SimpleNamespace(invoke_timeout=1),
+            )
+
+        assert result["choices"][0]["delta"]["content"] == "done"
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+
+    def test_non_streaming_invoke_error_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(side_effect=RuntimeError("model failed"))
+
+        with (
+            patch.object(client, "aclose", close_spy),
+            pytest.raises(AgentException, match="model failed"),
+        ):
+            agent._invoke(
+                agent_e,
+                {},
+                {},
+                [HumanMessage(content="hello")],
+                SimpleNamespace(invoke_timeout=1),
+            )
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -747,6 +747,20 @@ class TestOnComplete:
         agent._on_complete()
         mock_handler.set_streaming_finished.assert_called_once()
 
+    def test_background_stream_defers_set_streaming_finished(self):
+        """后台 drain 的 producer 完成回调不写会话终态。"""
+        mock_handler = MagicMock(spec=BaseSessionWriter)
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"], stream_chunk_size=2),
+            checkpointer=MemorySaver(),
+            chat_history=[ChatPrompt(role="user", content="hi")],
+            event_handler=mock_handler,
+        )
+
+        list(agent.execute(ExecuteKwargs(stream=True, background_only=True)))
+
+        mock_handler.set_streaming_finished.assert_not_called()
+
     def test_on_complete_invoked_during_stream(self):
         """端到端验证：流式执行结束后 on_complete 被触发"""
         mock_handler = MagicMock(spec=BaseSessionWriter)

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -1,11 +1,13 @@
 """测试 InMemoryQueueMessageHandler 的基本功能"""
 
 import contextlib
+import json
 import threading
 import time
 
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
+from ag_ui.core import EventType
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
     CANCELLED_CHUNK,
@@ -23,6 +25,10 @@ from aidev_agent.utils.event import RunId, emit_run_finished_event
 def _make_run_finished_chunk(thread_id: str, run_id: str) -> str:
     """生成 RUN_FINISHED SSE 字符串，用于测试期望值对比。"""
     return emit_run_finished_event(thread_id=thread_id, run_id=run_id)
+
+
+def _event_types(chunks: list[str]) -> list[str]:
+    return [json.loads(chunk.removeprefix("data: "))["type"] for chunk in chunks if chunk.startswith("data: ")]
 
 
 class ReplayFromStartHandler:
@@ -177,17 +183,18 @@ class TestReplayFromStartStreamingHelper:
     def test_replay_mode_runs_on_complete_in_producer_once(self):
         thread_id = "test_replay_on_complete_once"
         handler = ReplayFromStartHandler()
-        completed = []
+        lifecycle = []
+        handler.flush = lambda _thread_id: lifecycle.append("flush")
 
         result = list(
             GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
                 iter(["chunk_0"]),
-                on_complete=lambda: completed.append(True),
+                on_complete=lambda: lifecycle.append("complete"),
             )
         )
 
         assert result == ["chunk_0"]
-        assert completed == [True]
+        assert lifecycle == ["flush", "complete"]
         assert thread_id not in handler.producer_locks
 
 
@@ -570,7 +577,7 @@ class TestInMemoryQueueMessageHandler:
         assert handler.is_empty(thread_id)
 
     def test_stream_keeps_alive_when_generator_blocked(self, handler, monkeypatch):
-        """generator 长时间无产出时，独立心跳应维持连接且不超时。"""
+        """generator 长时间无产出时，独立心跳应通过 RAW 事件维持 SSE 连接。"""
         thread_id = "test_stream_heartbeat_keepalive"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 0.05)
@@ -592,22 +599,104 @@ class TestInMemoryQueueMessageHandler:
             yield "late_chunk"
 
         result = list(helper.stream(slow_first_chunk()))
-        assert result == ["late_chunk"]
+        heartbeat_events = [
+            json.loads(chunk.removeprefix("data: "))
+            for chunk in result
+            if isinstance(chunk, str) and chunk.startswith("data: ") and '"type":"RAW"' in chunk
+        ]
+
+        assert result[-1] == "late_chunk"
+        assert heartbeat_events
+        assert all(event == {"type": "RAW", "event": {"type": "heartbeat"}} for event in heartbeat_events)
         assert heartbeat_count > 0
 
-    def test_stream_raises_when_heartbeat_timeout(self, handler, monkeypatch):
-        """心跳发送慢于超时阈值时，消费者应抛出心跳超时异常。"""
+    def test_stream_emits_terminal_events_when_heartbeat_timeout(self, handler, monkeypatch):
+        """心跳超时应输出完整终止事件，不能以异常中断 SSE。"""
         thread_id = "test_stream_heartbeat_timeout"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.2)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.05)
+        dispatched = []
+        original_put = handler.put
+
+        def drop_heartbeat(tid, message):
+            if message != streaming_helper_module.HEARTBEAT_CHUNK:
+                original_put(tid, message)
+
+        monkeypatch.setattr(handler, "put", drop_heartbeat)
 
         def slow_first_chunk():
-            time.sleep(0.8)
+            time.sleep(1.2)
             yield "late_chunk"
 
-        with pytest.raises(RuntimeError, match="心跳超时"):
-            list(helper.stream(slow_first_chunk()))
+        result = list(helper.stream(slow_first_chunk(), event_handler=dispatched.append))
+
+        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+
+    def test_producer_marks_success_after_eod_flush(self, handler):
+        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_success")
+        producer_succeeded_event = threading.Event()
+
+        helper._producer(iter(["chunk"]), producer_succeeded_event=producer_succeeded_event)
+
+        assert producer_succeeded_event.is_set()
+
+    def test_producer_does_not_mark_success_when_eod_flush_fails(self, handler, monkeypatch):
+        thread_id = "test_producer_flush_failure"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        producer_succeeded_event = threading.Event()
+        assert handler.acquire_producer(thread_id)
+
+        def fail_flush(thread_id):
+            raise RuntimeError("flush failed")
+
+        monkeypatch.setattr(handler, "flush", fail_flush)
+
+        with pytest.raises(RuntimeError, match="flush failed"):
+            helper._producer(
+                iter(["chunk"]),
+                release_producer=True,
+                producer_succeeded_event=producer_succeeded_event,
+            )
+
+        assert not producer_succeeded_event.is_set()
+        assert handler.acquire_producer(thread_id)
+
+    def test_stream_treats_missing_eod_as_error(self, handler, monkeypatch):
+        """即使 producer 标记成功，未消费到 EOD 也不能静默判定完成。"""
+        thread_id = "test_stream_finished_without_eod"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        consumer_id = handler.acquire_consumer(thread_id)
+        completed_threads = []
+
+        def timeout_without_messages(*, timeout, replay_offset):
+            raise TimeoutError
+
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+        producer_succeeded_event = threading.Event()
+        producer_succeeded_event.set()
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
+        monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
+
+        result = list(
+            helper._consume_stream_messages(
+                consumer_id=consumer_id,
+                cancel_event=threading.Event(),
+                is_resuming=False,
+                enable_heartbeat_check=True,
+                producer_thread=producer_thread,
+                producer_succeeded_event=producer_succeeded_event,
+            )
+        )
+
+        assert _event_types(result) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert completed_threads == []
 
 
 class TestMessageHandlerConfig:

--- a/src/agent/tests/services/test_rabbitmq_release_producer.py
+++ b/src/agent/tests/services/test_rabbitmq_release_producer.py
@@ -1,0 +1,67 @@
+"""release_producer 容错单测：连接被对端重置时不应抛异常。
+
+复现 celery 日志中 _producer 线程 release_producer → connection.channel()
+抛 StreamLostError 导致 "Exception in thread" 的问题。
+"""
+
+import threading
+
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler():
+    # 绕过单例 __new__ 与 _init_rabbitmq（后者需要真实 RabbitMQ 连接）
+    handler = object.__new__(RabbitMQMessageHandler)
+    handler._producer_lock_connections = {}
+    handler._producer_lock_guard = threading.Lock()
+    return handler
+
+
+class _FakeConnection:
+    """模拟已被对端重置的 RabbitMQ 连接：本地状态仍认为 open，但底层 stream 已断。"""
+
+    def __init__(self, channel_error):
+        self.is_open = True
+        self._channel_error = channel_error
+        self.closed = False
+
+    def channel(self):
+        raise self._channel_error
+
+    def close(self):
+        self.closed = True
+        self.is_open = False
+
+
+def test_release_producer_tolerates_stream_lost_error():
+    """connection.channel() 抛 StreamLostError 时，release_producer 不应抛异常。"""
+    from pika.exceptions import StreamLostError
+
+    handler = _make_handler()
+    thread_id = "test-stream-lost"
+    conn = _FakeConnection(StreamLostError("Stream connection lost"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)  # 不应抛异常
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_tolerates_connection_reset_error():
+    """connection.channel() 抛 ConnectionResetError 时，release_producer 不应抛异常。"""
+    handler = _make_handler()
+    thread_id = "test-conn-reset"
+    conn = _FakeConnection(ConnectionResetError(104, "Connection reset by peer"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_no_connection_is_safe():
+    """没有待释放的连接时，release_producer 应安全返回。"""
+    handler = _make_handler()
+    handler.release_producer("nonexistent-thread")  # 不应抛异常

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -1,0 +1,58 @@
+import contextlib
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler(message_count: int, messages: list[str]) -> tuple[RabbitMQMessageHandler, MagicMock]:
+    handler = object.__new__(RabbitMQMessageHandler)
+    channel = MagicMock()
+    channel.queue_declare.return_value.method.message_count = message_count
+
+    handler._get_flush_peek_lock = MagicMock(return_value=threading.Lock())
+    handler._with_replay_lock = MagicMock(return_value=contextlib.nullcontext(channel))
+    handler._ensure_queue = MagicMock(return_value="replay-queue")
+    handler._peek_queue_messages = MagicMock(return_value=messages)
+    handler._get_dlq_count = MagicMock(return_value=0)
+    handler._restore_from_dlq = MagicMock(return_value=0)
+    return handler, channel
+
+
+def test_get_messages_since_skips_full_peek_without_new_messages():
+    handler, channel = _make_handler(message_count=835, messages=[])
+
+    with pytest.raises(TimeoutError, match="No message available within timeout"):
+        handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    channel.queue_declare.assert_called_once_with(queue="replay-queue", durable=True, passive=True)
+    handler._peek_queue_messages.assert_not_called()
+
+
+def test_get_messages_since_peeks_when_queue_has_new_messages():
+    messages = [f"message-{index}" for index in range(836)]
+    handler, channel = _make_handler(message_count=836, messages=messages)
+
+    new_messages, next_offset = handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    assert new_messages == ["message-835"]
+    assert next_offset == 836
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+
+
+def test_get_messages_since_preserves_legacy_dlq_restore():
+    handler, channel = _make_handler(message_count=0, messages=["restored-message"])
+    channel.queue_declare.side_effect = [
+        MagicMock(method=MagicMock(message_count=0)),
+        MagicMock(method=MagicMock(message_count=1)),
+    ]
+    handler._get_dlq_count.return_value = 1
+    handler._restore_from_dlq.return_value = 1
+
+    messages, next_offset = handler.get_messages_since("thread-id", offset=0, timeout=0)
+
+    assert messages == ["restored-message"]
+    assert next_offset == 1
+    handler._restore_from_dlq.assert_called_once_with("thread-id")
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")

--- a/src/agent/tests/utils/test_async_utils.py
+++ b/src/agent/tests/utils/test_async_utils.py
@@ -47,6 +47,47 @@ def test_async_to_sync_generator():
     assert result == ["run_id-0", "run_id-1", "run_id-2"]
 
 
+@pytest.mark.asyncio
+async def test_async_to_sync_generator_in_running_loop():
+    request_local.run_id = "async"
+
+    result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
+
+    assert result == ["async-0", "async-1", "async-2"]
+
+
+def test_async_to_sync_generator_runs_finalizer_on_consumer_loop():
+    loop_ids: list[int] = []
+
+    async def _gen():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        yield "value"
+
+    async def _finalize():
+        loop_ids.append(id(asyncio.get_running_loop()))
+
+    assert list(async_to_sync_generator(_gen(), async_finalizer=_finalize)) == ["value"]
+    assert len(set(loop_ids)) == 1
+
+
+def test_async_to_sync_generator_finalizes_when_consumer_closes():
+    finalized = False
+
+    async def _gen():
+        yield "value"
+        await asyncio.Event().wait()
+
+    async def _finalize():
+        nonlocal finalized
+        finalized = True
+
+    generator = async_to_sync_generator(_gen(), async_finalizer=_finalize)
+    assert next(generator) == "value"
+    generator.close()
+
+    assert finalized is True
+
+
 async def test_async_gen_with_timeout():
     request_local.run_id = "run_id"
     result = [each async for each in async_generator_with_timeout(gen(), timeout=0.18)]
@@ -63,7 +104,6 @@ def test_async_to_sync_generator_in_worker_thread():
     def _consume():
         request_local.run_id = "worker"
         result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
-        # get_event_loop() 会在 worker 线程缓存事件循环用于复用，has_loop 为 True 是预期行为
         has_loop = hasattr(_thread_local, "loop") and _thread_local.loop is not None
         return result, has_loop
 
@@ -71,4 +111,4 @@ def test_async_to_sync_generator_in_worker_thread():
         result, has_loop = pool.submit(_consume).result()
 
     assert result == ["worker-0", "worker-1", "worker-2"]
-    assert has_loop is True
+    assert has_loop is False

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 
 import pytest
 
@@ -133,3 +134,45 @@ def test_run_coro_sync_preserves_worker_thread_loop():
 
     assert result == 10
     assert has_loop is True
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_delegates_to_new_thread():
+    """已有 running loop 时，run_coro_sync 应委托独立线程执行，不抛 already running。
+
+    复现 construct_mcp 在 async→sync 桥接上下文被调用导致
+    "This event loop is already running" 的场景。
+    """
+    marker = ContextVar("marker", default="")
+    token = marker.set("request-context")
+
+    async def _probe():
+        await asyncio.sleep(0)
+        return marker.get()
+
+    try:
+        assert run_coro_sync(_probe) == "request-context"
+    finally:
+        marker.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_propagates_exception():
+    """已有 running loop 时，协程抛出的异常应原样冒泡到调用方。"""
+
+    async def _boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_coro_sync(_boom)
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_rejects_coroutine_object():
+    """running loop 下必须传工厂，避免搬运已关联当前 loop 的协程对象。"""
+
+    async def _probe():
+        return "ok"
+
+    with pytest.raises(RuntimeError, match="requires a coroutine factory"):
+        run_coro_sync(_probe())

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 import json
 import random
 import threading
+import time
 from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import Any, Optional, Tuple, cast
 
-from django.db import connections, router, transaction
+from django.db import OperationalError, close_old_connections, connections, router, transaction
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
     WRITES_IDX_MAP,
@@ -39,6 +40,10 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import ChannelProtocol
+
+RETRYABLE_DATABASE_ERROR_CODES = {1205, 1213}
+CHECKPOINT_WRITE_MAX_RETRIES = 3
+CHECKPOINT_WRITE_RETRY_DELAY_SECONDS = 0.05
 
 
 def bulk_upsert(model, objs, update_fields, unique_fields):
@@ -605,17 +610,26 @@ class BKDjangoSaver(BaseCheckpointSaver[str]):
         serialized_metadata = json.loads(json.dumps(raw_metadata, default=str).replace("\\u0000", ""))
         # 使用Django的update_or_create方法
         with self.lock:
-            self.checkpoint_model.objects.update_or_create(
-                thread_id=thread_id,
-                checkpoint_ns=checkpoint_ns,
-                checkpoint_id=checkpoint["id"],
-                defaults={
-                    "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
-                    "type": type_,
-                    "checkpoint": serialized_checkpoint,
-                    "metadata": serialized_metadata,
-                },
-            )
+            for attempt in range(CHECKPOINT_WRITE_MAX_RETRIES):
+                try:
+                    self.checkpoint_model.objects.update_or_create(
+                        thread_id=thread_id,
+                        checkpoint_ns=checkpoint_ns,
+                        checkpoint_id=checkpoint["id"],
+                        defaults={
+                            "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                            "type": type_,
+                            "checkpoint": serialized_checkpoint,
+                            "metadata": serialized_metadata,
+                        },
+                    )
+                    break
+                except OperationalError as exc:
+                    error_code = exc.args[0] if exc.args else None
+                    if error_code not in RETRYABLE_DATABASE_ERROR_CODES or attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1:
+                        raise
+                    close_old_connections()
+                    time.sleep(CHECKPOINT_WRITE_RETRY_DELAY_SECONDS * (2**attempt))
 
         return {
             "configurable": {

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
@@ -16,12 +16,13 @@
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from aidev_agent.config import settings as agent_settings
-from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole
+from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole, SessionsStatus
 from aidev_agent.packages.resource_manager.agent import AgentResourceManager
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent import AgentInstanceFactory
@@ -212,11 +213,42 @@ class BkpluginAgentRunner(ABC):
         chat_context: list[dict] | None = None,
     ) -> None:
         """Celery worker 入口：捕获异常并写 session 失败状态。"""
+        logger.info(
+            "[Bkplugin] run_worker enter session_code=%s turn_id=%s thread=%s",
+            session_code,
+            execute_payload.get("turn_id") or "",
+            threading.current_thread().name,
+        )
         try:
             self.invoke_agent(session_code, execute_payload, chat_context=chat_context or [])
         except Exception as e:
             logger.exception("[Bkplugin] worker error session_code=%s", session_code)
-            SessionManager(self.username or "").save_stream_failure(
+            manager = SessionManager(self.username or "")
+            # 幂等保护：心跳超时误报时 producer 实际已完成（session=FINISHED），
+            # 不应再覆盖为 FAILED。仅当 session 仍处于非终态时才写失败，
+            # 避免覆盖已确定的终态（FINISHED/CANCELLED/FAILED）。
+            try:
+                current_status = str(manager.retrieve_session(session_code).get("status") or "")
+            except Exception:
+                logger.exception(
+                    "[Bkplugin] retrieve_session failed before save_stream_failure session_code=%s",
+                    session_code,
+                )
+                current_status = ""
+            if current_status in (
+                SessionsStatus.FINISHED.value,
+                SessionsStatus.CANCELLED.value,
+                SessionsStatus.FAILED.value,
+            ):
+                logger.warning(
+                    "[Bkplugin] skip save_stream_failure: session already %s "
+                    "(likely heartbeat-timeout false positive) session_code=%s exc=%r",
+                    current_status,
+                    session_code,
+                    e,
+                )
+                return
+            manager.save_stream_failure(
                 session_code,
                 f"Agent 执行异常: {e}",
                 turn_id=execute_payload.get("turn_id") or "",

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -89,7 +89,7 @@ class AgentExecutor:
         *,
         turn_id: str = "",
     ):
-        """执行 agent 直至结束；AG-UI 流式负责事件落库并收尾会话状态。"""
+        """执行 agent 直至结束；后台消费者完整 drain 后统一收尾会话状态。"""
         # 后台 drain（for _ in out: pass，无 SSE 下游）：标记为 background_only，
         # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
         execute_kwargs.background_only = True
@@ -99,24 +99,18 @@ class AgentExecutor:
                 handler.turn_id = turn_id
             if hasattr(handler, "set_streaming_started"):
                 handler.set_streaming_started()
-        try:
-            out = cls(session_manager).execute_with_save(
-                agent_instance,
-                execute_kwargs,
-                session_code,
-                turn_id=turn_id,
-            )
-            if execute_kwargs.stream:
-                for _ in out:
-                    pass
-            return out
-        finally:
-            if (
-                execute_kwargs.stream
-                and isinstance(handler, BaseSessionWriter)
-                and hasattr(handler, "set_streaming_finished")
-            ):
+        out = cls(session_manager).execute_with_save(
+            agent_instance,
+            execute_kwargs,
+            session_code,
+            turn_id=turn_id,
+        )
+        if execute_kwargs.stream:
+            for _ in out:
+                pass
+            if isinstance(handler, BaseSessionWriter) and hasattr(handler, "set_streaming_finished"):
                 handler.set_streaming_finished()
+        return out
 
     def wrap_generator(self, generator, session_code: str, *, turn_id: str = ""):
         """SSE 数据格式约定：

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -238,24 +238,39 @@ class SessionManager:
         if status in (SessionsStatus.PENDING.value, SessionsStatus.RUNNING.value):
             return PluginPollTaskState.RUNNING, ""
         if status in (SessionsStatus.FAILED.value, SessionsStatus.CANCELLED.value):
-            return PluginPollTaskState.FAILED, "Agent 执行失败"
-        if status == SessionsStatus.FINISHED.value:
-            return PluginPollTaskState.SUCCESS, self._last_assistant_output(
+            # 取回 save_stream_failure 写入的实际异常内容，避免 UI 只显示通用 "Agent 执行失败"
+            return PluginPollTaskState.FAILED, self._last_output(
                 self.list_session_contents(session_code),
                 turn_id=turn_id,
+                statuses=(ChatContentStatus.ERROR.value,),
+            ) or "Agent 执行失败"
+        if status == SessionsStatus.FINISHED.value:
+            return PluginPollTaskState.SUCCESS, self._last_output(
+                self.list_session_contents(session_code),
+                turn_id=turn_id,
+                statuses=(ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value),
             )
         return PluginPollTaskState.RUNNING, ""
 
     @staticmethod
-    def _last_assistant_output(items: list[dict], *, turn_id: str = "") -> str:
-        """取最后一条有内容的 assistant/ai；有 ``turn_id`` 时仅取同轮消息。"""
+    def _last_output(
+        items: list[dict],
+        *,
+        turn_id: str = "",
+        statuses: tuple[str, ...],
+    ) -> str:
+        """取最后一条指定 status 的 assistant/ai 内容；有 ``turn_id`` 时仅取同轮消息。
+
+        FINISHED 取 COMPLETE/SUCCESS 的正常回复；FAILED/CANCELLED 取 ERROR 的实际异常
+        （save_stream_failure 写入），避免上层只看到通用 "Agent 执行失败"。
+        """
         assistant_roles = (PromptRole.ASSISTANT.value, PromptRole.AI.value)
         for item in reversed(items):
             if item.get("role") not in assistant_roles:
                 continue
             if turn_id and (item.get("property") or {}).get("turn_id") != turn_id:
                 continue
-            if item.get("status") not in (ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value):
+            if item.get("status") not in statuses:
                 continue
             text = str(item.get("content") or "").strip()
             if text:

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import threading
+
+import pytest
+from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver
+from django.db import OperationalError
+
+
+@pytest.fixture
+def saver(mocker):
+    instance = object.__new__(BKDjangoSaver)
+    instance.lock = threading.Lock()
+    instance.checkpoint_model = mocker.Mock()
+    instance.serde = mocker.Mock()
+    instance.serde.dumps_typed.return_value = ("json", b"checkpoint")
+    return instance
+
+
+@pytest.fixture
+def checkpoint_args():
+    return (
+        {"configurable": {"thread_id": "thread-id"}},
+        {"id": "checkpoint-id"},
+        {},
+        {},
+    )
+
+
+@pytest.mark.parametrize("error_code", [1205, 1213])
+def test_put_retries_transient_database_lock_error(mocker, saver, checkpoint_args, error_code):
+    saver.checkpoint_model.objects.update_or_create.side_effect = [
+        OperationalError(error_code, "retryable"),
+        (mocker.Mock(), True),
+    ]
+    close_old_connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    saver.put(*checkpoint_args)
+
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 2
+    close_old_connections.assert_called_once_with()
+    sleep.assert_called_once_with(0.05)
+
+
+def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args):
+    error = OperationalError(2006, "server has gone away")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpoint_args):
+    error = OperationalError(1213, "deadlock")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 3
+    assert [call.args[0] for call in sleep.call_args_list] == [0.05, 0.1]

--- a/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+"""后台 Agent 流式终态写入回归测试。"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if "pkg_resources" not in sys.modules:
+    sys.modules["pkg_resources"] = MagicMock()
+
+sys.modules.setdefault("aidev_bkplugin.models", MagicMock())
+_bk_plugin_framework = MagicMock()
+_bk_plugin_framework.kit.decorators.inject_user_token = lambda func: func
+sys.modules.setdefault("bk_plugin_framework", _bk_plugin_framework)
+sys.modules.setdefault("bk_plugin_framework.kit", _bk_plugin_framework.kit)
+sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framework.kit.decorators)
+
+
+class TestAgentExecutorCompletion:
+    def test_sets_finished_after_stream_is_drained(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        lifecycle = []
+
+        def stream():
+            yield "chunk"
+            lifecycle.append("drained")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        handler.set_streaming_finished.side_effect = lambda: lifecycle.append("finished")
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with patch.object(AgentExecutor, "execute_with_save", return_value=stream()):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        assert execute_kwargs.background_only is True
+        assert lifecycle == ["drained", "finished"]
+
+    def test_does_not_set_finished_when_stream_drain_fails(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        def failing_stream():
+            yield "chunk"
+            raise RuntimeError("producer heartbeat timeout")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with (
+            patch.object(AgentExecutor, "execute_with_save", return_value=failing_stream()),
+            pytest.raises(RuntimeError, match="heartbeat timeout"),
+        ):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        handler.set_streaming_finished.assert_not_called()

--- a/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
@@ -16,6 +16,7 @@ except ImportError:
 if "pkg_resources" not in sys.modules:
     sys.modules["pkg_resources"] = MagicMock()
 
+sys.modules.setdefault("aidev_bkplugin.models", MagicMock())
 _bk_plugin_framework = MagicMock()
 _bk_plugin_framework.kit.decorators.inject_user_token = lambda func: func
 sys.modules.setdefault("bk_plugin_framework", _bk_plugin_framework)

--- a/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
@@ -266,3 +266,32 @@ class TestBkpluginExecution:
         assert runner.execute_kwargs["session_code"] == "thread-x"
         assert runner.plugin_context == [{"k": "v"}]
         mock_resolve.assert_called_once_with("alice")
+
+    def test_run_worker_skips_save_stream_failure_when_session_finished(self, monkeypatch):
+        """心跳超时误报：producer 实际已完成（session=FINISHED），不应覆盖为 FAILED。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时")))
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.FINISHED.value}
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.retrieve_session.assert_called_once_with("sess-1")
+        mock_sm.save_stream_failure.assert_not_called()
+
+    def test_run_worker_calls_save_stream_failure_when_session_running(self, monkeypatch):
+        """producer 真崩溃：session 仍 RUNNING 时应写失败。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时")))
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.RUNNING.value}
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.save_stream_failure.assert_called_once_with("sess-1", ANY, turn_id="t1")


### PR DESCRIPTION
## 背景

将已在维护分支验证的 Agent 流式稳定性修复同步到 develop，并按 develop 当前实现重新适配。

## 原因

- 会话轮询可能把生产者心跳超时误判为成功终态。
- 异步 HTTP client 跨线程复用会产生 event loop 归属冲突。
- producer、consumer 和后台任务存在重复终态写入及异常链路不完整的问题。
- replay 等待新消息时重复扫描历史队列，会放大 RabbitMQ 压力。

## 改动内容

- 补充 bkplugin 会话状态校验及失败链路日志。
- 隔离模型异步 HTTP client 的生命周期，并完善跨线程协程执行与资源释放。
- 完善 producer 心跳、异常事件、重连和流式资源清理逻辑。
- 将后台会话终态收敛到消息消费完成路径。
- replay 无新消息时先检查队列深度，避免全量读取并重新入队历史消息。
- 保留 develop 现有 fallback 逻辑和较新的模板依赖版本。
- committed queue log 修复已存在于 develop，因此不重复提交。

## 收益

降低流式请求异常断连、错误成功终态和 RabbitMQ 空轮询压力，同时保持 develop 当前功能演进不回退。

## 测试验证

- Agent 定向测试：135 passed，39 skipped。
- bkplugin 定向测试：20 passed。
- 所有变更提交的 Ruff、格式化和冲突检查通过。
- 仓库全量 pre-commit 仍存在 develop 基线中的无关 Ruff 与语法问题，本 PR 未修改这些文件。
