### PR TITLE
feat: 延长 RabbitMQ replay 心跳与清理窗口 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -303,6 +303,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     ACTIVE_CONSUMER_PREFIX: ClassVar[str] = "aidev_agent.consumer_active."
     QUEUE_TTL_MS: ClassVar[int] = QueueTTLConfig.QUEUE_EXPIRE_MS
     BUFFER_FLUSH_INTERVAL: ClassVar[float] = 0.5
+    SSE_PUBLISH_CHUNK_MAX_BYTES: ClassVar[int] = 256 * 1024
     REPLAY_LOCK_RETRY_INTERVAL: ClassVar[float] = 0.05
     REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.5
 
@@ -890,6 +891,55 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         except Exception as e:
             logger.error(f"Error flushing messages on daemon exit: {e}")
 
+    @classmethod
+    def _coalesce_sse_messages(cls, messages: list[Any]) -> list[Any]:
+        """合并相邻 SSE 帧，减少 RabbitMQ 物理消息数并保持原始协议字节流。"""
+        coalesced_messages: list[Any] = []
+        sse_parts: list[str] = []
+        sse_size = 0
+
+        def flush_sse_parts() -> None:
+            nonlocal sse_size
+            if not sse_parts:
+                return
+            coalesced_messages.append("".join(sse_parts))
+            sse_parts.clear()
+            sse_size = 0
+
+        for message in messages:
+            if not isinstance(message, str) or not message.startswith("data: "):
+                flush_sse_parts()
+                coalesced_messages.append(message)
+                continue
+
+            message_size = len(message.encode("utf-8"))
+            if sse_parts and sse_size + message_size > cls.SSE_PUBLISH_CHUNK_MAX_BYTES:
+                flush_sse_parts()
+            if message_size > cls.SSE_PUBLISH_CHUNK_MAX_BYTES:
+                coalesced_messages.append(message)
+                continue
+            sse_parts.append(message)
+            sse_size += message_size
+
+        flush_sse_parts()
+        return coalesced_messages
+
+    @staticmethod
+    def _expand_sse_messages(messages: list[Any]) -> list[Any]:
+        """将 RabbitMQ 中合并的 SSE 字节流还原为调用方原有的逐帧消息。"""
+        expanded_messages: list[Any] = []
+        for message in messages:
+            if not isinstance(message, str) or not message.startswith("data: ") or "\n\ndata: " not in message:
+                expanded_messages.append(message)
+                continue
+
+            parts = message.split("\n\n")
+            if parts[-1] or any(not part.startswith("data: ") for part in parts[:-1]):
+                expanded_messages.append(message)
+                continue
+            expanded_messages.extend(f"{part}\n\n" for part in parts[:-1])
+        return expanded_messages
+
     def _flush_messages(self) -> None:
         """批量推送缓冲区中的所有消息到 RabbitMQ
 
@@ -914,11 +964,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                         messages = self._message_buffer.pop(thread_id, [])
                     if not messages:
                         continue
+                    messages_to_publish = self._coalesce_sse_messages(messages)
 
                     # 在同一个 flush_peek_lock 内 publish 到 RabbitMQ
                     with self._with_channel() as channel:
                         queue_name = self._ensure_queue(channel, thread_id)
-                        for message in messages:
+                        for message in messages_to_publish:
                             body = pickle.dumps(message)
                             channel.basic_publish(
                                 exchange="",
@@ -926,12 +977,18 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
-                    logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
+                    logger.debug(
+                        "Flushed %d logical messages as %d RabbitMQ messages to queue %s",
+                        len(messages),
+                        len(messages_to_publish),
+                        queue_name,
+                    )
                     if EOD_CHUNK in messages:
                         logger.info(
-                            "[EOD] flush thread_id=%s published=%d (background)",
+                            "[EOD] flush thread_id=%s logical=%d published=%d (background)",
                             thread_id,
                             len(messages),
+                            len(messages_to_publish),
                         )
                     self._notify_eod_committed(thread_id, messages)
                     any_flushed = True
@@ -1088,12 +1145,13 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     return
 
                 logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
+                messages_to_publish = self._coalesce_sse_messages(messages_to_flush)
 
                 try:
                     with self._with_channel() as channel:
                         queue_name = self._ensure_queue(channel, thread_id)
 
-                        for message in messages_to_flush:
+                        for message in messages_to_publish:
                             body = pickle.dumps(message)
                             channel.basic_publish(
                                 exchange="",
@@ -1103,9 +1161,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                             )
                     if EOD_CHUNK in messages_to_flush:
                         logger.info(
-                            "[EOD] flush thread_id=%s published=%d",
+                            "[EOD] flush thread_id=%s logical=%d published=%d",
                             thread_id,
                             len(messages_to_flush),
+                            len(messages_to_publish),
                         )
                     self._notify_eod_committed(thread_id, messages_to_flush)
                     self._notify_replay_waiters()
@@ -1238,7 +1297,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if all_messages is not None:
                     next_offset = len(all_messages)
                     if next_offset > offset:
-                        return all_messages[offset:], next_offset
+                        return self._expand_sse_messages(all_messages[offset:]), next_offset
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
 

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -67,15 +67,17 @@ class GeneratorStreamingHelper:
     # 取消后等待 generator 产出 RUN_FINISHED 的宽限时间（秒）
     CANCEL_DRAIN_TIMEOUT = TimeoutConfig.CANCEL_DRAIN_TIMEOUT
 
-    # 生产者结束后延迟清理会话资源的等待时间（秒）
-    # 需足够长以允许活跃消费者处理 EOD_CHUNK，又不至于长时间占用资源
-    _PRODUCER_CLEANUP_DELAY = 30.0
+    # 生产者结束后延迟清理会话资源的等待时间（秒）。
+    # 覆盖 60 秒 replay 心跳窗口，并为前端重连预留约 30 秒。
+    _PRODUCER_CLEANUP_DELAY = 90.0
     # 业务流已发出 [DONE] 且当前无活跃消费者时，保留队列等待前端接管续流的窗口（秒）。
     # 注意：后台 drain（background_only）完成后不会立即清理队列，需保留足够窗口让前端重连后
     # 通过 restore_messages 接管已生产的完整内容；窗口内若有消费者接管则跳过清理。
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
     _HEARTBEAT_TIMEOUT_GRACE = 5.0
+    # RabbitMQ replay 需要扫描已提交历史队列，消费耗时可能超过通用的 15 秒心跳窗口。
+    _REPLAY_HEARTBEAT_TIMEOUT = 60.0
     # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口。
     # 窗口耗尽仅退出异常消费者，producer 后续仍可在 EOD 提交后收敛会话终态。
     _BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT = 60.0
@@ -589,6 +591,7 @@ class GeneratorStreamingHelper:
         last_progress_ts = time.time()
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        heartbeat_timeout = self._REPLAY_HEARTBEAT_TIMEOUT if supports_replay_from_start else HEARTBEAT_TIMEOUT
         heartbeat_grace_deadline: float | None = None
         background_recovery_deadline: float | None = None
 
@@ -748,7 +751,7 @@ class GeneratorStreamingHelper:
                     ):
                         raise self._producer_completion_error
                     time_since_last = time.monotonic() - last_message_monotonic
-                    if enable_heartbeat_check and time_since_last > HEARTBEAT_TIMEOUT:
+                    if enable_heartbeat_check and time_since_last > heartbeat_timeout:
                         producer_finished = producer_thread is not None and not producer_thread.is_alive()
 
                         # producer 仍可能存活时仅给予一次短暂宽限，不重新启动 Agent，
@@ -963,10 +966,12 @@ class GeneratorStreamingHelper:
                     fast_grace_hit = (
                         done_event_seen
                         and not has_active_consumer
+                        and not consumer_ever_seen
                         and fast_cleanup_at is not None
                         and now >= fast_cleanup_at
                     )
-                    deadline_hit = now >= deadline
+                    # 活跃消费者可能仍在回放较大的历史队列，不能在固定 deadline 到达后删除其队列。
+                    deadline_hit = now >= deadline and not has_active_consumer
                     if fast_grace_hit or deadline_hit:
                         should_cleanup_now = True
                         trigger_reason = "fast_grace" if fast_grace_hit and not deadline_hit else "deadline"
@@ -986,7 +991,8 @@ class GeneratorStreamingHelper:
                         logger.info(f"Cleaned up orphaned session data for thread_id={thread_id}")
                         return
 
-                    time.sleep(min(poll_interval, max(deadline - now, 0.0)))
+                    sleep_for = min(poll_interval, deadline - now) if now < deadline else poll_interval
+                    time.sleep(sleep_for)
             except Exception:
                 logger.exception(f"Error in delayed session cleanup for thread_id={thread_id}")
 

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -642,6 +642,31 @@ class TestInMemoryQueueMessageHandler:
         assert cleanup_called.wait(timeout=0.3), "done orphaned cleanup should happen promptly without active consumer"
         assert handler.is_empty(thread_id)
 
+    def test_orphaned_cleanup_waits_for_active_replay_consumer(self, monkeypatch):
+        """replay consumer 曾活跃时，应保留队列到完整 deadline。"""
+        thread_id = "test_stream_active_replay_cleanup"
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        assert helper._PRODUCER_CLEANUP_DELAY == 90.0
+        handler.put(thread_id, "chunk_0")
+        consumer_id = handler.acquire_consumer(thread_id)
+        monkeypatch.setattr(helper, "_PRODUCER_CLEANUP_DELAY", 0.15)
+        monkeypatch.setattr(helper, "_DONE_ORPHAN_CLEANUP_GRACE", 0.02)
+        monkeypatch.setattr(helper, "_ORPHAN_CLEANUP_POLL_INTERVAL", 0.01)
+
+        helper._schedule_session_cleanup(done_event_seen=True)
+        time.sleep(0.05)
+        assert handler.has_pending_messages(thread_id)
+
+        handler.release_consumer(thread_id, consumer_id)
+        time.sleep(0.05)
+        assert handler.has_pending_messages(thread_id)
+
+        deadline = time.time() + 0.3
+        while handler.has_pending_messages(thread_id) and time.time() < deadline:
+            time.sleep(0.01)
+        assert not handler.has_pending_messages(thread_id)
+
     def test_stream_keeps_alive_when_generator_blocked(self, handler, monkeypatch):
         """generator 长时间无产出时，独立心跳应通过 RAW 事件维持 SSE 连接。"""
         thread_id = "test_stream_heartbeat_keepalive"
@@ -707,6 +732,32 @@ class TestInMemoryQueueMessageHandler:
         assert [event.type for event in dispatched] == [EventType.RAW]
         with pytest.raises(RetryableHeartbeatTimeoutError, match="生产者心跳超时"):
             next(stream)
+
+    def test_replay_stream_uses_extended_heartbeat_timeout(self, monkeypatch):
+        """RabbitMQ replay 使用独立的较长心跳窗口，不受通用 15 秒阈值影响。"""
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_replay_heartbeat_timeout")
+        assert helper._REPLAY_HEARTBEAT_TIMEOUT == 60.0
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+        calls = 0
+
+        def delayed_eod(*, timeout, replay_offset):
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise TimeoutError
+            return [EOD_CHUNK], replay_offset + 1
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_REPLAY_HEARTBEAT_TIMEOUT", 0.2)
+        monkeypatch.setattr(helper, "_get_consumer_messages", delayed_eod)
+        stream = helper._consume_stream_messages(
+            handler.acquire_consumer(helper.thread_id), threading.Event(), False, True, producer_thread=producer_thread
+        )
+
+        assert (list(stream), calls) == ([], 3)
 
     def test_background_stream_keeps_running_during_heartbeat_recovery(self, handler, monkeypatch):
         """后台 schedule 无前端可接管，producer 存活时心跳超时应继续消费。"""

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -1,4 +1,5 @@
 import contextlib
+import pickle
 import threading
 from unittest.mock import MagicMock
 
@@ -72,3 +73,64 @@ def test_eod_commit_event_is_notified_only_after_eod_publish():
     handler._notify_eod_committed("thread-id", [EOD_CHUNK])
     assert event.is_set()
     assert "thread-id" not in handler._eod_commit_events
+
+
+def test_coalesce_sse_messages_preserves_mixed_order_and_eod():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    third = 'data: {"type":"RUN_FINISHED"}\n\n'
+
+    messages = RabbitMQMessageHandler._coalesce_sse_messages([first, second, "legacy-message", third, EOD_CHUNK])
+
+    assert messages == [first + second, "legacy-message", third, EOD_CHUNK]
+
+
+def test_expand_sse_messages_restores_original_frames():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+
+    messages = RabbitMQMessageHandler._expand_sse_messages([first + second, "legacy-message", EOD_CHUNK])
+
+    assert messages == [first, second, "legacy-message", EOD_CHUNK]
+
+
+def test_coalesce_sse_messages_splits_by_utf8_bytes(monkeypatch):
+    first = "data: 一\n\n"
+    second = "data: 二\n\n"
+    monkeypatch.setattr(RabbitMQMessageHandler, "SSE_PUBLISH_CHUNK_MAX_BYTES", len(first.encode("utf-8")))
+
+    messages = RabbitMQMessageHandler._coalesce_sse_messages([first, second])
+
+    assert messages == [first, second]
+
+
+def test_flush_publishes_coalesced_sse_and_eod():
+    handler = object.__new__(RabbitMQMessageHandler)
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    channel = MagicMock()
+    handler._buffer_lock = threading.Lock()
+    handler._message_buffer = {"thread-id": [first, second, EOD_CHUNK]}
+    handler._get_flush_peek_lock = MagicMock(return_value=threading.Lock())
+    handler._with_channel = MagicMock(return_value=contextlib.nullcontext(channel))
+    handler._ensure_queue = MagicMock(return_value="replay-queue")
+    handler._notify_eod_committed = MagicMock()
+    handler._notify_replay_waiters = MagicMock()
+
+    handler.flush("thread-id")
+
+    published = [pickle.loads(call.kwargs["body"]) for call in channel.basic_publish.call_args_list]
+    assert published == [first + second, EOD_CHUNK]
+    handler._notify_eod_committed.assert_called_once_with("thread-id", [first, second, EOD_CHUNK])
+
+
+def test_get_messages_since_replays_mixed_physical_messages():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    stored_messages = ["legacy-message", first + second, EOD_CHUNK]
+    handler, _ = _make_handler(message_count=3, messages=stored_messages)
+
+    messages, next_offset = handler.get_messages_since("thread-id", offset=1, timeout=0)
+
+    assert messages == [first, second, EOD_CHUNK]
+    assert next_offset == 3


### PR DESCRIPTION
## 背景

- 长会话结束阶段可能因 RabbitMQ replay 扫描耗时超过通用心跳窗口而误报生产者心跳超时。

## 原因

- replay-from-start 消费需要扫描已提交历史队列，大队列下单次读取可能超过 15 秒。
- 原 cleanup deadline 早于延长后的心跳窗口，消费者退出后无法为前端保留足够的重连时间。

## 改动内容

- 仅将 replay-from-start 消费心跳窗口调整为 60 秒，其他 handler 保持原阈值。
- 将生产者完成后的 cleanup deadline 调整为 90 秒。
- active consumer 存在时不删除队列；曾有消费者的会话不走无消费者快速清理。
- 补充 replay 超时选择和 cleanup 生命周期回归测试。

## 收益

- 覆盖较大历史队列的 replay 延迟，并在消费者退出后保留约 30 秒前端重连窗口。
- 避免 cleanup 与活跃 replay consumer 竞争删除队列。

## 测试验证

- `pytest tests/services/test_in_memory_handler.py tests/services/test_consumer_observability.py tests/services/test_rabbitmq_replay.py -q`：52 passed。
- 本次目标文件 pre-commit：通过。
- 仓库全量 pre-commit 仍受与本次无关的既有检查错误阻塞。
