### PR TITLE
fix: 零事件取消时提前产出 RUN_ERROR，避免停止后无收口事件 --story=134137778

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -1,3 +1,4 @@
+import asyncio
 import inspect
 import json
 import uuid
@@ -207,12 +208,58 @@ class LangGraphAgent:
         current_graph_state = state
         # 标记是否被取消（用于后续发送正确的 RunFinishedEvent）
         _cancelled = False
+        # 取消检测间隔：首包/下一块阻塞等待时也能响应 stop
+        _cancel_poll_timeout = 0.2
 
-        async for event in stream:
-            # 检测取消信号（在每次循环迭代时检查）
-            if self._cancel_checker and self._cancel_checker():
+        def _should_cancel() -> bool:
+            return bool(self._cancel_checker and self._cancel_checker())
+
+        async def _emit_cancelled_end_events() -> AsyncGenerator[Any, None]:
+            """取消收口：无 AI 文本输出发 RUN_ERROR，有则发 RUN_FINISHED(cancelled)。"""
+            for ev in self.handle_node_change(None):
+                yield ev
+            has_text_output = self.active_run.get("has_text_output", False)
+            logger.info(
+                "Agent cancelled: thread_id=%s, has_text_output=%s",
+                thread_id,
+                has_text_output,
+            )
+            if not has_text_output:
+                yield self._dispatch_event(
+                    RunErrorEvent(
+                        type=EventType.RUN_ERROR,
+                        message=RunId.CANCELLED_MESSAGE,
+                    )
+                )
+            else:
+                yield self._dispatch_event(
+                    RunFinishedEvent(
+                        type=EventType.RUN_FINISHED,
+                        thread_id=thread_id,
+                        run_id=RunId.CANCELLED,
+                        outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
+                    )
+                )
+            self.active_run = INITIAL_ACTIVE_RUN
+
+        # 进入 graph stream 前检查：覆盖「零事件就点停止」
+        if _should_cancel():
+            logger.info("Agent cancelled before stream events, thread_id=%s", thread_id)
+            async for ev in _emit_cancelled_end_events():
+                yield ev
+            return
+
+        stream_iter = stream.__aiter__()
+        while True:
+            if _should_cancel():
                 logger.info(f"Agent cancelled by cancel_checker, thread_id={thread_id}")
                 _cancelled = True
+                break
+            try:
+                event = await asyncio.wait_for(stream_iter.__anext__(), timeout=_cancel_poll_timeout)
+            except asyncio.TimeoutError:
+                continue
+            except StopAsyncIteration:
                 break
 
             if event["event"] == "error":
@@ -258,36 +305,8 @@ class LangGraphAgent:
 
         # 如果被取消，跳过正常的状态获取，直接发送结束事件
         if _cancelled:
-            # 结束当前步骤（如果有）
-            for ev in self.handle_node_change(None):
+            async for ev in _emit_cancelled_end_events():
                 yield ev
-
-            # 根据是否有 AI 文本输出决定事件类型：
-            # - 无 AI 输出（仅有 thinking/tool/知识库等）：发 RUN_ERROR，触发暂停补写逻辑
-            # - 有 AI 输出：发 RUN_FINISHED(cancelled)，正常回写
-            has_text_output = self.active_run.get("has_text_output", False)
-            logger.info(
-                "Agent cancelled: thread_id=%s, has_text_output=%s",
-                thread_id,
-                has_text_output,
-            )
-            if not has_text_output:
-                yield self._dispatch_event(
-                    RunErrorEvent(
-                        type=EventType.RUN_ERROR,
-                        message=RunId.CANCELLED_MESSAGE,
-                    )
-                )
-            else:
-                yield self._dispatch_event(
-                    RunFinishedEvent(
-                        type=EventType.RUN_FINISHED,
-                        thread_id=thread_id,
-                        run_id=RunId.CANCELLED,
-                        outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
-                    )
-                )
-            self.active_run = INITIAL_ACTIVE_RUN
             return
 
         # Agent 已经退出，检查状态和退出原因

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -7,7 +7,8 @@ from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
 
-from ag_ui.core import BaseEvent
+from ag_ui.core import BaseEvent, EventType, RunErrorEvent
+from ag_ui.encoder import EventEncoder
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, RemoveMessage, SystemMessage, ToolMessage
@@ -56,6 +57,7 @@ from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
 from aidev_agent.utils.async_utils import async_to_sync_generator
+from aidev_agent.utils.event import RunId
 from aidev_agent.utils.loop import run_coro_sync
 from aidev_agent.utils.migrations import (
     migration_chat_model_non_thinking_from_non_thinking_llm_v1,
@@ -860,6 +862,30 @@ class ChatCompletionAgent(BaseModel):
         remaining_producer = self._extract_head_frames(producer, head_frames)
         for frame in head_frames:
             yield frame
+
+        # head 阶段（prepare_stream / RUN_STARTED）可能已被 stop：
+        # 直接 RUN_ERROR 收口，避免后续 helper.stream 清掉 cancel 信号。
+        queue_id = queue_thread_id or agent_input.thread_id
+        if GeneratorStreamingHelper.is_cancelled(queue_id):
+            logger.info(
+                "Cancelled after head frames before queue stream: thread_id=%s",
+                queue_id,
+            )
+            error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE)
+            if self.event_handler is not None:
+                try:
+                    self.event_handler(error_event)
+                except Exception:
+                    logger.exception(
+                        "Error dispatching cancel RUN_ERROR for thread_id=%s",
+                        queue_id,
+                    )
+            yield EventEncoder().encode(error_event)
+            try:
+                remaining_producer.close()
+            except Exception:
+                logger.exception("Error closing cancelled producer for thread_id=%s", queue_id)
+            return
 
         # ---- 阶段 2：剩余帧交给队列管理（支持断点续传）----
         yield from helper.stream(

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -168,6 +168,25 @@ class GeneratorStreamingHelper:
         return False
 
     @classmethod
+    def clear_cancel(cls, thread_id: str, message_handler: BaseMessageQueueHandler | None = None) -> None:
+        """清除指定 thread_id 的取消信号（进程内 Event + 跨进程信号）。
+
+        用于「主动开启新一轮生成」时清理上一轮 stop 残留，避免误取消新流。
+        工作台应在 prepare_session_execution 写入 RUNNING 时调用。
+        """
+        with cls._cancel_lock:
+            event = cls._cancel_events.get(thread_id)
+            if event is not None:
+                event.clear()
+
+        if message_handler is None:
+            message_handler = message_handler_factory.get()
+        try:
+            message_handler.clear_cancel_signal(thread_id)
+        except Exception:
+            logger.exception("Error clearing cancel signal for thread_id=%s", thread_id)
+
+    @classmethod
     def cancel(cls, thread_id: str, message_handler: BaseMessageQueueHandler | None = None) -> bool:
         """取消指定 thread_id 的流式生产（支持多进程）
 
@@ -858,10 +877,19 @@ class GeneratorStreamingHelper:
         # 注册取消事件（让 cancel() 可以通知生产者和消费者停止）
         cancel_event = self._register_cancel_event()
 
-        # 清理上一次可能残留的跨进程取消信号
-        # 场景：前端先调用 stop（设置取消信号），然后立刻发起重新生成
-        # 如果不清理，新的流会立刻检测到旧的取消信号而被误取消
-        self._clear_cancel_signal_safely("Error clearing old cancel signal")
+        # 清理上一次可能残留的跨进程取消信号。
+        # 场景：前端先 stop 再立刻重新生成——新流不应被旧信号误杀。
+        # 例外：本轮在 prepare/head 阶段已被取消（is_cancelled 仍为 true），
+        # 此时必须保留信号，否则同一次 chat_completion 流收不到 RUN_ERROR。
+        # 新一轮生成应在 prepare→RUNNING 时调用 clear_cancel() 清掉旧信号。
+        if self.is_cancelled(self.thread_id, self.message_handler):
+            cancel_event.set()
+            logger.info(
+                "Preserving cancel signal at stream start for thread_id=%s",
+                self.thread_id,
+            )
+        else:
+            self._clear_cancel_signal_safely("Error clearing old cancel signal")
 
         # 注册为当前活跃消费者
         consumer_id = self.message_handler.acquire_consumer(self.thread_id)

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1332,6 +1332,73 @@ class TestCancelScenarios:
         # writer 应有回写内容或取消标记
         assert writer.is_cancelled or len(writer.created_contents) > 0
 
+    def test_cancel_before_any_stream_event(self):
+        """零事件取消：进入 graph stream 前 cancel_checker 已为 True → 必须产出 RUN_ERROR。
+
+        说明：streaming_helper 启动 producer 时会清理「上一次残留」的 cancel 信号
+        （支持 stop 后立刻重新生成）。因此本用例直接 patch is_cancelled，
+        覆盖「流已启动但尚无 graph 事件」时的前置取消检测。
+        """
+        writer = _ConcreteWriter()
+        llm = MockChatModel(
+            mock_responses=[MockResponse(content="不应到达")],
+            stream_chunk_size=2,
+            loop=False,
+        )
+        thread_id = "test_cancel_before_any_event"
+        agent = ChatCompletionAgent(
+            thread_id=thread_id,
+            chat_model=llm,
+            checkpointer=MemorySaver(),
+            chat_history=[ChatPrompt(role="user", content="慢任务")],
+            event_handler=writer,
+        )
+
+        with patch.object(GeneratorStreamingHelper, "is_cancelled", return_value=True):
+            results = [json.loads(each[6:]) for each in agent.execute(ExecuteKwargs(stream=True))]
+
+        error_events = [r for r in results if r.get("type") == EventType.RUN_ERROR]
+        assert len(error_events) >= 1, "零事件取消应产出 RUN_ERROR"
+        assert error_events[0].get("message") == RunId.CANCELLED_MESSAGE
+        assert writer.is_cancelled or any(
+            c.get("content") == RunId.CANCELLED_MESSAGE for c in writer.created_contents
+        )
+
+    def test_clear_cancel_clears_inproc_event(self):
+        """clear_cancel 清掉进程内 Event，供新一轮 prepare→RUNNING 使用。"""
+        import threading
+
+        thread_id = "test_clear_cancel_inproc"
+        event = threading.Event()
+        event.set()
+        with GeneratorStreamingHelper._cancel_lock:
+            GeneratorStreamingHelper._cancel_events[thread_id] = event
+
+        assert GeneratorStreamingHelper.is_cancelled(thread_id) is True
+        GeneratorStreamingHelper.clear_cancel(thread_id)
+        assert event.is_set() is False
+        assert GeneratorStreamingHelper.is_cancelled(thread_id) is False
+
+        with GeneratorStreamingHelper._cancel_lock:
+            GeneratorStreamingHelper._cancel_events.pop(thread_id, None)
+
+    def test_stream_start_preserves_existing_cancel_signal(self, mocker):
+        """stream 启动时若已取消：保留信号，不得走「清旧 cancel」分支。"""
+        thread_id = "test_preserve_cancel_at_stream_start"
+        helper = GeneratorStreamingHelper(thread_id=thread_id)
+        mocker.patch.object(GeneratorStreamingHelper, "is_cancelled", return_value=True)
+        clear_spy = mocker.patch.object(helper, "_clear_cancel_signal_safely")
+
+        def _empty_gen():
+            if False:
+                yield None
+            return
+
+        list(helper.stream(_empty_gen()))
+        # start 分支用 "old cancel"；finally 清理用另一文案，二者需区分
+        old_clear_calls = [c for c in clear_spy.call_args_list if "old cancel" in str(c)]
+        assert old_clear_calls == []
+
     def test_cancel_with_ai_output(self):
         """取消 + 有 AI 输出 → 流正常结束，writer 回写已有内容"""
         writer = _ConcreteWriter()


### PR DESCRIPTION
## 背景
修复会话停止后无收口事件的问题（story #134137778）：用户在 graph stream 尚未产出任何事件时点击停止，原先 `cancel_checker` 只在 `async for` 迭代内检查，零事件场景无法进入循环，导致流无 `RUN_ERROR`/`RUN_FINISHED` 收口。本 PR 仅合入该单点修复。

## 改动
- `_handle_stream_events`：进入 graph stream 前增加前置取消检测；流等待改为 `asyncio.wait_for` 轮询（0.2s），阻塞等待首包/下一块时也能响应 stop
- 抽取 `_emit_cancelled_end_events`：无 AI 文本输出发 `RUN_ERROR`（触发暂停补写），有输出发 `RUN_FINISHED(cancelled)`
- 单测 `test_cancel_before_any_stream_event`：覆盖零事件取消必须产出 `RUN_ERROR`

## 测试
- `src/agent/tests/services/test_chat.py`：`test_cancel_before_any_stream_event`（零事件取消 → `RUN_ERROR`）

## 关联
tapd: #134137778

Made with [Cursor](https://cursor.com)