### PR TITLE
fix: 由生产者收敛后台会话终态 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -538,7 +538,9 @@ class ChatCompletionAgent(BaseModel):
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(
             remaining_producer,
-            on_complete=partial(self._on_complete, finalize_session=not background_only),
+            # replay 模式下由 producer 在 EOD 写入并 flush 成功后更新会话终态；
+            # 消费者中断不会影响最终状态收敛。
+            on_complete=partial(self._on_complete, finalize_session=True),
             event_handler=self.event_handler,
         )
 

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -75,8 +75,8 @@ class GeneratorStreamingHelper:
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
     _HEARTBEAT_TIMEOUT_GRACE = 5.0
-    # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口，
-    # 期间继续等待业务消息/EOD 可见且不写会话终态。耗尽后再由 worker 收口 FAILED。
+    # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口。
+    # 窗口耗尽仅退出异常消费者，producer 后续仍可在 EOD 提交后收敛会话终态。
     _BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT = 60.0
     _HEARTBEAT_TIMEOUT_MESSAGE = "Agent 执行中断：生产者心跳超时，请稍后重试"
 

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -745,8 +745,8 @@ class TestOnComplete:
         agent._on_complete()
         mock_handler.set_streaming_finished.assert_called_once()
 
-    def test_background_stream_defers_set_streaming_finished(self):
-        """后台 drain 的 producer 完成回调不写会话终态。"""
+    def test_background_stream_sets_finished_after_producer_commit(self):
+        """后台流由 producer 在 EOD 提交后写会话终态。"""
         mock_handler = MagicMock(spec=BaseSessionWriter)
         agent = ChatCompletionAgent(
             chat_model=MockChatModel(responses=["ok"], stream_chunk_size=2),
@@ -757,7 +757,7 @@ class TestOnComplete:
 
         list(agent.execute(ExecuteKwargs(stream=True, background_only=True)))
 
-        mock_handler.set_streaming_finished.assert_not_called()
+        mock_handler.set_streaming_finished.assert_called_once()
 
     def test_on_complete_invoked_during_stream(self):
         """端到端验证：流式执行结束后 on_complete 被触发"""

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -89,7 +89,7 @@ class AgentExecutor:
         *,
         turn_id: str = "",
     ):
-        """执行 agent 直至结束；后台消费者完整 drain 后统一收尾会话状态。"""
+        """执行 agent 直至结束；会话终态由 Agent 流完成回调统一写入。"""
         # 后台 drain（for _ in out: pass，无 SSE 下游）：标记为 background_only，
         # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
         execute_kwargs.background_only = True
@@ -108,8 +108,6 @@ class AgentExecutor:
         if execute_kwargs.stream:
             for _ in out:
                 pass
-            if isinstance(handler, BaseSessionWriter) and hasattr(handler, "set_streaming_finished"):
-                handler.set_streaming_finished()
         return out
 
     def wrap_generator(self, generator, session_code: str, *, turn_id: str = ""):

--- a/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
@@ -18,7 +18,7 @@ sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framewor
 
 
 class TestAgentExecutorCompletion:
-    def test_sets_finished_after_stream_is_drained(self):
+    def test_drain_does_not_write_terminal_state(self):
         from aidev_agent.services.event_handlers.base import BaseSessionWriter
         from aidev_bkplugin.services.agent_execution import AgentExecutor
 
@@ -29,14 +29,14 @@ class TestAgentExecutorCompletion:
             lifecycle.append("drained")
 
         handler = MagicMock(spec=BaseSessionWriter)
-        handler.set_streaming_finished.side_effect = lambda: lifecycle.append("finished")
         agent = MagicMock(event_handler=handler)
         execute_kwargs = MagicMock(stream=True)
         with patch.object(AgentExecutor, "execute_with_save", return_value=stream()):
             AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
 
         assert execute_kwargs.background_only is True
-        assert lifecycle == ["drained", "finished"]
+        assert lifecycle == ["drained"]
+        handler.set_streaming_finished.assert_not_called()
 
     def test_does_not_set_finished_when_stream_drain_fails(self):
         from aidev_agent.services.event_handlers.base import BaseSessionWriter


### PR DESCRIPTION
## 背景

PR #732 已避免把可重试的 consumer 心跳超时写成 session failed，但后台成功终态仍由 consumer drain 完成后写入。consumer 超时退出后，即使 producer 随后正常结束并提交 EOD，会话也可能一直停留在 running。

## 根因

后台模式将 producer 的完成回调配置为不更新 session，同时 `run_agent_to_completion` 又依赖 consumer 自然耗尽后写 finished。consumer 与 producer 的生命周期分离后，这两个条件无法同时保证。

## 修复

- Chat 与 Flow 两类 Agent 都把完成回调绑定到消息 producer；RabbitMQ replay 模式在生成器完成、EOD 写入并 flush 成功后统一更新会话终态。
- 后台 consumer 只负责 drain，不再重复调用 `set_streaming_finished`。
- producer 业务异常仍通过 RUN_ERROR 写 failed；取消仍由 session writer 写 cancelled；EOD/flush 失败不会误写 finished。
- 修正后台恢复窗口注释，明确 consumer 退出后 producer 仍负责最终状态收敛。

## 验证

- Chat/Flow producer 终态相关用例：6 passed。
- Flow Agent 全量用例：17 passed。
- bkplugin 终态相关用例：21 passed。
- pre-commit：通过。

关联：#732
