### PR TITLE
refactor: 移除 RabbitMQ DLQ/DLX 消费链路 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -35,7 +35,7 @@ class ExecuteKwargs(BaseModel):
         default=False,
         description=(
             "后台 drain 执行标志（无 SSE 下游，如 celery/flow 的 run_agent_to_completion）。"
-            "为 True 时，消费者读到 EOD 不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流，"
+            "为 True 时，消费者读到 EOD 不立即清理队列，保留缓存历史供前端在清理窗口内接管续流，"
             "清理交由 producer 的延迟清理线程兜底。"
         ),
     )

--- a/src/agent/aidev_agent/services/messages_handler/base.py
+++ b/src/agent/aidev_agent/services/messages_handler/base.py
@@ -335,7 +335,7 @@ class BaseMessageQueueHandler(ABC):
         """标记 session 已被用户主动停止
 
         用户点击 Stop 时调用。标记后，下次进入该 session 时：
-        - 只展示 DLQ 中已有的内容
+        - 只展示缓存中已有的内容
         - 不启动新的生产者
 
         默认实现为空，子类可覆盖。

--- a/src/agent/aidev_agent/services/messages_handler/multi_process_mixin.py
+++ b/src/agent/aidev_agent/services/messages_handler/multi_process_mixin.py
@@ -27,7 +27,6 @@ class MultiProcessMixin:
 
     前提条件：
     - 宿主类必须提供 _with_connection() 上下文管理器来获取 RabbitMQ 连接
-    - 宿主类必须提供 restore_messages(thread_id) 方法
 
     使用方式：
         class MyHandler(MultiProcessMixin, BaseMessageQueueHandler):
@@ -172,7 +171,7 @@ class MultiProcessMixin:
         return consumer_id
 
     def wait_for_previous_consumer(self, thread_id: str, timeout: float = 3.0) -> bool:
-        """等待旧消费者完全退出（包括 DLQ restore）
+        """等待旧消费者完全退出（包括兼容模式的消息恢复）
 
         通过轮询退出通知队列来等待旧消费者发送退出信号。
 
@@ -261,7 +260,7 @@ class MultiProcessMixin:
         """释放消费者
 
         如果自己仍是当前活跃消费者（正常结束），清空控制队列。
-        如果自己已被抢占，恢复 DLQ 消息并向退出通知队列发送信号。
+        如果自己已被抢占，保留 replay 缓存并向退出通知队列发送信号。
 
         Args:
             thread_id: 线程ID
@@ -307,17 +306,12 @@ class MultiProcessMixin:
                     release_outcome = "preempted"
 
         if is_preempted:
-            # 被抢占：将 DLQ 中自己消费过的消息恢复到主队列，然后发送退出信号
-            try:
-                restored = self.restore_messages(thread_id)
-                logger.info(
-                    f"Preempted consumer {consumer_id[:8]} restored {restored} DLQ messages for thread_id={thread_id}"
-                )
-            except Exception as e:
-                logger.error(f"Failed to restore DLQ messages for consumer {consumer_id[:8]}: {e}")
-            finally:
-                # 无论恢复消息是否成功，都要向退出通知队列发送信号，避免新消费者无限等待
-                self._send_exit_signal(thread_id, consumer_id)
+            logger.info(
+                "Preempted replay consumer %s preserved cached messages for thread_id=%s",
+                consumer_id[:8],
+                thread_id,
+            )
+            self._send_exit_signal(thread_id, consumer_id)
 
         logger.info(
             "[RabbitMQ] consumer released thread_id=%s consumer_id=%s reason=%s",
@@ -522,10 +516,10 @@ class MultiProcessMixin:
         return f"{self.CANCELLED_QUEUE_PREFIX}{thread_id}"
 
     def notify_consumer_cancelled(self, thread_id: str) -> bool:
-        """通知 stop_session 消费者已因取消信号退出（DLQ 可以读取了）
+        """通知 stop_session 消费者已因取消信号退出（缓存内容可以读取了）
 
         消费者在检测到取消信号并退出时调用此方法。
-        stop_session 通过 wait_for_consumer_cancelled() 等待这个信号后再读取 DLQ。
+        stop_session 通过 wait_for_consumer_cancelled() 等待这个信号后再读取缓存内容。
 
         Args:
             thread_id: 线程ID / session_code
@@ -555,7 +549,7 @@ class MultiProcessMixin:
     def wait_for_consumer_cancelled(self, thread_id: str, timeout: float = 3.0) -> bool:
         """等待消费者因取消信号退出
 
-        stop_session 调用此方法等待消费者退出后，再从 DLQ 读取消息。
+        stop_session 调用此方法等待消费者退出后，再读取缓存消息。
 
         Args:
             thread_id: 线程ID / session_code
@@ -595,7 +589,7 @@ class MultiProcessMixin:
             time.sleep(self.WAIT_POLL_INTERVAL)
 
     def clear_cancelled_signal(self, thread_id: str) -> None:
-        """清除消费者取消完成通知（在获取 DLQ 后调用）
+        """清除消费者取消完成通知（在获取缓存内容后调用）
 
         Args:
             thread_id: 线程ID / session_code

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -275,28 +275,22 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     """基于RabbitMQ的消息处理器（多进程版本）
 
     使用 RabbitMQ 作为远端存储，支持分布式场景下的流式消息处理。
-    每个 thread_id 对应一个主队列和一个死信队列。
-
-    消息流转机制（使用死信队列优化性能）：
-    - 主队列：存放待消费的消息
-    - 死信队列：存放已消费但未确认完成的消息
+    每个 thread_id 对应一个持久化主队列，消费者按 offset 非破坏性 replay。
 
     工作流程：
     1. 生产者将消息放入主队列
-    2. 消费者从主队列获取消息，ack 后消息自动进入死信队列
-    3. 消费者断开重连时，将死信队列的消息移回主队列，从头消费
-    4. 流完成时（mark_completed），清空主队列和死信队列
+    2. 消费者从自己的 offset 读取主队列，消息始终保留在主队列
+    3. 消费者断开重连时从主队列开头独立 replay
+    4. 流完成时（mark_completed）清理主队列及控制资源
 
     特点：
-    - 避免每次都全量读取消息（只读取主队列中的新消息）
-    - 支持断点续传（从死信队列恢复消息）
+    - 多端消费者互不抢占消息，各自完整回放
+    - offset 未变化时只读取队列深度，避免反复全量扫描
     - 后台守护线程每隔 0.5 秒批量推送消息，减少连接开销
     """
 
     # 使用统一的队列名称前缀和 TTL 配置
     QUEUE_PREFIX: ClassVar[str] = QueueNamePrefixes.MESSAGE_QUEUE
-    DLX_EXCHANGE_PREFIX: ClassVar[str] = "aidev_agent.dlx."  # 死信交换机前缀（无需抽取）
-    DLQ_PREFIX: ClassVar[str] = QueueNamePrefixes.DEAD_LETTER_QUEUE
     CANCEL_QUEUE_PREFIX: ClassVar[str] = QueueNamePrefixes.CANCEL_REQUEST
     PRODUCER_LOCK_PREFIX: ClassVar[str] = "aidev_agent.producer_lock."
     REPLAY_LOCK_PREFIX: ClassVar[str] = "aidev_agent.replay_lock."
@@ -382,14 +376,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
     def _get_queue_name(self, thread_id: str) -> str:
         """获取 thread_id 对应的主队列名"""
         return f"{self.QUEUE_PREFIX}{thread_id}"
-
-    def _get_dlx_exchange_name(self, thread_id: str) -> str:
-        """获取 thread_id 对应的死信交换机名"""
-        return f"{self.DLX_EXCHANGE_PREFIX}{thread_id}"
-
-    def _get_dlq_name(self, thread_id: str) -> str:
-        """获取 thread_id 对应的死信队列名"""
-        return f"{self.DLQ_PREFIX}{thread_id}"
 
     def _get_cancel_queue_name(self, thread_id: str) -> str:
         """获取 thread_id 对应的取消请求队列名"""
@@ -508,57 +494,52 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         with self._replay_wait_condition:
             self._replay_wait_condition.wait(timeout=wait_time)
 
-    def _ensure_queue_with_dlx(self, channel: Any, thread_id: str) -> tuple[str, str]:
-        """确保主队列和死信队列都存在，返回 (主队列名, 死信队列名)
-
-        死信队列机制：
-        - 当消息被 ack 时，不会进入死信队列（这是正常消费）
-        - 当消息被 reject/nack 且 requeue=False 时，进入死信队列
-        - 我们使用 reject(requeue=False) 将已读取的消息移到死信队列
-        """
+    def _ensure_queue(self, channel: Any, thread_id: str) -> str:
+        """确保持久化主队列存在，不创建 DLX/DLQ。"""
         main_queue_name = self._get_queue_name(thread_id)
-        dlx_exchange_name = self._get_dlx_exchange_name(thread_id)
-        dlq_name = self._get_dlq_name(thread_id)
-
-        # 1. 声明死信交换机（direct 类型）
-        channel.exchange_declare(
-            exchange=dlx_exchange_name,
-            exchange_type="direct",
-            durable=True,
-        )
-
-        # 2. 声明死信队列
-        channel.queue_declare(
-            queue=dlq_name,
-            durable=True,
-            arguments={"x-expires": self.QUEUE_TTL_MS},
-        )
-
-        # 3. 绑定死信队列到死信交换机
-        channel.queue_bind(
-            queue=dlq_name,
-            exchange=dlx_exchange_name,
-            routing_key=dlq_name,  # 使用队列名作为 routing key
-        )
-
-        # 4. 声明主队列，配置死信交换机
-        main_queue_args = {
-            "x-expires": self.QUEUE_TTL_MS,
-            "x-dead-letter-exchange": dlx_exchange_name,
-            "x-dead-letter-routing-key": dlq_name,
-        }
         channel.queue_declare(
             queue=main_queue_name,
             durable=True,
-            arguments=main_queue_args,
+            arguments={"x-expires": self.QUEUE_TTL_MS},
         )
+        return main_queue_name
 
-        return main_queue_name, dlq_name
+    def _delete_legacy_dead_letter_resources(self, thread_id: str) -> None:
+        """删除旧实现遗留的 DLQ/DLX，不读取或恢复其中的历史消息。"""
+        dlq_name = f"{QueueNamePrefixes.DEAD_LETTER_QUEUE}{thread_id}"
+        dlx_exchange_name = f"aidev_agent.dlx.{thread_id}"
+        connection = None
+        channel = None
+        try:
+            connection = self._connection_pool.get_connection()
+            for resource_type, resource_name in (("queue", dlq_name), ("exchange", dlx_exchange_name)):
+                channel = connection.channel()
+                try:
+                    if resource_type == "queue":
+                        channel.queue_delete(queue=resource_name)
+                    else:
+                        channel.exchange_delete(exchange=resource_name)
+                except pika.exceptions.ChannelClosedByBroker as e:
+                    if e.reply_code != 404:
+                        raise
+                finally:
+                    if getattr(channel, "is_open", False):
+                        channel.close()
+                channel = None
+        except Exception as e:
+            logger.warning(f"Failed to delete legacy dead-letter resources for thread_id={thread_id}: {e}")
+        finally:
+            if channel is not None and getattr(channel, "is_open", False):
+                with contextlib.suppress(Exception):
+                    channel.close()
+            if connection is not None:
+                self._connection_pool.release_connection(connection)
 
     def _migrate_queue_if_needed(self, thread_id: str) -> bool:
         """检查并迁移不兼容的旧队列
 
-        如果队列存在但参数不兼容（例如没有死信配置），则删除旧队列。
+        旧主队列携带 DLX 参数，RabbitMQ 不允许原地修改队列参数。
+        发现不兼容声明时删除旧主队列，并清理遗留 DLQ/DLX；后续写入会按新参数重建。
         这个方法应该在首次使用队列时调用一次。
 
         Args:
@@ -568,58 +549,43 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             True 表示进行了迁移，False 表示无需迁移
         """
         main_queue_name = self._get_queue_name(thread_id)
+        migrated = False
+        connection = None
+        channel = None
 
         try:
-            with self._with_channel() as channel:
-                # 尝试被动声明来检查队列是否存在
-                try:
-                    channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
-                except Exception:
-                    # 队列不存在，无需迁移
-                    return False
-
-                # 队列存在，尝试用新参数声明
-                dlx_exchange_name = self._get_dlx_exchange_name(thread_id)
-                dlq_name = self._get_dlq_name(thread_id)
-
-                # 先声明死信交换机和队列
-                channel.exchange_declare(exchange=dlx_exchange_name, exchange_type="direct", durable=True)
-                channel.queue_declare(queue=dlq_name, durable=True, arguments={"x-expires": self.QUEUE_TTL_MS})
-                channel.queue_bind(queue=dlq_name, exchange=dlx_exchange_name, routing_key=dlq_name)
-
-                # 尝试声明主队列（会检查参数是否匹配）
-                try:
-                    channel.queue_declare(
-                        queue=main_queue_name,
-                        durable=True,
-                        arguments={
-                            "x-expires": self.QUEUE_TTL_MS,
-                            "x-dead-letter-exchange": dlx_exchange_name,
-                            "x-dead-letter-routing-key": dlq_name,
-                        },
-                    )
-                    # 声明成功，参数匹配，无需迁移
-                    return False
-                except Exception as e:
-                    if "PRECONDITION_FAILED" not in str(e):
-                        raise
-                    # 参数不匹配，需要删除旧队列
-                    logger.warning(f"Queue {main_queue_name} has incompatible arguments, will be deleted")
-
-            # 使用新连接删除旧队列（因为上面的 channel 可能已关闭）
-            with self._with_channel() as channel:
+            # Queue 参数冲突会由 broker 主动关闭 channel。这里显式管理连接，避免
+            # RabbitMQConnectionPool.connection() 把业务 channel 异常当成连接重试，
+            # 继而在同一个 contextmanager 中二次 yield。
+            connection = self._connection_pool.get_connection()
+            channel = connection.channel()
+            try:
+                channel.queue_declare(
+                    queue=main_queue_name,
+                    durable=True,
+                    arguments={"x-expires": self.QUEUE_TTL_MS},
+                )
+            except pika.exceptions.ChannelClosedByBroker as e:
+                if e.reply_code != 406:
+                    raise
+                logger.warning(f"Queue {main_queue_name} has incompatible arguments, will be deleted")
+                channel = connection.channel()
                 channel.queue_delete(queue=main_queue_name)
                 logger.info(f"Deleted incompatible queue {main_queue_name}")
-                return True
+                migrated = True
 
         except Exception as e:
             logger.error(f"Error during queue migration check: {e}")
-            return False
+        finally:
+            if channel is not None and getattr(channel, "is_open", False):
+                with contextlib.suppress(Exception):
+                    channel.close()
+            if connection is not None:
+                self._connection_pool.release_connection(connection)
+            if migrated:
+                self._delete_legacy_dead_letter_resources(thread_id)
 
-    def _ensure_queue(self, channel: Any, thread_id: str) -> str:
-        """确保队列存在，返回主队列名（兼容旧接口）"""
-        main_queue_name, _ = self._ensure_queue_with_dlx(channel, thread_id)
-        return main_queue_name
+        return migrated
 
     # ================== replay-from-start / 并发控制 ==================
 
@@ -627,7 +593,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         """声明 RabbitMQ backend 支持从会话日志开头独立 replay。
 
         这个能力位供 GeneratorStreamingHelper 选择消费策略：RabbitMQ 返回 True，
-        旧的 in-memory/默认 handler 返回 False，继续使用竞争消费 + DLQ 恢复语义。
+        旧的 in-memory/默认 handler 返回 False，继续使用竞争消费与兼容恢复语义。
         """
         return True
 
@@ -1003,103 +969,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         if any_flushed:
             self._notify_replay_waiters()
 
-    # ================== 死信队列操作 ==================
-
-    def _restore_from_dlq(self, thread_id: str) -> int:
-        """将死信队列中的消息恢复到主队列（用于断点续传）
-
-        断点续传时，DLQ 中的消息（已被旧消费者读取过）需要与主队列中的消息（未被读取）
-        合并，且 DLQ 消息应该排在前面，保证消息的正确顺序：
-        [DLQ历史消息] + [主队列新消息] = 完整的消息序列
-
-        Args:
-            thread_id: 线程ID
-
-        Returns:
-            恢复的消息数量
-        """
-        with self._with_channel() as channel:
-            main_queue_name, dlq_name = self._ensure_queue_with_dlx(channel, thread_id)
-
-            # 检查死信队列中的消息数量
-            try:
-                dlq_info = channel.queue_declare(queue=dlq_name, durable=True, passive=True)
-                dlq_count = dlq_info.method.message_count
-            except Exception:
-                # 死信队列不存在
-                return 0
-
-            if dlq_count == 0:
-                return 0
-
-            # 检查主队列中的消息数量
-            try:
-                main_queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
-                main_queue_count = main_queue_info.method.message_count
-            except Exception:
-                main_queue_count = 0
-
-            logger.info(f"Restoring messages for thread_id={thread_id}: DLQ={dlq_count}, main_queue={main_queue_count}")
-
-            # 1. 先把主队列中的消息暂存（如果有的话）
-            main_queue_messages = []
-            if main_queue_count > 0:
-                for _ in range(main_queue_count):
-                    method_frame, properties, body = channel.basic_get(queue=main_queue_name, auto_ack=True)
-                    if not method_frame:
-                        break
-                    main_queue_messages.append(body)
-
-            # 2. 从 DLQ 获取所有消息
-            dlq_messages = []
-            for _ in range(dlq_count):
-                method_frame, properties, body = channel.basic_get(queue=dlq_name, auto_ack=False)
-                if not method_frame:
-                    break
-                dlq_messages.append((method_frame.delivery_tag, body))
-
-            # 3. 按正确顺序重新发布到主队列：先 DLQ（历史），后主队列（新消息）
-            for _, body in dlq_messages:
-                channel.basic_publish(
-                    exchange="",
-                    routing_key=main_queue_name,
-                    body=body,
-                    properties=pika.BasicProperties(delivery_mode=2),
-                )
-
-            for body in main_queue_messages:
-                channel.basic_publish(
-                    exchange="",
-                    routing_key=main_queue_name,
-                    body=body,
-                    properties=pika.BasicProperties(delivery_mode=2),
-                )
-
-            # 4. 确认 DLQ 中的消息（删除）
-            for delivery_tag, _ in dlq_messages:
-                channel.basic_ack(delivery_tag=delivery_tag)
-
-            restored_count = len(dlq_messages)
-            logger.info(
-                f"Restored {restored_count} messages from DLQ for thread_id={thread_id}, "
-                f"merged with {len(main_queue_messages)} main queue messages"
-            )
-            return restored_count
-
-    def _get_dlq_count(self, thread_id: str) -> int:
-        """获取死信队列中的消息数量"""
-        try:
-            with self._with_channel() as channel:
-                dlq_name = self._get_dlq_name(thread_id)
-                try:
-                    dlq_info = channel.queue_declare(queue=dlq_name, durable=True, passive=True)
-                    return dlq_info.method.message_count
-                except Exception:
-                    return 0
-        except Exception as e:
-            logger.error(f"Error getting DLQ count: {e}")
-            return 0
-
     # ================== BaseMessageQueueHandler 接口实现 ==================
 
     def _ensure_daemon_alive(self) -> None:
@@ -1181,50 +1050,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             # 推送所有消息
             self._flush_messages()
 
-    def _get_available_messages(self, thread_id: str, max_messages: int = 0) -> list[Any]:
-        """从主队列获取可用消息
-
-        消息被读取后，通过 reject(requeue=False) 移动到死信队列。
-        这样实现增量读取，而不是每次全量读取。
-
-        Args:
-            thread_id: 线程ID
-            max_messages: 最大获取消息数量，0 表示获取所有可用消息
-
-        Returns:
-            消息列表
-        """
-        with self._with_channel() as channel:
-            main_queue_name = self._ensure_queue(channel, thread_id)
-
-            # 查询主队列中有多少消息
-            queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
-            available_count = queue_info.method.message_count
-
-            if available_count == 0:
-                return []
-
-            # 确定要获取的消息数量
-            fetch_count = available_count if max_messages == 0 else min(available_count, max_messages)
-
-            # 获取消息
-            messages = []
-            for _ in range(fetch_count):
-                method_frame, properties, body = channel.basic_get(queue=main_queue_name, auto_ack=False)
-                if not method_frame:
-                    break
-
-                message = pickle.loads(body)
-                messages.append(message)
-
-                # 拒绝消息（不重新入队），消息会进入死信队列
-                channel.basic_reject(delivery_tag=method_frame.delivery_tag, requeue=False)
-
-            if messages:
-                logger.debug(f"Fetched {len(messages)} messages from queue {main_queue_name}, moved to DLQ")
-
-            return messages
-
     def _peek_queue_messages(self, channel: Any, queue_name: str) -> list[Any]:
         """非破坏性读取队列中的全部消息，仅在读取或 requeue 异常时记录诊断。"""
         messages = []
@@ -1278,17 +1103,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                         queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
                         committed_count = queue_info.method.message_count
 
-                        # 兼容升级前已经进入 DLQ 的旧缓存：仅在主队列为空时恢复一次。
-                        if committed_count == 0 and self._get_dlq_count(thread_id) > 0:
-                            restored = self._restore_from_dlq(thread_id)
-                            logger.info(
-                                "[RabbitMQ] restored legacy DLQ messages before replay thread_id=%s restored=%d",
-                                thread_id,
-                                restored,
-                            )
-                            queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
-                            committed_count = queue_info.method.message_count
-
                         # 没有新消息时避免反复 basic_get/basic_nack 全量扫描历史队列。
                         all_messages = (
                             self._peek_queue_messages(channel, main_queue_name) if committed_count > offset else None
@@ -1306,60 +1120,14 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
 
             self._wait_for_replay_retry(deadline, self.REPLAY_MESSAGE_RETRY_INTERVAL)
 
-    def _get_block(self, thread_id: str, timeout: Optional[float] = None) -> list[Any]:
-        """阻塞方式获取消息
-
-        Args:
-            thread_id: 线程ID
-            timeout: 超时时间（秒）
-
-        Returns:
-            消息列表
-
-        Raises:
-            TimeoutError: 超时时抛出
-        """
-        start_time = time.time()
-        deadline = start_time + timeout if timeout is not None else None
-
-        while True:
-            try:
-                messages = self._get_available_messages(thread_id)
-                if messages:
-                    return messages
-            except Exception as e:
-                logger.exception(f"Error in _get_block: {e}")
-
-            # 检查超时
-            if deadline is not None:
-                elapsed = time.time() - start_time
-                if time.time() >= deadline:
-                    logger.debug("[Streaming] rabbitmq get timeout thread_id=%s, elapsed=%.3fs", thread_id, elapsed)
-                    raise TimeoutError("No message available within timeout")
-
-            self._wait_for_replay_retry(deadline, self.REPLAY_MESSAGE_RETRY_INTERVAL)
-
     def get(self, thread_id: str, timeout: Optional[float] = None) -> list[Any]:
-        """从指定 thread_id 的队列中获取消息
-
-        增量获取：只获取主队列中的新消息，已读取的消息会移动到死信队列。
-
-        Args:
-            thread_id: 线程ID
-            timeout: 超时时间（秒）
-
-        Returns:
-            消息列表
-
-        Raises:
-            TimeoutError: 队列为空且超时时抛出
-        """
-        return self._get_block(thread_id, timeout=timeout)
+        """RabbitMQ replay 必须携带 offset，禁止使用破坏性旧消费接口。"""
+        raise NotImplementedError("RabbitMQMessageHandler requires get_messages_since(thread_id, offset, timeout)")
 
     def has_pending_messages(self, thread_id: str) -> bool:
         """检查是否有未消费的消息（用于判断是否需要创建生产者）
 
-        检查主队列、死信队列以及本地缓冲区是否有消息。
+        检查主队列以及本地缓冲区是否有消息。
         如果有消息，说明已有生产者在工作或已完成但消息未消费完，不需要创建新的生产者。
 
         Args:
@@ -1374,48 +1142,22 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             if thread_id in self._message_buffer and self._message_buffer[thread_id]:
                 return True
 
-        # 检查 RabbitMQ 主队列和死信队列
-        # 每次 passive declare 使用独立 channel，避免主队列不存在时
-        # channel 被 404 error 关闭导致 DLQ 检查静默失败
+        # 检查 RabbitMQ 主队列。
         try:
             main_queue_name = self._get_queue_name(thread_id)
-            dlq_name = self._get_dlq_name(thread_id)
-
-            # 检查主队列（独立 channel）
             with self._with_channel() as channel:
                 try:
                     queue_info = channel.queue_declare(queue=main_queue_name, durable=True, passive=True)
-                    if queue_info.method.message_count > 0:
-                        return True
+                    return queue_info.method.message_count > 0
                 except Exception:
-                    pass
-
-            # 检查死信队列（独立 channel）
-            with self._with_channel() as channel:
-                try:
-                    dlq_info = channel.queue_declare(queue=dlq_name, durable=True, passive=True)
-                    if dlq_info.method.message_count > 0:
-                        return True
-                except Exception:
-                    pass
-
-                return False
+                    return False
         except Exception as e:
             logger.error(f"Error checking pending messages for thread_id={thread_id}: {e}")
             return False
 
     def restore_messages(self, thread_id: str) -> int:
-        """将死信队列中的消息恢复到主队列（断点续传）
-
-        消费者重连时调用此方法，将之前消费过的消息恢复到主队列，从头开始消费。
-
-        Args:
-            thread_id: 线程ID
-
-        Returns:
-            恢复的消息数量
-        """
-        return self._restore_from_dlq(thread_id)
+        """Replay 模式不移动消息，无需恢复。"""
+        return 0
 
     def _safe_purge_queue(self, connection: Any, queue_name: str, passive_check: bool = False) -> bool:
         """安全清空队列（内部方法）
@@ -1462,8 +1204,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             with self._with_connection() as connection:
                 # 每个 purge 操作使用独立 channel，避免 404 channel error 影响后续操作
                 self._safe_purge_queue(connection, self._get_queue_name(thread_id))
-                self._safe_purge_queue(connection, self._get_dlq_name(thread_id))
-
                 # 清空取消请求队列（如果需要，先检查是否存在）
                 if include_cancel_queue:
                     self._safe_purge_queue(connection, self._get_cancel_queue_name(thread_id), passive_check=True)
@@ -1472,15 +1212,14 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
 
     def _delete_all_resources(self, thread_id: str) -> None:
         """
-        删除指定 thread_id 的所有 RabbitMQ 资源（队列 + 交换机）
-        在消费完成后调用，主动释放资源，避免空队列空占 1 小时以及死信交换机永久残留。
+        删除指定 thread_id 的所有 RabbitMQ 队列资源。
+        在消费完成后调用，主动释放资源，避免空队列空占 1 小时。
         """
         try:
             with self._with_channel() as channel:
                 # 收集所有需要删除的队列名
                 queue_names = [
                     self._get_queue_name(thread_id),
-                    self._get_dlq_name(thread_id),
                     self._get_cancel_queue_name(thread_id),
                     self._get_active_consumer_queue_name(thread_id),
                 ]
@@ -1495,13 +1234,6 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
                     except Exception as e:
                         logger.exception(f"Queue {queue_name} delete failed: {e}")
 
-                # 删除死信交换机（exchange_delete 对不存在的交换机也是幂等的）
-                try:
-                    channel.exchange_delete(exchange=self._get_dlx_exchange_name(thread_id))
-                    logger.debug(f"Deleted exchange {self._get_dlx_exchange_name(thread_id)}")
-                except Exception as e:
-                    logger.debug(f"Exchange {self._get_dlx_exchange_name(thread_id)} delete failed: {e}")
-
                 logger.info(f"Deleted all RabbitMQ resources for thread_id={thread_id}")
         except Exception as e:
             logger.error(f"Error deleting resources for thread_id={thread_id}: {e}")
@@ -1512,7 +1244,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
         消费者在读取到结束标记时调用此方法：
         1. 先清理本地缓冲区（防止守护线程 flush 时重建已删除的队列）
         2. 清空所有队列中的消息（purge）
-        3. 主动删除所有队列和交换机（delete）
+        3. 主动删除所有队列（delete）
 
         Args:
             thread_id: 线程ID
@@ -1568,7 +1300,7 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return False
 
     def clear(self, thread_id: str) -> None:
-        """清空指定 thread_id 的所有队列（主队列和死信队列）"""
+        """清空指定 thread_id 的主队列和控制队列。"""
         # 清空缓冲区中的消息
         with self._buffer_lock:
             if thread_id in self._message_buffer:
@@ -1595,10 +1327,8 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return 0
 
     def get_total_count(self, thread_id: str) -> int:
-        """获取主队列和死信队列的总消息数量"""
-        main_count = self.get_cached_count(thread_id)
-        dlq_count = self._get_dlq_count(thread_id)
-        return main_count + dlq_count
+        """获取主队列消息数量。"""
+        return self.get_cached_count(thread_id)
 
     # is_empty() 和 size() 使用基类的通用实现
 
@@ -1628,51 +1358,5 @@ class RabbitMQMessageHandler(MultiProcessMixin, BaseMessageQueueHandler):
             return list(self._message_buffer.keys())
 
     def get_dlq_messages(self, thread_id: str) -> list[Any]:
-        """获取死信队列中的所有消息（不移除）
-
-        用于在流被取消时，获取已发送给前端但未回写数据库的完整消息内容。
-        使用 basic_get + basic_nack(requeue=True) 实现"偷看"效果。
-
-        Args:
-            thread_id: 线程ID
-
-        Returns:
-            死信队列中的消息列表（已发送给前端的消息）
-        """
-        messages = []
-        delivery_tags = []
-
-        try:
-            with self._with_channel() as channel:
-                dlq_name = self._get_dlq_name(thread_id)
-
-                # 先获取 DLQ 中的消息数量
-                try:
-                    dlq_info = channel.queue_declare(queue=dlq_name, durable=True, passive=True)
-                    dlq_count = dlq_info.method.message_count
-                except Exception:
-                    return []
-
-                if dlq_count == 0:
-                    return []
-
-                # 获取所有消息（不自动确认）
-                for _ in range(dlq_count):
-                    method_frame, properties, body = channel.basic_get(queue=dlq_name, auto_ack=False)
-                    if not method_frame:
-                        break
-
-                    message = pickle.loads(body)
-                    messages.append(message)
-                    delivery_tags.append(method_frame.delivery_tag)
-
-                # 将消息放回队列（不消费，只是"偷看"）
-                for tag in delivery_tags:
-                    channel.basic_nack(delivery_tag=tag, requeue=True)
-
-                logger.debug(f"Peeked {len(messages)} messages from DLQ for thread_id={thread_id}")
-
-        except Exception as e:
-            logger.error(f"Error getting DLQ messages for thread_id={thread_id}: {e}")
-
-        return messages
+        """RabbitMQ replay 不使用死信队列。"""
+        return []

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -35,10 +35,10 @@ _RESUME_FILTER_EVENT_TYPES: frozenset[str] = frozenset({"flow_agent_start"})
 class GeneratorStreamingHelper:
     """生成器流式处理辅助类
 
-    使用死信队列机制支持断点续传的流式处理：
+    根据 handler 能力选择断点续传策略：
+    - replay-from-start handler 按 offset 非破坏性读取同一份持久化日志
+    - 旧 handler 保留竞争消费与 restore_messages() 兼容语义
     - 通过 has_pending_messages() 判断是否需要创建新的生产者
-    - 消费者读取消息后，消息从主队列移动到死信队列
-    - 消费者断开后重连时，先调用 restore_messages() 恢复消息，再继续消费
     - 读到 EOD_CHUNK 时调用 mark_completed() 清理所有队列
 
     心跳机制：
@@ -51,10 +51,11 @@ class GeneratorStreamingHelper:
 
     工作流程：
     1. 客户端首次请求时，队列为空，启动生产者线程生产数据
-    2. 消费者从主队列获取消息，消息被移动到死信队列
+    2. 消费者读取缓存消息；replay 模式下消息始终保留在主队列
     3. 如果客户端断开连接，生产者继续运行直到完成
     4. 客户端重连时，检查队列中是否有数据：
-       - 如果有数据，先调用 restore_messages() 恢复消息，再消费
+       - replay 模式从当前连接的 offset 继续读取
+       - 旧模式先调用 restore_messages() 恢复消息再消费
        - 如果没有数据，启动新的生产者
     5. 读到 EOD_CHUNK 时，调用 mark_completed() 清理队列
     """
@@ -72,7 +73,7 @@ class GeneratorStreamingHelper:
     _PRODUCER_CLEANUP_DELAY = 90.0
     # 业务流已发出 [DONE] 且当前无活跃消费者时，保留队列等待前端接管续流的窗口（秒）。
     # 注意：后台 drain（background_only）完成后不会立即清理队列，需保留足够窗口让前端重连后
-    # 通过 restore_messages 接管已生产的完整内容；窗口内若有消费者接管则跳过清理。
+    # replay 已生产的完整内容；窗口内若有消费者接管则跳过清理。
     _DONE_ORPHAN_CLEANUP_GRACE = 30.0
     _ORPHAN_CLEANUP_POLL_INTERVAL = 0.1
     _HEARTBEAT_TIMEOUT_GRACE = 5.0
@@ -117,7 +118,7 @@ class GeneratorStreamingHelper:
         self.message_handler = message_handler if message_handler else message_handler_factory.get()
         self.thread_id = thread_id or uuid.uuid4().hex
         # 后台 drain（无 SSE 下游）场景：读到 EOD 时不立即 mark_completed 清队列，
-        # 保留 DLQ 历史供前端在清理窗口内接管续流；清理交由 producer 的延迟清理线程兜底。
+        # 保留缓存历史供前端在清理窗口内接管续流；清理交由 producer 的延迟清理线程兜底。
         self.defer_cleanup_on_complete = defer_cleanup_on_complete
         self._producer_completion_error: Exception | None = None
 
@@ -222,9 +223,7 @@ class GeneratorStreamingHelper:
     def has_output(cls, thread_id: str, message_handler: BaseMessageQueueHandler | None = None) -> bool:
         """检查指定 thread_id 的流是否已有输出
 
-        通过检查消息队列中是否有消息来判断：
-        - 主队列有消息：说明生产者已产生输出
-        - 死信队列有消息：说明消费者已读取过输出
+        通过 handler 的缓存状态判断生产者是否已经产生输出。
 
         Args:
             thread_id: 线程 ID / session_code
@@ -508,7 +507,7 @@ class GeneratorStreamingHelper:
         is_resuming = True
         logger.info(
             f"Pending messages exist for thread_id={self.thread_id}, "
-            f"restored {restored} messages from DLQ, consuming from start"
+            f"restored {restored} cached messages, consuming from start"
         )
         return producer_thread, is_resuming, enable_heartbeat_check
 
@@ -694,7 +693,7 @@ class GeneratorStreamingHelper:
                                 self.message_handler.mark_completed(self.thread_id)
                                 logger.info(f"Stream completed for thread_id={self.thread_id}")
                             elif self.defer_cleanup_on_complete:
-                                # 后台 drain（无 SSE 下游）：不立即清理队列，保留 DLQ 历史供前端接管续流。
+                                # 后台 drain（无 SSE 下游）：不立即清理队列，保留缓存历史供前端接管续流。
                                 # 实际清理由 producer 的 _schedule_session_cleanup 在窗口内兜底，
                                 # 若窗口内有前端接管消费则跳过清理。
                                 logger.info(
@@ -714,7 +713,7 @@ class GeneratorStreamingHelper:
                         if item == CANCELLED_CHUNK:
                             if hasattr(self.message_handler, "mark_stopped"):
                                 self.message_handler.mark_stopped(self.thread_id)
-                            logger.info(f"Stream cancelled for thread_id={self.thread_id}, DLQ content preserved")
+                            logger.info(f"Stream cancelled for thread_id={self.thread_id}, cached content preserved")
                             self._notify_consumer_cancelled_safely()
                             yield emit_run_finished_event(thread_id=self.thread_id, run_id=RunId.CANCELLED)
                             yielded_total += 1
@@ -910,8 +909,8 @@ class GeneratorStreamingHelper:
                 event_handler=event_handler,
             )
         except GeneratorExit:
-            # 客户端断开连接，不清理队列，消息已在死信队列中保留
-            logger.info(f"Consumer disconnected for thread_id={self.thread_id}, messages preserved in DLQ")
+            # 客户端断开连接时仅释放消费者，缓存消息继续保留供重连 replay。
+            logger.info(f"Consumer disconnected for thread_id={self.thread_id}, cached messages preserved")
             raise
         finally:
             self._unregister_cancel_event()

--- a/src/agent/tests/services/test_rabbitmq_consumer_mixin.py
+++ b/src/agent/tests/services/test_rabbitmq_consumer_mixin.py
@@ -1,555 +1,76 @@
 import contextlib
-import multiprocessing
 import os
 import time
 
 import pytest
-from aidev_agent.services.messages_handler.base import EOD_CHUNK, ConsumerPreemptedError
+from aidev_agent.services.messages_handler.base import EOD_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
 
-# 标记：所有测试均需要 RabbitMQ
 pytestmark = pytest.mark.skipif(
     not os.getenv("RABBITMQ_HOST"),
     reason="Live test requires RABBITMQ_HOST",
 )
 
 
-# ==================== Fixtures ====================
-
-
 @pytest.fixture()
 def handler():
-    """创建 handler 实例，每个测试重置单例"""
     RabbitMQMessageHandler._instance = None
-    h = RabbitMQMessageHandler()
-    yield h
+    instance = RabbitMQMessageHandler()
+    yield instance
 
 
 @pytest.fixture()
 def thread_id(request, handler):
-    """为每个测试生成唯一的 thread_id，测试后自动清理"""
-    tid = f"test-cm-{request.node.name}-{int(time.time() * 1000) % 100000}"
-    yield tid
+    value = f"test-replay-{request.node.name}-{int(time.time() * 1000) % 100000}"
+    yield value
     with contextlib.suppress(Exception):
-        handler.clear(tid)
+        handler.mark_completed(value)
 
 
-@pytest.fixture()
-def mp_ctx():
-    """提供 spawn 上下文用于多进程测试"""
-    return multiprocessing.get_context("spawn")
+class TestReplayConsumers:
+    def test_multiple_consumers_are_independent(self, handler, thread_id):
+        first = handler.acquire_consumer(thread_id)
+        second = handler.acquire_consumer(thread_id)
 
+        assert first != second
+        handler.check_consumer(thread_id, first)
+        handler.check_consumer(thread_id, second)
+        assert handler.has_active_consumer(thread_id) is True
 
-@pytest.fixture()
-def env_vars():
-    """收集当前进程的 RabbitMQ 环境变量，传递给子进程"""
-    keys = ["RABBITMQ_HOST", "RABBITMQ_PORT", "RABBITMQ_USER", "RABBITMQ_PASSWORD", "RABBITMQ_VHOST"]
-    return {k: os.environ[k] for k in keys if k in os.environ}
+        handler.release_consumer(thread_id, first)
+        assert handler.has_active_consumer(thread_id) is True
+        handler.release_consumer(thread_id, second)
+        assert handler.has_active_consumer(thread_id) is False
 
-
-# ==================== 单进程单元测试 ====================
-
-
-class TestConsumerAcquire:
-    """acquire_consumer 核心行为"""
-
-    def test_returns_32char_hex(self, handler, thread_id):
-        """返回 32 位十六进制字符串"""
-        consumer_id = handler.acquire_consumer(thread_id)
-        assert len(consumer_id) == 32
-        int(consumer_id, 16)
-
-    def test_consecutive_acquire_returns_unique_ids(self, handler, thread_id):
-        """连续 acquire 返回不同 ID，且新 ID 抢占旧 ID"""
-        id1 = handler.acquire_consumer(thread_id)
-        id2 = handler.acquire_consumer(thread_id)
-        assert id1 != id2
-
-        handler.check_consumer(thread_id, id2)
-        with pytest.raises(ConsumerPreemptedError):
-            handler.check_consumer(thread_id, id1)
-
-    def test_control_queue_keeps_only_latest(self, handler, thread_id):
-        """连续 5 次 acquire，控制队列始终只保留最后一个 consumer_id"""
-        ids = [handler.acquire_consumer(thread_id) for _ in range(5)]
-
-        handler.check_consumer(thread_id, ids[-1])
-        for old_id in ids[:-1]:
-            with pytest.raises(ConsumerPreemptedError):
-                handler.check_consumer(thread_id, old_id)
-
-
-class TestConsumerCheck:
-    """check_consumer 核心行为"""
-
-    def test_active_consumer_passes(self, handler, thread_id):
-        """当前活跃消费者 check 不抛异常"""
-        cid = handler.acquire_consumer(thread_id)
-        handler.check_consumer(thread_id, cid)
-
-    def test_empty_queue_passes(self, handler, thread_id):
-        """控制队列不存在 / 为空时 check 任意 ID 都通过"""
-        handler.check_consumer(thread_id, "nonexistent-id")
-
-
-class TestConsumerRelease:
-    """release_consumer 核心行为"""
-
-    def test_normal_release_clears_control_queue(self, handler, thread_id):
-        """正常释放后控制队列为空"""
-        cid = handler.acquire_consumer(thread_id)
-        handler.release_consumer(thread_id, cid)
-        handler.check_consumer(thread_id, "any-id-after-release")
-
-    def test_preempted_release_restores_dlq_and_sends_signal(self, handler):
-        """被抢占的消费者释放时：恢复 DLQ → 主队列 + 发送退出信号"""
-        tid = f"test-dlq-restore-{int(time.time() * 1000) % 100000}"
-        try:
-            handler.clear(tid)
-
-            for msg in ["m1", "m2", "m3"]:
-                handler.put(tid, msg)
-            handler.flush(tid)
-            assert handler.get_cached_count(tid) == 3
-
-            old_id = handler.acquire_consumer(tid)
-            messages = handler.get(tid, timeout=1)
-            assert messages == ["m1", "m2", "m3"]
-            assert handler._get_dlq_count(tid) == 3
-            assert handler.get_cached_count(tid) == 0
-
-            new_id = handler.acquire_consumer(tid)
-            handler.release_consumer(tid, old_id)
-
-            assert handler._get_dlq_count(tid) == 0
-            assert handler.get_cached_count(tid) == 3
-
-            assert handler.wait_for_previous_consumer(tid, timeout=2.0) is True
-
-            msgs = handler.get(tid, timeout=1)
-            assert msgs == ["m1", "m2", "m3"]
-
-            handler.release_consumer(tid, new_id)
-            handler.mark_completed(tid)
-        finally:
-            handler.clear(tid)
-
-    def test_double_release_is_safe(self, handler, thread_id):
-        """重复释放不报错"""
-        cid = handler.acquire_consumer(thread_id)
-        handler.release_consumer(thread_id, cid)
-        handler.release_consumer(thread_id, cid)
-
-    def test_rapid_acquire_release_cycle(self, handler, thread_id):
-        """10 次快速 acquire/release 不出现状态不一致"""
-        for _ in range(10):
-            cid = handler.acquire_consumer(thread_id)
-            handler.check_consumer(thread_id, cid)
-            handler.release_consumer(thread_id, cid)
-        handler.check_consumer(thread_id, "any-id")
-
-
-class TestWaitForPreviousConsumer:
-    """wait_for_previous_consumer 核心行为"""
-
-    def test_no_signal_timeout(self, handler, thread_id):
-        """没有退出信号时超时返回 False"""
-        handler.acquire_consumer(thread_id)
-        assert handler.wait_for_previous_consumer(thread_id, timeout=0.5) is False
-
-    def test_queue_not_exist_returns_true(self, handler, thread_id):
-        """退出通知队列不存在时立即返回 True"""
-        assert handler.wait_for_previous_consumer(thread_id, timeout=0.5) is True
-
-
-class TestEndToEnd:
-    """端到端完整流程"""
-
-    def test_preemption_and_resume(self, handler, thread_id):
-        """完整断点续传：写入 → A 消费 → B 抢占 → A release(恢复DLQ+信号) → B 消费"""
-        handler.clear(thread_id)
-        all_msgs = [f"c_{i}" for i in range(5)] + [EOD_CHUNK]
-        for msg in all_msgs:
-            handler.put(thread_id, msg)
+    def test_consumers_replay_same_main_queue_log(self, handler, thread_id):
+        expected = ["message-1", "message-2", EOD_CHUNK]
+        for message in expected:
+            handler.put(thread_id, message)
         handler.flush(thread_id)
 
-        consumer_a = handler.acquire_consumer(thread_id)
-        handler.get(thread_id, timeout=1)
-        assert handler._get_dlq_count(thread_id) == 6
+        first_messages, first_offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
+        second_messages, second_offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
 
-        consumer_b = handler.acquire_consumer(thread_id)
+        assert first_messages == expected
+        assert second_messages == expected
+        assert first_offset == second_offset == len(expected)
+        assert handler.get_cached_count(thread_id) == len(expected)
 
-        with pytest.raises(ConsumerPreemptedError):
-            handler.check_consumer(thread_id, consumer_a)
-
-        handler.release_consumer(thread_id, consumer_a)
-        assert handler.get_cached_count(thread_id) == 6
-        assert handler.wait_for_previous_consumer(thread_id, timeout=2.0) is True
-
-        assert handler.get(thread_id, timeout=1) == all_msgs
-
-        # 先释放消费者，再 mark_completed（避免 release_consumer 内部
-        # _ensure_consumer_queues 重新创建已删除的 consumer/exit 队列）
-        handler.release_consumer(thread_id, consumer_b)
-        handler.mark_completed(thread_id)
-        assert handler.is_empty(thread_id) is True
-
-    def test_normal_flow_no_preemption(self, handler, thread_id):
-        """正常流程：acquire → check → 消费 → mark_completed → release"""
-        handler.clear(thread_id)
-        for msg in ["d1", "d2", EOD_CHUNK]:
-            handler.put(thread_id, msg)
+    def test_restore_is_noop_and_legacy_get_is_rejected(self, handler, thread_id):
+        handler.put(thread_id, "message")
         handler.flush(thread_id)
 
-        cid = handler.acquire_consumer(thread_id)
-        handler.check_consumer(thread_id, cid)
-        assert handler.get(thread_id, timeout=1) == ["d1", "d2", EOD_CHUNK]
-
-        handler.mark_completed(thread_id)
-        handler.release_consumer(thread_id, cid)
-        assert handler.is_empty(thread_id) is True
-
-
-# ==================== 多进程集成测试 ====================
-#
-# 所有 worker 函数定义在模块顶层，便于 spawn 子进程 pickle。
-# 导入语句在函数内部仅限 RabbitMQMessageHandler（子进程需要独立初始化）。
-
-
-def _setup_env(env_vars):
-    """在子进程中设置 RabbitMQ 环境变量"""
-    for key, value in env_vars.items():
-        os.environ[key] = value
-
-
-def _new_handler():
-    """在子进程中创建独立的 handler 实例"""
-    RabbitMQMessageHandler._instance = None
-    return RabbitMQMessageHandler()
-
-
-def _worker_acquire(env_vars, thread_id, result_queue):
-    """Worker：注册消费者并返回 consumer_id"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    cid = h.acquire_consumer(thread_id)
-    result_queue.put({"pid": os.getpid(), "consumer_id": cid})
-
-
-def _worker_check(env_vars, thread_id, consumer_id, result_queue):
-    """Worker：检查 consumer_id 是否仍是活跃消费者"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    try:
-        h.check_consumer(thread_id, consumer_id)
-        result_queue.put({"pid": os.getpid(), "preempted": False})
-    except ConsumerPreemptedError:
-        result_queue.put({"pid": os.getpid(), "preempted": True})
-
-
-def _worker_release(env_vars, thread_id, consumer_id, result_queue):
-    """Worker：释放消费者（被抢占场景）"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    h.release_consumer(thread_id, consumer_id)
-    result_queue.put({"pid": os.getpid(), "released": True})
-
-
-def _worker_wait_exit(env_vars, thread_id, timeout, result_queue):
-    """Worker：等待旧消费者退出"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    exited = h.wait_for_previous_consumer(thread_id, timeout=timeout)
-    result_queue.put({"pid": os.getpid(), "exited": exited})
-
-
-def _worker_put_and_flush(env_vars, thread_id, messages, result_queue):
-    """Worker：写入消息并 flush"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    for msg in messages:
-        h.put(thread_id, msg)
-    h.flush(thread_id)
-    result_queue.put({"pid": os.getpid(), "count": len(messages)})
-
-
-def _worker_get_messages(env_vars, thread_id, timeout, result_queue):
-    """Worker：消费消息"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    try:
-        msgs = h.get(thread_id, timeout=timeout)
-        result_queue.put({"pid": os.getpid(), "messages": msgs})
-    except TimeoutError:
-        result_queue.put({"pid": os.getpid(), "messages": []})
-
-
-def _worker_get_dlq_count(env_vars, thread_id, result_queue):
-    """Worker：获取 DLQ 消息数量"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    count = h._get_dlq_count(thread_id)
-    result_queue.put({"pid": os.getpid(), "dlq_count": count})
-
-
-def _worker_get_cached_count(env_vars, thread_id, result_queue):
-    """Worker：获取主队列消息数量"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    count = h.get_cached_count(thread_id)
-    result_queue.put({"pid": os.getpid(), "cached_count": count})
-
-
-def _worker_clear(env_vars, thread_id, result_queue):
-    """Worker：清空队列"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    h.clear(thread_id)
-    result_queue.put({"pid": os.getpid(), "cleared": True})
-
-
-def _worker_mark_completed(env_vars, thread_id, result_queue):
-    """Worker：标记完成"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    h.mark_completed(thread_id)
-    result_queue.put({"pid": os.getpid(), "completed": True})
-
-
-def _worker_restore_messages(env_vars, thread_id, result_queue):
-    """Worker：恢复 DLQ 消息到主队列"""
-    _setup_env(env_vars)
-    h = _new_handler()
-    restored = h.restore_messages(thread_id)
-    result_queue.put({"pid": os.getpid(), "restored": restored})
-
-
-def _run_worker(ctx, target, args, timeout=15):
-    """启动 spawn 子进程并获取结果"""
-    result_queue = ctx.Queue()
-    p = ctx.Process(target=target, args=(*args, result_queue))
-    p.start()
-    p.join(timeout=timeout)
-    if p.exitcode != 0:
-        raise RuntimeError(f"Worker process exited with code {p.exitcode}")
-    return result_queue.get(timeout=5)
-
-
-class TestMultiProcessAcquireAndCheck:
-    """多进程：acquire + check 跨进程状态共享"""
-
-    def test_cross_process_acquire_produces_unique_ids(self, mp_ctx, env_vars, handler, thread_id):
-        """不同进程 acquire 返回不同 consumer_id"""
-        r1 = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        r2 = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-
-        assert r1["pid"] != r2["pid"], "应在不同进程中运行"
-        assert r1["consumer_id"] != r2["consumer_id"], "两次 acquire 应产生不同 ID"
-
-    def test_cross_process_preemption_detection(self, mp_ctx, env_vars, handler, thread_id):
-        """进程 A acquire → 进程 B acquire → A 被抢占, B 活跃"""
-        ra = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        rb = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-
-        check_a = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, ra["consumer_id"]))
-        assert check_a["preempted"] is True, "旧消费者 A 应被抢占"
-
-        check_b = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, rb["consumer_id"]))
-        assert check_b["preempted"] is False, "新消费者 B 应仍然活跃"
-
-    def test_cross_process_multiple_acquire_only_latest_active(self, mp_ctx, env_vars, handler, thread_id):
-        """4 次跨进程 acquire，只有最后一个有效"""
-        consumer_ids = []
-        for _ in range(4):
-            r = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-            consumer_ids.append(r["consumer_id"])
-
-        last_check = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, consumer_ids[-1]))
-        assert last_check["preempted"] is False, "最新消费者应活跃"
-
-        for i, old_cid in enumerate(consumer_ids[:-1]):
-            old_check = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, old_cid))
-            assert old_check["preempted"] is True, f"第 {i + 1} 个消费者应被抢占"
-
-
-class TestMultiProcessReleaseAndWait:
-    """多进程：release + wait 退出信号跨进程传递"""
-
-    def test_exit_signal_delivered_cross_process(self, mp_ctx, env_vars, handler, thread_id):
-        """被抢占消费者 release 后，新消费者 wait 能收到退出信号"""
-        ra = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-
-        release_r = _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, ra["consumer_id"]))
-        assert release_r["released"] is True
-
-        wait_r = _run_worker(mp_ctx, _worker_wait_exit, (env_vars, thread_id, 3.0))
-        assert wait_r["exited"] is True, "应收到旧消费者退出信号"
-
-    def test_wait_timeout_when_no_signal(self, mp_ctx, env_vars, handler):
-        """无退出信号时 wait 超时返回 False"""
-        tid = f"test-mp-timeout-{int(time.time() * 1000) % 100000}"
-        try:
-            _run_worker(mp_ctx, _worker_acquire, (env_vars, tid))
-
-            wait_r = _run_worker(mp_ctx, _worker_wait_exit, (env_vars, tid, 1.0))
-            assert wait_r["exited"] is False, "无退出信号应超时"
-        finally:
-            handler = RabbitMQMessageHandler()
-            handler.clear(tid)
-
-
-class TestMultiProcessEndToEnd:
-    """多进程：完整端到端流程"""
-
-    def test_write_consume_preempt_restore_reconsume(self, mp_ctx, env_vars, handler, thread_id):
-        """跨进程端到端：写入 → 消费 → 抢占 → DLQ恢复 → 重新消费
-
-        模拟 gunicorn 多 worker 场景下的断点续传：
-        1. 进程 I 写入 3 条消息
-        2. 进程 J acquire
-        3. 进程 K 消费消息（进入 DLQ）
-        4. 进程 L acquire（抢占 J）
-        5. 进程 M 验证 J 被抢占
-        6. 进程 N release 旧消费者（恢复 DLQ + 发退出信号）
-        7. 进程 O wait 收到退出信号
-        8. 进程 P 验证 DLQ 已清空，主队列已恢复
-        9. 进程 Q 重新消费
-        """
-        _run_worker(mp_ctx, _worker_clear, (env_vars, thread_id))
-
-        msgs = ["e2e_1", "e2e_2", "e2e_3"]
-
-        # 1. 写入消息
-        ri = _run_worker(mp_ctx, _worker_put_and_flush, (env_vars, thread_id, msgs))
-        assert ri["count"] == 3
-
-        # 2. 消费者 J acquire
-        rj = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        consumer_j = rj["consumer_id"]
-
-        # 3. 消费消息（进入 DLQ）
-        rk = _run_worker(mp_ctx, _worker_get_messages, (env_vars, thread_id, 2))
-        assert rk["messages"] == msgs
-
-        # 验证 DLQ 有 3 条，主队列为 0
-        r_dlq = _run_worker(mp_ctx, _worker_get_dlq_count, (env_vars, thread_id))
-        assert r_dlq["dlq_count"] == 3
-        r_cached = _run_worker(mp_ctx, _worker_get_cached_count, (env_vars, thread_id))
-        assert r_cached["cached_count"] == 0
-
-        # 4. 消费者 L acquire（抢占 J）
-        rl = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        consumer_l = rl["consumer_id"]
-        assert consumer_l != consumer_j
-
-        # 5. 验证 J 被抢占
-        rm = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, consumer_j))
-        assert rm["preempted"] is True
-
-        # 6. release 旧消费者 J（恢复 DLQ + 退出信号）
-        rn = _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, consumer_j))
-        assert rn["released"] is True
-
-        # 7. wait 收到退出信号
-        ro = _run_worker(mp_ctx, _worker_wait_exit, (env_vars, thread_id, 3.0))
-        assert ro["exited"] is True
-
-        # 8. 验证 DLQ 清空，主队列恢复
-        r_dlq2 = _run_worker(mp_ctx, _worker_get_dlq_count, (env_vars, thread_id))
-        assert r_dlq2["dlq_count"] == 0
-        r_cached2 = _run_worker(mp_ctx, _worker_get_cached_count, (env_vars, thread_id))
-        assert r_cached2["cached_count"] == 3
-
-        # 9. 重新消费
-        rq = _run_worker(mp_ctx, _worker_get_messages, (env_vars, thread_id, 2))
-        assert rq["messages"] == msgs
-
-        # 清理
-        _run_worker(mp_ctx, _worker_mark_completed, (env_vars, thread_id))
-
-    def test_cross_process_normal_flow(self, mp_ctx, env_vars, handler, thread_id):
-        """跨进程正常流程（无抢占）：写入 → acquire → 消费 → mark_completed"""
-        _run_worker(mp_ctx, _worker_clear, (env_vars, thread_id))
-
-        msgs = ["nf_1", "nf_2", EOD_CHUNK]
-
-        _run_worker(mp_ctx, _worker_put_and_flush, (env_vars, thread_id, msgs))
-
-        ra = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        consumer_id = ra["consumer_id"]
-
-        check_r = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, consumer_id))
-        assert check_r["preempted"] is False
-
-        rg = _run_worker(mp_ctx, _worker_get_messages, (env_vars, thread_id, 2))
-        assert rg["messages"] == msgs
-
-        _run_worker(mp_ctx, _worker_mark_completed, (env_vars, thread_id))
-        _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, consumer_id))
-
-    def test_cross_process_restore_without_preemption(self, mp_ctx, env_vars, handler, thread_id):
-        """跨进程断点续传（无抢占）：写入 → 消费 → 断开 → restore → 重新消费"""
-        _run_worker(mp_ctx, _worker_clear, (env_vars, thread_id))
-
-        msgs = ["rs_1", "rs_2", "rs_3"]
-        _run_worker(mp_ctx, _worker_put_and_flush, (env_vars, thread_id, msgs))
-
-        _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-
-        rg = _run_worker(mp_ctx, _worker_get_messages, (env_vars, thread_id, 2))
-        assert rg["messages"] == msgs
-
-        # 验证消息进入 DLQ
-        r_dlq = _run_worker(mp_ctx, _worker_get_dlq_count, (env_vars, thread_id))
-        assert r_dlq["dlq_count"] == 3
-
-        # 模拟断开：直接 restore
-        r_restore = _run_worker(mp_ctx, _worker_restore_messages, (env_vars, thread_id))
-        assert r_restore["restored"] == 3
-
-        # 验证主队列恢复
-        r_cached = _run_worker(mp_ctx, _worker_get_cached_count, (env_vars, thread_id))
-        assert r_cached["cached_count"] == 3
-
-        # 重新消费
-        rg2 = _run_worker(mp_ctx, _worker_get_messages, (env_vars, thread_id, 2))
-        assert rg2["messages"] == msgs
-
-        _run_worker(mp_ctx, _worker_mark_completed, (env_vars, thread_id))
-
-    def test_cross_process_double_preemption(self, mp_ctx, env_vars, handler, thread_id):
-        """跨进程双重抢占：A → B 抢占 → C 抢占 B，验证只有 C 活跃"""
-        ra = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        rb = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-        rc = _run_worker(mp_ctx, _worker_acquire, (env_vars, thread_id))
-
-        check_a = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, ra["consumer_id"]))
-        assert check_a["preempted"] is True
-
-        check_b = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, rb["consumer_id"]))
-        assert check_b["preempted"] is True
-
-        check_c = _run_worker(mp_ctx, _worker_check, (env_vars, thread_id, rc["consumer_id"]))
-        assert check_c["preempted"] is False
-
-        # release A（被抢占）
-        _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, ra["consumer_id"]))
-        # release B（被抢占）
-        _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, rb["consumer_id"]))
-        # release C（正常）
-        _run_worker(mp_ctx, _worker_release, (env_vars, thread_id, rc["consumer_id"]))
+        assert handler.restore_messages(thread_id) == 0
+        assert handler.get_dlq_messages(thread_id) == []
+        with pytest.raises(NotImplementedError, match="get_messages_since"):
+            handler.get(thread_id, timeout=1)
 
 
 class TestResourceCleanup:
-    """mark_completed 后资源清理：队列删除 + 信号队列删除"""
-
     @staticmethod
     def _queue_exists(handler, queue_name: str) -> bool:
-        """通过 passive declare 检查队列是否存在"""
         try:
-            with handler._with_connection() as connection:
-                channel = connection.channel()
+            with handler._with_channel() as channel:
                 channel.queue_declare(queue=queue_name, durable=True, passive=True)
                 return True
         except Exception:
@@ -557,107 +78,64 @@ class TestResourceCleanup:
 
     @staticmethod
     def _exchange_exists(handler, exchange_name: str) -> bool:
-        """通过 passive declare 检查交换机是否存在"""
         try:
-            with handler._with_connection() as connection:
-                channel = connection.channel()
+            with handler._with_channel() as channel:
                 channel.exchange_declare(exchange=exchange_name, passive=True)
                 return True
         except Exception:
             return False
 
-    def test_mark_completed_deletes_all_resources(self, handler, thread_id):
-        """mark_completed 后主队列、死信队列、死信交换机以及信号队列全部被删除"""
+    @staticmethod
+    def _declare_legacy_resources(handler, thread_id: str) -> None:
+        dlq_name = f"aidev_agent.dlq.{thread_id}"
+        exchange_name = f"aidev_agent.dlx.{thread_id}"
+        with handler._with_channel() as channel:
+            channel.exchange_declare(exchange=exchange_name, exchange_type="direct", durable=True)
+            channel.queue_declare(queue=dlq_name, durable=True, arguments={"x-expires": handler.QUEUE_TTL_MS})
+            channel.queue_bind(queue=dlq_name, exchange=exchange_name, routing_key=dlq_name)
+            channel.queue_declare(
+                queue=handler._get_queue_name(thread_id),
+                durable=True,
+                arguments={
+                    "x-expires": handler.QUEUE_TTL_MS,
+                    "x-dead-letter-exchange": exchange_name,
+                    "x-dead-letter-routing-key": dlq_name,
+                },
+            )
+
+    def test_main_queue_has_no_dead_letter_resources(self, handler, thread_id):
         handler.clear(thread_id)
-
-        # 发送消息并消费（创建主队列 + DLQ + DLX）
-        for msg in ["m1", "m2", "m3"]:
-            handler.put(thread_id, msg)
+        handler.put(thread_id, "message")
         handler.flush(thread_id)
-        handler.get(thread_id, timeout=1)
 
-        # 触发信号队列创建
+        assert self._queue_exists(handler, handler._get_queue_name(thread_id))
+        assert not self._queue_exists(handler, f"aidev_agent.dlq.{thread_id}")
+        assert not self._exchange_exists(handler, f"aidev_agent.dlx.{thread_id}")
+
+    def test_clear_migrates_and_deletes_legacy_dead_letter_resources(self, handler, thread_id):
+        self._declare_legacy_resources(handler, thread_id)
+
+        handler.clear(thread_id)
+        handler.put(thread_id, "message")
+        handler.flush(thread_id)
+
+        assert self._queue_exists(handler, handler._get_queue_name(thread_id))
+        assert not self._queue_exists(handler, f"aidev_agent.dlq.{thread_id}")
+        assert not self._exchange_exists(handler, f"aidev_agent.dlx.{thread_id}")
+
+    def test_mark_completed_deletes_main_and_control_queues(self, handler, thread_id):
+        handler.clear(thread_id)
+        handler.put(thread_id, "message")
+        handler.flush(thread_id)
         consumer_id = handler.acquire_consumer(thread_id)
-        handler.mark_stopped(thread_id)
 
-        # 收集所有资源名称
         main_queue = handler._get_queue_name(thread_id)
-        dlq_name = handler._get_dlq_name(thread_id)
-        dlx_exchange = handler._get_dlx_exchange_name(thread_id)
-        consumer_queue = handler._get_consumer_queue_name(thread_id)
-        exit_queue = handler._get_consumer_exit_queue_name(thread_id)
-        stopped_queue = handler._get_stopped_queue_name(thread_id)
-
-        # 确认资源存在
+        active_queue = handler._get_active_consumer_queue_name(thread_id)
         assert self._queue_exists(handler, main_queue)
-        assert self._queue_exists(handler, dlq_name)
-        assert self._exchange_exists(handler, dlx_exchange)
-        assert self._queue_exists(handler, consumer_queue)
-        assert self._queue_exists(handler, exit_queue)
-        assert self._queue_exists(handler, stopped_queue)
-        # 先释放消费者，再 mark_completed（避免 release_consumer 内部
-        # _ensure_consumer_queues 重新创建已删除的 consumer/exit 队列）
+        assert self._queue_exists(handler, active_queue)
+
         handler.release_consumer(thread_id, consumer_id)
-
-        # 执行 mark_completed
         handler.mark_completed(thread_id)
 
-        # 验证所有资源已被删除
-        assert not self._queue_exists(handler, main_queue), "主队列应被删除"
-        assert not self._queue_exists(handler, dlq_name), "死信队列应被删除"
-        assert not self._exchange_exists(handler, dlx_exchange), "死信交换机应被删除"
-        assert not self._queue_exists(handler, consumer_queue), "消费者控制队列应被删除"
-        assert not self._queue_exists(handler, exit_queue), "退出通知队列应被删除"
-        assert not self._queue_exists(handler, stopped_queue), "停止状态队列应被删除"
-
-    def test_double_delete_is_safe(self, handler, thread_id):
-        """重复执行 _delete_all_resources 不报错"""
-        handler.clear(thread_id)
-
-        handler.put(thread_id, "msg")
-        handler.flush(thread_id)
-
-        # 第一次删除
-        handler.mark_completed(thread_id)
-        # 第二次删除（资源已不存在）
-        handler._delete_all_resources(thread_id)
-
-    def test_preemption_then_mark_completed_cleans_all(self, handler):
-        """完整抢占流程后 mark_completed 清理所有资源"""
-        tid = f"test-cleanup-preempt-{int(time.time() * 1000) % 100000}"
-        try:
-            handler.clear(tid)
-
-            # 写入消息
-            for msg in ["p1", "p2"]:
-                handler.put(tid, msg)
-            handler.flush(tid)
-
-            # A 消费 → B 抢占 → A release
-            consumer_a = handler.acquire_consumer(tid)
-            handler.get(tid, timeout=1)
-            consumer_b = handler.acquire_consumer(tid)
-            handler.release_consumer(tid, consumer_a)
-
-            # B 等待旧消费者退出
-            handler.wait_for_previous_consumer(tid, timeout=2.0)
-
-            # B 消费恢复的消息
-            handler.get(tid, timeout=1)
-
-            # 先释放消费者，再 mark_completed（避免 release_consumer 内部
-            # _ensure_consumer_queues 重新创建已删除的 consumer/exit 队列）
-            handler.release_consumer(tid, consumer_b)
-            handler.mark_completed(tid)
-
-            # 验证所有资源被删除
-            main_queue = handler._get_queue_name(tid)
-            dlq_name = handler._get_dlq_name(tid)
-            dlx_exchange = handler._get_dlx_exchange_name(tid)
-
-            assert not self._queue_exists(handler, main_queue)
-            assert not self._queue_exists(handler, dlq_name)
-            assert not self._exchange_exists(handler, dlx_exchange)
-        finally:
-            with contextlib.suppress(Exception):
-                handler.clear(tid)
+        assert not self._queue_exists(handler, main_queue)
+        assert not self._queue_exists(handler, active_queue)

--- a/src/agent/tests/services/test_rabbitmq_handler.py
+++ b/src/agent/tests/services/test_rabbitmq_handler.py
@@ -5,7 +5,6 @@ import threading
 import time
 
 import pytest
-
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
@@ -80,28 +79,19 @@ class TestRabbitMQMessageHandler:
         # 验证有未消费的消息
         assert handler.has_pending_messages(thread_id) is True
 
-        # 获取消息（消息会被移动到死信队列）
-        messages = handler.get(thread_id, timeout=1)
+        # offset replay 不移动主队列消息
+        messages, offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
         assert messages == ["test_msg_1", "test_msg_2", "test_msg_3"]
+        assert offset == 3
 
-        # 主队列应该为空，消息已移动到死信队列
-        assert handler.get_cached_count(thread_id) == 0
-        assert handler._get_dlq_count(thread_id) == 3
-
-        # 仍然有未消费的消息（在死信队列中）
+        # 主队列保留完整 replay 日志
+        assert handler.get_cached_count(thread_id) == 3
         assert handler.has_pending_messages(thread_id) is True
 
-        # 恢复消息到主队列（模拟断点续传）
-        restored = handler.restore_messages(thread_id)
-        assert restored == 3
-
-        # 消息已恢复到主队列
-        assert handler.get_cached_count(thread_id) == 3
-        assert handler._get_dlq_count(thread_id) == 0
-
-        # 再次获取消息
-        messages = handler.get(thread_id, timeout=1)
+        # 新消费者从 offset=0 独立 replay 同一批消息
+        messages, replay_offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
         assert messages == ["test_msg_1", "test_msg_2", "test_msg_3"]
+        assert replay_offset == 3
 
         # 标记完成并清理
         handler.mark_completed(thread_id)
@@ -109,7 +99,6 @@ class TestRabbitMQMessageHandler:
         # 验证所有队列已清空
         assert handler.is_empty(thread_id) is True
         assert handler.get_cached_count(thread_id) == 0
-        assert handler._get_dlq_count(thread_id) == 0
 
     def test_live_chat(self, handler):
         """实际连接 LLM + RabbitMQ 的端到端流式测试"""
@@ -240,91 +229,55 @@ class TestRabbitMQMessageHandler:
         assert messages == buffered_messages
         assert next_offset == 2_000
 
-    def test_consumer_reconnect_with_dlq(self, handler, thread_id):
-        """测试消费者断开后重连可以从死信队列恢复消息
-
-        验证：
-        1. 生产者产生消息后，消费者读取消息
-        2. 消息被移动到死信队列
-        3. 消费者断开后，消息仍在死信队列中
-        4. 新的消费者调用 restore_messages 恢复消息
-        5. 从主队列重新消费所有消息
-        """
+    def test_consumer_reconnect_replays_main_queue(self, handler, thread_id):
+        """消费者断开后，新消费者从主队列开头独立 replay。"""
         # 模拟生产者产生消息
         for i in range(5):
             handler.put(thread_id, f"msg_{i}")
         handler.put(thread_id, EOD_CHUNK)
         handler.flush(thread_id)
 
-        # 第一个消费者读取部分消息
-        messages1 = handler.get(thread_id, timeout=1)
+        messages1, offset1 = handler.get_messages_since(thread_id, offset=0, timeout=1)
         assert len(messages1) == 6  # 包括 EOD_CHUNK
+        assert offset1 == 6
 
-        # 主队列为空，消息在死信队列
-        assert handler.get_cached_count(thread_id) == 0
-        assert handler._get_dlq_count(thread_id) == 6
-
-        # 模拟消费者断开（不调用 mark_completed）
-
-        # 新的消费者重连，恢复消息
-        restored = handler.restore_messages(thread_id)
-        assert restored == 6
-
-        # 消息已恢复到主队列
+        # 消费不会删除主队列数据
         assert handler.get_cached_count(thread_id) == 6
-        assert handler._get_dlq_count(thread_id) == 0
 
-        # 重新消费所有消息
-        messages2 = handler.get(thread_id, timeout=1)
+        # 新消费者使用独立 offset，从头 replay 全部消息
+        messages2, offset2 = handler.get_messages_since(thread_id, offset=0, timeout=1)
         expected = [f"msg_{i}" for i in range(5)] + [EOD_CHUNK]
         assert messages2 == expected
+        assert offset2 == 6
 
         # 清理
         handler.mark_completed(thread_id)
         assert handler.is_empty(thread_id) is True
 
-    def test_dlq_mechanism(self, handler, thread_id):
-        """测试死信队列机制
-
-        验证：
-        1. 消息被消费后进入死信队列
-        2. restore_messages 能正确恢复消息
-        3. mark_completed 能清空所有队列
-        """
+    def test_replay_does_not_remove_main_queue_messages(self, handler, thread_id):
+        """多次 replay 都读取同一份主队列日志。"""
         # 发送消息
         handler.put(thread_id, "msg_1")
         handler.put(thread_id, "msg_2")
         handler.flush(thread_id)
 
-        # 初始状态：主队列有消息，死信队列为空
         assert handler.get_cached_count(thread_id) == 2
-        assert handler._get_dlq_count(thread_id) == 0
 
-        # 消费消息
-        messages = handler.get(thread_id, timeout=1)
+        messages, offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
         assert messages == ["msg_1", "msg_2"]
+        assert offset == 2
 
-        # 消费后：主队列为空，死信队列有消息
-        assert handler.get_cached_count(thread_id) == 0
-        assert handler._get_dlq_count(thread_id) == 2
-
-        # 恢复消息
-        handler.restore_messages(thread_id)
-
-        # 恢复后：主队列有消息，死信队列为空
+        # replay 后主队列仍保留消息，第二个消费者可再次读取
         assert handler.get_cached_count(thread_id) == 2
-        assert handler._get_dlq_count(thread_id) == 0
-
-        # 再次消费
-        messages = handler.get(thread_id, timeout=1)
-        assert messages == ["msg_1", "msg_2"]
+        replayed, replay_offset = handler.get_messages_since(thread_id, offset=0, timeout=1)
+        assert replayed == ["msg_1", "msg_2"]
+        assert replay_offset == 2
 
         # 标记完成
         handler.mark_completed(thread_id)
 
         # 所有队列都应该为空
         assert handler.get_cached_count(thread_id) == 0
-        assert handler._get_dlq_count(thread_id) == 0
         assert handler.is_empty(thread_id) is True
 
     def test_producer_stop_request_cancel_live(self, handler, thread_id):
@@ -362,7 +315,7 @@ class TestRabbitMQMessageHandler:
 class TestResourceCleanup:
     """测试 mark_completed 后的资源清理逻辑
     验证：
-    1. mark_completed 后队列和交换机被真正删除（而非仅清空）
+    1. mark_completed 后队列被真正删除（而非仅清空）
     2. _delete_all_resources 对不存在的资源不报错
     3. 信号队列（consumer/exit/cancelled/stopped）也会被清理
     4. clear() 不会删除队列（只清空消息，因为后续还要重建）
@@ -378,48 +331,25 @@ class TestResourceCleanup:
         except Exception:
             return False
 
-    def _exchange_exists(self, handler, exchange_name: str) -> bool:
-        """辅助方法：通过 passive declare 检查交换机是否存在"""
-        try:
-            with handler._with_connection() as connection:
-                channel = connection.channel()
-                channel.exchange_declare(exchange=exchange_name, passive=True)
-                return True
-        except Exception:
-            return False
-
     @pytest.mark.skipif(not os.getenv("RABBITMQ_HOST"), reason="Live test requires RABBITMQ_HOST")
-    def test_mark_completed_deletes_queues_and_exchange(self):
-        """mark_completed 后主队列、死信队列、死信交换机被真正删除"""
+    def test_mark_completed_deletes_main_queue(self):
+        """mark_completed 后主队列被真正删除。"""
         handler = RabbitMQMessageHandler()
         thread_id = "thread-cleanup-delete-test"
 
         handler.clear(thread_id)
 
-        # 发送消息以确保队列和交换机被创建
+        # 发送消息以确保主队列被创建
         handler.put(thread_id, "msg_1")
         handler.put(thread_id, "msg_2")
         handler.flush(thread_id)
 
-        # 消费消息使其进入死信队列
-        handler.get(thread_id, timeout=1)
-
-        # 确认队列和交换机存在
         main_queue = handler._get_queue_name(thread_id)
-        dlq_name = handler._get_dlq_name(thread_id)
-        dlx_exchange = handler._get_dlx_exchange_name(thread_id)
-
         assert self._queue_exists(handler, main_queue), "主队列应该存在"
-        assert self._queue_exists(handler, dlq_name), "死信队列应该存在"
-        assert self._exchange_exists(handler, dlx_exchange), "死信交换机应该存在"
 
-        # 执行 mark_completed
         handler.mark_completed(thread_id)
 
-        # 验证队列和交换机已被删除
         assert not self._queue_exists(handler, main_queue), "主队列应该被删除"
-        assert not self._queue_exists(handler, dlq_name), "死信队列应该被删除"
-        assert not self._exchange_exists(handler, dlx_exchange), "死信交换机应该被删除"
 
     @pytest.mark.skipif(not os.getenv("RABBITMQ_HOST"), reason="Live test requires RABBITMQ_HOST")
     def test_mark_completed_deletes_signal_queues(self):
@@ -449,9 +379,6 @@ class TestResourceCleanup:
         assert self._queue_exists(handler, exit_queue), "退出通知队列应该存在"
         assert self._queue_exists(handler, cancelled_queue), "取消完成通知队列应该存在"
         assert self._queue_exists(handler, stopped_queue), "停止状态队列应该存在"
-
-        # 消费消息
-        handler.get(thread_id, timeout=1)
 
         # 先释放消费者，再 mark_completed（避免 release_consumer 内部
         # _ensure_consumer_queues 重新创建已删除的 consumer/exit 队列）
@@ -490,7 +417,7 @@ class TestResourceCleanup:
 
     @pytest.mark.skipif(not os.getenv("RABBITMQ_HOST"), reason="Live test requires RABBITMQ_HOST")
     def test_delete_nonexistent_resources_no_error(self):
-        """对不存在的队列/交换机执行删除不会报错"""
+        """对不存在的队列执行删除不会报错"""
         handler = RabbitMQMessageHandler()
         thread_id = "thread-cleanup-nonexist-test"
 
@@ -512,18 +439,15 @@ class TestResourceCleanup:
         handler.flush(thread_id)
 
         main_queue = handler._get_queue_name(thread_id)
-        dlq_name = handler._get_dlq_name(thread_id)
 
         # 确认队列存在
         assert self._queue_exists(handler, main_queue), "主队列应该存在"
-        assert self._queue_exists(handler, dlq_name), "死信队列应该存在"
 
         # 执行 clear
         handler.clear(thread_id)
 
         # 验证队列仍然存在（只是消息被清空了）
         assert self._queue_exists(handler, main_queue), "clear 后主队列应该仍然存在"
-        assert self._queue_exists(handler, dlq_name), "clear 后死信队列应该仍然存在"
         assert handler.get_cached_count(thread_id) == 0, "主队列消息应该被清空"
 
         # 最终清理
@@ -545,8 +469,6 @@ class TestResourceCleanup:
         cancel_queue = handler._get_cancel_queue_name(thread_id)
         assert self._queue_exists(handler, cancel_queue), "取消请求队列应该存在"
 
-        # 消费并完成
-        handler.get(thread_id, timeout=1)
         handler.mark_completed(thread_id)
 
         # 验证取消请求队列已被删除
@@ -578,23 +500,18 @@ class TestResourceCleanup:
 
         # 验证 RabbitMQ 中也没有残留消息（守护线程不应该 flush 已清理的消息）
         assert handler.get_cached_count(thread_id) == 0, "主队列不应该有残留消息"
-        assert handler._get_dlq_count(thread_id) == 0, "死信队列不应该有残留消息"
 
     @pytest.mark.skipif(not os.getenv("RABBITMQ_HOST"), reason="Live test requires RABBITMQ_HOST")
     def test_has_pending_messages_independent_channel(self):
-        """主队列不存在时，has_pending_messages 仍能正确检查死信队列（独立 channel 隔离性）"""
+        """主队列不存在时，has_pending_messages 返回 False。"""
         handler = RabbitMQMessageHandler()
         thread_id = "thread-cleanup-pending-check-test"
 
         handler.clear(thread_id)
 
-        # 发送消息并消费，让消息进入死信队列
+        # 发送消息后手动删除主队列
         handler.put(thread_id, "msg_1")
         handler.flush(thread_id)
-        handler.get(thread_id, timeout=1)
-
-        # 确认消息在死信队列中
-        assert handler._get_dlq_count(thread_id) == 1, "死信队列应该有 1 条消息"
 
         # 手动删除主队列，模拟主队列不存在的场景
         with handler._with_connection() as connection:
@@ -604,11 +521,7 @@ class TestResourceCleanup:
         # 确认主队列已被删除
         assert not self._queue_exists(handler, handler._get_queue_name(thread_id)), "主队列应该已被删除"
 
-        # 核心验证：即使主队列不存在（passive declare 触发 404），
-        # has_pending_messages 仍能正确检查死信队列并返回 True
-        assert handler.has_pending_messages(thread_id) is True, (
-            "主队列不存在时，has_pending_messages 应该仍能检查到死信队列中的消息"
-        )
+        assert handler.has_pending_messages(thread_id) is False
 
         # 清理
         handler.mark_completed(thread_id)

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -17,8 +17,6 @@ def _make_handler(message_count: int, messages: list[str]) -> tuple[RabbitMQMess
     handler._with_replay_lock = MagicMock(return_value=contextlib.nullcontext(channel))
     handler._ensure_queue = MagicMock(return_value="replay-queue")
     handler._peek_queue_messages = MagicMock(return_value=messages)
-    handler._get_dlq_count = MagicMock(return_value=0)
-    handler._restore_from_dlq = MagicMock(return_value=0)
     return handler, channel
 
 
@@ -43,21 +41,27 @@ def test_get_messages_since_peeks_when_queue_has_new_messages():
     handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
 
 
-def test_get_messages_since_preserves_legacy_dlq_restore():
-    handler, channel = _make_handler(message_count=0, messages=["restored-message"])
-    channel.queue_declare.side_effect = [
-        MagicMock(method=MagicMock(message_count=0)),
-        MagicMock(method=MagicMock(message_count=1)),
-    ]
-    handler._get_dlq_count.return_value = 1
-    handler._restore_from_dlq.return_value = 1
+def test_ensure_queue_does_not_declare_dead_letter_resources():
+    handler = object.__new__(RabbitMQMessageHandler)
+    channel = MagicMock()
 
-    messages, next_offset = handler.get_messages_since("thread-id", offset=0, timeout=0)
+    queue_name = handler._ensure_queue(channel, "thread-id")
 
-    assert messages == ["restored-message"]
-    assert next_offset == 1
-    handler._restore_from_dlq.assert_called_once_with("thread-id")
-    handler._peek_queue_messages.assert_called_once_with(channel, "replay-queue")
+    assert queue_name == "aidev_agent.thread.thread-id"
+    channel.queue_declare.assert_called_once_with(
+        queue=queue_name,
+        durable=True,
+        arguments={"x-expires": handler.QUEUE_TTL_MS},
+    )
+    channel.exchange_declare.assert_not_called()
+    channel.queue_bind.assert_not_called()
+
+
+def test_legacy_get_is_not_supported():
+    handler = object.__new__(RabbitMQMessageHandler)
+
+    with pytest.raises(NotImplementedError, match="get_messages_since"):
+        handler.get("thread-id", timeout=1)
 
 
 def test_eod_commit_event_is_notified_only_after_eod_publish():

--- a/src/frontend/ai-blueking/packages/chat-helper/src/agent/use-agent.ts
+++ b/src/frontend/ai-blueking/packages/chat-helper/src/agent/use-agent.ts
@@ -184,7 +184,7 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
     clearReconnectTimer(false);
   };
 
-  /** 裁掉尾部尚未完成的非用户消息，避免 DLQ 重放时重复气泡 */
+  /** 裁掉尾部尚未完成的非用户消息，避免断线重放时重复气泡 */
   const pruneTrailingIncompleteMessages = () => {
     const list = mediator.message?.list.value;
     if (!list?.length) {

--- a/src/frontend/ai-blueking/packages/chat-helper/src/event/ag-ui.ts
+++ b/src/frontend/ai-blueking/packages/chat-helper/src/event/ag-ui.ts
@@ -462,7 +462,7 @@ export class AGUIProtocol implements ISSEProtocol {
 
   /**
    * 处理文本消息开始事件
-   * 断线续传时 DLQ 会重放事件：同 messageId 已存在则重置内容，避免重复气泡/文本翻倍
+   * 断线续传时会重放缓存事件：同 messageId 已存在则重置内容，避免重复气泡/文本翻倍
    */
   handleTextMessageStartEvent(event: ITextMessageStartEvent) {
     const existing = this.messageModule.getMessageByMessageId(event.messageId);

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -94,7 +94,7 @@ class AgentExecutor:
     ):
         """执行 agent 直至结束；会话终态由 Agent 流完成回调统一写入。"""
         # 后台 drain（for _ in out: pass，无 SSE 下游）：标记为 background_only，
-        # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
+        # 使消费者读到 EOD 时不立即清理队列，保留缓存历史供前端在清理窗口内接管续流。
         execute_kwargs.background_only = True
         handler = getattr(agent_instance, "event_handler", None)
         if execute_kwargs.stream and isinstance(handler, BaseSessionWriter):

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -16,6 +16,7 @@ from logging import getLogger
 
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent.approval import ApprovalStateHandler
+
 from aidev_bkplugin.services.agent_builder import AgentBuilder
 from aidev_bkplugin.services.agent_execution import AgentExecutor
 from aidev_bkplugin.services.agent_session import SessionManager
@@ -45,7 +46,8 @@ def start_approval_resume_worker(
     thread.start()
     logger.info(
         "[ApprovalResume] 后台续流线程已启动: session_code=%s, graph_thread_id=%s",
-        session_code, graph_thread_id,
+        session_code,
+        graph_thread_id,
     )
 
 
@@ -53,7 +55,8 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
     """后台续流工作线程：轮询审批结果，完成后续流。"""
     logger.info(
         "[ApprovalResume] 开始轮询审批结果: session_code=%s, username=%s",
-        session_code, username,
+        session_code,
+        username,
     )
 
     # 1. 轮询是否需要续流（ITSM 回调后 is_resume 返回 True），无超时，收到回调前持续轮询
@@ -64,7 +67,8 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
         if handler.check_resume(session_code):
             logger.info(
                 "[ApprovalResume] 审批已回调，准备续流: session_code=%s (第 %d 次轮询)",
-                session_code, poll_count,
+                session_code,
+                poll_count,
             )
             break
         time.sleep(_POLL_INTERVAL)
@@ -106,19 +110,22 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
             thread_id=graph_thread_id,
             resume=resume_items,
             # 后台 drain（无 SSE 下游，下方 for _ in generator 自行排空）：标记 background_only，
-            # 使消费者读到 EOD 时不立即清理队列，保留 DLQ 历史供前端在清理窗口内接管续流。
+            # 使消费者读到 EOD 时不立即清理队列，保留缓存历史供前端在清理窗口内接管续流。
             background_only=True,
         )
 
         logger.info(
             "[ApprovalResume] 开始后台续流: session_code=%s, approve_result=%s",
-            session_code, approve_result,
+            session_code,
+            approve_result,
         )
 
         # 使用 stream=True + execute_with_save，事件经由 AGUISessionWriter 写入 DB
         session_manager = SessionManager(username=username)
         generator = AgentExecutor(session_manager).execute_with_save(
-            agent_instance, execute_kwargs, session_code,
+            agent_instance,
+            execute_kwargs,
+            session_code,
         )
 
         # 消费生成器，触发事件回写


### PR DESCRIPTION
## 背景

RabbitMQ 已改为基于 offset 的非破坏性 replay，正常消费不再需要通过 DLQ 保存已读消息。

## 改动内容

- Main Queue 仅保留 `x-expires`，不再创建或绑定 DLQ/DLX
- 移除 `basic_reject(requeue=False)`、DLQ 恢复及旧破坏性消费实现
- 多消费者按各自 offset 独立回放 Main Queue
- replay 消费者被抢占时不再执行兼容 `restore_messages()`
- 仅在检测到旧队列参数冲突时删除遗留 Main Queue、DLQ 和 DLX
- 更新对应测试及前后端旧 DLQ 语义说明

## 验证

- RabbitMQ replay 单测：10 passed
- 连接本地真实 RabbitMQ 的多消费者与旧资源迁移测试：6 passed
- ruff、ruff-format、merge-conflict check 通过

## 发布注意

旧 worker 仍可能声明带 DLX 参数的同名队列，不宜与新 worker 长时间混跑。建议停止接收新会话并等待活跃会话结束后整体替换 worker；旧格式队列迁移时会删除其中未完成的历史消息。