### PR TITLE
fix: 补全插件同步与 Flow 会话终态 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/services/agent/flow.py
+++ b/src/agent/aidev_agent/services/agent/flow.py
@@ -134,8 +134,21 @@ class FlowAgentCompletionAgent(BaseModel):
             execute_kwargs: 兼容 ChatCompletionAgent 接口，FlowAgent 中不使用
         """
         stream_thread_id = self.session_code or self.thread_id
-        helper = GeneratorStreamingHelper(thread_id=stream_thread_id)
-        return helper.stream(self._run_flow(), event_handler=self.event_handler)
+        background_only = bool(getattr(execute_kwargs, "background_only", False))
+        helper = GeneratorStreamingHelper(
+            thread_id=stream_thread_id,
+            defer_cleanup_on_complete=background_only,
+        )
+        return helper.stream(
+            self._run_flow(),
+            on_complete=self._on_complete,
+            event_handler=self.event_handler,
+        )
+
+    def _on_complete(self) -> None:
+        """EOD 提交后由 producer 统一收敛 Flow 会话终态。"""
+        if self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
+            self.event_handler.set_streaming_finished()
 
     def stop(self):
         """停止 Flow Agent"""

--- a/src/agent/tests/services/test_flow_agent.py
+++ b/src/agent/tests/services/test_flow_agent.py
@@ -93,6 +93,24 @@ class MockResourceManager:
         return {}
 
 
+class TestFlowAgentCompletion:
+    @patch.object(GeneratorStreamingHelper, "is_cancelled", return_value=False)
+    def test_background_execute_updates_session_after_flow_completion(self, mock_cancelled):
+        event_handler = MagicMock()
+        agent = FlowAgentCompletionAgent(
+            resource_manager=MockResourceManager(),
+            flow_start_params={"session_code": "flow-session"},
+            poll_interval=0.01,
+            poll_timeout=10.0,
+            session_code="flow-session",
+            event_handler=event_handler,
+        )
+
+        list(agent.execute(MagicMock(background_only=True)))
+
+        event_handler.set_streaming_finished.assert_called_once_with()
+
+
 class TestFlowAgentMainFlow:
     """主流程：start → SSE 流式输出 → 轮询到终态"""
 

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -77,6 +77,9 @@ class AgentExecutor:
         result = agent_instance.execute(execute_kwargs)
         # 非流式 ainvoke 不经过 AG-UI 事件分发，必须显式写回 assistant
         self.session_manager.save_ai_response(session_code, result, turn_id=turn_id)
+        event_handler = getattr(agent_instance, "event_handler", None)
+        if isinstance(event_handler, BaseSessionWriter) and hasattr(event_handler, "set_streaming_finished"):
+            event_handler.set_streaming_finished()
         return result
 
     @classmethod

--- a/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
@@ -18,6 +18,23 @@ sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framewor
 
 
 class TestAgentExecutorCompletion:
+    def test_non_streaming_sets_finished_after_response_is_saved(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        result = {"choices": [{"delta": {"content": "done"}}]}
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        agent.execute.return_value = result
+        execute_kwargs = MagicMock(stream=False)
+        manager = MagicMock()
+
+        assert (
+            AgentExecutor(manager).execute_with_save(agent, execute_kwargs, "session-abc", turn_id="turn-1") == result
+        )
+        manager.save_ai_response.assert_called_once_with("session-abc", result, turn_id="turn-1")
+        handler.set_streaming_finished.assert_called_once_with()
+
     def test_drain_does_not_write_terminal_state(self):
         from aidev_agent.services.event_handlers.base import BaseSessionWriter
         from aidev_bkplugin.services.agent_execution import AgentExecutor


### PR DESCRIPTION
## 背景

插件调用存在两条未覆盖的成功终态路径：流式轮询版本按 Agent 配置分流到 Flow 时，Flow 未绑定消息 producer 完成回调；同步版本的 Chat 保存 assistant 内容后直接返回。两种情况都会出现执行已结束但 session 仍未进入 finished。

## 原因

- Flow 的 `GeneratorStreamingHelper.stream()` 未传入 `on_complete`，consumer 终态写入收敛后无人更新 session。
- 非流式 Chat 不经过 AG-UI 流结束事件，`save_ai_response()` 后缺少成功终态写入。

## 改动内容

- Flow 绑定完成回调，并在生成器完成、EOD 写入和 flush 成功后通过 session writer 收敛终态。
- Flow 透传后台执行标识，保持后台消息清理和前端接管窗口行为一致。
- 非流式 Chat 在 assistant 内容保存成功后调用 session writer 写入 finished。
- 异常、取消和 EOD 提交失败路径保持原有 failed/cancelled/不误写 finished 的语义。

## 测试验证

- Flow Agent 全量用例：17 passed。
- 插件同步执行、后台执行及轮询相关用例：19 passed。
- pre-commit：通过。

关联：#733
