### PR TITLE
feat: 收敛流式会话终态并补全结束事件 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -542,6 +542,7 @@ class ChatCompletionAgent(BaseModel):
             # 消费者中断不会影响最终状态收敛。
             on_complete=partial(self._on_complete, finalize_session=True),
             event_handler=self.event_handler,
+            expected_run_id=agent_input.run_id or self.thread_id,
         )
 
     @staticmethod

--- a/src/agent/aidev_agent/services/event_handlers/agui_writer.py
+++ b/src/agent/aidev_agent/services/event_handlers/agui_writer.py
@@ -6,6 +6,7 @@
 """
 
 import json
+import time
 from logging import getLogger
 from typing import Any
 
@@ -42,6 +43,9 @@ class AGUISessionWriter(BaseSessionWriter):
         )
         ```
     """
+
+    _SESSION_STATUS_MAX_ATTEMPTS = 3
+    _SESSION_STATUS_RETRY_BASE_DELAY = 0.2
 
     def __init__(
         self,
@@ -126,9 +130,7 @@ class AGUISessionWriter(BaseSessionWriter):
         outcome = getattr(event, "outcome", None)
         # 兼容 outcome 为 dict 或对象的情况
         outcome_type = (
-            outcome.get("type")
-            if isinstance(outcome, dict)
-            else getattr(outcome, "type", None) if outcome else None
+            outcome.get("type") if isinstance(outcome, dict) else getattr(outcome, "type", None) if outcome else None
         )
         if outcome and outcome_type == RunFinishedOutcomeType.INTERRUPT.value:
             graph_thread_id = getattr(event, "thread_id", "")
@@ -147,9 +149,7 @@ class AGUISessionWriter(BaseSessionWriter):
 
                 start_approval_resume_worker(self.session_code, self.username, graph_thread_id, interrupts)
             except Exception:
-                logger.exception(
-                    "[AGUISessionWriter] 触发后台续流失败: session_code=%s", self.session_code
-                )
+                logger.exception("[AGUISessionWriter] 触发后台续流失败: session_code=%s", self.session_code)
             return
 
         self._clear_pending_interrupt_context()
@@ -233,38 +233,62 @@ class AGUISessionWriter(BaseSessionWriter):
         - 用户取消/暂停：会话状态设为 cancelled
         """
         if self._is_cancelled:
-            self._update_session_status(SessionsStatus.CANCELLED.value)
+            status = SessionsStatus.CANCELLED.value
         elif self._has_run_error:
-            self._update_session_status(SessionsStatus.FAILED.value)
+            status = SessionsStatus.FAILED.value
         else:
-            self._update_session_status(SessionsStatus.FINISHED.value)
+            status = SessionsStatus.FINISHED.value
+        self._update_session_status(status, raise_on_failure=True)
 
     def handle_run_error(self, event) -> None:
-        """处理运行错误，并确保会话状态进入 failed；同时清理 pending_interrupt。"""
+        """记录运行错误；会话终态由 EOD 提交后的唯一完成回调统一写入。"""
         super().handle_run_error(event)
         # 中断审批场景下清理 pending_interrupt
         self._clear_pending_interrupt_context()
         if not self._is_cancelled:
             self._has_run_error = True
-            self._update_session_status(SessionsStatus.FAILED.value)
 
-    def _update_session_status(self, status: str) -> None:
+    def _update_session_status(self, status: str, *, raise_on_failure: bool = False) -> None:
         """更新会话状态（内部方法）
 
         Args:
             status: 会话状态，如 "running", "finished"
         """
         headers = {"X-BKAIDEV-USER": self.username} if self.username else {}
-        try:
-            logger.info("开始更新会话状态: session_code=%s, status=%s", self.session_code, status)
-            result = self.client.api.update_chat_session(
-                path_params={"session_code": self.session_code},
-                json={"status": status},
-                headers=headers,
-            )
-            logger.info("会话状态更新成功: session_code=%s, status=%s, result=%s", self.session_code, status, result)
-        except Exception:
-            logger.exception("会话状态更新失败: session_code=%s, status=%s", self.session_code, status)
+        for attempt in range(self._SESSION_STATUS_MAX_ATTEMPTS):
+            try:
+                logger.info(
+                    "开始更新会话状态: session_code=%s, status=%s, attempt=%d",
+                    self.session_code,
+                    status,
+                    attempt + 1,
+                )
+                result = self.client.api.update_chat_session(
+                    path_params={"session_code": self.session_code},
+                    json={"status": status},
+                    headers=headers,
+                )
+                logger.info(
+                    "会话状态更新成功: session_code=%s, status=%s, result=%s", self.session_code, status, result
+                )
+                return
+            except Exception:
+                is_last_attempt = attempt == self._SESSION_STATUS_MAX_ATTEMPTS - 1
+                if is_last_attempt:
+                    logger.exception("会话状态更新失败: session_code=%s, status=%s", self.session_code, status)
+                    if raise_on_failure:
+                        raise
+                    return
+
+                delay = self._SESSION_STATUS_RETRY_BASE_DELAY * (2**attempt)
+                logger.warning(
+                    "会话状态更新失败，将重试: session_code=%s, status=%s, delay=%.1fs",
+                    self.session_code,
+                    status,
+                    delay,
+                    exc_info=True,
+                )
+                time.sleep(delay)
 
     def update_flow_agent_info(self, task_id: str) -> None:
         """更新 session 中的 Flow Agent task_id

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -344,6 +344,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         self._flush_peek_locks: dict[str, threading.Lock] = {}
         self._flush_peek_locks_guard = threading.Lock()
 
+        # producer 只有在 EOD 已提交到 RabbitMQ 后才能写外部会话终态。
+        # 同步 flush 失败时，后台 daemon 补发成功会唤醒同进程 producer。
+        self._eod_commit_events: dict[str, set[threading.Event]] = {}
+        self._eod_commit_events_lock = threading.Lock()
+
         # 后台守护线程
         self._daemon_thread: Optional[threading.Thread] = None
         self._daemon_running = False
@@ -461,6 +466,30 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """唤醒等待 replay lock 或新消息的本进程消费者。"""
         with self._replay_wait_condition:
             self._replay_wait_condition.notify_all()
+
+    def register_eod_commit_event(self, thread_id: str, event: threading.Event) -> None:
+        """注册 EOD 提交确认事件，供 producer 等待同步/后台 flush 的最终结果。"""
+        with self._eod_commit_events_lock:
+            self._eod_commit_events.setdefault(thread_id, set()).add(event)
+
+    def unregister_eod_commit_event(self, thread_id: str, event: threading.Event) -> None:
+        """移除尚未被 EOD 成功提交消费的确认事件。"""
+        with self._eod_commit_events_lock:
+            events = self._eod_commit_events.get(thread_id)
+            if events is None:
+                return
+            events.discard(event)
+            if not events:
+                self._eod_commit_events.pop(thread_id, None)
+
+    def _notify_eod_committed(self, thread_id: str, messages: list[Any]) -> None:
+        """仅在包含 EOD 的完整批次成功发布后确认提交。"""
+        if EOD_CHUNK not in messages:
+            return
+        with self._eod_commit_events_lock:
+            events = self._eod_commit_events.pop(thread_id, set())
+        for event in events:
+            event.set()
 
     def _wait_for_replay_retry(self, deadline: float | None, interval: float) -> None:
         """等待下一次 replay 检查。
@@ -904,6 +933,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             thread_id,
                             len(messages),
                         )
+                    self._notify_eod_committed(thread_id, messages)
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1077,6 +1107,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             thread_id,
                             len(messages_to_flush),
                         )
+                    self._notify_eod_committed(thread_id, messages_to_flush)
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -845,7 +845,7 @@ class GeneratorStreamingHelper:
         Args:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
-                replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+                producer 将 RUN_FINISHED 入队后立即调用；缺少 RUN_FINISHED 时在 EOD 路径兜底调用。
             event_handler: AG-UI 事件处理器，用于同步记录受控错误和结束状态。
             expected_run_id: 正常 AG-UI 流的 run_id；提供时保证 EOD 前至少输出一次 RUN_FINISHED。
 
@@ -867,6 +867,20 @@ class GeneratorStreamingHelper:
         consumer_exit_reason: str | None = None
         self._producer_completion_error = None
 
+        completion_lock = threading.Lock()
+        completion_called = False
+
+        def _on_complete_once() -> None:
+            nonlocal completion_called
+            with completion_lock:
+                if completion_called:
+                    return
+                completion_called = True
+            if on_complete is not None:
+                on_complete()
+
+        completion_callback = _on_complete_once if on_complete is not None else None
+
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
 
         try:
@@ -879,7 +893,7 @@ class GeneratorStreamingHelper:
                 generator=generator,
                 cancel_event=cancel_event,
                 has_pending=has_pending,
-                on_complete=on_complete,
+                on_complete=completion_callback,
                 event_handler=event_handler,
                 expected_run_id=expected_run_id,
             )
@@ -888,7 +902,7 @@ class GeneratorStreamingHelper:
                 cancel_event=cancel_event,
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
-                on_complete=on_complete,
+                on_complete=completion_callback,
                 producer_thread=producer_thread,
                 event_handler=event_handler,
             )
@@ -1023,6 +1037,15 @@ class GeneratorStreamingHelper:
                 except Exception as e:
                     logger.exception(f"Error sending heartbeat for thread_id={self.thread_id}: {e}")
 
+        def _complete_session() -> None:
+            if on_complete is None:
+                return
+            try:
+                on_complete()
+            except Exception as completion_error:
+                self._producer_completion_error = completion_error
+                logger.exception("on_complete callback error in producer for thread_id=%s", self.thread_id)
+
         try:
             heartbeat_thread = threading.Thread(
                 target=_heartbeat_worker,
@@ -1082,7 +1105,11 @@ class GeneratorStreamingHelper:
                 self.message_handler.put(self.thread_id, chunk)
                 logger.debug(f"Produced chunk for thread_id={self.thread_id}")
                 if is_run_finished:
-                    logger.info("[RUN_FINISHED] terminal event queued; stopping producer thread_id=%s", self.thread_id)
+                    _complete_session()
+                    logger.info(
+                        "[RUN_FINISHED] terminal event queued and session finalized; stopping producer thread_id=%s",
+                        self.thread_id,
+                    )
                     break
         except GeneratorExit:
             logger.info(f"Generator closed for thread_id={self.thread_id}")
@@ -1094,9 +1121,12 @@ class GeneratorStreamingHelper:
                     "Agent 执行异常，请稍后重试",
                     event_handler=event_handler,
                 ):
-                    if self._is_run_finished_event_chunk(event):
+                    is_run_finished = self._is_run_finished_event_chunk(event)
+                    if is_run_finished:
                         run_finished_seen = True
                     self.message_handler.put(self.thread_id, event)
+                    if is_run_finished:
+                        _complete_session()
             except Exception as encode_err:
                 logger.exception(f"Failed to send terminal error events for thread_id={self.thread_id}: {encode_err}")
         finally:
@@ -1134,6 +1164,7 @@ class GeneratorStreamingHelper:
                             event_handler=event_handler,
                         ),
                     )
+                    _complete_session()
 
                 # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。
                 logger.info(
@@ -1173,16 +1204,13 @@ class GeneratorStreamingHelper:
                         unregister_eod_commit(self.thread_id, eod_commit_event)
                 logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
-                # EOD 已提交后即可安排队列资源清理，外部会话终态失败不应造成队列泄漏。
+                # EOD 仅负责消费者结束与队列资源回收；会话终态已在 RUN_FINISHED 入队后回写。
                 self._schedule_session_cleanup(done_event_seen=done_event_seen)
 
                 if on_complete and self._supports_replay_from_start():
-                    try:
-                        on_complete()
-                    except Exception as completion_error:
-                        self._producer_completion_error = completion_error
-                        logger.exception("on_complete callback error in producer for thread_id=%s", self.thread_id)
-                        raise
+                    _complete_session()
+                if self._producer_completion_error is not None:
+                    raise self._producer_completion_error
             finally:
                 if release_producer:
                     logger.info(

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -1035,7 +1035,8 @@ class GeneratorStreamingHelper:
                 chunk_count += 1
                 if self._is_done_event_chunk(chunk):
                     done_event_seen = True
-                if self._is_run_finished_event_chunk(chunk):
+                is_run_finished = self._is_run_finished_event_chunk(chunk)
+                if is_run_finished:
                     run_finished_seen = True
 
                 if not draining:
@@ -1080,6 +1081,9 @@ class GeneratorStreamingHelper:
 
                 self.message_handler.put(self.thread_id, chunk)
                 logger.debug(f"Produced chunk for thread_id={self.thread_id}")
+                if is_run_finished:
+                    logger.info("[RUN_FINISHED] terminal event queued; stopping producer thread_id=%s", self.thread_id)
+                    break
         except GeneratorExit:
             logger.info(f"Generator closed for thread_id={self.thread_id}")
         except Exception as e:
@@ -1103,6 +1107,12 @@ class GeneratorStreamingHelper:
                 f"elapsed={time.monotonic() - _producer_start:.1f}s"
             )
             heartbeat_stop_event.set()
+            close_generator = getattr(generator, "close", None)
+            if callable(close_generator):
+                try:
+                    close_generator()
+                except Exception:
+                    logger.exception("Error closing producer generator thread_id=%s", self.thread_id)
             if heartbeat_thread is not None:
                 try:
                     heartbeat_thread.join(timeout=HEARTBEAT_INTERVAL + 0.2)

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -1,3 +1,4 @@
+import json
 import threading
 import time
 import uuid
@@ -78,6 +79,7 @@ class GeneratorStreamingHelper:
     # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口。
     # 窗口耗尽仅退出异常消费者，producer 后续仍可在 EOD 提交后收敛会话终态。
     _BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT = 60.0
+    _EOD_COMMIT_RECOVERY_TIMEOUT = 15.0
     _HEARTBEAT_TIMEOUT_MESSAGE = "Agent 执行中断：生产者心跳超时，请稍后重试"
 
     @staticmethod
@@ -115,6 +117,7 @@ class GeneratorStreamingHelper:
         # 后台 drain（无 SSE 下游）场景：读到 EOD 时不立即 mark_completed 清队列，
         # 保留 DLQ 历史供前端在清理窗口内接管续流；清理交由 producer 的延迟清理线程兜底。
         self.defer_cleanup_on_complete = defer_cleanup_on_complete
+        self._producer_completion_error: Exception | None = None
 
     @classmethod
     def _check_cancel_status(
@@ -254,6 +257,17 @@ class GeneratorStreamingHelper:
     def _is_done_event_chunk(chunk: Any) -> bool:
         """判断 chunk 是否为 SSE 的业务完成标记。"""
         return isinstance(chunk, str) and chunk.strip() == "data: [DONE]"
+
+    @staticmethod
+    def _is_run_finished_event_chunk(chunk: Any) -> bool:
+        """判断 chunk 是否为 AG-UI RUN_FINISHED 事件。"""
+        if not isinstance(chunk, str) or not chunk.startswith("data:"):
+            return False
+        try:
+            payload = json.loads(chunk.removeprefix("data:").strip())
+        except (TypeError, json.JSONDecodeError):
+            return False
+        return isinstance(payload, dict) and payload.get("type") == EventType.RUN_FINISHED.value
 
     def _is_cancelled(self, cancel_event: threading.Event) -> bool:
         """检查是否被取消（同时检查进程内事件和跨进程信号）
@@ -439,6 +453,7 @@ class GeneratorStreamingHelper:
         has_pending: bool,
         on_complete: Callable[[], None] | None = None,
         event_handler: Callable[[Any], None] | None = None,
+        expected_run_id: str | None = None,
     ) -> tuple[threading.Thread | None, bool, bool]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
         producer_thread: threading.Thread | None = None
@@ -462,12 +477,13 @@ class GeneratorStreamingHelper:
                 raise
 
             producer_thread = threading.Thread(
-                target=self._producer,
+                target=self._run_producer,
                 kwargs={
                     "generator": generator,
                     "cancel_event": cancel_event,
                     "on_complete": on_complete,
                     "event_handler": event_handler,
+                    "expected_run_id": expected_run_id,
                     "release_producer": True,
                 },
                 daemon=True,
@@ -664,11 +680,13 @@ class GeneratorStreamingHelper:
                         if item == EOD_CHUNK:
                             logger.info(f"[EOD] Consumer received EOD_CHUNK for thread_id={self.thread_id}")
                             should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
+                            completion_error: Exception | None = None
                             if on_complete and not supports_replay_from_start:
                                 try:
                                     on_complete()
-                                except Exception as e:
-                                    logger.exception(f"on_complete callback error: {e}")
+                                except Exception as exc:
+                                    completion_error = exc
+                                    logger.exception("on_complete callback error for thread_id=%s", self.thread_id)
                             if not supports_replay_from_start and not self.defer_cleanup_on_complete:
                                 self.message_handler.mark_completed(self.thread_id)
                                 logger.info(f"Stream completed for thread_id={self.thread_id}")
@@ -686,6 +704,8 @@ class GeneratorStreamingHelper:
                             if should_notify_cancelled:
                                 # cancel 可能已发出但 Agent 恰好也完成了，此时仍需通知 stop 接口。
                                 self._notify_consumer_cancelled_safely()
+                            if completion_error is not None:
+                                raise completion_error
                             exit_reason = "completed"
                             return exit_reason
                         if item == CANCELLED_CHUNK:
@@ -721,6 +741,12 @@ class GeneratorStreamingHelper:
                     exit_reason = "preempted"
                     raise
                 except TimeoutError:
+                    if (
+                        producer_thread is not None
+                        and not producer_thread.is_alive()
+                        and self._producer_completion_error is not None
+                    ):
+                        raise self._producer_completion_error
                     time_since_last = time.monotonic() - last_message_monotonic
                     if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
                         producer_finished = producer_thread is not None and not producer_thread.is_alive()
@@ -809,6 +835,7 @@ class GeneratorStreamingHelper:
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
         event_handler: Callable[[Any], None] | None = None,
+        expected_run_id: str | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -820,6 +847,7 @@ class GeneratorStreamingHelper:
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
                 replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
             event_handler: AG-UI 事件处理器，用于同步记录受控错误和结束状态。
+            expected_run_id: 正常 AG-UI 流的 run_id；提供时保证 EOD 前至少输出一次 RUN_FINISHED。
 
         Yields:
             生成器产生的数据
@@ -837,6 +865,7 @@ class GeneratorStreamingHelper:
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
         consumer_exit_reason: str | None = None
+        self._producer_completion_error = None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
 
@@ -852,6 +881,7 @@ class GeneratorStreamingHelper:
                 has_pending=has_pending,
                 on_complete=on_complete,
                 event_handler=event_handler,
+                expected_run_id=expected_run_id,
             )
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
@@ -880,6 +910,8 @@ class GeneratorStreamingHelper:
                     logger.exception(f"Error joining producer thread for thread_id={self.thread_id}: {e}")
             if consumer_exit_reason == "completed":
                 self._cleanup_replay_session_if_idle()
+                if self._producer_completion_error is not None:
+                    raise self._producer_completion_error
 
     def _schedule_session_cleanup(self, done_event_seen: bool = False) -> None:
         """生产者完成后延迟清理孤立的会话资源。
@@ -957,6 +989,7 @@ class GeneratorStreamingHelper:
         on_complete: Callable[[], None] | None = None,
         event_handler: Callable[[Any], None] | None = None,
         release_producer: bool = False,
+        expected_run_id: str | None = None,
     ) -> None:
         """生产者线程：将生成器产生的消息推送到队列
 
@@ -979,6 +1012,7 @@ class GeneratorStreamingHelper:
         drain_start_time = 0.0
         done_event_seen = False
         producer_error = False
+        run_finished_seen = False
 
         def _heartbeat_worker() -> None:
             """独立心跳线程：即使 generator 阻塞也保持心跳。"""
@@ -1001,6 +1035,8 @@ class GeneratorStreamingHelper:
                 chunk_count += 1
                 if self._is_done_event_chunk(chunk):
                     done_event_seen = True
+                if self._is_run_finished_event_chunk(chunk):
+                    run_finished_seen = True
 
                 if not draining:
                     # 检查是否被取消（进程内快速检查）
@@ -1054,6 +1090,8 @@ class GeneratorStreamingHelper:
                     "Agent 执行异常，请稍后重试",
                     event_handler=event_handler,
                 ):
+                    if self._is_run_finished_event_chunk(event):
+                        run_finished_seen = True
                     self.message_handler.put(self.thread_id, event)
             except Exception as encode_err:
                 logger.exception(f"Failed to send terminal error events for thread_id={self.thread_id}: {encode_err}")
@@ -1072,23 +1110,69 @@ class GeneratorStreamingHelper:
                     logger.exception(f"Error joining heartbeat thread for thread_id={self.thread_id}: {e}")
 
             try:
+                if expected_run_id and not producer_error and not draining and not run_finished_seen:
+                    logger.warning(
+                        "[RUN_FINISHED] missing from normal producer stream; emitting fallback thread_id=%s run_id=%s",
+                        self.thread_id,
+                        expected_run_id,
+                    )
+                    self.message_handler.put(
+                        self.thread_id,
+                        emit_run_finished_event(
+                            thread_id=self.thread_id,
+                            run_id=expected_run_id,
+                            event_handler=event_handler,
+                        ),
+                    )
+
                 # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。
                 logger.info(
                     f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
                 )
-                self.message_handler.put(self.thread_id, EOD_CHUNK)
-                self.message_handler.flush(self.thread_id)
+                eod_commit_event = threading.Event()
+                register_eod_commit = getattr(self.message_handler, "register_eod_commit_event", None)
+                unregister_eod_commit = getattr(self.message_handler, "unregister_eod_commit_event", None)
+                eod_commit_registered = callable(register_eod_commit) and callable(unregister_eod_commit)
+                if eod_commit_registered:
+                    register_eod_commit(self.thread_id, eod_commit_event)
+
+                try:
+                    self.message_handler.put(self.thread_id, EOD_CHUNK)
+                    try:
+                        self.message_handler.flush(self.thread_id)
+                    except Exception as flush_error:
+                        if not eod_commit_registered:
+                            self._producer_completion_error = flush_error
+                            raise
+                        logger.warning(
+                            "[EOD] synchronous flush failed; waiting for background recovery "
+                            "thread_id=%s timeout=%.1fs",
+                            self.thread_id,
+                            self._EOD_COMMIT_RECOVERY_TIMEOUT,
+                            exc_info=True,
+                        )
+                        if not eod_commit_event.wait(timeout=self._EOD_COMMIT_RECOVERY_TIMEOUT):
+                            completion_error = RuntimeError(
+                                f"EOD commit did not recover within {self._EOD_COMMIT_RECOVERY_TIMEOUT:.1f}s"
+                            )
+                            self._producer_completion_error = completion_error
+                            raise completion_error from flush_error
+                        logger.info("[EOD] background flush recovered thread_id=%s", self.thread_id)
+                finally:
+                    if eod_commit_registered:
+                        unregister_eod_commit(self.thread_id, eod_commit_event)
                 logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
-                if on_complete and self._supports_replay_from_start() and not producer_error:
+                # EOD 已提交后即可安排队列资源清理，外部会话终态失败不应造成队列泄漏。
+                self._schedule_session_cleanup(done_event_seen=done_event_seen)
+
+                if on_complete and self._supports_replay_from_start():
                     try:
                         on_complete()
-                    except Exception as e:
-                        logger.exception(f"on_complete callback error in producer: {e}")
-
-                # 延迟清理：如果消费者已断开且未重连，主动释放队列资源。
-                # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争。
-                self._schedule_session_cleanup(done_event_seen=done_event_seen)
+                    except Exception as completion_error:
+                        self._producer_completion_error = completion_error
+                        logger.exception("on_complete callback error in producer for thread_id=%s", self.thread_id)
+                        raise
             finally:
                 if release_producer:
                     logger.info(
@@ -1099,3 +1183,12 @@ class GeneratorStreamingHelper:
                         self.message_handler.release_producer(self.thread_id)
                     except Exception as e:
                         logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")
+
+    def _run_producer(self, **kwargs: Any) -> None:
+        """线程入口：记录 producer 终结异常，由消费线程统一向调用方传播。"""
+        try:
+            self._producer(**kwargs)
+        except Exception as exc:
+            if self._producer_completion_error is None:
+                self._producer_completion_error = exc
+            logger.exception("Producer finalization failed for thread_id=%s", self.thread_id)

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -239,7 +239,7 @@ class TestReplayFromStartStreamingHelper:
 
         assert result == [finished]
 
-    def test_run_finished_stops_immediately_and_closes_generator_before_eod(self, monkeypatch):
+    def test_run_finished_finalizes_session_then_closes_generator_before_eod(self, monkeypatch):
         handler = ReplayFromStartHandler()
         helper = GeneratorStreamingHelper(handler, thread_id="thread-1")
         finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
@@ -260,8 +260,8 @@ class TestReplayFromStartStreamingHelper:
             original_put(thread_id, message)
 
         monkeypatch.setattr(handler, "put", track_eod)
-        assert list(helper.stream(terminal_generator())) == [finished]
-        assert lifecycle == ["close", "eod"]
+        assert list(helper.stream(terminal_generator(), on_complete=lambda: lifecycle.append("complete"))) == [finished]
+        assert lifecycle == ["complete", "close", "eod"]
 
 
 class TestInMemoryQueueMessageHandler:

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -198,6 +198,47 @@ class TestReplayFromStartStreamingHelper:
         assert lifecycle == ["flush", "complete"]
         assert thread_id not in handler.producer_locks
 
+    def test_replay_mode_propagates_on_complete_failure(self):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_replay_complete_failure")
+
+        with pytest.raises(RuntimeError, match="status update failed"):
+            list(
+                helper.stream(
+                    iter(["chunk_0"]),
+                    on_complete=lambda: (_ for _ in ()).throw(RuntimeError("status update failed")),
+                )
+            )
+
+    def test_normal_agui_stream_emits_run_finished_fallback_before_eod(self):
+        handler = ReplayFromStartHandler()
+        dispatched = []
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id="thread-1").stream(
+                iter(["chunk_0"]),
+                event_handler=dispatched.append,
+                expected_run_id="run-1",
+            )
+        )
+
+        assert result[0] == "chunk_0"
+        assert _event_types(result[1:]) == [EventType.RUN_FINISHED]
+        assert [event.type for event in dispatched] == [EventType.RUN_FINISHED]
+
+    def test_normal_agui_stream_does_not_duplicate_existing_run_finished(self):
+        handler = ReplayFromStartHandler()
+        finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id="thread-1").stream(
+                iter([finished]),
+                expected_run_id="run-1",
+            )
+        )
+
+        assert result == [finished]
+
 
 class TestInMemoryQueueMessageHandler:
     """测试 InMemoryQueueMessageHandler"""
@@ -537,8 +578,8 @@ class TestInMemoryQueueMessageHandler:
         else:
             assert result == gen_items
 
-    def test_stream_on_complete_exception_is_swallowed(self, handler):
-        """on_complete 抛异常时不影响流返回和队列清理。"""
+    def test_stream_on_complete_exception_is_propagated(self, handler):
+        """终态回写失败必须向上传播，不能留下 running 会话。"""
         thread_id = "test_stream_on_complete_error"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         callback_called = []
@@ -547,9 +588,9 @@ class TestInMemoryQueueMessageHandler:
             callback_called.append(True)
             raise RuntimeError("boom")
 
-        result = list(helper.stream(iter(["chunk_0"]), on_complete=broken_on_complete))
+        with pytest.raises(RuntimeError, match="boom"):
+            list(helper.stream(iter(["chunk_0"]), on_complete=broken_on_complete))
 
-        assert result == ["chunk_0"]
         assert callback_called
         assert handler.is_empty(thread_id)
 
@@ -697,16 +738,24 @@ class TestInMemoryQueueMessageHandler:
         """producer 异常应形成完整终止事件对并同步分发。"""
         helper = GeneratorStreamingHelper(handler, thread_id="test_producer_error")
         dispatched = []
+        completed = []
 
         def broken_generator():
             yield "chunk"
             raise RuntimeError("producer failed")
 
-        result = list(helper.stream(broken_generator(), event_handler=dispatched.append))
+        result = list(
+            helper.stream(
+                broken_generator(),
+                event_handler=dispatched.append,
+                on_complete=lambda: completed.append(True),
+            )
+        )
 
         assert result[0] == "chunk"
         assert _event_types(result[1:]) == ["RUN_ERROR", "RUN_FINISHED"]
         assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+        assert completed == [True]
 
     def test_producer_releases_lock_when_eod_flush_fails(self, handler, monkeypatch):
         thread_id = "test_producer_flush_failure"
@@ -725,6 +774,28 @@ class TestInMemoryQueueMessageHandler:
             )
 
         assert handler.acquire_producer(thread_id)
+
+    def test_producer_waits_for_background_eod_commit_before_completion(self, monkeypatch):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_eod_recovery")
+        committed_event = None
+        lifecycle = []
+
+        def register(_thread_id, event):
+            nonlocal committed_event
+            committed_event = event
+
+        monkeypatch.setattr(handler, "register_eod_commit_event", register, raising=False)
+        monkeypatch.setattr(handler, "unregister_eod_commit_event", lambda *_args: None, raising=False)
+
+        def fail_after_background_commit(_thread_id):
+            committed_event.set()
+            raise RuntimeError("sync flush failed")
+
+        monkeypatch.setattr(handler, "flush", fail_after_background_commit)
+        helper._producer(iter(["chunk"]), on_complete=lambda: lifecycle.append("complete"))
+
+        assert lifecycle == ["complete"]
 
     def test_stream_treats_missing_eod_as_error(self, handler, monkeypatch):
         """即使 producer 标记成功，未消费到 EOD 也不能静默判定完成。"""

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -239,6 +239,30 @@ class TestReplayFromStartStreamingHelper:
 
         assert result == [finished]
 
+    def test_run_finished_stops_immediately_and_closes_generator_before_eod(self, monkeypatch):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="thread-1")
+        finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
+        lifecycle = []
+
+        def terminal_generator():
+            try:
+                yield finished
+                raise AssertionError("producer read after RUN_FINISHED")
+            finally:
+                lifecycle.append("close")
+
+        original_put = handler.put
+
+        def track_eod(thread_id, message):
+            if message == EOD_CHUNK:
+                lifecycle.append("eod")
+            original_put(thread_id, message)
+
+        monkeypatch.setattr(handler, "put", track_eod)
+        assert list(helper.stream(terminal_generator())) == [finished]
+        assert lifecycle == ["close", "eod"]
+
 
 class TestInMemoryQueueMessageHandler:
     """测试 InMemoryQueueMessageHandler"""

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -3,6 +3,7 @@ import threading
 from unittest.mock import MagicMock
 
 import pytest
+from aidev_agent.services.messages_handler.constants import EOD_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
 
 
@@ -56,3 +57,18 @@ def test_get_messages_since_preserves_legacy_dlq_restore():
     assert next_offset == 1
     handler._restore_from_dlq.assert_called_once_with("thread-id")
     handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+
+
+def test_eod_commit_event_is_notified_only_after_eod_publish():
+    handler = object.__new__(RabbitMQMessageHandler)
+    handler._eod_commit_events = {}
+    handler._eod_commit_events_lock = threading.Lock()
+    event = threading.Event()
+
+    handler.register_eod_commit_event("thread-id", event)
+    handler._notify_eod_committed("thread-id", ["chunk"])
+    assert not event.is_set()
+
+    handler._notify_eod_committed("thread-id", [EOD_CHUNK])
+    assert event.is_set()
+    assert "thread-id" not in handler._eod_commit_events

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -136,14 +136,8 @@ class ChatCompletionViewSet(PluginViewSet):
                     turn_id=turn_id,
                 )
                 handler = getattr(agent_instance, "event_handler", None)
-                if handler and all(hasattr(handler, m) for m in ["set_streaming_started", "set_streaming_finished"]):
+                if handler and hasattr(handler, "set_streaming_started"):
                     handler.set_streaming_started()
-                    stream_out = self._wrap_streaming_with_status(
-                        stream_out,
-                        handler,
-                        session_code=session_code,
-                        username=username,
-                    )
                 return self.streaming_response(stream_out, session_code=session_code)
             else:
                 result = AgentExecutor(SessionManager(username=username)).execute_with_save(
@@ -374,16 +368,8 @@ class ChatCompletionViewSet(PluginViewSet):
             raise ClientBlueException(message=message)
 
         logger.info(f"[FLOW_AGENT] Streaming started: session_code={session_code}, task_id={task_id}")
-        if event_handler and all(
-            hasattr(event_handler, m) for m in ["set_streaming_started", "set_streaming_finished"]
-        ):
+        if event_handler and hasattr(event_handler, "set_streaming_started"):
             event_handler.set_streaming_started()
-            generator = self._wrap_streaming_with_status(
-                generator,
-                event_handler,
-                session_code=session_code,
-                username=username,
-            )
         return self.streaming_response(generator, session_code=session_code)
 
     def _wrap_streaming_with_status(self, generator, event_handler, session_code: str = "", username: str = ""):

--- a/src/plugins/aidev_bkplugin/tests/services/test_agui_handler.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agui_handler.py
@@ -254,8 +254,8 @@ class TestCustomEventSessionPath:
 class TestHandleRunError:
     """测试 handle_run_error 的回写逻辑"""
 
-    def test_run_error_writes_fail_status(self, session_writer, mock_client):
-        """运行错误时回写 fail 状态"""
+    def test_run_error_defers_session_status(self, session_writer, mock_client):
+        """RUN_ERROR 只记录错误内容，不能抢先写会话终态。"""
         event = RunErrorEvent(type=EventType.RUN_ERROR, message="执行过程中发生错误")
 
         session_writer(event)
@@ -268,11 +268,7 @@ class TestHandleRunError:
         assert payload["role"] == PromptRole.ASSISTANT.value
         assert payload["content"] == "执行过程中发生错误"
         assert payload["property"]["builtin_property"]["error"] is True
-        mock_client.api.update_chat_session.assert_called_once_with(
-            path_params={"session_code": "test-session-123"},
-            json={"status": SessionsStatus.FAILED.value},
-            headers={"X-BKAIDEV-USER": "test-user"},
-        )
+        mock_client.api.update_chat_session.assert_not_called()
 
     def test_run_error_finished_keeps_session_failed(self, session_writer, mock_client):
         """运行错误后结束流，不应把会话覆盖为 finished"""
@@ -281,11 +277,30 @@ class TestHandleRunError:
         session_writer(event)
         session_writer.set_streaming_finished()
 
-        status_payloads = [call.kwargs["json"] for call in mock_client.api.update_chat_session.call_args_list]
-        assert status_payloads == [
-            {"status": SessionsStatus.FAILED.value},
-            {"status": SessionsStatus.FAILED.value},
-        ]
+        mock_client.api.update_chat_session.assert_called_once_with(
+            path_params={"session_code": "test-session-123"},
+            json={"status": SessionsStatus.FAILED.value},
+            headers={"X-BKAIDEV-USER": "test-user"},
+        )
+
+    def test_finished_status_retries_then_succeeds(self, session_writer, mock_client, monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr("aidev_agent.services.event_handlers.agui_writer.time.sleep", sleep)
+        mock_client.api.update_chat_session.side_effect = [RuntimeError("one"), RuntimeError("two"), {}]
+
+        session_writer.set_streaming_finished()
+
+        assert mock_client.api.update_chat_session.call_count == 3
+        assert [call.args[0] for call in sleep.call_args_list] == [0.2, 0.4]
+
+    def test_finished_status_raises_after_retries_exhausted(self, session_writer, mock_client, monkeypatch):
+        monkeypatch.setattr("aidev_agent.services.event_handlers.agui_writer.time.sleep", MagicMock())
+        mock_client.api.update_chat_session.side_effect = RuntimeError("platform unavailable")
+
+        with pytest.raises(RuntimeError, match="platform unavailable"):
+            session_writer.set_streaming_finished()
+
+        assert mock_client.api.update_chat_session.call_count == 3
 
 
 def make_flow_agent_result_event(task_id: str, task_state: str = "RUNNING"):

--- a/src/plugins/aidev_bkplugin/tests/views/test_chat_flow_agent.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_chat_flow_agent.py
@@ -72,3 +72,15 @@ def test_no_marker_starts_new_task_without_touching_marker(flow_agent_env):
 
     assert build_agent.call_args.kwargs["task_id"] is None
     sm.set_flow_resume_pending.assert_not_called()
+
+
+def test_flow_http_does_not_install_second_terminal_status_writer(flow_agent_env):
+    view, _build_agent, sm, writer_cls = flow_agent_env
+    sm.get_flow_info.return_value = {}
+    view._wrap_streaming_with_status = MagicMock(side_effect=AssertionError("duplicate terminal writer"))
+
+    result = view._handle_flow_agent(_data(), "sc-1", "alice", turn_id="turn-1")
+
+    assert result == "STREAM"
+    writer_cls.return_value.set_streaming_started.assert_called_once_with()
+    view._wrap_streaming_with_status.assert_not_called()


### PR DESCRIPTION
## 背景

流式 Agent 在异常恢复和正常结束路径中，可能出现会话终态写入时机不一致，或 SSE 缺少标准结束事件的问题。

## 原因

- HTTP 包装层和 Agent producer 同时参与终态写入，存在状态竞争。
- `RUN_ERROR` 到达时过早写入终态，没有等待流数据和 EOD 完成。
- 少数正常流结束时没有输出 `RUN_FINISHED`，前端无法完整收敛运行状态。

## 改动内容

- 将流式会话终态统一收敛到 Agent producer 的完成回调。
- 在 EOD 发布完成后更新会话终态，并为终态接口增加有限重试和失败传播。
- 正常 Chat 流缺少 `RUN_FINISHED` 时在 EOD 前补发，同时避免重复事件。
- 移除 Chat 和 Flow HTTP 层的第二个终态写入路径。
- 增加 EOD 恢复、终态异常传播和结束事件相关单元测试。

## 收益

- 降低会话提前结束、结束后仍保持 running，以及 SSE 缺少结束事件的概率。
- 保持生产者异常路径的事件与会话状态一致。

## 测试验证

- 目标文件 pre-commit：通过。
- Agent 相关单元测试：44 passed。
- bkplugin AG-UI 会话写入测试：18 passed。
- Flow view 测试在当前最小 Django 测试配置下受既有 `INSTALLED_APPS` 配置问题阻塞，等待 CI 环境复验。

## 后续项

- RabbitMQ publisher confirm 和部分批次发布失败后的精确重试策略另行评估，不包含在本 PR。
