### PR TITLE
fix: 心跳超时恢复期间保持会话运行 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/__init__.py
+++ b/src/agent/aidev_agent/services/messages_handler/__init__.py
@@ -2,6 +2,7 @@ from .base import (
     BaseMessageQueueHandler,
     ConsumerManagementProtocol,
     ConsumerPreemptedError,
+    RetryableHeartbeatTimeoutError,
     StreamCancelledError,
 )
 from .constants import (
@@ -34,6 +35,7 @@ __all__ = [
     "MultiProcessMixin",
     # 异常类
     "ConsumerPreemptedError",
+    "RetryableHeartbeatTimeoutError",
     "StreamCancelledError",
     # 常量类
     "StreamMarkers",

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -23,6 +23,7 @@ __all__ = [
     "QueueTTLConfig",
     "ConsumerPreemptedError",
     "StreamCancelledError",
+    "RetryableHeartbeatTimeoutError",
     "ConsumerManagementProtocol",
     "BaseMessageQueueHandler",
 ]
@@ -34,6 +35,10 @@ class ConsumerPreemptedError(Exception):
 
 class StreamCancelledError(Exception):
     """流被用户主动取消（停止会话）"""
+
+
+class RetryableHeartbeatTimeoutError(RuntimeError):
+    """消费者心跳超时，可通过重新消费恢复且不应更新会话终态。"""
 
 
 @runtime_checkable
@@ -297,7 +302,6 @@ class BaseMessageQueueHandler(ABC):
 
     def release_producer(self, thread_id: str) -> None:
         """释放会话级生产者写入权。默认无操作。"""
-        pass
 
     def size(self, thread_id: str) -> int:
         """获取主队列中的消息数量（get_cached_count 的别名）

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -9,7 +9,7 @@ from ag_ui.encoder import EventEncoder
 
 from aidev_agent.utils.event import RunId, emit_run_finished_event
 
-from .base import BaseMessageQueueHandler, ConsumerPreemptedError
+from .base import BaseMessageQueueHandler, ConsumerPreemptedError, RetryableHeartbeatTimeoutError
 from .constants import (
     CANCELLED_CHUNK,
     EOD_CHUNK,
@@ -75,6 +75,9 @@ class GeneratorStreamingHelper:
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
     _HEARTBEAT_TIMEOUT_GRACE = 5.0
+    # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口，
+    # 期间继续等待业务消息/EOD 可见且不写会话终态。耗尽后再由 worker 收口 FAILED。
+    _BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT = 60.0
     _HEARTBEAT_TIMEOUT_MESSAGE = "Agent 执行中断：生产者心跳超时，请稍后重试"
 
     @staticmethod
@@ -538,7 +541,7 @@ class GeneratorStreamingHelper:
         yield EventEncoder().encode(retry_event)
 
         # 后续增加独立重试事件后，前端无需再依赖 transport/network error。
-        raise RuntimeError(self._HEARTBEAT_TIMEOUT_MESSAGE)
+        raise RetryableHeartbeatTimeoutError(self._HEARTBEAT_TIMEOUT_MESSAGE)
 
     def _consume_stream_messages(
         self,
@@ -561,6 +564,7 @@ class GeneratorStreamingHelper:
         consumer_draining = False
         consumer_drain_start = 0.0
         last_message_time = time.time()
+        last_message_monotonic = time.monotonic()
 
         consumer_id_short = consumer_id[:8] if consumer_id else "?"
         loop_iter = 0
@@ -570,6 +574,7 @@ class GeneratorStreamingHelper:
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
         heartbeat_grace_deadline: float | None = None
+        background_recovery_deadline: float | None = None
 
         logger.info(
             "[RabbitMQ] consumer loop enter thread_id=%s consumer_id=%s is_resuming=%s heartbeat_check=%s",
@@ -646,7 +651,9 @@ class GeneratorStreamingHelper:
 
                     if messages:
                         last_message_time = time.time()
+                        last_message_monotonic = time.monotonic()
                         heartbeat_grace_deadline = None
+                        background_recovery_deadline = None
 
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
@@ -714,7 +721,7 @@ class GeneratorStreamingHelper:
                     exit_reason = "preempted"
                     raise
                 except TimeoutError:
-                    time_since_last = time.time() - last_message_time
+                    time_since_last = time.monotonic() - last_message_monotonic
                     if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
                         producer_finished = producer_thread is not None and not producer_thread.is_alive()
 
@@ -731,6 +738,22 @@ class GeneratorStreamingHelper:
                             continue
                         if heartbeat_grace_deadline is not None and time.monotonic() < heartbeat_grace_deadline:
                             continue
+
+                        if self.defer_cleanup_on_complete:
+                            if background_recovery_deadline is None:
+                                background_recovery_deadline = (
+                                    time.monotonic() + self._BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT
+                                )
+                                logger.warning(
+                                    "[RabbitMQ] background consumer keeps waiting after heartbeat timeout "
+                                    "thread_id=%s recovery_timeout=%.1fs replay_offset=%d producer_finished=%s",
+                                    self.thread_id,
+                                    self._BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT,
+                                    replay_offset,
+                                    producer_finished,
+                                )
+                            if time.monotonic() < background_recovery_deadline:
+                                continue
 
                         logger.error(
                             f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -14,6 +14,7 @@ from aidev_agent.services.messages_handler import (
     EOD_CHUNK,
     GeneratorStreamingHelper,
     InMemoryQueueMessageHandler,
+    RetryableHeartbeatTimeoutError,
     message_handler_factory,
 )
 from aidev_agent.services.messages_handler.config import MessageHandlerConfig
@@ -639,8 +640,58 @@ class TestInMemoryQueueMessageHandler:
             "message": helper._HEARTBEAT_TIMEOUT_MESSAGE,
         }
         assert [event.type for event in dispatched] == [EventType.RAW]
-        with pytest.raises(RuntimeError, match="生产者心跳超时"):
+        with pytest.raises(RetryableHeartbeatTimeoutError, match="生产者心跳超时"):
             next(stream)
+
+    def test_background_stream_keeps_running_during_heartbeat_recovery(self, handler, monkeypatch):
+        """后台 schedule 无前端可接管，producer 存活时心跳超时应继续消费。"""
+        thread_id = "test_background_heartbeat_recovery"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id, defer_cleanup_on_complete=True)
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.1)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.02)
+        monkeypatch.setattr(helper, "_BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT", 2.0)
+        original_put = handler.put
+
+        def drop_heartbeat(tid, message):
+            if message != streaming_helper_module.HEARTBEAT_CHUNK:
+                original_put(tid, message)
+
+        monkeypatch.setattr(handler, "put", drop_heartbeat)
+
+        def delayed_chunk():
+            time.sleep(1.2)
+            yield "late_chunk"
+
+        result = list(helper.stream(delayed_chunk()))
+
+        assert result == ["late_chunk"]
+
+    def test_background_stream_waits_for_delayed_eod_after_producer_finished(self, handler, monkeypatch):
+        """producer 已结束但 EOD 暂不可见时，后台消费者不应立即误报失败。"""
+        helper = GeneratorStreamingHelper(handler, thread_id="test_delayed_eod", defer_cleanup_on_complete=True)
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+        calls = 0
+
+        def delayed_eod(*, timeout, replay_offset):
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise TimeoutError
+            return [streaming_helper_module.EOD_CHUNK], replay_offset + 1
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.0)
+        monkeypatch.setattr(helper, "_BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT", 1.0)
+        monkeypatch.setattr(helper, "_get_consumer_messages", delayed_eod)
+
+        stream = helper._consume_stream_messages(
+            handler.acquire_consumer(helper.thread_id), threading.Event(), False, True, producer_thread=producer_thread
+        )
+
+        assert (list(stream), calls) == ([], 3)
 
     def test_producer_error_emits_terminal_events(self, handler):
         """producer 异常应形成完整终止事件对并同步分发。"""

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
@@ -28,6 +28,7 @@ from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent import AgentInstanceFactory
 from aidev_agent.services.common_agent import common_agent_factory
 from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+from aidev_agent.services.messages_handler import RetryableHeartbeatTimeoutError
 from aidev_agent.utils.local import request_local
 from django.contrib.auth import get_user_model
 
@@ -173,6 +174,13 @@ class BkpluginAgentRunner(ABC):
         """同步执行 Agent，返回最终 AI 回复字符串；异常时写回失败状态 (D-01)。"""
         try:
             return self._do_execute()
+        except RetryableHeartbeatTimeoutError:
+            logger.warning(
+                "[Bkplugin] skip session terminal update for retryable consumer heartbeat timeout session_code=%s",
+                self.session_code or "",
+                exc_info=True,
+            )
+            raise
         except Exception as e:
             logger.exception("[Bkplugin] execute error: %s", e)
             session_code = self.session_code or ""
@@ -212,7 +220,7 @@ class BkpluginAgentRunner(ABC):
         *,
         chat_context: list[dict] | None = None,
     ) -> None:
-        """Celery worker 入口：捕获异常并写 session 失败状态。"""
+        """Celery worker 入口：业务异常写失败；可重试消费异常保持 session 原状态。"""
         logger.info(
             "[Bkplugin] run_worker enter session_code=%s turn_id=%s thread=%s",
             session_code,
@@ -221,6 +229,14 @@ class BkpluginAgentRunner(ABC):
         )
         try:
             self.invoke_agent(session_code, execute_payload, chat_context=chat_context or [])
+        except RetryableHeartbeatTimeoutError:
+            logger.warning(
+                "[Bkplugin] skip session terminal update for retryable consumer heartbeat timeout "
+                "session_code=%s turn_id=%s",
+                session_code,
+                execute_payload.get("turn_id") or "",
+                exc_info=True,
+            )
         except Exception as e:
             logger.exception("[Bkplugin] worker error session_code=%s", session_code)
             manager = SessionManager(self.username or "")

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -397,9 +397,11 @@ class ChatCompletionViewSet(PluginViewSet):
         _preempted = False
         _client_disconnected = False
         _cancelled = False
+        _stream_completed = False
         try:
             for chunk in generator:
                 yield chunk
+            _stream_completed = True
         except GeneratorExit:
             _client_disconnected = True
             logger.info(f"[WRAP_STATUS] Client disconnected (GeneratorExit): session_code={session_code}")
@@ -421,7 +423,7 @@ class ChatCompletionViewSet(PluginViewSet):
                 if GeneratorStreamingHelper.is_cancelled(session_code):
                     _cancelled = True
                     logger.info(f"[WRAP_STATUS] Generator结束后检测到取消标志: session_code={session_code}")
-            if not _preempted and not _client_disconnected and not _cancelled:
+            if _stream_completed and not _preempted and not _client_disconnected and not _cancelled:
                 logger.info(f"[WRAP_STATUS] 流正常结束, 调用 set_streaming_finished: session_code={session_code}")
                 event_handler.set_streaming_finished()
 

--- a/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
@@ -23,6 +23,7 @@ sys.modules.setdefault("bk_plugin_framework.kit", _bk_plugin_framework.kit)
 sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framework.kit.decorators)
 
 from aidev_agent.enums import AgentType, ChatContentStatus, PromptRole, SessionsStatus  # noqa: E402
+from aidev_agent.services.messages_handler import RetryableHeartbeatTimeoutError  # noqa: E402
 from aidev_bkplugin.enums import PluginPollTaskState  # noqa: E402
 from aidev_bkplugin.services.agent_session import SessionManager  # noqa: E402
 
@@ -272,14 +273,10 @@ class TestBkpluginExecution:
         from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
 
         agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
-        monkeypatch.setattr(
-            agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时"))
-        )
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时")))
         mock_sm = MagicMock()
         mock_sm.retrieve_session.return_value = {"status": SessionsStatus.FINISHED.value}
-        monkeypatch.setattr(
-            "aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm
-        )
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
 
         agent.run_worker("sess-1", {"turn_id": "t1"})
 
@@ -291,16 +288,46 @@ class TestBkpluginExecution:
         from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
 
         agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
-        monkeypatch.setattr(
-            agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时"))
-        )
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("producer crashed")))
         mock_sm = MagicMock()
         mock_sm.retrieve_session.return_value = {"status": SessionsStatus.RUNNING.value}
-        monkeypatch.setattr(
-            "aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm
-        )
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
 
         agent.run_worker("sess-1", {"turn_id": "t1"})
 
         mock_sm.save_stream_failure.assert_called_once_with("sess-1", ANY, turn_id="t1")
 
+    def test_run_worker_skips_session_update_for_retryable_heartbeat_timeout(self, monkeypatch):
+        """消费者心跳超时可重试，不应更新 session 终态。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(
+            agent,
+            "invoke_agent",
+            MagicMock(side_effect=RetryableHeartbeatTimeoutError("生产者心跳超时")),
+        )
+        manager_factory = MagicMock()
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", manager_factory)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        manager_factory.assert_not_called()
+
+    def test_execute_skips_session_update_for_retryable_heartbeat_timeout(self, monkeypatch):
+        """同步消费遇到可重试心跳超时，也不应覆盖 session 状态。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={"session_code": "sess-1"}, username="alice")
+        monkeypatch.setattr(
+            agent,
+            "_do_execute",
+            MagicMock(side_effect=RetryableHeartbeatTimeoutError("生产者心跳超时")),
+        )
+        manager_factory = MagicMock()
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", manager_factory)
+
+        with pytest.raises(RetryableHeartbeatTimeoutError):
+            agent.execute()
+
+        manager_factory.assert_not_called()

--- a/src/plugins/aidev_bkplugin/tests/views/test_chat_stream_status.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_chat_stream_status.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Chat SSE 异常时的会话终态回归测试。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.parametrize("error", [RuntimeError("生产者心跳超时"), SystemExit("worker abort")])
+def test_unexpected_stream_error_does_not_mark_session_finished(monkeypatch, error):
+    from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
+    from aidev_bkplugin.views.chat import ChatCompletionViewSet
+
+    def failing_stream():
+        yield "chunk"
+        raise error
+
+    monkeypatch.setattr(GeneratorStreamingHelper, "is_cancelled", lambda _session_code: False)
+    event_handler = MagicMock()
+    stream = ChatCompletionViewSet()._wrap_streaming_with_status(
+        failing_stream(), event_handler, session_code="session-1"
+    )
+
+    assert next(stream) == "chunk"
+    with pytest.raises(type(error)):
+        next(stream)
+    event_handler.set_streaming_finished.assert_not_called()
+
+
+def test_normal_stream_marks_session_finished(monkeypatch):
+    from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
+    from aidev_bkplugin.views.chat import ChatCompletionViewSet
+
+    monkeypatch.setattr(GeneratorStreamingHelper, "is_cancelled", lambda _session_code: False)
+    event_handler = MagicMock()
+
+    assert list(
+        ChatCompletionViewSet()._wrap_streaming_with_status(iter(["chunk"]), event_handler, session_code="session-1")
+    ) == ["chunk"]
+    event_handler.set_streaming_finished.assert_called_once_with()


### PR DESCRIPTION
## 背景

后台 schedule 在 RabbitMQ 消息短暂不可读时可能先于 EOD 抛出生产者心跳超时。此前 consumer 是后台成功终态的唯一写入者；consumer 异常退出后，即使 producer 随后正常结束，会话仍会停留在 running。

## 改动内容

- 后台消费在心跳超时后增加最长 60 秒恢复窗口，继续等待业务消息或 EOD。
- 恢复窗口耗尽后输出 RAW `type=error` 并抛出专用异常，维持前端 network error 重试语义，且不把该消费异常写成 session failed。
- RabbitMQ replay 模式由 producer 在生成器完成、EOD 写入并 flush 成功后统一更新会话终态；consumer 只负责 drain，不再重复写 finished。
- producer 业务异常仍通过 RUN_ERROR 写 failed；取消仍由 session writer 写 cancelled；EOD/flush 失败不会误写 finished。
- SSE 包装器仅在生成器自然耗尽时执行正常完成收尾，异常、断连、抢占或取消均不误写完成。

## 收益

- consumer 心跳超时或短暂读失败不再导致会话误失败或永久停留在 running。
- producer 正常完成后，即使后台 consumer 已退出，会话仍可收敛为 finished。
- 前端 RAW 提示及 network error 自动重试行为保持不变。

## 测试验证

- Agent 本次终态相关用例：7 passed。
- bkplugin 终态相关用例：21 passed。
- 本次变更文件 pre-commit：通过。
- Agent 扩展回归：111 passed、5 skipped；另有 1 个既存心跳时序用例首次出现竞态失败，单独复跑通过，与本次终态改动无关。
