### PR TITLE
fix: 优化输入区附件栏高度与内边距

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-attachment/input-attachment.vue
@@ -77,12 +77,12 @@
 <style lang="scss">
   .ai-input-attachment {
     display: flex;
-    flex: 0 0 40px;
+    flex: 0 0 32px;
     gap: 6px;
     align-items: center;
     width: 100%;
-    height: 40px;
-    padding: 0 12px;
+    height: 32px;
+    padding: 0 8px;
 
     &-default {
       display: flex;


### PR DESCRIPTION
## 背景
TAPD: 优化输入区附件栏高度与内边距
ID: 1070093903136783988

## 改动
- `packages/chat-x/.../input-attachment.vue`: 附件栏高度 40→32px，左右 padding 12→8px，flex-basis 同步

## 影响面
- 仅影响 ChatInput 附件操作区视觉尺寸，不改业务逻辑

## 测试
- [ ] 附件栏实际高度为 32px
- [ ] 左右内边距为 8px
- [ ] 发送按钮与左侧插槽布局不错位、不溢出

Made with [Cursor](https://cursor.com)