### PR TITLE
feat: 合并 2.2 会话与 RabbitMQ 稳定性修复 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -29,7 +29,7 @@ from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
-from pydantic import BaseModel, model_validator
+from pydantic import BaseModel, PrivateAttr, model_validator
 
 from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
@@ -65,11 +65,18 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
+    _owns_http_async_client: bool = PrivateAttr(default=False)
 
     @classmethod
     def get_setup_instance(cls, **kwargs) -> "ChatModel | RunnableWithFallbacks":
         """创建网关模型；配置备用模型时返回 LangChain fallback Runnable。"""
+        owns_http_async_client = False
+        if kwargs.get("http_async_client") is None and kwargs.get("async_client") is None:
+            kwargs["http_async_client"] = openai.DefaultAsyncHttpxClient()
+            owns_http_async_client = True
+
         model = super().get_setup_instance(**kwargs)
+        model._owns_http_async_client = owns_http_async_client
         fallback = model._get_fallback_model()
         if fallback is None:
             return model

--- a/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
+++ b/src/agent/aidev_agent/packages/langgraph/streaming/streaming_protocol.py
@@ -738,7 +738,15 @@ class AgentStreamAdapter:
         )
 
     # 流协议处理
-    def stream_standard_event(self, agent_e, cfg, input_state, skip_thought=False, timeout: int = 30):
+    def stream_standard_event(
+        self,
+        agent_e,
+        cfg,
+        input_state,
+        skip_thought=False,
+        timeout: int = 30,
+        async_finalizer=None,
+    ):
         try:
             protocol = BkAiStreamingProtocol(
                 skip_thought=skip_thought,
@@ -755,7 +763,7 @@ class AgentStreamAdapter:
                 durability="exit",
             )
             _aiter = async_generator_with_timeout(_aiter, timeout=timeout)
-            g = async_to_sync_generator(_aiter)
+            g = async_to_sync_generator(_aiter, async_finalizer=async_finalizer)
             yield from protocol.stream_standard_event(g)
         except Exception:
             logger.error(traceback.format_exc())

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -544,12 +544,13 @@ class BaseResourceManager(abc.ABC):
                         ),
                     )
 
-        coros = [_load_tool(server_name, selected_tools_map, i + 1) for i, server_name in enumerate(new_server_config)]
-
         async def _load_all_tools():
+            coros = [
+                _load_tool(server_name, selected_tools_map, i + 1) for i, server_name in enumerate(new_server_config)
+            ]
             return await asyncio.gather(*coros)
 
-        coro_results = run_coro_sync(_load_all_tools())
+        coro_results = run_coro_sync(_load_all_tools)
         tools_list: List[StructuredTool] = []
         failures: List[McpToolFetchFailure] = []
         for tlist, fail in coro_results:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -2,6 +2,7 @@ import json
 import re
 import uuid
 import warnings
+from functools import partial
 from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
@@ -241,6 +242,32 @@ class ChatCompletionAgent(BaseModel):
                 logger.warning("ChatCompletionAgent.release_resources: 关闭沙箱资源失败", exc_info=True)
             finally:
                 self.runtime_backend_resolver = None
+
+    async def _aclose_chat_models(self) -> None:
+        """在模型执行 loop 上关闭当前 agent 自己创建的异步 HTTP client。"""
+        models: list[Any] = []
+        for configured_model in (self.chat_model, self.chat_model_non_thinking, self.chat_model_fast):
+            if isinstance(configured_model, RunnableWithFallbacks):
+                models.extend((configured_model.runnable, *configured_model.fallbacks))
+            else:
+                models.append(configured_model)
+
+        clients: dict[int, tuple[Any, list[Any]]] = {}
+        for model in models:
+            if model is None or not getattr(model, "_owns_http_async_client", False):
+                continue
+            client = getattr(model, "http_async_client", None)
+            if client is not None:
+                clients.setdefault(id(client), (client, []))[1].append(model)
+
+        for client, owners in clients.values():
+            try:
+                await client.aclose()
+            except Exception:
+                logger.warning("ChatCompletionAgent: 关闭模型异步 HTTP client 失败", exc_info=True)
+            else:
+                for model in owners:
+                    model._owns_http_async_client = False
 
     def _query_approval_status(self, session_code: str) -> dict | None:
         """查询 gongfeng 后端判断是否需要续流，并从 interrupt 记录获取审批结果及 interrupts。
@@ -642,10 +669,14 @@ class ChatCompletionAgent(BaseModel):
         """
         try:
             input_state: dict[str, Any] = {"messages": messages, "execute_kwargs": execute_kwargs, **state}
-            result = run_coro_sync(
-                agent_e.ainvoke(input_state, cfg),
-                timeout=execute_kwargs.invoke_timeout,
-            )
+
+            async def _ainvoke_with_cleanup():
+                try:
+                    return await agent_e.ainvoke(input_state, cfg)
+                finally:
+                    await self._aclose_chat_models()
+
+            result = run_coro_sync(_ainvoke_with_cleanup, timeout=execute_kwargs.invoke_timeout)
             result_output = result.get("messages")[-1]
             return_data = {
                 "choices": [{"delta": {"role": "assistant", "content": result_output.content}}],
@@ -671,7 +702,12 @@ class ChatCompletionAgent(BaseModel):
         _input: dict[str, Any] = {"messages": messages, **state}
         agent_type = self.model_context_options.llm_code_agent_type if self.model_context_options else None
         adapter = AgentStreamAdapter(agent_type=agent_type)
-        return adapter.stream_standard_event(agent_e, cfg, _input)
+        return adapter.stream_standard_event(
+            agent_e,
+            cfg,
+            _input,
+            async_finalizer=self._aclose_chat_models,
+        )
 
     def _stream(
         self,
@@ -826,7 +862,14 @@ class ChatCompletionAgent(BaseModel):
             yield frame
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
-        yield from helper.stream(remaining_producer, on_complete=self._on_complete)
+        yield from helper.stream(
+            remaining_producer,
+            # replay 模式下由 producer 在 EOD 写入并 flush 成功后更新会话终态；
+            # 消费者中断不会影响最终状态收敛。
+            on_complete=partial(self._on_complete, finalize_session=True),
+            event_handler=self.event_handler,
+            expected_run_id=agent_input.run_id or self.thread_id,
+        )
 
     @staticmethod
     def _extract_head_frames(
@@ -878,9 +921,15 @@ class ChatCompletionAgent(BaseModel):
                         "(scheme B fallback), thread_id=%s",
                         agent_input.thread_id,
                     )
-                    yield from replay
+                    try:
+                        yield from replay
+                    finally:
+                        run_coro_sync(self._aclose_chat_models)
                     return
-            yield from async_to_sync_generator(agui_entry.run(agent_input))
+            yield from async_to_sync_generator(
+                agui_entry.run(agent_input),
+                async_finalizer=self._aclose_chat_models,
+            )
 
         return _gen()
 
@@ -939,8 +988,8 @@ class ChatCompletionAgent(BaseModel):
 
         return agui_entry.build_terminal_replay_stream(agent_input, non_system)
 
-    def _on_complete(self):
-        if self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
+    def _on_complete(self, *, finalize_session: bool = True):
+        if finalize_session and self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
             self.event_handler.set_streaming_finished()
         # 流式执行结束后释放资源
         self.release_resources()

--- a/src/agent/aidev_agent/services/agent/flow.py
+++ b/src/agent/aidev_agent/services/agent/flow.py
@@ -134,8 +134,21 @@ class FlowAgentCompletionAgent(BaseModel):
             execute_kwargs: 兼容 ChatCompletionAgent 接口，FlowAgent 中不使用
         """
         stream_thread_id = self.session_code or self.thread_id
-        helper = GeneratorStreamingHelper(thread_id=stream_thread_id)
-        return helper.stream(self._run_flow())
+        background_only = bool(getattr(execute_kwargs, "background_only", False))
+        helper = GeneratorStreamingHelper(
+            thread_id=stream_thread_id,
+            defer_cleanup_on_complete=background_only,
+        )
+        return helper.stream(
+            self._run_flow(),
+            on_complete=self._on_complete,
+            event_handler=self.event_handler,
+        )
+
+    def _on_complete(self) -> None:
+        """EOD 提交后由 producer 统一收敛 Flow 会话终态。"""
+        if self.event_handler and hasattr(self.event_handler, "set_streaming_finished"):
+            self.event_handler.set_streaming_finished()
 
     def stop(self):
         """停止 Flow Agent"""

--- a/src/agent/aidev_agent/services/event_handlers/agui_writer.py
+++ b/src/agent/aidev_agent/services/event_handlers/agui_writer.py
@@ -6,6 +6,7 @@
 """
 
 import json
+import time
 from logging import getLogger
 from typing import Any
 
@@ -45,6 +46,9 @@ class AGUISessionWriter(BaseSessionWriter):
         )
         ```
     """
+
+    _SESSION_STATUS_MAX_ATTEMPTS = 3
+    _SESSION_STATUS_RETRY_BASE_DELAY = 0.2
 
     def __init__(
         self,
@@ -352,38 +356,62 @@ class AGUISessionWriter(BaseSessionWriter):
         - 用户取消/暂停：会话状态设为 cancelled
         """
         if self._is_cancelled:
-            self._update_session_status(SessionsStatus.CANCELLED.value)
+            status = SessionsStatus.CANCELLED.value
         elif self._has_run_error:
-            self._update_session_status(SessionsStatus.FAILED.value)
+            status = SessionsStatus.FAILED.value
         else:
-            self._update_session_status(SessionsStatus.FINISHED.value)
+            status = SessionsStatus.FINISHED.value
+        self._update_session_status(status, raise_on_failure=True)
 
     def handle_run_error(self, event) -> None:
-        """处理运行错误，并确保会话状态进入 failed；同时清理 pending_interrupt。"""
+        """记录运行错误；会话终态由 EOD 提交后的唯一完成回调统一写入。"""
         super().handle_run_error(event)
         # 中断审批场景下清理 pending_interrupt
         self._clear_pending_interrupt_context()
         if not self._is_cancelled:
             self._has_run_error = True
-            self._update_session_status(SessionsStatus.FAILED.value)
 
-    def _update_session_status(self, status: str) -> None:
+    def _update_session_status(self, status: str, *, raise_on_failure: bool = False) -> None:
         """更新会话状态（内部方法）
 
         Args:
             status: 会话状态，如 "running", "finished"
         """
         headers = {"X-BKAIDEV-USER": self.username} if self.username else {}
-        try:
-            logger.info("开始更新会话状态: session_code=%s, status=%s", self.session_code, status)
-            result = self.client.api.update_chat_session(
-                path_params={"session_code": self.session_code},
-                json={"status": status},
-                headers=headers,
-            )
-            logger.info("会话状态更新成功: session_code=%s, status=%s, result=%s", self.session_code, status, result)
-        except Exception:
-            logger.exception("会话状态更新失败: session_code=%s, status=%s", self.session_code, status)
+        for attempt in range(self._SESSION_STATUS_MAX_ATTEMPTS):
+            try:
+                logger.info(
+                    "开始更新会话状态: session_code=%s, status=%s, attempt=%d",
+                    self.session_code,
+                    status,
+                    attempt + 1,
+                )
+                result = self.client.api.update_chat_session(
+                    path_params={"session_code": self.session_code},
+                    json={"status": status},
+                    headers=headers,
+                )
+                logger.info(
+                    "会话状态更新成功: session_code=%s, status=%s, result=%s", self.session_code, status, result
+                )
+                return
+            except Exception:
+                is_last_attempt = attempt == self._SESSION_STATUS_MAX_ATTEMPTS - 1
+                if is_last_attempt:
+                    logger.exception("会话状态更新失败: session_code=%s, status=%s", self.session_code, status)
+                    if raise_on_failure:
+                        raise
+                    return
+
+                delay = self._SESSION_STATUS_RETRY_BASE_DELAY * (2**attempt)
+                logger.warning(
+                    "会话状态更新失败，将重试: session_code=%s, status=%s, delay=%.1fs",
+                    self.session_code,
+                    status,
+                    delay,
+                    exc_info=True,
+                )
+                time.sleep(delay)
 
     def update_flow_agent_info(self, task_id: str) -> None:
         """更新 session 中的 Flow Agent task_id

--- a/src/agent/aidev_agent/services/messages_handler/__init__.py
+++ b/src/agent/aidev_agent/services/messages_handler/__init__.py
@@ -2,6 +2,7 @@ from .base import (
     BaseMessageQueueHandler,
     ConsumerManagementProtocol,
     ConsumerPreemptedError,
+    RetryableHeartbeatTimeoutError,
     StreamCancelledError,
 )
 from .constants import (
@@ -34,6 +35,7 @@ __all__ = [
     "MultiProcessMixin",
     # 异常类
     "ConsumerPreemptedError",
+    "RetryableHeartbeatTimeoutError",
     "StreamCancelledError",
     # 常量类
     "StreamMarkers",

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -23,6 +23,7 @@ __all__ = [
     "QueueTTLConfig",
     "ConsumerPreemptedError",
     "StreamCancelledError",
+    "RetryableHeartbeatTimeoutError",
     "ConsumerManagementProtocol",
     "BaseMessageQueueHandler",
 ]
@@ -34,6 +35,10 @@ class ConsumerPreemptedError(Exception):
 
 class StreamCancelledError(Exception):
     """流被用户主动取消（停止会话）"""
+
+
+class RetryableHeartbeatTimeoutError(RuntimeError):
+    """消费者心跳超时，可通过重新消费恢复且不应更新会话终态。"""
 
 
 @runtime_checkable
@@ -297,7 +302,6 @@ class BaseMessageQueueHandler(ABC):
 
     def release_producer(self, thread_id: str) -> None:
         """释放会话级生产者写入权。默认无操作。"""
-        pass
 
     def size(self, thread_id: str) -> int:
         """获取主队列中的消息数量（get_cached_count 的别名）

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -18,7 +18,7 @@ import pika
 from environs import Env
 
 from .base import BaseMessageQueueHandler, QueueTTLConfig
-from .constants import QueueNamePrefixes
+from .constants import EOD_CHUNK, QueueNamePrefixes
 from .multi_process_mixin import MultiProcessMixin
 
 logger = getLogger(__name__)
@@ -302,8 +302,10 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     REPLAY_LOCK_PREFIX: ClassVar[str] = "aidev_agent.replay_lock."
     ACTIVE_CONSUMER_PREFIX: ClassVar[str] = "aidev_agent.consumer_active."
     QUEUE_TTL_MS: ClassVar[int] = QueueTTLConfig.QUEUE_EXPIRE_MS
+    BUFFER_FLUSH_INTERVAL: ClassVar[float] = 0.5
+    SSE_PUBLISH_CHUNK_MAX_BYTES: ClassVar[int] = 256 * 1024
     REPLAY_LOCK_RETRY_INTERVAL: ClassVar[float] = 0.05
-    REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.1
+    REPLAY_MESSAGE_RETRY_INTERVAL: ClassVar[float] = 0.5
 
     _instance: Optional["RabbitMQMessageHandler"] = None
     _lock: ClassVar[threading.Lock] = threading.Lock()
@@ -342,6 +344,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         # 避免 replay 读取到本进程尚未完整发布的 flush 批次
         self._flush_peek_locks: dict[str, threading.Lock] = {}
         self._flush_peek_locks_guard = threading.Lock()
+
+        # producer 只有在 EOD 已提交到 RabbitMQ 后才能写外部会话终态。
+        # 同步 flush 失败时，后台 daemon 补发成功会唤醒同进程 producer。
+        self._eod_commit_events: dict[str, set[threading.Event]] = {}
+        self._eod_commit_events_lock = threading.Lock()
 
         # 后台守护线程
         self._daemon_thread: Optional[threading.Thread] = None
@@ -460,6 +467,30 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """唤醒等待 replay lock 或新消息的本进程消费者。"""
         with self._replay_wait_condition:
             self._replay_wait_condition.notify_all()
+
+    def register_eod_commit_event(self, thread_id: str, event: threading.Event) -> None:
+        """注册 EOD 提交确认事件，供 producer 等待同步/后台 flush 的最终结果。"""
+        with self._eod_commit_events_lock:
+            self._eod_commit_events.setdefault(thread_id, set()).add(event)
+
+    def unregister_eod_commit_event(self, thread_id: str, event: threading.Event) -> None:
+        """移除尚未被 EOD 成功提交消费的确认事件。"""
+        with self._eod_commit_events_lock:
+            events = self._eod_commit_events.get(thread_id)
+            if events is None:
+                return
+            events.discard(event)
+            if not events:
+                self._eod_commit_events.pop(thread_id, None)
+
+    def _notify_eod_committed(self, thread_id: str, messages: list[Any]) -> None:
+        """仅在包含 EOD 的完整批次成功发布后确认提交。"""
+        if EOD_CHUNK not in messages:
+            return
+        with self._eod_commit_events_lock:
+            events = self._eod_commit_events.pop(thread_id, set())
+        for event in events:
+            event.set()
 
     def _wait_for_replay_retry(self, deadline: float | None, interval: float) -> None:
         """等待下一次 replay 检查。
@@ -627,14 +658,39 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             connection = self._producer_lock_connections.pop(thread_id, None)
 
         if not connection:
+            logger.info(
+                "[RabbitMQ] producer lock release skipped (no connection) thread_id=%s queue=%s",
+                thread_id,
+                lock_queue,
+            )
             return
 
+        logger.info(
+            "[RabbitMQ] release_producer enter thread_id=%s queue=%s connection_is_open=%s",
+            thread_id,
+            lock_queue,
+            getattr(connection, "is_open", None),
+        )
         channel = None
+        connection_already_closed = False
         try:
             if getattr(connection, "is_open", False):
-                channel = connection.channel()
-                with contextlib.suppress(Exception):
-                    channel.queue_delete(queue=lock_queue)
+                try:
+                    channel = connection.channel()
+                    with contextlib.suppress(Exception):
+                        channel.queue_delete(queue=lock_queue)
+                except Exception as e:
+                    # 连接已被对端重置/关闭：exclusive queue 随连接断开自动删除，
+                    # 无需再 queue_delete，降级走连接清理路径，不让异常冒泡
+                    connection_already_closed = True
+                    channel = None
+                    logger.warning(
+                        "[RabbitMQ] producer lock connection already closed, skip queue_delete "
+                        "thread_id=%s queue=%s error=%s",
+                        thread_id,
+                        lock_queue,
+                        e,
+                    )
         finally:
             if channel and getattr(channel, "is_open", False):
                 with contextlib.suppress(Exception):
@@ -642,7 +698,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if getattr(connection, "is_open", False):
                 with contextlib.suppress(Exception):
                     connection.close()
-            logger.info("[RabbitMQ] producer lock released thread_id=%s queue=%s", thread_id, lock_queue)
+            logger.info(
+                "[RabbitMQ] producer lock released thread_id=%s queue=%s connection_already_closed=%s",
+                thread_id,
+                lock_queue,
+                connection_already_closed,
+            )
 
     def _ensure_active_consumer_queue(self, channel: Any, thread_id: str) -> str:
         queue_name = self._get_active_consumer_queue_name(thread_id)
@@ -812,11 +873,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             logger.info("RabbitMQ daemon thread stopped")
 
     def _daemon_worker(self) -> None:
-        """后台守护线程工作函数：每隔 0.1 秒批量推送消息到 RabbitMQ"""
+        """后台守护线程工作函数：每隔 0.5 秒批量推送消息到 RabbitMQ"""
         while self._daemon_running:
             try:
-                # 等待 0.1 秒或直到停止事件触发
-                if self._daemon_stop_event.wait(timeout=0.1):
+                # 等待批量刷新周期或直到停止事件触发
+                if self._daemon_stop_event.wait(timeout=self.BUFFER_FLUSH_INTERVAL):
                     break
 
                 # 批量推送消息
@@ -829,6 +890,55 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             self._flush_messages()
         except Exception as e:
             logger.error(f"Error flushing messages on daemon exit: {e}")
+
+    @classmethod
+    def _coalesce_sse_messages(cls, messages: list[Any]) -> list[Any]:
+        """合并相邻 SSE 帧，减少 RabbitMQ 物理消息数并保持原始协议字节流。"""
+        coalesced_messages: list[Any] = []
+        sse_parts: list[str] = []
+        sse_size = 0
+
+        def flush_sse_parts() -> None:
+            nonlocal sse_size
+            if not sse_parts:
+                return
+            coalesced_messages.append("".join(sse_parts))
+            sse_parts.clear()
+            sse_size = 0
+
+        for message in messages:
+            if not isinstance(message, str) or not message.startswith("data: "):
+                flush_sse_parts()
+                coalesced_messages.append(message)
+                continue
+
+            message_size = len(message.encode("utf-8"))
+            if sse_parts and sse_size + message_size > cls.SSE_PUBLISH_CHUNK_MAX_BYTES:
+                flush_sse_parts()
+            if message_size > cls.SSE_PUBLISH_CHUNK_MAX_BYTES:
+                coalesced_messages.append(message)
+                continue
+            sse_parts.append(message)
+            sse_size += message_size
+
+        flush_sse_parts()
+        return coalesced_messages
+
+    @staticmethod
+    def _expand_sse_messages(messages: list[Any]) -> list[Any]:
+        """将 RabbitMQ 中合并的 SSE 字节流还原为调用方原有的逐帧消息。"""
+        expanded_messages: list[Any] = []
+        for message in messages:
+            if not isinstance(message, str) or not message.startswith("data: ") or "\n\ndata: " not in message:
+                expanded_messages.append(message)
+                continue
+
+            parts = message.split("\n\n")
+            if parts[-1] or any(not part.startswith("data: ") for part in parts[:-1]):
+                expanded_messages.append(message)
+                continue
+            expanded_messages.extend(f"{part}\n\n" for part in parts[:-1])
+        return expanded_messages
 
     def _flush_messages(self) -> None:
         """批量推送缓冲区中的所有消息到 RabbitMQ
@@ -854,11 +964,12 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                         messages = self._message_buffer.pop(thread_id, [])
                     if not messages:
                         continue
+                    messages_to_publish = self._coalesce_sse_messages(messages)
 
                     # 在同一个 flush_peek_lock 内 publish 到 RabbitMQ
                     with self._with_channel() as channel:
                         queue_name = self._ensure_queue(channel, thread_id)
-                        for message in messages:
+                        for message in messages_to_publish:
                             body = pickle.dumps(message)
                             channel.basic_publish(
                                 exchange="",
@@ -866,7 +977,20 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
-                    logger.debug(f"Flushed {len(messages)} messages to queue {queue_name}")
+                    logger.debug(
+                        "Flushed %d logical messages as %d RabbitMQ messages to queue %s",
+                        len(messages),
+                        len(messages_to_publish),
+                        queue_name,
+                    )
+                    if EOD_CHUNK in messages:
+                        logger.info(
+                            "[EOD] flush thread_id=%s logical=%d published=%d (background)",
+                            thread_id,
+                            len(messages),
+                            len(messages_to_publish),
+                        )
+                    self._notify_eod_committed(thread_id, messages)
                     any_flushed = True
             except Exception as e:
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
@@ -1021,12 +1145,13 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     return
 
                 logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
+                messages_to_publish = self._coalesce_sse_messages(messages_to_flush)
 
                 try:
                     with self._with_channel() as channel:
                         queue_name = self._ensure_queue(channel, thread_id)
 
-                        for message in messages_to_flush:
+                        for message in messages_to_publish:
                             body = pickle.dumps(message)
                             channel.basic_publish(
                                 exchange="",
@@ -1034,6 +1159,14 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                    if EOD_CHUNK in messages_to_flush:
+                        logger.info(
+                            "[EOD] flush thread_id=%s logical=%d published=%d",
+                            thread_id,
+                            len(messages_to_flush),
+                            len(messages_to_publish),
+                        )
+                    self._notify_eod_committed(thread_id, messages_to_flush)
                     self._notify_replay_waiters()
                 except Exception as e:
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
@@ -1093,9 +1226,11 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return messages
 
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
-        """非破坏性读取队列中的全部消息。"""
+        """非破坏性读取队列中的全部消息，仅在读取或 requeue 异常时记录诊断。"""
         messages = []
         delivery_tags = []
+        message_count = 0
+        nack_error = None
 
         try:
             queue_info = channel.queue_declare(queue=queue_name, durable=True, passive=True)
@@ -1105,10 +1240,23 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                 if not method_frame:
                     break
                 delivery_tags.append(method_frame.delivery_tag)
-                messages.append(pickle.loads(body))
+                msg = pickle.loads(body)
+                messages.append(msg)
         finally:
             for tag in delivery_tags:
-                channel.basic_nack(delivery_tag=tag, requeue=True)
+                try:
+                    channel.basic_nack(delivery_tag=tag, requeue=True)
+                except Exception as e:
+                    nack_error = e
+            if message_count != len(messages) or nack_error is not None:
+                logger.warning(
+                    "[EOD] _peek_queue_messages queue=%s declared=%d got=%d nack_error=%s peek_eod=%s",
+                    queue_name,
+                    message_count,
+                    len(messages),
+                    nack_error,
+                    EOD_CHUNK in messages,
+                )
 
         return messages
 
@@ -1127,21 +1275,29 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     # replay offset 只描述 RabbitMQ 已提交队列，不能包含本地未发布 buffer。
                     # flush_peek_lock 避免读取到本进程尚未完整发布的 flush 批次。
                     with flush_peek_lock:
-                        all_messages = self._peek_queue_messages(channel, main_queue_name)
+                        queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                        committed_count = queue_info.method.message_count
 
                         # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if not all_messages and self._get_dlq_count(thread_id) > 0:
+                        if committed_count == 0 and self._get_dlq_count(thread_id) > 0:
                             restored = self._restore_from_dlq(thread_id)
                             logger.info(
                                 "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
                                 thread_id,
                                 restored,
                             )
-                            all_messages = self._peek_queue_messages(channel, main_queue_name)
+                            queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
+                            committed_count = queue_info.method.message_count
 
-                next_offset = len(all_messages)
-                if next_offset > offset:
-                    return all_messages[offset:], next_offset
+                        # 没有新消息时避免反复 basic_get/basic_nack 全量扫描历史队列。
+                        all_messages = (
+                            self._peek_queue_messages(channel, main_queue_name) if committed_count > offset else None
+                        )
+
+                if all_messages is not None:
+                    next_offset = len(all_messages)
+                    if next_offset > offset:
+                        return self._expand_sse_messages(all_messages[offset:]), next_offset
             except Exception:
                 logger.exception("Error in get_messages_since for thread_id=%s", thread_id)
 

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -1,15 +1,16 @@
+import json
 import threading
 import time
 import uuid
 from logging import getLogger
 from typing import Any, Callable, Generator
 
-from ag_ui.core import EventType, RunErrorEvent
+from ag_ui.core import EventType, RawEvent, RunErrorEvent
 from ag_ui.encoder import EventEncoder
 
 from aidev_agent.utils.event import RunId, emit_run_finished_event
 
-from .base import BaseMessageQueueHandler, ConsumerPreemptedError
+from .base import BaseMessageQueueHandler, ConsumerPreemptedError, RetryableHeartbeatTimeoutError
 from .constants import (
     CANCELLED_CHUNK,
     EOD_CHUNK,
@@ -21,6 +22,10 @@ from .constants import (
 from .factory import message_handler_factory
 
 logger = getLogger(__name__)
+
+_SSE_HEARTBEAT_EVENT = EventEncoder().encode(
+    RawEvent(type=EventType.RAW, event={"type": "heartbeat"}),
+)
 
 # 断点续传时需要过滤的事件类型
 # flow_agent_start 事件在续聊时不应该重复发送，避免前端重新渲染
@@ -62,14 +67,22 @@ class GeneratorStreamingHelper:
     # 取消后等待 generator 产出 RUN_FINISHED 的宽限时间（秒）
     CANCEL_DRAIN_TIMEOUT = TimeoutConfig.CANCEL_DRAIN_TIMEOUT
 
-    # 生产者结束后延迟清理会话资源的等待时间（秒）
-    # 需足够长以允许活跃消费者处理 EOD_CHUNK，又不至于长时间占用资源
-    _PRODUCER_CLEANUP_DELAY = 30.0
+    # 生产者结束后延迟清理会话资源的等待时间（秒）。
+    # 覆盖 60 秒 replay 心跳窗口，并为前端重连预留约 30 秒。
+    _PRODUCER_CLEANUP_DELAY = 90.0
     # 业务流已发出 [DONE] 且当前无活跃消费者时，保留队列等待前端接管续流的窗口（秒）。
     # 注意：后台 drain（background_only）完成后不会立即清理队列，需保留足够窗口让前端重连后
     # 通过 restore_messages 接管已生产的完整内容；窗口内若有消费者接管则跳过清理。
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
+    _HEARTBEAT_TIMEOUT_GRACE = 5.0
+    # RabbitMQ replay 需要扫描已提交历史队列，消费耗时可能超过通用的 15 秒心跳窗口。
+    _REPLAY_HEARTBEAT_TIMEOUT = 60.0
+    # 后台 schedule 没有前端可接管重连；心跳超时后保留最多 60 秒恢复窗口。
+    # 窗口耗尽仅退出异常消费者，producer 后续仍可在 EOD 提交后收敛会话终态。
+    _BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT = 60.0
+    _EOD_COMMIT_RECOVERY_TIMEOUT = 15.0
+    _HEARTBEAT_TIMEOUT_MESSAGE = "Agent 执行中断：生产者心跳超时，请稍后重试"
 
     @staticmethod
     def _should_filter_on_resume(item: Any) -> bool:
@@ -106,6 +119,7 @@ class GeneratorStreamingHelper:
         # 后台 drain（无 SSE 下游）场景：读到 EOD 时不立即 mark_completed 清队列，
         # 保留 DLQ 历史供前端在清理窗口内接管续流；清理交由 producer 的延迟清理线程兜底。
         self.defer_cleanup_on_complete = defer_cleanup_on_complete
+        self._producer_completion_error: Exception | None = None
 
     @classmethod
     def _check_cancel_status(
@@ -245,6 +259,17 @@ class GeneratorStreamingHelper:
     def _is_done_event_chunk(chunk: Any) -> bool:
         """判断 chunk 是否为 SSE 的业务完成标记。"""
         return isinstance(chunk, str) and chunk.strip() == "data: [DONE]"
+
+    @staticmethod
+    def _is_run_finished_event_chunk(chunk: Any) -> bool:
+        """判断 chunk 是否为 AG-UI RUN_FINISHED 事件。"""
+        if not isinstance(chunk, str) or not chunk.startswith("data:"):
+            return False
+        try:
+            payload = json.loads(chunk.removeprefix("data:").strip())
+        except (TypeError, json.JSONDecodeError):
+            return False
+        return isinstance(payload, dict) and payload.get("type") == EventType.RUN_FINISHED.value
 
     def _is_cancelled(self, cancel_event: threading.Event) -> bool:
         """检查是否被取消（同时检查进程内事件和跨进程信号）
@@ -429,6 +454,8 @@ class GeneratorStreamingHelper:
         cancel_event: threading.Event,
         has_pending: bool,
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
+        expected_run_id: str | None = None,
     ) -> tuple[threading.Thread | None, bool, bool]:
         """根据队列状态决定启动生产者还是恢复旧消息。"""
         producer_thread: threading.Thread | None = None
@@ -452,8 +479,15 @@ class GeneratorStreamingHelper:
                 raise
 
             producer_thread = threading.Thread(
-                target=self._producer,
-                args=(generator, cancel_event, on_complete, True),
+                target=self._run_producer,
+                kwargs={
+                    "generator": generator,
+                    "cancel_event": cancel_event,
+                    "on_complete": on_complete,
+                    "event_handler": event_handler,
+                    "expected_run_id": expected_run_id,
+                    "release_producer": True,
+                },
                 daemon=True,
             )
             producer_thread.start()
@@ -486,6 +520,47 @@ class GeneratorStreamingHelper:
     _CONSUMER_PROGRESS_EVERY_N = 50
     _CONSUMER_PROGRESS_EVERY_SECONDS = 10.0
 
+    def _emit_terminal_error_events(
+        self,
+        message: str,
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> Generator[str, None, None]:
+        """输出 AG-UI 错误与结束事件，并同步通知会话事件处理器。"""
+        error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=message)
+        if event_handler is not None:
+            try:
+                event_handler(error_event)
+            except Exception:
+                logger.exception("Error dispatching RUN_ERROR for thread_id=%s", self.thread_id)
+        yield EventEncoder().encode(error_event)
+        yield emit_run_finished_event(
+            thread_id=self.thread_id,
+            run_id="error",
+            event_handler=event_handler,
+        )
+
+    def _emit_retryable_heartbeat_timeout(
+        self,
+        event_handler: Callable[[Any], None] | None = None,
+    ) -> Generator[str, None, None]:
+        """先输出 RAW 提示，再中断 SSE 让前端按 network error 重连。"""
+        retry_event = RawEvent(
+            type=EventType.RAW,
+            event={
+                "type": "error",
+                "message": self._HEARTBEAT_TIMEOUT_MESSAGE,
+            },
+        )
+        if event_handler is not None:
+            try:
+                event_handler(retry_event)
+            except Exception:
+                logger.exception("Error dispatching retryable RAW event for thread_id=%s", self.thread_id)
+        yield EventEncoder().encode(retry_event)
+
+        # 后续增加独立重试事件后，前端无需再依赖 transport/network error。
+        raise RetryableHeartbeatTimeoutError(self._HEARTBEAT_TIMEOUT_MESSAGE)
+
     def _consume_stream_messages(
         self,
         consumer_id: str,
@@ -493,6 +568,8 @@ class GeneratorStreamingHelper:
         is_resuming: bool,
         enable_heartbeat_check: bool,
         on_complete: Callable[[], None] | None = None,
+        producer_thread: threading.Thread | None = None,
+        event_handler: Callable[[Any], None] | None = None,
     ) -> Generator[Any, None, str]:
         """消费者循环：读取队列、处理控制消息并向上游产出业务消息。
 
@@ -505,6 +582,7 @@ class GeneratorStreamingHelper:
         consumer_draining = False
         consumer_drain_start = 0.0
         last_message_time = time.time()
+        last_message_monotonic = time.monotonic()
 
         consumer_id_short = consumer_id[:8] if consumer_id else "?"
         loop_iter = 0
@@ -513,6 +591,9 @@ class GeneratorStreamingHelper:
         last_progress_ts = time.time()
         replay_offset = 0
         supports_replay_from_start = self._supports_replay_from_start()
+        heartbeat_timeout = self._REPLAY_HEARTBEAT_TIMEOUT if supports_replay_from_start else HEARTBEAT_TIMEOUT
+        heartbeat_grace_deadline: float | None = None
+        background_recovery_deadline: float | None = None
 
         logger.info(
             "[RabbitMQ] consumer loop enter thread_id=%s consumer_id=%s is_resuming=%s heartbeat_check=%s",
@@ -589,18 +670,26 @@ class GeneratorStreamingHelper:
 
                     if messages:
                         last_message_time = time.time()
+                        last_message_monotonic = time.monotonic()
+                        heartbeat_grace_deadline = None
+                        background_recovery_deadline = None
 
                     for item in messages:
                         if item == HEARTBEAT_CHUNK:
                             logger.debug(f"Received heartbeat for thread_id={self.thread_id}")
+                            yield _SSE_HEARTBEAT_EVENT
+                            yielded_total += 1
                             continue
                         if item == EOD_CHUNK:
+                            logger.info(f"[EOD] Consumer received EOD_CHUNK for thread_id={self.thread_id}")
                             should_notify_cancelled = self._should_notify_consumer_cancelled_on_complete(cancel_event)
+                            completion_error: Exception | None = None
                             if on_complete and not supports_replay_from_start:
                                 try:
                                     on_complete()
-                                except Exception as e:
-                                    logger.exception(f"on_complete callback error: {e}")
+                                except Exception as exc:
+                                    completion_error = exc
+                                    logger.exception("on_complete callback error for thread_id=%s", self.thread_id)
                             if not supports_replay_from_start and not self.defer_cleanup_on_complete:
                                 self.message_handler.mark_completed(self.thread_id)
                                 logger.info(f"Stream completed for thread_id={self.thread_id}")
@@ -618,6 +707,8 @@ class GeneratorStreamingHelper:
                             if should_notify_cancelled:
                                 # cancel 可能已发出但 Agent 恰好也完成了，此时仍需通知 stop 接口。
                                 self._notify_consumer_cancelled_safely()
+                            if completion_error is not None:
+                                raise completion_error
                             exit_reason = "completed"
                             return exit_reason
                         if item == CANCELLED_CHUNK:
@@ -653,12 +744,54 @@ class GeneratorStreamingHelper:
                     exit_reason = "preempted"
                     raise
                 except TimeoutError:
-                    if enable_heartbeat_check and (time.time() - last_message_time > HEARTBEAT_TIMEOUT):
-                        logger.error(f"心跳超时 thread_id={self.thread_id}，超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息")
-                        exit_reason = "starved"
-                        raise RuntimeError(
-                            f"生产者心跳超时：超过 {HEARTBEAT_TIMEOUT}s 未收到任何消息，生产者可能已崩溃"
+                    if (
+                        producer_thread is not None
+                        and not producer_thread.is_alive()
+                        and self._producer_completion_error is not None
+                    ):
+                        raise self._producer_completion_error
+                    time_since_last = time.monotonic() - last_message_monotonic
+                    if enable_heartbeat_check and time_since_last > heartbeat_timeout:
+                        producer_finished = producer_thread is not None and not producer_thread.is_alive()
+
+                        # producer 仍可能存活时仅给予一次短暂宽限，不重新启动 Agent，
+                        # 也不刷新业务执行超时。producer 已结束却未收到 EOD 时按链路异常处理。
+                        if not producer_finished and heartbeat_grace_deadline is None:
+                            heartbeat_grace_deadline = time.monotonic() + self._HEARTBEAT_TIMEOUT_GRACE
+                            logger.warning(
+                                "[RabbitMQ] producer heartbeat grace started thread_id=%s grace=%.1fs replay_offset=%d",
+                                self.thread_id,
+                                self._HEARTBEAT_TIMEOUT_GRACE,
+                                replay_offset,
+                            )
+                            continue
+                        if heartbeat_grace_deadline is not None and time.monotonic() < heartbeat_grace_deadline:
+                            continue
+
+                        if self.defer_cleanup_on_complete:
+                            if background_recovery_deadline is None:
+                                background_recovery_deadline = (
+                                    time.monotonic() + self._BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT
+                                )
+                                logger.warning(
+                                    "[RabbitMQ] background consumer keeps waiting after heartbeat timeout "
+                                    "thread_id=%s recovery_timeout=%.1fs replay_offset=%d producer_finished=%s",
+                                    self.thread_id,
+                                    self._BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT,
+                                    replay_offset,
+                                    producer_finished,
+                                )
+                            if time.monotonic() < background_recovery_deadline:
+                                continue
+
+                        logger.error(
+                            f"心跳超时 thread_id={self.thread_id}，距上次消息 {time_since_last:.1f}s "
+                            f"(last_message_time={last_message_time:.1f}, now={time.time():.1f}) "
+                            f"replay_offset={replay_offset} producer_finished={producer_finished}"
                         )
+                        yielded_total += 1
+                        exit_reason = "heartbeat_timeout"
+                        yield from self._emit_retryable_heartbeat_timeout(event_handler=event_handler)
                     continue
                 except Exception as exc:
                     # L-5：避免 unexpected 异常被上层 _wrap_streaming_with_status 吞成沉默
@@ -704,6 +837,8 @@ class GeneratorStreamingHelper:
         self,
         generator: Generator[Any, None, None],
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
+        expected_run_id: str | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求
 
@@ -713,13 +848,13 @@ class GeneratorStreamingHelper:
         Args:
             generator: 数据生成器
             on_complete: 流完成时的回调函数，用于及时更新 session status 等外部状态。
-                replay-from-start handler 在 producer 完成时调用；旧 handler 在消费到 EOD 后调用。
+                producer 将 RUN_FINISHED 入队后立即调用；缺少 RUN_FINISHED 时在 EOD 路径兜底调用。
+            event_handler: AG-UI 事件处理器，用于同步记录受控错误和结束状态。
+            expected_run_id: 正常 AG-UI 流的 run_id；提供时保证 EOD 前至少输出一次 RUN_FINISHED。
 
         Yields:
             生成器产生的数据
 
-        Raises:
-            RuntimeError: 当心跳超时时抛出，表示生产者可能已异常结束
         """
         # 注册取消事件（让 cancel() 可以通知生产者和消费者停止）
         cancel_event = self._register_cancel_event()
@@ -733,6 +868,21 @@ class GeneratorStreamingHelper:
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)
         producer_thread: threading.Thread | None = None
         consumer_exit_reason: str | None = None
+        self._producer_completion_error = None
+
+        completion_lock = threading.Lock()
+        completion_called = False
+
+        def _on_complete_once() -> None:
+            nonlocal completion_called
+            with completion_lock:
+                if completion_called:
+                    return
+                completion_called = True
+            if on_complete is not None:
+                on_complete()
+
+        completion_callback = _on_complete_once if on_complete is not None else None
 
         should_consume_stopped, has_pending = self._resolve_stopped_or_pending_state()
 
@@ -746,14 +896,18 @@ class GeneratorStreamingHelper:
                 generator=generator,
                 cancel_event=cancel_event,
                 has_pending=has_pending,
-                on_complete=on_complete,
+                on_complete=completion_callback,
+                event_handler=event_handler,
+                expected_run_id=expected_run_id,
             )
             consumer_exit_reason = yield from self._consume_stream_messages(
                 consumer_id=consumer_id,
                 cancel_event=cancel_event,
                 is_resuming=is_resuming,
                 enable_heartbeat_check=enable_heartbeat_check,
-                on_complete=on_complete,
+                on_complete=completion_callback,
+                producer_thread=producer_thread,
+                event_handler=event_handler,
             )
         except GeneratorExit:
             # 客户端断开连接，不清理队列，消息已在死信队列中保留
@@ -773,6 +927,8 @@ class GeneratorStreamingHelper:
                     logger.exception(f"Error joining producer thread for thread_id={self.thread_id}: {e}")
             if consumer_exit_reason == "completed":
                 self._cleanup_replay_session_if_idle()
+                if self._producer_completion_error is not None:
+                    raise self._producer_completion_error
 
     def _schedule_session_cleanup(self, done_event_seen: bool = False) -> None:
         """生产者完成后延迟清理孤立的会话资源。
@@ -810,10 +966,12 @@ class GeneratorStreamingHelper:
                     fast_grace_hit = (
                         done_event_seen
                         and not has_active_consumer
+                        and not consumer_ever_seen
                         and fast_cleanup_at is not None
                         and now >= fast_cleanup_at
                     )
-                    deadline_hit = now >= deadline
+                    # 活跃消费者可能仍在回放较大的历史队列，不能在固定 deadline 到达后删除其队列。
+                    deadline_hit = now >= deadline and not has_active_consumer
                     if fast_grace_hit or deadline_hit:
                         should_cleanup_now = True
                         trigger_reason = "fast_grace" if fast_grace_hit and not deadline_hit else "deadline"
@@ -833,7 +991,8 @@ class GeneratorStreamingHelper:
                         logger.info(f"Cleaned up orphaned session data for thread_id={thread_id}")
                         return
 
-                    time.sleep(min(poll_interval, max(deadline - now, 0.0)))
+                    sleep_for = min(poll_interval, deadline - now) if now < deadline else poll_interval
+                    time.sleep(sleep_for)
             except Exception:
                 logger.exception(f"Error in delayed session cleanup for thread_id={thread_id}")
 
@@ -848,7 +1007,9 @@ class GeneratorStreamingHelper:
         generator: Generator[Any, None, None],
         cancel_event: threading.Event | None = None,
         on_complete: Callable[[], None] | None = None,
+        event_handler: Callable[[Any], None] | None = None,
         release_producer: bool = False,
+        expected_run_id: str | None = None,
     ) -> None:
         """生产者线程：将生成器产生的消息推送到队列
 
@@ -858,6 +1019,8 @@ class GeneratorStreamingHelper:
         而是继续 drain generator 一段时间，等待 Agent 内部的 cancel_checker 触发
         并 yield RUN_FINISHED 事件，确保前端能收到完整的结束信号。
         """
+        _producer_start = time.monotonic()
+        logger.info(f"[PRODUCER] start thread_id={self.thread_id} thread={threading.current_thread().name}")
         heartbeat_stop_event = threading.Event()
         heartbeat_thread: threading.Thread | None = None
         # 跨进程取消检查计数器（每 N 个 chunk 检查一次，避免频繁访问 RabbitMQ）
@@ -869,6 +1032,7 @@ class GeneratorStreamingHelper:
         drain_start_time = 0.0
         done_event_seen = False
         producer_error = False
+        run_finished_seen = False
 
         def _heartbeat_worker() -> None:
             """独立心跳线程：即使 generator 阻塞也保持心跳。"""
@@ -878,6 +1042,15 @@ class GeneratorStreamingHelper:
                     logger.debug(f"Sent heartbeat for thread_id={self.thread_id}")
                 except Exception as e:
                     logger.exception(f"Error sending heartbeat for thread_id={self.thread_id}: {e}")
+
+        def _complete_session() -> None:
+            if on_complete is None:
+                return
+            try:
+                on_complete()
+            except Exception as completion_error:
+                self._producer_completion_error = completion_error
+                logger.exception("on_complete callback error in producer for thread_id=%s", self.thread_id)
 
         try:
             heartbeat_thread = threading.Thread(
@@ -891,6 +1064,9 @@ class GeneratorStreamingHelper:
                 chunk_count += 1
                 if self._is_done_event_chunk(chunk):
                     done_event_seen = True
+                is_run_finished = self._is_run_finished_event_chunk(chunk)
+                if is_run_finished:
+                    run_finished_seen = True
 
                 if not draining:
                     # 检查是否被取消（进程内快速检查）
@@ -934,39 +1110,129 @@ class GeneratorStreamingHelper:
 
                 self.message_handler.put(self.thread_id, chunk)
                 logger.debug(f"Produced chunk for thread_id={self.thread_id}")
+                if is_run_finished:
+                    _complete_session()
+                    logger.info(
+                        "[RUN_FINISHED] terminal event queued and session finalized; stopping producer thread_id=%s",
+                        self.thread_id,
+                    )
+                    break
         except GeneratorExit:
             logger.info(f"Generator closed for thread_id={self.thread_id}")
         except Exception as e:
             producer_error = True
             logger.exception(f"Producer error for thread_id={self.thread_id}: {e}")
-            # 将错误信息作为 SSE error event 推送到队列，让消费者能感知并传播给前端
             try:
-                encoder = EventEncoder()
-                error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=f"Producer error: {e}")
-                self.message_handler.put(self.thread_id, encoder.encode(error_event))
+                for event in self._emit_terminal_error_events(
+                    "Agent 执行异常，请稍后重试",
+                    event_handler=event_handler,
+                ):
+                    is_run_finished = self._is_run_finished_event_chunk(event)
+                    if is_run_finished:
+                        run_finished_seen = True
+                    self.message_handler.put(self.thread_id, event)
+                    if is_run_finished:
+                        _complete_session()
             except Exception as encode_err:
-                logger.exception(f"Failed to encode/send error event for thread_id={self.thread_id}: {encode_err}")
+                logger.exception(f"Failed to send terminal error events for thread_id={self.thread_id}: {encode_err}")
         finally:
+            logger.info(
+                f"[PRODUCER] finally enter thread_id={self.thread_id} "
+                f"producer_error={producer_error} done_event_seen={done_event_seen} "
+                f"draining={draining} "
+                f"elapsed={time.monotonic() - _producer_start:.1f}s"
+            )
             heartbeat_stop_event.set()
+            close_generator = getattr(generator, "close", None)
+            if callable(close_generator):
+                try:
+                    close_generator()
+                except Exception:
+                    logger.exception("Error closing producer generator thread_id=%s", self.thread_id)
             if heartbeat_thread is not None:
                 try:
                     heartbeat_thread.join(timeout=HEARTBEAT_INTERVAL + 0.2)
                 except Exception as e:
                     logger.exception(f"Error joining heartbeat thread for thread_id={self.thread_id}: {e}")
 
-            if on_complete and self._supports_replay_from_start() and not producer_error:
+            try:
+                if expected_run_id and not producer_error and not draining and not run_finished_seen:
+                    logger.warning(
+                        "[RUN_FINISHED] missing from normal producer stream; emitting fallback thread_id=%s run_id=%s",
+                        self.thread_id,
+                        expected_run_id,
+                    )
+                    self.message_handler.put(
+                        self.thread_id,
+                        emit_run_finished_event(
+                            thread_id=self.thread_id,
+                            run_id=expected_run_id,
+                            event_handler=event_handler,
+                        ),
+                    )
+                    _complete_session()
+
+                # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。
+                logger.info(
+                    f"[EOD] Producer sending EOD_CHUNK for thread_id={self.thread_id} (producer_error={producer_error})"
+                )
+                eod_commit_event = threading.Event()
+                register_eod_commit = getattr(self.message_handler, "register_eod_commit_event", None)
+                unregister_eod_commit = getattr(self.message_handler, "unregister_eod_commit_event", None)
+                eod_commit_registered = callable(register_eod_commit) and callable(unregister_eod_commit)
+                if eod_commit_registered:
+                    register_eod_commit(self.thread_id, eod_commit_event)
+
                 try:
-                    on_complete()
-                except Exception as e:
-                    logger.exception(f"on_complete callback error in producer: {e}")
+                    self.message_handler.put(self.thread_id, EOD_CHUNK)
+                    try:
+                        self.message_handler.flush(self.thread_id)
+                    except Exception as flush_error:
+                        if not eod_commit_registered:
+                            self._producer_completion_error = flush_error
+                            raise
+                        logger.warning(
+                            "[EOD] synchronous flush failed; waiting for background recovery "
+                            "thread_id=%s timeout=%.1fs",
+                            self.thread_id,
+                            self._EOD_COMMIT_RECOVERY_TIMEOUT,
+                            exc_info=True,
+                        )
+                        if not eod_commit_event.wait(timeout=self._EOD_COMMIT_RECOVERY_TIMEOUT):
+                            completion_error = RuntimeError(
+                                f"EOD commit did not recover within {self._EOD_COMMIT_RECOVERY_TIMEOUT:.1f}s"
+                            )
+                            self._producer_completion_error = completion_error
+                            raise completion_error from flush_error
+                        logger.info("[EOD] background flush recovered thread_id=%s", self.thread_id)
+                finally:
+                    if eod_commit_registered:
+                        unregister_eod_commit(self.thread_id, eod_commit_event)
+                logger.info(f"[EOD] Producer EOD_CHUNK sent successfully for thread_id={self.thread_id}")
 
-            # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束
-            self.message_handler.put(self.thread_id, EOD_CHUNK)
-            self.message_handler.flush(self.thread_id)
-            logger.debug(f"Producer finished, sent EOD_CHUNK for thread_id={self.thread_id}")
+                # EOD 仅负责消费者结束与队列资源回收；会话终态已在 RUN_FINISHED 入队后回写。
+                self._schedule_session_cleanup(done_event_seen=done_event_seen)
 
-            # 延迟清理：如果消费者已断开且未重连，主动释放队列资源
-            # 不能立即清理，否则会与正在读取 EOD_CHUNK 的活跃消费者竞争
-            self._schedule_session_cleanup(done_event_seen=done_event_seen)
-            if release_producer:
-                self.message_handler.release_producer(self.thread_id)
+                if on_complete and self._supports_replay_from_start():
+                    _complete_session()
+                if self._producer_completion_error is not None:
+                    raise self._producer_completion_error
+            finally:
+                if release_producer:
+                    logger.info(
+                        f"[PRODUCER] releasing producer lock thread_id={self.thread_id} "
+                        f"elapsed={time.monotonic() - _producer_start:.1f}s"
+                    )
+                    try:
+                        self.message_handler.release_producer(self.thread_id)
+                    except Exception as e:
+                        logger.exception(f"Error releasing producer for thread_id={self.thread_id}: {e}")
+
+    def _run_producer(self, **kwargs: Any) -> None:
+        """线程入口：记录 producer 终结异常，由消费线程统一向调用方传播。"""
+        try:
+            self._producer(**kwargs)
+        except Exception as exc:
+            if self._producer_completion_error is None:
+                self._producer_completion_error = exc
+            logger.exception("Producer finalization failed for thread_id=%s", self.thread_id)

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -10,10 +10,16 @@ specific language governing permissions and limitations under the License.
 """
 
 import asyncio
-from typing import AsyncGenerator
+import queue
+import threading
+from contextlib import suppress
+from contextvars import copy_context
+from logging import getLogger
+from typing import AsyncGenerator, Awaitable, Callable
 
 from aidev_agent.utils import Empty
-from aidev_agent.utils.loop import get_event_loop
+
+logger = getLogger(__name__)
 
 
 async def async_generator_with_timeout(
@@ -37,31 +43,68 @@ async def async_generator_with_timeout(
         return
 
 
-def async_to_sync_generator(async_gen):
-    data_queue = asyncio.Queue()
+def async_to_sync_generator(
+    async_gen: AsyncGenerator,
+    async_finalizer: Callable[[], Awaitable[None]] | None = None,
+):
+    """在独立 loop 中消费异步生成器，并在同一 loop 执行 finalizer。"""
+    data_queue = queue.Queue()
+    end = object()
     error = None
 
-    loop = get_event_loop()
+    loop = asyncio.new_event_loop()
+    context = copy_context()
+    task_ready = threading.Event()
+    consumer_task = None
 
-    # 定义异步消费任务
     async def consume_async():
         nonlocal error
         try:
             async for item in async_gen:
-                await data_queue.put(item)
+                data_queue.put(item)
         except Exception as e:
+            logger.warning(f"[ASYNC] consume_async error: {e}", exc_info=True)
             error = e
         finally:
-            await data_queue.put(None)  # 结束信号
+            if async_finalizer is not None:
+                try:
+                    await async_finalizer()
+                except Exception as e:
+                    if error is None:
+                        error = e
+            data_queue.put(end)
 
-    # 线程运行函数（仅当需要新线程时启动）
-    # 提交异步任务到指定循环
-    asyncio.run_coroutine_threadsafe(consume_async(), loop)
+    def run_loop():
+        nonlocal consumer_task
+        asyncio.set_event_loop(loop)
+        consumer_task = context.run(loop.create_task, consume_async())
+        task_ready.set()
+        try:
+            loop.run_until_complete(consumer_task)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            pending_tasks = asyncio.all_tasks(loop)
+            for task in pending_tasks:
+                task.cancel()
+            if pending_tasks:
+                loop.run_until_complete(asyncio.gather(*pending_tasks, return_exceptions=True))
+            with suppress(RuntimeError):
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            loop.close()
 
-    while True:
-        item = loop.run_until_complete(data_queue.get())
-        if item is None:
-            if error is not None:
-                raise error
-            break
-        yield item
+    loop_thread = threading.Thread(target=run_loop, name="aidev-async-generator", daemon=True)
+    loop_thread.start()
+    task_ready.wait()
+    try:
+        while True:
+            item = data_queue.get()
+            if item is end:
+                if error is not None:
+                    raise error
+                break
+            yield item
+    finally:
+        if not consumer_task.done():
+            loop.call_soon_threadsafe(consumer_task.cancel)
+        loop_thread.join()

--- a/src/agent/aidev_agent/utils/loop.py
+++ b/src/agent/aidev_agent/utils/loop.py
@@ -20,6 +20,12 @@ import asyncio
 import atexit
 import contextlib
 import threading
+from collections.abc import Awaitable, Callable
+from contextvars import copy_context
+from logging import getLogger
+from typing import Any
+
+logger = getLogger(__name__)
 
 # Thread-local storage for event loops
 _thread_local = threading.local()
@@ -92,18 +98,78 @@ def close_thread_loop() -> None:
     _thread_local.loop = None
 
 
-def run_coro_sync(coro, timeout=None):
+def run_coro_sync(
+    coro_or_factory: Awaitable[Any] | Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
     """Run a coroutine synchronously in the current thread's event loop.
 
-    Note: The event loop is intentionally kept open after execution, so that
-    long-lived async clients (e.g. httpx.AsyncClient) can safely reuse their
-    connections across multiple calls on the same thread. Cleanup is handled by
-    atexit registration and by async_to_sync_generator's finally block.
+    若当前线程没有 running loop，复用线程局部 loop 跑（保持 loop 开启以便
+    long-lived async client 复用连接）；若当前线程已有 running loop（嵌套调用
+    场景，如 async→sync 桥接、gevent monkey patch），仅接受协程工厂并在独立
+    线程创建、执行协程，避免把已关联当前 loop 的协程对象直接搬到新 loop。
+
+    Note: 正常分支下 event loop 故意保持开启，long-lived async client（如
+    httpx.AsyncClient）可跨多次调用复用连接；清理由 atexit 与
+    async_to_sync_generator 的 finally 块负责。
     """
     loop = get_event_loop()
+    if loop.is_running():
+        if not callable(coro_or_factory):
+            with contextlib.suppress(AttributeError):
+                coro_or_factory.close()
+            raise RuntimeError("run_coro_sync requires a coroutine factory when called from a running event loop")
+        logger.warning(
+            "[LOOP] run_coro_sync: running loop detected, delegate to new thread, thread=%s",
+            threading.current_thread().name,
+        )
+        return _run_coro_in_new_thread(coro_or_factory, timeout)
+
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
     if timeout is not None:
         coro = asyncio.wait_for(coro, timeout=timeout)
-    return loop.run_until_complete(coro)
+    try:
+        return loop.run_until_complete(coro)
+    except RuntimeError as e:
+        if "already running" in str(e):
+            logger.error(
+                "[LOOP] run_coro_sync failed: event loop already running. thread=%s, loop=%s",
+                threading.current_thread().name,
+                loop,
+            )
+        raise
+
+
+def _run_coro_in_new_thread(
+    coro_factory: Callable[[], Awaitable[Any]],
+    timeout: float | None = None,
+):
+    """在独立线程创建并执行协程，返回结果或重新抛出异常。
+
+    用于 run_coro_sync 检测到当前线程已有 running loop 的兜底场景：
+    工厂和协程都在新线程的 Context 与 event loop 内运行。
+    """
+    box: dict = {}
+    context = copy_context()
+
+    async def _execute():
+        coro = coro_factory()
+        if timeout is not None:
+            return await asyncio.wait_for(coro, timeout=timeout)
+        return await coro
+
+    def _runner():
+        try:
+            box["value"] = context.run(asyncio.run, _execute())
+        except BaseException as err:  # noqa: BLE001
+            box["error"] = err
+
+    worker = threading.Thread(target=_runner, name="run-coroutine-sync", daemon=True)
+    worker.start()
+    worker.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
 
 
 def _cleanup_thread_loop(loop):

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -16,9 +16,12 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import asyncio
 import base64
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import openai
 import pytest
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
@@ -38,12 +41,46 @@ TEST_VISION_MODELS = ["qwen3-vl-32B"]
 
 # 测试图片路径
 TEST_IMAGE_PATH = Path(__file__).parent.parent.parent.parent / "mock_data" / "bkaidev.png"
+TEST_BASE_URL = "https://llm-gateway.example.com/v1"
 
 
 def get_test_image_base64() -> str:
     """读取测试图片并返回 base64 编码"""
     with open(TEST_IMAGE_PATH, "rb") as f:
         return base64.b64encode(f.read()).decode("utf-8")
+
+
+def test_chat_model_async_clients_are_isolated_across_worker_threads():
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        models = list(
+            pool.map(
+                lambda index: ChatModel.get_setup_instance(model=f"model-{index}", base_url=TEST_BASE_URL),
+                range(16),
+            )
+        )
+
+    try:
+        clients = [model.http_async_client for model in models]
+        assert len({id(client) for client in clients}) == len(clients)
+        assert all(model._owns_http_async_client for model in models)
+    finally:
+        for client in clients:
+            asyncio.run(client.aclose())
+
+
+def test_chat_model_preserves_caller_owned_async_http_client():
+    client = openai.DefaultAsyncHttpxClient()
+    model = ChatModel.get_setup_instance(
+        model="explicit-client",
+        base_url=TEST_BASE_URL,
+        http_async_client=client,
+    )
+
+    try:
+        assert model.http_async_client is client
+        assert model._owns_http_async_client is False
+    finally:
+        asyncio.run(client.aclose())
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2,7 +2,7 @@ import json
 import threading
 import time
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
@@ -746,6 +746,20 @@ class TestOnComplete:
         agent._on_complete()
         mock_handler.set_streaming_finished.assert_called_once()
 
+    def test_background_stream_sets_finished_after_producer_commit(self):
+        """后台流由 producer 在 EOD 提交后写会话终态。"""
+        mock_handler = MagicMock(spec=BaseSessionWriter)
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"], stream_chunk_size=2),
+            checkpointer=MemorySaver(),
+            chat_history=[ChatPrompt(role="user", content="hi")],
+            event_handler=mock_handler,
+        )
+
+        list(agent.execute(ExecuteKwargs(stream=True, background_only=True)))
+
+        mock_handler.set_streaming_finished.assert_called_once()
+
     def test_on_complete_invoked_during_stream(self):
         """端到端验证：流式执行结束后 on_complete 被触发"""
         mock_handler = MagicMock(spec=BaseSessionWriter)
@@ -758,6 +772,48 @@ class TestOnComplete:
         )
         list(agent.execute(ExecuteKwargs(stream=True)))
         mock_handler.set_streaming_finished.assert_called_once()
+
+
+class TestChatModelClientCleanup:
+    @pytest.mark.asyncio
+    async def test_owned_client_is_closed_once(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model, chat_model_non_thinking=model)
+
+        with patch.object(client, "aclose", close_spy):
+            await agent._aclose_chat_models()
+
+        close_spy.assert_awaited_once()
+        assert client.is_closed
+        assert model._owns_http_async_client is False
+
+    def test_non_streaming_execute_closes_owned_client(self):
+        model = ChatModel.get_setup_instance(
+            model="primary",
+            base_url="https://llm-gateway.example.com/v1",
+        )
+        client = model.http_async_client
+        close_spy = AsyncMock(wraps=client.aclose)
+        agent = ChatCompletionAgent(chat_model=model)
+        agent_e = MagicMock()
+        agent_e.ainvoke = AsyncMock(return_value={"messages": [AIMessage(content="done", id="message-id")]})
+
+        with (
+            patch.object(agent, "_update_aidev_agent_header"),
+            patch.object(agent, "_get_agent", return_value=(agent_e, {})),
+            patch.object(agent, "_sync_checkpoint_messages"),
+            patch.object(client, "aclose", close_spy),
+        ):
+            result = agent._execute([HumanMessage(content="hello")], ExecuteKwargs(stream=False))
+
+        assert result["choices"][0]["delta"]["content"] == "done"
+        close_spy.assert_awaited_once()
+        assert client.is_closed
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_flow_agent.py
+++ b/src/agent/tests/services/test_flow_agent.py
@@ -93,6 +93,24 @@ class MockResourceManager:
         return {}
 
 
+class TestFlowAgentCompletion:
+    @patch.object(GeneratorStreamingHelper, "is_cancelled", return_value=False)
+    def test_background_execute_updates_session_after_flow_completion(self, mock_cancelled):
+        event_handler = MagicMock()
+        agent = FlowAgentCompletionAgent(
+            resource_manager=MockResourceManager(),
+            flow_start_params={"session_code": "flow-session"},
+            poll_interval=0.01,
+            poll_timeout=10.0,
+            session_code="flow-session",
+            event_handler=event_handler,
+        )
+
+        list(agent.execute(MagicMock(background_only=True)))
+
+        event_handler.set_streaming_finished.assert_called_once_with()
+
+
 class TestFlowAgentMainFlow:
     """主流程：start → SSE 流式输出 → 轮询到终态"""
 

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -1,17 +1,20 @@
 """测试 InMemoryQueueMessageHandler 的基本功能"""
 
 import contextlib
+import json
 import threading
 import time
 
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
+from ag_ui.core import EventType
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
     CANCELLED_CHUNK,
     EOD_CHUNK,
     GeneratorStreamingHelper,
     InMemoryQueueMessageHandler,
+    RetryableHeartbeatTimeoutError,
     message_handler_factory,
 )
 from aidev_agent.services.messages_handler.config import MessageHandlerConfig
@@ -23,6 +26,10 @@ from aidev_agent.utils.event import RunId, emit_run_finished_event
 def _make_run_finished_chunk(thread_id: str, run_id: str) -> str:
     """生成 RUN_FINISHED SSE 字符串，用于测试期望值对比。"""
     return emit_run_finished_event(thread_id=thread_id, run_id=run_id)
+
+
+def _event_types(chunks: list[str]) -> list[str]:
+    return [json.loads(chunk.removeprefix("data: "))["type"] for chunk in chunks if chunk.startswith("data: ")]
 
 
 class ReplayFromStartHandler:
@@ -177,18 +184,84 @@ class TestReplayFromStartStreamingHelper:
     def test_replay_mode_runs_on_complete_in_producer_once(self):
         thread_id = "test_replay_on_complete_once"
         handler = ReplayFromStartHandler()
-        completed = []
+        lifecycle = []
+        handler.flush = lambda _thread_id: lifecycle.append("flush")
 
         result = list(
             GeneratorStreamingHelper(handler, thread_id=thread_id).stream(
                 iter(["chunk_0"]),
-                on_complete=lambda: completed.append(True),
+                on_complete=lambda: lifecycle.append("complete"),
             )
         )
 
         assert result == ["chunk_0"]
-        assert completed == [True]
+        assert lifecycle == ["flush", "complete"]
         assert thread_id not in handler.producer_locks
+
+    def test_replay_mode_propagates_on_complete_failure(self):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_replay_complete_failure")
+
+        with pytest.raises(RuntimeError, match="status update failed"):
+            list(
+                helper.stream(
+                    iter(["chunk_0"]),
+                    on_complete=lambda: (_ for _ in ()).throw(RuntimeError("status update failed")),
+                )
+            )
+
+    def test_normal_agui_stream_emits_run_finished_fallback_before_eod(self):
+        handler = ReplayFromStartHandler()
+        dispatched = []
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id="thread-1").stream(
+                iter(["chunk_0"]),
+                event_handler=dispatched.append,
+                expected_run_id="run-1",
+            )
+        )
+
+        assert result[0] == "chunk_0"
+        assert _event_types(result[1:]) == [EventType.RUN_FINISHED]
+        assert [event.type for event in dispatched] == [EventType.RUN_FINISHED]
+
+    def test_normal_agui_stream_does_not_duplicate_existing_run_finished(self):
+        handler = ReplayFromStartHandler()
+        finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id="thread-1").stream(
+                iter([finished]),
+                expected_run_id="run-1",
+            )
+        )
+
+        assert result == [finished]
+
+    def test_run_finished_finalizes_session_then_closes_generator_before_eod(self, monkeypatch):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="thread-1")
+        finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
+        lifecycle = []
+
+        def terminal_generator():
+            try:
+                yield finished
+                raise AssertionError("producer read after RUN_FINISHED")
+            finally:
+                lifecycle.append("close")
+
+        original_put = handler.put
+
+        def track_eod(thread_id, message):
+            if message == EOD_CHUNK:
+                lifecycle.append("eod")
+            original_put(thread_id, message)
+
+        monkeypatch.setattr(handler, "put", track_eod)
+        assert list(helper.stream(terminal_generator(), on_complete=lambda: lifecycle.append("complete"))) == [finished]
+        assert lifecycle == ["complete", "close", "eod"]
 
 
 class TestInMemoryQueueMessageHandler:
@@ -529,8 +602,8 @@ class TestInMemoryQueueMessageHandler:
         else:
             assert result == gen_items
 
-    def test_stream_on_complete_exception_is_swallowed(self, handler):
-        """on_complete 抛异常时不影响流返回和队列清理。"""
+    def test_stream_on_complete_exception_is_propagated(self, handler):
+        """终态回写失败必须向上传播，不能留下 running 会话。"""
         thread_id = "test_stream_on_complete_error"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         callback_called = []
@@ -539,9 +612,9 @@ class TestInMemoryQueueMessageHandler:
             callback_called.append(True)
             raise RuntimeError("boom")
 
-        result = list(helper.stream(iter(["chunk_0"]), on_complete=broken_on_complete))
+        with pytest.raises(RuntimeError, match="boom"):
+            list(helper.stream(iter(["chunk_0"]), on_complete=broken_on_complete))
 
-        assert result == ["chunk_0"]
         assert callback_called
         assert handler.is_empty(thread_id)
 
@@ -569,8 +642,33 @@ class TestInMemoryQueueMessageHandler:
         assert cleanup_called.wait(timeout=0.3), "done orphaned cleanup should happen promptly without active consumer"
         assert handler.is_empty(thread_id)
 
+    def test_orphaned_cleanup_waits_for_active_replay_consumer(self, monkeypatch):
+        """replay consumer 曾活跃时，应保留队列到完整 deadline。"""
+        thread_id = "test_stream_active_replay_cleanup"
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        assert helper._PRODUCER_CLEANUP_DELAY == 90.0
+        handler.put(thread_id, "chunk_0")
+        consumer_id = handler.acquire_consumer(thread_id)
+        monkeypatch.setattr(helper, "_PRODUCER_CLEANUP_DELAY", 0.15)
+        monkeypatch.setattr(helper, "_DONE_ORPHAN_CLEANUP_GRACE", 0.02)
+        monkeypatch.setattr(helper, "_ORPHAN_CLEANUP_POLL_INTERVAL", 0.01)
+
+        helper._schedule_session_cleanup(done_event_seen=True)
+        time.sleep(0.05)
+        assert handler.has_pending_messages(thread_id)
+
+        handler.release_consumer(thread_id, consumer_id)
+        time.sleep(0.05)
+        assert handler.has_pending_messages(thread_id)
+
+        deadline = time.time() + 0.3
+        while handler.has_pending_messages(thread_id) and time.time() < deadline:
+            time.sleep(0.01)
+        assert not handler.has_pending_messages(thread_id)
+
     def test_stream_keeps_alive_when_generator_blocked(self, handler, monkeypatch):
-        """generator 长时间无产出时，独立心跳应维持连接且不超时。"""
+        """generator 长时间无产出时，独立心跳应通过 RAW 事件维持 SSE 连接。"""
         thread_id = "test_stream_heartbeat_keepalive"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 0.05)
@@ -592,22 +690,219 @@ class TestInMemoryQueueMessageHandler:
             yield "late_chunk"
 
         result = list(helper.stream(slow_first_chunk()))
-        assert result == ["late_chunk"]
+        heartbeat_events = [
+            json.loads(chunk.removeprefix("data: "))
+            for chunk in result
+            if isinstance(chunk, str) and chunk.startswith("data: ") and '"type":"RAW"' in chunk
+        ]
+
+        assert result[-1] == "late_chunk"
+        assert heartbeat_events
+        assert all(event == {"type": "RAW", "event": {"type": "heartbeat"}} for event in heartbeat_events)
         assert heartbeat_count > 0
 
-    def test_stream_raises_when_heartbeat_timeout(self, handler, monkeypatch):
-        """心跳发送慢于超时阈值时，消费者应抛出心跳超时异常。"""
+    def test_stream_emits_raw_then_raises_when_heartbeat_timeout(self, handler, monkeypatch):
+        """心跳超时先输出 RAW，再中断 SSE 触发前端重试。"""
         thread_id = "test_stream_heartbeat_timeout"
         helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
         monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.2)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.05)
+        dispatched = []
+        original_put = handler.put
+
+        def drop_heartbeat(tid, message):
+            if message != streaming_helper_module.HEARTBEAT_CHUNK:
+                original_put(tid, message)
+
+        monkeypatch.setattr(handler, "put", drop_heartbeat)
 
         def slow_first_chunk():
-            time.sleep(0.8)
+            time.sleep(1.2)
             yield "late_chunk"
 
-        with pytest.raises(RuntimeError, match="心跳超时"):
-            list(helper.stream(slow_first_chunk()))
+        stream = helper.stream(slow_first_chunk(), event_handler=dispatched.append)
+        error_chunk = next(stream)
+
+        assert _event_types([error_chunk]) == ["RAW"]
+        assert json.loads(error_chunk.removeprefix("data: "))["event"] == {
+            "type": "error",
+            "message": helper._HEARTBEAT_TIMEOUT_MESSAGE,
+        }
+        assert [event.type for event in dispatched] == [EventType.RAW]
+        with pytest.raises(RetryableHeartbeatTimeoutError, match="生产者心跳超时"):
+            next(stream)
+
+    def test_replay_stream_uses_extended_heartbeat_timeout(self, monkeypatch):
+        """RabbitMQ replay 使用独立的较长心跳窗口，不受通用 15 秒阈值影响。"""
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_replay_heartbeat_timeout")
+        assert helper._REPLAY_HEARTBEAT_TIMEOUT == 60.0
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+        calls = 0
+
+        def delayed_eod(*, timeout, replay_offset):
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise TimeoutError
+            return [EOD_CHUNK], replay_offset + 1
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_REPLAY_HEARTBEAT_TIMEOUT", 0.2)
+        monkeypatch.setattr(helper, "_get_consumer_messages", delayed_eod)
+        stream = helper._consume_stream_messages(
+            handler.acquire_consumer(helper.thread_id), threading.Event(), False, True, producer_thread=producer_thread
+        )
+
+        assert (list(stream), calls) == ([], 3)
+
+    def test_background_stream_keeps_running_during_heartbeat_recovery(self, handler, monkeypatch):
+        """后台 schedule 无前端可接管，producer 存活时心跳超时应继续消费。"""
+        thread_id = "test_background_heartbeat_recovery"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id, defer_cleanup_on_complete=True)
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_INTERVAL", 1.0)
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.1)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.02)
+        monkeypatch.setattr(helper, "_BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT", 2.0)
+        original_put = handler.put
+
+        def drop_heartbeat(tid, message):
+            if message != streaming_helper_module.HEARTBEAT_CHUNK:
+                original_put(tid, message)
+
+        monkeypatch.setattr(handler, "put", drop_heartbeat)
+
+        def delayed_chunk():
+            time.sleep(1.2)
+            yield "late_chunk"
+
+        result = list(helper.stream(delayed_chunk()))
+
+        assert result == ["late_chunk"]
+
+    def test_background_stream_waits_for_delayed_eod_after_producer_finished(self, handler, monkeypatch):
+        """producer 已结束但 EOD 暂不可见时，后台消费者不应立即误报失败。"""
+        helper = GeneratorStreamingHelper(handler, thread_id="test_delayed_eod", defer_cleanup_on_complete=True)
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+        calls = 0
+
+        def delayed_eod(*, timeout, replay_offset):
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise TimeoutError
+            return [streaming_helper_module.EOD_CHUNK], replay_offset + 1
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_HEARTBEAT_TIMEOUT_GRACE", 0.0)
+        monkeypatch.setattr(helper, "_BACKGROUND_HEARTBEAT_RECOVERY_TIMEOUT", 1.0)
+        monkeypatch.setattr(helper, "_get_consumer_messages", delayed_eod)
+
+        stream = helper._consume_stream_messages(
+            handler.acquire_consumer(helper.thread_id), threading.Event(), False, True, producer_thread=producer_thread
+        )
+
+        assert (list(stream), calls) == ([], 3)
+
+    def test_producer_error_emits_terminal_events(self, handler):
+        """producer 异常应形成完整终止事件对并同步分发。"""
+        helper = GeneratorStreamingHelper(handler, thread_id="test_producer_error")
+        dispatched = []
+        completed = []
+
+        def broken_generator():
+            yield "chunk"
+            raise RuntimeError("producer failed")
+
+        result = list(
+            helper.stream(
+                broken_generator(),
+                event_handler=dispatched.append,
+                on_complete=lambda: completed.append(True),
+            )
+        )
+
+        assert result[0] == "chunk"
+        assert _event_types(result[1:]) == ["RUN_ERROR", "RUN_FINISHED"]
+        assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+        assert completed == [True]
+
+    def test_producer_releases_lock_when_eod_flush_fails(self, handler, monkeypatch):
+        thread_id = "test_producer_flush_failure"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        assert handler.acquire_producer(thread_id)
+
+        def fail_flush(thread_id):
+            raise RuntimeError("flush failed")
+
+        monkeypatch.setattr(handler, "flush", fail_flush)
+
+        with pytest.raises(RuntimeError, match="flush failed"):
+            helper._producer(
+                iter(["chunk"]),
+                release_producer=True,
+            )
+
+        assert handler.acquire_producer(thread_id)
+
+    def test_producer_waits_for_background_eod_commit_before_completion(self, monkeypatch):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="test_eod_recovery")
+        committed_event = None
+        lifecycle = []
+
+        def register(_thread_id, event):
+            nonlocal committed_event
+            committed_event = event
+
+        monkeypatch.setattr(handler, "register_eod_commit_event", register, raising=False)
+        monkeypatch.setattr(handler, "unregister_eod_commit_event", lambda *_args: None, raising=False)
+
+        def fail_after_background_commit(_thread_id):
+            committed_event.set()
+            raise RuntimeError("sync flush failed")
+
+        monkeypatch.setattr(handler, "flush", fail_after_background_commit)
+        helper._producer(iter(["chunk"]), on_complete=lambda: lifecycle.append("complete"))
+
+        assert lifecycle == ["complete"]
+
+    def test_stream_treats_missing_eod_as_error(self, handler, monkeypatch):
+        """即使 producer 标记成功，未消费到 EOD 也不能静默判定完成。"""
+        thread_id = "test_stream_finished_without_eod"
+        helper = GeneratorStreamingHelper(handler, thread_id=thread_id)
+        consumer_id = handler.acquire_consumer(thread_id)
+        completed_threads = []
+
+        def timeout_without_messages(*, timeout, replay_offset):
+            raise TimeoutError
+
+        producer_thread = threading.Thread(target=lambda: None)
+        producer_thread.start()
+        producer_thread.join()
+
+        monkeypatch.setattr(streaming_helper_module, "HEARTBEAT_TIMEOUT", 0.0)
+        monkeypatch.setattr(helper, "_get_consumer_messages", timeout_without_messages)
+        monkeypatch.setattr(handler, "mark_completed", completed_threads.append)
+
+        stream = helper._consume_stream_messages(
+            consumer_id=consumer_id,
+            cancel_event=threading.Event(),
+            is_resuming=False,
+            enable_heartbeat_check=True,
+            producer_thread=producer_thread,
+        )
+
+        error_chunk = next(stream)
+        assert _event_types([error_chunk]) == ["RAW"]
+        with pytest.raises(RuntimeError, match="生产者心跳超时"):
+            next(stream)
+        assert completed_threads == []
 
 
 class TestMessageHandlerConfig:

--- a/src/agent/tests/services/test_rabbitmq_release_producer.py
+++ b/src/agent/tests/services/test_rabbitmq_release_producer.py
@@ -1,0 +1,72 @@
+"""release_producer 容错单测：连接被对端重置时不应抛异常。
+
+复现 celery 日志中 _producer 线程 release_producer → connection.channel()
+抛 StreamLostError 导致 "Exception in thread" 的问题。
+"""
+
+import threading
+
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler():
+    # 绕过单例 __new__ 与 _init_rabbitmq（后者需要真实 RabbitMQ 连接）
+    handler = object.__new__(RabbitMQMessageHandler)
+    handler._producer_lock_connections = {}
+    handler._producer_lock_guard = threading.Lock()
+    return handler
+
+
+class _FakeConnection:
+    """模拟已被对端重置的 RabbitMQ 连接：本地状态仍认为 open，但底层 stream 已断。"""
+
+    def __init__(self, channel_error):
+        self.is_open = True
+        self._channel_error = channel_error
+        self.closed = False
+
+    def channel(self):
+        raise self._channel_error
+
+    def close(self):
+        self.closed = True
+        self.is_open = False
+
+
+def test_release_producer_tolerates_stream_lost_error():
+    """connection.channel() 抛 StreamLostError 时，release_producer 不应抛异常。"""
+    from pika.exceptions import StreamLostError
+
+    handler = _make_handler()
+    thread_id = "test-stream-lost"
+    conn = _FakeConnection(StreamLostError("Stream connection lost"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)  # 不应抛异常
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_tolerates_connection_reset_error():
+    """connection.channel() 抛 ConnectionResetError 时，release_producer 不应抛异常。"""
+    handler = _make_handler()
+    thread_id = "test-conn-reset"
+    conn = _FakeConnection(ConnectionResetError(104, "Connection reset by peer"))
+    handler._producer_lock_connections[thread_id] = conn
+
+    handler.release_producer(thread_id)
+
+    assert thread_id not in handler._producer_lock_connections
+    assert conn.closed is True
+
+
+def test_release_producer_no_connection_is_safe():
+    """没有待释放的连接时，release_producer 应安全返回。"""
+    handler = _make_handler()
+    handler.release_producer("nonexistent-thread")  # 不应抛异常
+
+
+def test_rabbitmq_read_write_intervals_are_half_second():
+    assert RabbitMQMessageHandler.BUFFER_FLUSH_INTERVAL == 0.5
+    assert RabbitMQMessageHandler.REPLAY_MESSAGE_RETRY_INTERVAL == 0.5

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -1,0 +1,136 @@
+import contextlib
+import pickle
+import threading
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.services.messages_handler.constants import EOD_CHUNK
+from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
+
+
+def _make_handler(message_count: int, messages: list[str]) -> tuple[RabbitMQMessageHandler, MagicMock]:
+    handler = object.__new__(RabbitMQMessageHandler)
+    channel = MagicMock()
+    channel.queue_declare.return_value.method.message_count = message_count
+
+    handler._get_flush_peek_lock = MagicMock(return_value=threading.Lock())
+    handler._with_replay_lock = MagicMock(return_value=contextlib.nullcontext(channel))
+    handler._ensure_queue = MagicMock(return_value="replay-queue")
+    handler._peek_queue_messages = MagicMock(return_value=messages)
+    handler._get_dlq_count = MagicMock(return_value=0)
+    handler._restore_from_dlq = MagicMock(return_value=0)
+    return handler, channel
+
+
+def test_get_messages_since_skips_full_peek_without_new_messages():
+    handler, channel = _make_handler(message_count=835, messages=[])
+
+    with pytest.raises(TimeoutError, match="No message available within timeout"):
+        handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    channel.queue_declare.assert_called_once_with(queue="replay-queue", durable=True, passive=True)
+    handler._peek_queue_messages.assert_not_called()
+
+
+def test_get_messages_since_peeks_when_queue_has_new_messages():
+    messages = [f"message-{index}" for index in range(836)]
+    handler, channel = _make_handler(message_count=836, messages=messages)
+
+    new_messages, next_offset = handler.get_messages_since("thread-id", offset=835, timeout=0)
+
+    assert new_messages == ["message-835"]
+    assert next_offset == 836
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+
+
+def test_get_messages_since_preserves_legacy_dlq_restore():
+    handler, channel = _make_handler(message_count=0, messages=["restored-message"])
+    channel.queue_declare.side_effect = [
+        MagicMock(method=MagicMock(message_count=0)),
+        MagicMock(method=MagicMock(message_count=1)),
+    ]
+    handler._get_dlq_count.return_value = 1
+    handler._restore_from_dlq.return_value = 1
+
+    messages, next_offset = handler.get_messages_since("thread-id", offset=0, timeout=0)
+
+    assert messages == ["restored-message"]
+    assert next_offset == 1
+    handler._restore_from_dlq.assert_called_once_with("thread-id")
+    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+
+
+def test_eod_commit_event_is_notified_only_after_eod_publish():
+    handler = object.__new__(RabbitMQMessageHandler)
+    handler._eod_commit_events = {}
+    handler._eod_commit_events_lock = threading.Lock()
+    event = threading.Event()
+
+    handler.register_eod_commit_event("thread-id", event)
+    handler._notify_eod_committed("thread-id", ["chunk"])
+    assert not event.is_set()
+
+    handler._notify_eod_committed("thread-id", [EOD_CHUNK])
+    assert event.is_set()
+    assert "thread-id" not in handler._eod_commit_events
+
+
+def test_coalesce_sse_messages_preserves_mixed_order_and_eod():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    third = 'data: {"type":"RUN_FINISHED"}\n\n'
+
+    messages = RabbitMQMessageHandler._coalesce_sse_messages([first, second, "legacy-message", third, EOD_CHUNK])
+
+    assert messages == [first + second, "legacy-message", third, EOD_CHUNK]
+
+
+def test_expand_sse_messages_restores_original_frames():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+
+    messages = RabbitMQMessageHandler._expand_sse_messages([first + second, "legacy-message", EOD_CHUNK])
+
+    assert messages == [first, second, "legacy-message", EOD_CHUNK]
+
+
+def test_coalesce_sse_messages_splits_by_utf8_bytes(monkeypatch):
+    first = "data: 一\n\n"
+    second = "data: 二\n\n"
+    monkeypatch.setattr(RabbitMQMessageHandler, "SSE_PUBLISH_CHUNK_MAX_BYTES", len(first.encode("utf-8")))
+
+    messages = RabbitMQMessageHandler._coalesce_sse_messages([first, second])
+
+    assert messages == [first, second]
+
+
+def test_flush_publishes_coalesced_sse_and_eod():
+    handler = object.__new__(RabbitMQMessageHandler)
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    channel = MagicMock()
+    handler._buffer_lock = threading.Lock()
+    handler._message_buffer = {"thread-id": [first, second, EOD_CHUNK]}
+    handler._get_flush_peek_lock = MagicMock(return_value=threading.Lock())
+    handler._with_channel = MagicMock(return_value=contextlib.nullcontext(channel))
+    handler._ensure_queue = MagicMock(return_value="replay-queue")
+    handler._notify_eod_committed = MagicMock()
+    handler._notify_replay_waiters = MagicMock()
+
+    handler.flush("thread-id")
+
+    published = [pickle.loads(call.kwargs["body"]) for call in channel.basic_publish.call_args_list]
+    assert published == [first + second, EOD_CHUNK]
+    handler._notify_eod_committed.assert_called_once_with("thread-id", [first, second, EOD_CHUNK])
+
+
+def test_get_messages_since_replays_mixed_physical_messages():
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    stored_messages = ["legacy-message", first + second, EOD_CHUNK]
+    handler, _ = _make_handler(message_count=3, messages=stored_messages)
+
+    messages, next_offset = handler.get_messages_since("thread-id", offset=1, timeout=0)
+
+    assert messages == [first, second, EOD_CHUNK]
+    assert next_offset == 3

--- a/src/agent/tests/utils/test_async_utils.py
+++ b/src/agent/tests/utils/test_async_utils.py
@@ -47,6 +47,47 @@ def test_async_to_sync_generator():
     assert result == ["run_id-0", "run_id-1", "run_id-2"]
 
 
+@pytest.mark.asyncio
+async def test_async_to_sync_generator_in_running_loop():
+    request_local.run_id = "async"
+
+    result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
+
+    assert result == ["async-0", "async-1", "async-2"]
+
+
+def test_async_to_sync_generator_runs_finalizer_on_consumer_loop():
+    loop_ids: list[int] = []
+
+    async def _gen():
+        loop_ids.append(id(asyncio.get_running_loop()))
+        yield "value"
+
+    async def _finalize():
+        loop_ids.append(id(asyncio.get_running_loop()))
+
+    assert list(async_to_sync_generator(_gen(), async_finalizer=_finalize)) == ["value"]
+    assert len(set(loop_ids)) == 1
+
+
+def test_async_to_sync_generator_finalizes_when_consumer_closes():
+    finalized = False
+
+    async def _gen():
+        yield "value"
+        await asyncio.Event().wait()
+
+    async def _finalize():
+        nonlocal finalized
+        finalized = True
+
+    generator = async_to_sync_generator(_gen(), async_finalizer=_finalize)
+    assert next(generator) == "value"
+    generator.close()
+
+    assert finalized is True
+
+
 async def test_async_gen_with_timeout():
     request_local.run_id = "run_id"
     result = [each async for each in async_generator_with_timeout(gen(), timeout=0.18)]
@@ -63,7 +104,6 @@ def test_async_to_sync_generator_in_worker_thread():
     def _consume():
         request_local.run_id = "worker"
         result = list(async_to_sync_generator(async_generator_with_timeout(gen(), timeout=10)))
-        # get_event_loop() 会在 worker 线程缓存事件循环用于复用，has_loop 为 True 是预期行为
         has_loop = hasattr(_thread_local, "loop") and _thread_local.loop is not None
         return result, has_loop
 
@@ -71,4 +111,4 @@ def test_async_to_sync_generator_in_worker_thread():
         result, has_loop = pool.submit(_consume).result()
 
     assert result == ["worker-0", "worker-1", "worker-2"]
-    assert has_loop is True
+    assert has_loop is False

--- a/src/agent/tests/utils/test_loop.py
+++ b/src/agent/tests/utils/test_loop.py
@@ -1,5 +1,6 @@
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
+from contextvars import ContextVar
 
 import pytest
 
@@ -133,3 +134,45 @@ def test_run_coro_sync_preserves_worker_thread_loop():
 
     assert result == 10
     assert has_loop is True
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_delegates_to_new_thread():
+    """已有 running loop 时，run_coro_sync 应委托独立线程执行，不抛 already running。
+
+    复现 construct_mcp 在 async→sync 桥接上下文被调用导致
+    "This event loop is already running" 的场景。
+    """
+    marker = ContextVar("marker", default="")
+    token = marker.set("request-context")
+
+    async def _probe():
+        await asyncio.sleep(0)
+        return marker.get()
+
+    try:
+        assert run_coro_sync(_probe) == "request-context"
+    finally:
+        marker.reset(token)
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_propagates_exception():
+    """已有 running loop 时，协程抛出的异常应原样冒泡到调用方。"""
+
+    async def _boom():
+        raise ValueError("boom")
+
+    with pytest.raises(ValueError, match="boom"):
+        run_coro_sync(_boom)
+
+
+@pytest.mark.asyncio
+async def test_run_coro_sync_with_running_loop_rejects_coroutine_object():
+    """running loop 下必须传工厂，避免搬运已关联当前 loop 的协程对象。"""
+
+    async def _probe():
+        return "ok"
+
+    with pytest.raises(RuntimeError, match="requires a coroutine factory"):
+        run_coro_sync(_probe())

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
@@ -21,10 +21,11 @@ from __future__ import annotations
 import json
 import random
 import threading
+import time
 from collections.abc import AsyncIterator, Iterator, Sequence
 from typing import Any, Optional, Tuple, cast
 
-from django.db import connections, router, transaction
+from django.db import OperationalError, close_old_connections, connections, router, transaction
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
     WRITES_IDX_MAP,
@@ -39,6 +40,10 @@ from langgraph.checkpoint.base import (
 )
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import ChannelProtocol
+
+RETRYABLE_DATABASE_ERROR_CODES = {1205, 1213}
+CHECKPOINT_WRITE_MAX_RETRIES = 3
+CHECKPOINT_WRITE_RETRY_DELAY_SECONDS = 0.05
 
 
 def bulk_upsert(model, objs, update_fields, unique_fields):
@@ -605,17 +610,26 @@ class BKDjangoSaver(BaseCheckpointSaver[str]):
         serialized_metadata = json.loads(json.dumps(raw_metadata, default=str).replace("\\u0000", ""))
         # 使用Django的update_or_create方法
         with self.lock:
-            self.checkpoint_model.objects.update_or_create(
-                thread_id=thread_id,
-                checkpoint_ns=checkpoint_ns,
-                checkpoint_id=checkpoint["id"],
-                defaults={
-                    "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
-                    "type": type_,
-                    "checkpoint": serialized_checkpoint,
-                    "metadata": serialized_metadata,
-                },
-            )
+            for attempt in range(CHECKPOINT_WRITE_MAX_RETRIES):
+                try:
+                    self.checkpoint_model.objects.update_or_create(
+                        thread_id=thread_id,
+                        checkpoint_ns=checkpoint_ns,
+                        checkpoint_id=checkpoint["id"],
+                        defaults={
+                            "parent_checkpoint_id": config["configurable"].get("checkpoint_id"),
+                            "type": type_,
+                            "checkpoint": serialized_checkpoint,
+                            "metadata": serialized_metadata,
+                        },
+                    )
+                    break
+                except OperationalError as exc:
+                    error_code = exc.args[0] if exc.args else None
+                    if error_code not in RETRYABLE_DATABASE_ERROR_CODES or attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1:
+                        raise
+                    close_old_connections()
+                    time.sleep(CHECKPOINT_WRITE_RETRY_DELAY_SECONDS * (2**attempt))
 
         return {
             "configurable": {

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
@@ -16,17 +16,19 @@
 from __future__ import annotations
 
 import logging
+import threading
 import uuid
 from abc import ABC, abstractmethod
 from typing import Any, ClassVar
 
 from aidev_agent.config import settings as agent_settings
-from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole
+from aidev_agent.enums import AgentBuildType, AgentType, ChannelType, PromptRole, SessionsStatus
 from aidev_agent.packages.resource_manager.agent import AgentResourceManager
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent import AgentInstanceFactory
 from aidev_agent.services.common_agent import common_agent_factory
 from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+from aidev_agent.services.messages_handler import RetryableHeartbeatTimeoutError
 from aidev_agent.utils.local import request_local
 from django.contrib.auth import get_user_model
 
@@ -172,6 +174,13 @@ class BkpluginAgentRunner(ABC):
         """同步执行 Agent，返回最终 AI 回复字符串；异常时写回失败状态 (D-01)。"""
         try:
             return self._do_execute()
+        except RetryableHeartbeatTimeoutError:
+            logger.warning(
+                "[Bkplugin] skip session terminal update for retryable consumer heartbeat timeout session_code=%s",
+                self.session_code or "",
+                exc_info=True,
+            )
+            raise
         except Exception as e:
             logger.exception("[Bkplugin] execute error: %s", e)
             session_code = self.session_code or ""
@@ -211,12 +220,51 @@ class BkpluginAgentRunner(ABC):
         *,
         chat_context: list[dict] | None = None,
     ) -> None:
-        """Celery worker 入口：捕获异常并写 session 失败状态。"""
+        """Celery worker 入口：业务异常写失败；可重试消费异常保持 session 原状态。"""
+        logger.info(
+            "[Bkplugin] run_worker enter session_code=%s turn_id=%s thread=%s",
+            session_code,
+            execute_payload.get("turn_id") or "",
+            threading.current_thread().name,
+        )
         try:
             self.invoke_agent(session_code, execute_payload, chat_context=chat_context or [])
+        except RetryableHeartbeatTimeoutError:
+            logger.warning(
+                "[Bkplugin] skip session terminal update for retryable consumer heartbeat timeout "
+                "session_code=%s turn_id=%s",
+                session_code,
+                execute_payload.get("turn_id") or "",
+                exc_info=True,
+            )
         except Exception as e:
             logger.exception("[Bkplugin] worker error session_code=%s", session_code)
-            SessionManager(self.username or "").save_stream_failure(
+            manager = SessionManager(self.username or "")
+            # 幂等保护：心跳超时误报时 producer 实际已完成（session=FINISHED），
+            # 不应再覆盖为 FAILED。仅当 session 仍处于非终态时才写失败，
+            # 避免覆盖已确定的终态（FINISHED/CANCELLED/FAILED）。
+            try:
+                current_status = str(manager.retrieve_session(session_code).get("status") or "")
+            except Exception:
+                logger.exception(
+                    "[Bkplugin] retrieve_session failed before save_stream_failure session_code=%s",
+                    session_code,
+                )
+                current_status = ""
+            if current_status in (
+                SessionsStatus.FINISHED.value,
+                SessionsStatus.CANCELLED.value,
+                SessionsStatus.FAILED.value,
+            ):
+                logger.warning(
+                    "[Bkplugin] skip save_stream_failure: session already %s "
+                    "(likely heartbeat-timeout false positive) session_code=%s exc=%r",
+                    current_status,
+                    session_code,
+                    e,
+                )
+                return
+            manager.save_stream_failure(
                 session_code,
                 f"Agent 执行异常: {e}",
                 turn_id=execute_payload.get("turn_id") or "",

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -77,6 +77,9 @@ class AgentExecutor:
         result = agent_instance.execute(execute_kwargs)
         # 非流式 ainvoke 不经过 AG-UI 事件分发，必须显式写回 assistant
         self.session_manager.save_ai_response(session_code, result, turn_id=turn_id)
+        event_handler = getattr(agent_instance, "event_handler", None)
+        if isinstance(event_handler, BaseSessionWriter) and hasattr(event_handler, "set_streaming_finished"):
+            event_handler.set_streaming_finished()
         return result
 
     @classmethod
@@ -89,7 +92,7 @@ class AgentExecutor:
         *,
         turn_id: str = "",
     ):
-        """执行 agent 直至结束；AG-UI 流式负责事件落库并收尾会话状态。"""
+        """执行 agent 直至结束；会话终态由 Agent 流完成回调统一写入。"""
         # 后台 drain（for _ in out: pass，无 SSE 下游）：标记为 background_only，
         # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
         execute_kwargs.background_only = True
@@ -99,24 +102,16 @@ class AgentExecutor:
                 handler.turn_id = turn_id
             if hasattr(handler, "set_streaming_started"):
                 handler.set_streaming_started()
-        try:
-            out = cls(session_manager).execute_with_save(
-                agent_instance,
-                execute_kwargs,
-                session_code,
-                turn_id=turn_id,
-            )
-            if execute_kwargs.stream:
-                for _ in out:
-                    pass
-            return out
-        finally:
-            if (
-                execute_kwargs.stream
-                and isinstance(handler, BaseSessionWriter)
-                and hasattr(handler, "set_streaming_finished")
-            ):
-                handler.set_streaming_finished()
+        out = cls(session_manager).execute_with_save(
+            agent_instance,
+            execute_kwargs,
+            session_code,
+            turn_id=turn_id,
+        )
+        if execute_kwargs.stream:
+            for _ in out:
+                pass
+        return out
 
     def wrap_generator(self, generator, session_code: str, *, turn_id: str = ""):
         """SSE 数据格式约定：

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -238,24 +238,39 @@ class SessionManager:
         if status in (SessionsStatus.PENDING.value, SessionsStatus.RUNNING.value):
             return PluginPollTaskState.RUNNING, ""
         if status in (SessionsStatus.FAILED.value, SessionsStatus.CANCELLED.value):
-            return PluginPollTaskState.FAILED, "Agent 执行失败"
-        if status == SessionsStatus.FINISHED.value:
-            return PluginPollTaskState.SUCCESS, self._last_assistant_output(
+            # 取回 save_stream_failure 写入的实际异常内容，避免 UI 只显示通用 "Agent 执行失败"
+            return PluginPollTaskState.FAILED, self._last_output(
                 self.list_session_contents(session_code),
                 turn_id=turn_id,
+                statuses=(ChatContentStatus.ERROR.value,),
+            ) or "Agent 执行失败"
+        if status == SessionsStatus.FINISHED.value:
+            return PluginPollTaskState.SUCCESS, self._last_output(
+                self.list_session_contents(session_code),
+                turn_id=turn_id,
+                statuses=(ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value),
             )
         return PluginPollTaskState.RUNNING, ""
 
     @staticmethod
-    def _last_assistant_output(items: list[dict], *, turn_id: str = "") -> str:
-        """取最后一条有内容的 assistant/ai；有 ``turn_id`` 时仅取同轮消息。"""
+    def _last_output(
+        items: list[dict],
+        *,
+        turn_id: str = "",
+        statuses: tuple[str, ...],
+    ) -> str:
+        """取最后一条指定 status 的 assistant/ai 内容；有 ``turn_id`` 时仅取同轮消息。
+
+        FINISHED 取 COMPLETE/SUCCESS 的正常回复；FAILED/CANCELLED 取 ERROR 的实际异常
+        （save_stream_failure 写入），避免上层只看到通用 "Agent 执行失败"。
+        """
         assistant_roles = (PromptRole.ASSISTANT.value, PromptRole.AI.value)
         for item in reversed(items):
             if item.get("role") not in assistant_roles:
                 continue
             if turn_id and (item.get("property") or {}).get("turn_id") != turn_id:
                 continue
-            if item.get("status") not in (ChatContentStatus.COMPLETE.value, ChatContentStatus.SUCCESS.value):
+            if item.get("status") not in statuses:
                 continue
             text = str(item.get("content") or "").strip()
             if text:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -17,7 +17,13 @@ from aidev_bkplugin.services.agent_builder import AgentBuilder
 from aidev_bkplugin.services.agent_execution import AgentExecutor
 from aidev_bkplugin.services.agent_helpers import AgentHelper
 from aidev_bkplugin.services.agent_session import SessionManager
-from aidev_bkplugin.views.base import IgnoreClientContentNegotiation, PluginResourceManager, PluginViewSet, client, logger
+from aidev_bkplugin.views.base import (
+    IgnoreClientContentNegotiation,
+    PluginResourceManager,
+    PluginViewSet,
+    client,
+    logger,
+)
 
 
 class ChatCompletionViewSet(PluginViewSet):
@@ -136,9 +142,7 @@ class ChatCompletionViewSet(PluginViewSet):
                         session_code,
                         model,
                     )
-            agent_instance = AgentBuilder(
-                username=request.user.username, turn_id=turn_id, model=model
-            ).by_session_code(
+            agent_instance = AgentBuilder(username=request.user.username, turn_id=turn_id, model=model).by_session_code(
                 session_code,
                 version=execute_kwargs.version,
                 channel_type=self.channel_type,
@@ -155,14 +159,8 @@ class ChatCompletionViewSet(PluginViewSet):
                     turn_id=turn_id,
                 )
                 handler = getattr(agent_instance, "event_handler", None)
-                if handler and all(hasattr(handler, m) for m in ["set_streaming_started", "set_streaming_finished"]):
+                if handler and hasattr(handler, "set_streaming_started"):
                     handler.set_streaming_started()
-                    stream_out = self._wrap_streaming_with_status(
-                        stream_out,
-                        handler,
-                        session_code=session_code,
-                        username=username,
-                    )
                 return self.streaming_response(stream_out, session_code=session_code)
             else:
                 result = AgentExecutor(SessionManager(username=username)).execute_with_save(
@@ -408,16 +406,8 @@ class ChatCompletionViewSet(PluginViewSet):
             raise ClientBlueException(message=message)
 
         logger.info(f"[FLOW_AGENT] Streaming started: session_code={session_code}, task_id={task_id}")
-        if event_handler and all(
-            hasattr(event_handler, m) for m in ["set_streaming_started", "set_streaming_finished"]
-        ):
+        if event_handler and hasattr(event_handler, "set_streaming_started"):
             event_handler.set_streaming_started()
-            generator = self._wrap_streaming_with_status(
-                generator,
-                event_handler,
-                session_code=session_code,
-                username=username,
-            )
         return self.streaming_response(generator, session_code=session_code)
 
     def _wrap_streaming_with_status(self, generator, event_handler, session_code: str = "", username: str = ""):
@@ -431,9 +421,11 @@ class ChatCompletionViewSet(PluginViewSet):
         _preempted = False
         _client_disconnected = False
         _cancelled = False
+        _stream_completed = False
         try:
             for chunk in generator:
                 yield chunk
+            _stream_completed = True
         except GeneratorExit:
             _client_disconnected = True
             logger.info(f"[WRAP_STATUS] Client disconnected (GeneratorExit): session_code={session_code}")
@@ -455,7 +447,7 @@ class ChatCompletionViewSet(PluginViewSet):
                 if GeneratorStreamingHelper.is_cancelled(session_code):
                     _cancelled = True
                     logger.info(f"[WRAP_STATUS] Generator结束后检测到取消标志: session_code={session_code}")
-            if not _preempted and not _client_disconnected and not _cancelled:
+            if _stream_completed and not _preempted and not _client_disconnected and not _cancelled:
                 logger.info(f"[WRAP_STATUS] 流正常结束, 调用 set_streaming_finished: session_code={session_code}")
                 event_handler.set_streaming_finished()
 

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+import threading
+
+import pytest
+from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver
+from django.db import OperationalError
+
+
+@pytest.fixture
+def saver(mocker):
+    instance = object.__new__(BKDjangoSaver)
+    instance.lock = threading.Lock()
+    instance.checkpoint_model = mocker.Mock()
+    instance.serde = mocker.Mock()
+    instance.serde.dumps_typed.return_value = ("json", b"checkpoint")
+    return instance
+
+
+@pytest.fixture
+def checkpoint_args():
+    return (
+        {"configurable": {"thread_id": "thread-id"}},
+        {"id": "checkpoint-id"},
+        {},
+        {},
+    )
+
+
+@pytest.mark.parametrize("error_code", [1205, 1213])
+def test_put_retries_transient_database_lock_error(mocker, saver, checkpoint_args, error_code):
+    saver.checkpoint_model.objects.update_or_create.side_effect = [
+        OperationalError(error_code, "retryable"),
+        (mocker.Mock(), True),
+    ]
+    close_old_connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    saver.put(*checkpoint_args)
+
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 2
+    close_old_connections.assert_called_once_with()
+    sleep.assert_called_once_with(0.05)
+
+
+def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args):
+    error = OperationalError(2006, "server has gone away")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 1
+    sleep.assert_not_called()
+
+
+def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpoint_args):
+    error = OperationalError(1213, "deadlock")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 3
+    assert [call.args[0] for call in sleep.call_args_list] == [0.05, 0.1]

--- a/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agent_completion.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+"""后台 Agent 流式终态写入回归测试。"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if "pkg_resources" not in sys.modules:
+    sys.modules["pkg_resources"] = MagicMock()
+
+sys.modules.setdefault("aidev_bkplugin.models", MagicMock())
+_bk_plugin_framework = MagicMock()
+_bk_plugin_framework.kit.decorators.inject_user_token = lambda func: func
+sys.modules.setdefault("bk_plugin_framework", _bk_plugin_framework)
+sys.modules.setdefault("bk_plugin_framework.kit", _bk_plugin_framework.kit)
+sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framework.kit.decorators)
+
+
+class TestAgentExecutorCompletion:
+    def test_non_streaming_sets_finished_after_response_is_saved(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        result = {"choices": [{"delta": {"content": "done"}}]}
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        agent.execute.return_value = result
+        execute_kwargs = MagicMock(stream=False)
+        manager = MagicMock()
+
+        assert (
+            AgentExecutor(manager).execute_with_save(agent, execute_kwargs, "session-abc", turn_id="turn-1") == result
+        )
+        manager.save_ai_response.assert_called_once_with("session-abc", result, turn_id="turn-1")
+        handler.set_streaming_finished.assert_called_once_with()
+
+    def test_drain_does_not_write_terminal_state(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        lifecycle = []
+
+        def stream():
+            yield "chunk"
+            lifecycle.append("drained")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with patch.object(AgentExecutor, "execute_with_save", return_value=stream()):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        assert execute_kwargs.background_only is True
+        assert lifecycle == ["drained"]
+        handler.set_streaming_finished.assert_not_called()
+
+    def test_does_not_set_finished_when_stream_drain_fails(self):
+        from aidev_agent.services.event_handlers.base import BaseSessionWriter
+        from aidev_bkplugin.services.agent_execution import AgentExecutor
+
+        def failing_stream():
+            yield "chunk"
+            raise RuntimeError("producer heartbeat timeout")
+
+        handler = MagicMock(spec=BaseSessionWriter)
+        agent = MagicMock(event_handler=handler)
+        execute_kwargs = MagicMock(stream=True)
+        with (
+            patch.object(AgentExecutor, "execute_with_save", return_value=failing_stream()),
+            pytest.raises(RuntimeError, match="heartbeat timeout"),
+        ):
+            AgentExecutor.run_agent_to_completion(agent, execute_kwargs, "session-abc", MagicMock())
+
+        handler.set_streaming_finished.assert_not_called()

--- a/src/plugins/aidev_bkplugin/tests/services/test_agui_handler.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_agui_handler.py
@@ -254,8 +254,8 @@ class TestCustomEventSessionPath:
 class TestHandleRunError:
     """测试 handle_run_error 的回写逻辑"""
 
-    def test_run_error_writes_fail_status(self, session_writer, mock_client):
-        """运行错误时回写 fail 状态"""
+    def test_run_error_defers_session_status(self, session_writer, mock_client):
+        """RUN_ERROR 只记录错误内容，不能抢先写会话终态。"""
         event = RunErrorEvent(type=EventType.RUN_ERROR, message="执行过程中发生错误")
 
         session_writer(event)
@@ -268,11 +268,7 @@ class TestHandleRunError:
         assert payload["role"] == PromptRole.ASSISTANT.value
         assert payload["content"] == "执行过程中发生错误"
         assert payload["property"]["builtin_property"]["error"] is True
-        mock_client.api.update_chat_session.assert_called_once_with(
-            path_params={"session_code": "test-session-123"},
-            json={"status": SessionsStatus.FAILED.value},
-            headers={"X-BKAIDEV-USER": "test-user"},
-        )
+        mock_client.api.update_chat_session.assert_not_called()
 
     def test_run_error_finished_keeps_session_failed(self, session_writer, mock_client):
         """运行错误后结束流，不应把会话覆盖为 finished"""
@@ -281,11 +277,30 @@ class TestHandleRunError:
         session_writer(event)
         session_writer.set_streaming_finished()
 
-        status_payloads = [call.kwargs["json"] for call in mock_client.api.update_chat_session.call_args_list]
-        assert status_payloads == [
-            {"status": SessionsStatus.FAILED.value},
-            {"status": SessionsStatus.FAILED.value},
-        ]
+        mock_client.api.update_chat_session.assert_called_once_with(
+            path_params={"session_code": "test-session-123"},
+            json={"status": SessionsStatus.FAILED.value},
+            headers={"X-BKAIDEV-USER": "test-user"},
+        )
+
+    def test_finished_status_retries_then_succeeds(self, session_writer, mock_client, monkeypatch):
+        sleep = MagicMock()
+        monkeypatch.setattr("aidev_agent.services.event_handlers.agui_writer.time.sleep", sleep)
+        mock_client.api.update_chat_session.side_effect = [RuntimeError("one"), RuntimeError("two"), {}]
+
+        session_writer.set_streaming_finished()
+
+        assert mock_client.api.update_chat_session.call_count == 3
+        assert [call.args[0] for call in sleep.call_args_list] == [0.2, 0.4]
+
+    def test_finished_status_raises_after_retries_exhausted(self, session_writer, mock_client, monkeypatch):
+        monkeypatch.setattr("aidev_agent.services.event_handlers.agui_writer.time.sleep", MagicMock())
+        mock_client.api.update_chat_session.side_effect = RuntimeError("platform unavailable")
+
+        with pytest.raises(RuntimeError, match="platform unavailable"):
+            session_writer.set_streaming_finished()
+
+        assert mock_client.api.update_chat_session.call_count == 3
 
 
 def make_flow_agent_result_event(task_id: str, task_state: str = "RUNNING"):

--- a/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_bkplugin.py
@@ -23,6 +23,7 @@ sys.modules.setdefault("bk_plugin_framework.kit", _bk_plugin_framework.kit)
 sys.modules.setdefault("bk_plugin_framework.kit.decorators", _bk_plugin_framework.kit.decorators)
 
 from aidev_agent.enums import AgentType, ChatContentStatus, PromptRole, SessionsStatus  # noqa: E402
+from aidev_agent.services.messages_handler import RetryableHeartbeatTimeoutError  # noqa: E402
 from aidev_bkplugin.enums import PluginPollTaskState  # noqa: E402
 from aidev_bkplugin.services.agent_session import SessionManager  # noqa: E402
 
@@ -266,3 +267,67 @@ class TestBkpluginExecution:
         assert runner.execute_kwargs["session_code"] == "thread-x"
         assert runner.plugin_context == [{"k": "v"}]
         mock_resolve.assert_called_once_with("alice")
+
+    def test_run_worker_skips_save_stream_failure_when_session_finished(self, monkeypatch):
+        """心跳超时误报：producer 实际已完成（session=FINISHED），不应覆盖为 FAILED。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("生产者心跳超时")))
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.FINISHED.value}
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.retrieve_session.assert_called_once_with("sess-1")
+        mock_sm.save_stream_failure.assert_not_called()
+
+    def test_run_worker_calls_save_stream_failure_when_session_running(self, monkeypatch):
+        """producer 真崩溃：session 仍 RUNNING 时应写失败。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(agent, "invoke_agent", MagicMock(side_effect=RuntimeError("producer crashed")))
+        mock_sm = MagicMock()
+        mock_sm.retrieve_session.return_value = {"status": SessionsStatus.RUNNING.value}
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", lambda username: mock_sm)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        mock_sm.save_stream_failure.assert_called_once_with("sess-1", ANY, turn_id="t1")
+
+    def test_run_worker_skips_session_update_for_retryable_heartbeat_timeout(self, monkeypatch):
+        """消费者心跳超时可重试，不应更新 session 终态。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={}, username="alice")
+        monkeypatch.setattr(
+            agent,
+            "invoke_agent",
+            MagicMock(side_effect=RetryableHeartbeatTimeoutError("生产者心跳超时")),
+        )
+        manager_factory = MagicMock()
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", manager_factory)
+
+        agent.run_worker("sess-1", {"turn_id": "t1"})
+
+        manager_factory.assert_not_called()
+
+    def test_execute_skips_session_update_for_retryable_heartbeat_timeout(self, monkeypatch):
+        """同步消费遇到可重试心跳超时，也不应覆盖 session 状态。"""
+        from aidev_bkplugin.services.agent_bkplugin import BkpluginChat
+
+        agent = BkpluginChat(chat_history=[], execute_kwargs={"session_code": "sess-1"}, username="alice")
+        monkeypatch.setattr(
+            agent,
+            "_do_execute",
+            MagicMock(side_effect=RetryableHeartbeatTimeoutError("生产者心跳超时")),
+        )
+        manager_factory = MagicMock()
+        monkeypatch.setattr("aidev_bkplugin.services.agent_bkplugin.SessionManager", manager_factory)
+
+        with pytest.raises(RetryableHeartbeatTimeoutError):
+            agent.execute()
+
+        manager_factory.assert_not_called()

--- a/src/plugins/aidev_bkplugin/tests/views/test_chat_flow_agent.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_chat_flow_agent.py
@@ -72,3 +72,15 @@ def test_no_marker_starts_new_task_without_touching_marker(flow_agent_env):
 
     assert build_agent.call_args.kwargs["task_id"] is None
     sm.set_flow_resume_pending.assert_not_called()
+
+
+def test_flow_http_does_not_install_second_terminal_status_writer(flow_agent_env):
+    view, _build_agent, sm, writer_cls = flow_agent_env
+    sm.get_flow_info.return_value = {}
+    view._wrap_streaming_with_status = MagicMock(side_effect=AssertionError("duplicate terminal writer"))
+
+    result = view._handle_flow_agent(_data(), "sc-1", "alice", turn_id="turn-1")
+
+    assert result == "STREAM"
+    writer_cls.return_value.set_streaming_started.assert_called_once_with()
+    view._wrap_streaming_with_status.assert_not_called()

--- a/src/plugins/aidev_bkplugin/tests/views/test_chat_stream_status.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_chat_stream_status.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+"""Chat SSE 异常时的会话终态回归测试。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.mark.parametrize("error", [RuntimeError("生产者心跳超时"), SystemExit("worker abort")])
+def test_unexpected_stream_error_does_not_mark_session_finished(monkeypatch, error):
+    from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
+    from aidev_bkplugin.views.chat import ChatCompletionViewSet
+
+    def failing_stream():
+        yield "chunk"
+        raise error
+
+    monkeypatch.setattr(GeneratorStreamingHelper, "is_cancelled", lambda _session_code: False)
+    event_handler = MagicMock()
+    stream = ChatCompletionViewSet()._wrap_streaming_with_status(
+        failing_stream(), event_handler, session_code="session-1"
+    )
+
+    assert next(stream) == "chunk"
+    with pytest.raises(type(error)):
+        next(stream)
+    event_handler.set_streaming_finished.assert_not_called()
+
+
+def test_normal_stream_marks_session_finished(monkeypatch):
+    from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
+    from aidev_bkplugin.views.chat import ChatCompletionViewSet
+
+    monkeypatch.setattr(GeneratorStreamingHelper, "is_cancelled", lambda _session_code: False)
+    event_handler = MagicMock()
+
+    assert list(
+        ChatCompletionViewSet()._wrap_streaming_with_status(iter(["chunk"]), event_handler, session_code="session-1")
+    ) == ["chunk"]
+    event_handler.set_streaming_finished.assert_called_once_with()

--- a/template/{{cookiecutter.project_name}}/app_desc.yml
+++ b/template/{{cookiecutter.project_name}}/app_desc.yml
@@ -102,4 +102,5 @@ modules:
               port: 80
         - name: celery
           procCommand: celery -A blueapps.core.celery worker -P threads -Q plugin_schedule -l INFO -c 2 --max-tasks-per-child 256
+          resQuotaPlan: 4C4G
           targetReplicas: 1


### PR DESCRIPTION
## 背景

将 2.2 分支已验证的事件循环、RabbitMQ replay 与流式会话终态修复适配到 develop。该提交直接基于 develop 生成，未复用 2.2 的提交历史，也未带入 2.2 的版本号和锁文件变更。

## 改动

- 隔离异步生成器与模型客户端所属的 event loop，并在同一 loop 完成资源回收。
- RabbitMQ replay 仅以已提交队列为准，空闲期先检查队列深度，降低全量 peek 压力。
- 合并相邻 SSE 帧、延长 replay 恢复与清理窗口，并保留协议层逐帧输出。
- 收敛 producer、RUN_FINISHED、EOD 和会话终态的完成顺序，避免消费者异常抢写终态。
- 补充连接释放、心跳超时、后台执行、Flow 和同步执行的回归测试与链路日志。

## 验证

- Agent 定向回归：167 passed，39 skipped。
- bkplugin 本次新增及修改相关用例通过；仓库内 5 个既有事件协议用例仍按旧 RAW/Custom 结构构造数据，不属于本次差异。
- 本次变更的 31 个 Python 文件通过 Ruff lint 与 format check。
- `git diff --check` 通过。
- 全仓 pre-commit 仍被 develop 既有、非本次差异的 lint 与语法问题阻塞。
