### PR TITLE
fix: 兼容 MessageStatus.completed 并校准输入区控件尺寸样式 --story=136852438

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -186,7 +186,7 @@
   import CustomTabContent from './custom-tab-content.vue';
   import { MOCK_INTERRUPT_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
-  import { MOCK_ARTIFACTS_MESSAGES, MOCK_MODELS, MOCK_PROMPTS, MOCK_RESOURCES, mockArtifactClick } from './mock';
+  import { MOCK_MESSAGES, MOCK_MODELS, MOCK_PROMPTS, MOCK_RESOURCES, mockArtifactClick } from './mock';
   import { uploadFileToSession } from './upload-file';
 
   import type { CustomTab, IAiSlashMenuItem, Shortcut, TagSchema } from '../src/types';
@@ -206,7 +206,8 @@
   const handleModelChange = (model: IModelOption) => {
     console.log('model change:', model);
   };
-  const messages = deepRef<Message[]>([...MOCK_ARTIFACTS_MESSAGES]);
+  // 使用含 toolCalls 的 mock，用于验证「执行情况」侧栏
+  const messages = deepRef<Message[]>([...(MOCK_MESSAGES as Message[])]);
 
   const handleInterruptResume: OnInterruptResume = (payload, interrupt) => {
     // 取消审批与流程节点重试 / 跳过复用同一回调，业务侧按 payload.operation 分流处理

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/constants.ts
@@ -80,6 +80,7 @@ export enum MessageRole {
 }
 export enum MessageStatus {
   Complete = 'complete',
+  Completed = 'completed',
   Disabled = 'disabled',
   Error = 'error',
   Fetching = 'fetching', // 请求中

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -896,7 +896,7 @@
       > main {
         position: relative;
         width: var(--resize-main-width);
-        padding: 8px;
+        padding: 8px 16px;
 
         // overflow: visible;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -435,7 +435,7 @@ Use Shift + Enter to enter a new line`
 
       // 已选快捷指令 tag：默认态与 bkui Tag 一致，hover 使用 shortcut 语义色
       .selected-shortcut-btn {
-        height: 24px;
+        height: 32px;
         padding: 0 10px;
         color: #3a84ff;
         background: #e1ecff;
@@ -455,6 +455,12 @@ Use Shift + Enter to enter a new line`
             color: #3a84ff;
           }
         }
+      }
+
+      .ai-shortcut-btns-item {
+        height: 32px;
+        padding: 0 8px;
+        border-radius: 8px;
       }
     }
   }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-trigger.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/model-selector/model-selector-trigger.vue
@@ -43,11 +43,11 @@
     display: flex;
     gap: 4px;
     align-items: center;
-    height: 24px;
+    height: 32px;
     padding: 0 8px;
     color: variables.$color-text;
     cursor: pointer;
-    border-radius: 2px;
+    border-radius: 8px;
     transition: background-color 0.2s;
 
     &:hover,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
@@ -46,7 +46,20 @@
   import MessageArtifacts from './message-artifacts/message-artifacts.vue';
 
   import type { AssistantMessage } from '../../../ag-ui/types/messages';
-  const props = defineProps<Partial<AssistantMessage>>();
+
+  // 本地 interface：content 用字面量 string，避免 Vue 将泛型 BaseMessage.content 推断为 Object
+  interface AssistantMessageProps {
+    content?: string;
+    id?: AssistantMessage['id'];
+    messageId?: AssistantMessage['messageId'];
+    name?: AssistantMessage['name'];
+    property?: AssistantMessage['property'];
+    role?: AssistantMessage['role'];
+    status?: AssistantMessage['status'];
+    toolCalls?: AssistantMessage['toolCalls'];
+    uid?: AssistantMessage['uid'];
+  }
+  const props = defineProps<AssistantMessageProps>();
   const artifacts = computed(() => props.property?.artifacts);
   // 唯一消息标识：优先 uid，回退 id，供文件产物命中唯一文件与「在对话中定位」
   const messageUid = computed(() => props.uid ?? (props.id != null ? String(props.id) : ''));

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -335,7 +335,7 @@
       display: flex;
       gap: 8px;
       width: 100%;
-      padding: 8px;
+      padding: 8px 0;
 
       &-enabled-selection {
         .ai-user-message-tools {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -99,7 +99,7 @@
 
   import { Button } from 'bkui-vue';
 
-  import { type TextInputContent, MessageContentType } from '../../../ag-ui/types';
+  import { type InputContent, type TextInputContent, MessageContentType } from '../../../ag-ui/types';
   import { CONST_USER_MESSAGE_TOOLS } from '../../../common/constants';
   import { useClipboard } from '../../../composables';
   import { injectGlobalConfig } from '../../../composables/use-global-config';
@@ -128,9 +128,20 @@
     onInputConfirm?: (content: UserMessage['content'], docSchema: TagSchema) => Promise<void>;
     onShortcutConfirm?: (formModel: Record<string, unknown>) => Promise<void>;
   };
-  const props = defineProps<
-    Partial<UserMessage> & Pick<MessageToolsProps, 'onAction' | 'tippyOptions'> & UserMessageActionsProps
-  >();
+  // 本地 interface：content 用字面量联合，避免 Vue 将泛型 BaseMessage.content 推断为 Object
+  interface UserMessageProps extends UserMessageActionsProps {
+    content?: InputContent[] | string;
+    id?: UserMessage['id'];
+    messageId?: UserMessage['messageId'];
+    name?: UserMessage['name'];
+    onAction?: MessageToolsProps['onAction'];
+    property?: UserMessage['property'];
+    role?: UserMessage['role'];
+    status?: UserMessage['status'];
+    tippyOptions?: MessageToolsProps['tippyOptions'];
+    uid?: UserMessage['uid'];
+  }
+  const props = defineProps<UserMessageProps>();
   const globalConfig = injectGlobalConfig();
   const { copy } = useClipboard();
   const isEdit = shallowRef(false);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
@@ -222,6 +222,18 @@ describe('ToolcallRender', () => {
       expect(wrapper.find('.toolcall-status-title').text()).toContain('调用成功');
     });
 
+    // Completed 与 Complete 同为完成态，兼容协议/后端返回的 completed
+    it('Completed 状态应该显示调用成功', () => {
+      wrapper = mount(ToolcallRender, {
+        props: {
+          toolCall: mockToolCall,
+          status: MessageStatus.Completed,
+        },
+      });
+
+      expect(wrapper.find('.toolcall-status-title').text()).toContain('调用成功');
+    });
+
     it('Success 状态应该显示调用成功', () => {
       wrapper = mount(ToolcallRender, {
         props: {
@@ -249,6 +261,17 @@ describe('ToolcallRender', () => {
         props: {
           toolCall: mockToolCall,
           status: MessageStatus.Complete,
+        },
+      });
+
+      expect(wrapper.find('.mock-loading').exists()).toBe(false);
+    });
+
+    it('Completed 状态不应该显示 Loading', () => {
+      wrapper = mount(ToolcallRender, {
+        props: {
+          toolCall: mockToolCall,
+          status: MessageStatus.Completed,
         },
       });
 
@@ -425,6 +448,17 @@ describe('ToolcallRender', () => {
       });
 
       expect(wrapper.find('.ai-toolcall-render-header').classes()).toContain('toolcall-status-complete');
+    });
+
+    it('Completed 状态 class 应该正确应用', () => {
+      wrapper = mount(ToolcallRender, {
+        props: {
+          toolCall: mockToolCall,
+          status: MessageStatus.Completed,
+        },
+      });
+
+      expect(wrapper.find('.ai-toolcall-render-header').classes()).toContain('toolcall-status-completed');
     });
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
@@ -108,6 +108,7 @@
       default:
       case MessageStatus.Pending:
         return t('调用中');
+      case MessageStatus.Completed:
       case MessageStatus.Complete:
       case MessageStatus.Success:
         return t('调用成功');

--- a/src/frontend/ai-blueking/packages/chat-x/src/styles/variables.scss
+++ b/src/frontend/ai-blueking/packages/chat-x/src/styles/variables.scss
@@ -79,6 +79,10 @@ $toolcallStatusMap: (
     #ebfaf0,
     #a1e3ba,
   ),
+  completed: (
+    #ebfaf0,
+    #a1e3ba,
+  ),
   success: (
     #ebfaf0,
     #a1e3ba,

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
@@ -178,14 +178,14 @@ sinceVersion: 1.0.0
 
 `status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和 Loading 动画：
 
-| `status`                | 状态文案 | 背景色            | 边框色    | Loading |
-| ----------------------- | -------- | ----------------- | --------- | ------- |
-| `pending` / `streaming` | 调用中   | `#fafbfd`         | `#dcdee5` | ✓       |
-| `complete` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | -       |
-| `error`                 | 调用失败 | `#fff0f0`         | `#f8b4b4` | -       |
-| 其他 / `undefined`      | 调用中   | —（无匹配 class） | —         | -       |
+| `status`                              | 状态文案 | 背景色            | 边框色    | Loading |
+| ------------------------------------- | -------- | ----------------- | --------- | ------- |
+| `pending` / `streaming`               | 调用中   | `#fafbfd`         | `#dcdee5` | ✓       |
+| `complete` / `completed` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | -       |
+| `error`                               | 调用失败 | `#fff0f0`         | `#f8b4b4` | -       |
+| 其他 / `undefined`                    | 调用中   | —（无匹配 class） | —         | -       |
 
-> **说明**：`statusTitle` 的 `switch` 语句中 `default` 与 `case Pending` 共享同一返回值，`streaming` 和未知 status 均命中 `default` 分支，显示"调用中"。Loading 动画由 `v-if="status === 'pending' || status === 'streaming'"` 单独控制。
+> **说明**：`statusTitle` 将 `Completed`（`completed`）与 `Complete` / `Success` 一并视为成功；主题 `$toolcallStatusMap` 同步提供 `completed` 色值。`default` 与 `case Pending` 共享「调用中」文案，`streaming` 与未知 status 命中 `default`。Loading 由 `v-if="status === 'pending' || status === 'streaming'"` 控制。
 
 **三种状态对比**
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -867,18 +867,10 @@ const handleSendMessage = async (
 
 ## 类型定义
 
+> `MessageStatus` 完整取值见 [常量枚举](../../types/constants)。与输入区相关：`pending` / `streaming` / `fetching` → 停止按钮；`complete` / `completed` / `error` / `stop` → 发送；`disabled` → 置灰。
+
 ```typescript
 import type { UserMessage } from '@blueking/chat-x';
-
-// 消息状态
-enum MessageStatus {
-  Pending = 'pending', // 等待中（显示停止按钮）
-  Streaming = 'streaming', // 流式输出中（显示停止按钮）
-  Complete = 'complete', // 完成（显示发送按钮）
-  Error = 'error', // 错误（显示发送按钮）
-  Stop = 'stop', // 已停止（显示发送按钮）
-  Disabled = 'disabled', // 禁用（发送按钮置灰）
-}
 
 // 上传状态
 enum UploadStatus {

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/message-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/message-render.md
@@ -490,34 +490,11 @@ h(ContentRender, { content: message.content || '', status: message.status }, /* 
 ```typescript
 import { MessageRole, MessageStatus, MessageToolsStatus, type Message, type IToolBtn } from '@blueking/chat-x';
 
-// 消息角色
-enum MessageRole {
-  User = 'user',
-  Assistant = 'assistant',
-  Info = 'info',
-  Reasoning = 'reasoning',
-  Tool = 'tool',
-  Activity = 'activity',
-  Loading = 'loading',
-  Interrupt = 'interrupt',
-}
-
-// 消息状态
-enum MessageStatus {
-  Pending = 'pending',
-  Streaming = 'streaming',
-  Complete = 'complete',
-  Error = 'error',
-  Stop = 'stop',
-  Disabled = 'disabled',
-}
-
-// 工具按钮状态（仅转发给 UserMessage）
-enum MessageToolsStatus {
-  Disabled = 'disabled',
-  Hidden = 'hidden',
-}
+// MessageRole / MessageStatus 完整枚举见 ../../types/constants
+// MessageToolsStatus：Disabled | Hidden（仅转发给 UserMessage）
 ```
+
+> `MessageRole` / `MessageStatus` 完整取值见 [常量枚举](../../types/constants)。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/reasoning-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/reasoning-message.md
@@ -282,16 +282,9 @@ interface ReasoningMessage {
   duration?: number; // 推理耗时（毫秒）
   name?: string;
 }
-
-enum MessageStatus {
-  Pending = 'pending',
-  Streaming = 'streaming',
-  Complete = 'complete',
-  Success = 'success',
-  Error = 'error',
-  Stop = 'stop',
-}
 ```
+
+> `MessageStatus` 完整取值见 [常量枚举](../../types/constants)。本组件完成态识别 `complete` / `success`（与标题文案表一致）。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/content-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/content-render.md
@@ -338,17 +338,9 @@ enum MessageContentType {
   KnowledgeRag = 'knowledge_rag',
   Other = 'other',
 }
-
-// 消息状态
-enum MessageStatus {
-  Pending = 'pending',
-  Streaming = 'streaming',
-  Complete = 'complete',
-  Error = 'error',
-  Stop = 'stop',
-  Disabled = 'disabled',
-}
 ```
+
+> `MessageStatus` 完整取值见 [常量枚举](../../types/constants)；本组件主要关心 `error`（错误内容）与流式相关状态。
 
 ## 使用场景
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/message-container.md
@@ -1090,28 +1090,11 @@ enum MessageToolsStatus {
   Hidden = 'hidden',
 }
 
-// 消息角色
-enum MessageRole {
-  User = 'user',
-  Assistant = 'assistant',
-  Tool = 'tool',
-  Reasoning = 'reasoning',
-  Activity = 'activity',
-  Info = 'info',
-  Interrupt = 'interrupt',
-  Loading = 'loading',
-}
-
-// 消息状态
-enum MessageStatus {
-  Pending = 'pending',
-  Streaming = 'streaming',
-  Complete = 'complete',
-  Error = 'error',
-  Stop = 'stop',
-  Disabled = 'disabled',
-}
+// 消息角色 / 消息状态完整枚举见常量文档，勿在此维护副本
+// MessageRole、MessageStatus → ../../types/constants
 ```
+
+> `MessageRole` / `MessageStatus` 完整取值见 [常量枚举](../../types/constants)。
 
 ## 关联组件
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/constants.md
@@ -4,7 +4,7 @@ slug: constants
 category: type
 description: '`@blueking/chat-x` 导出的常量和枚举类型。'
 aiSummary: >
-  汇总 MessageRole、MessageStatus（含 Fetching 请求中）、MessageContentType、MessageToolsStatus、MessageState、Z-Index 与 CONST_MESSAGE_TOOLS 等导出常量。
+  汇总 MessageRole、MessageStatus（含 Fetching 请求中、Complete/Completed 完成态兼容）、MessageContentType、MessageToolsStatus、MessageState、Z-Index 与 CONST_MESSAGE_TOOLS 等导出常量。
   用于构造消息、配置 MessageContainer 工具栏与输入态，以及层级与默认快捷指令。与类型 messages 配套使用。
 relatedComponents:
   - slug: message-tools
@@ -63,6 +63,7 @@ enum MessageRole {
 ```typescript
 enum MessageStatus {
   Complete = 'complete',
+  Completed = 'completed', // 与 Complete 同为完成态，兼容后端/协议返回的 completed
   Disabled = 'disabled',
   Error = 'error',
   Fetching = 'fetching', // 请求中（例如已发用户消息、尚未开始流式，与末尾 Loading 占位一致）
@@ -76,6 +77,7 @@ enum MessageStatus {
 
 | 枚举值          | 说明 |
 | --------------- | ---- |
+| `Complete` / `Completed` | 已完成。`complete` 为库内常用值；`completed` 与之语义相同，用于兼容外部协议或后端返回。`ToolcallRender` 等将二者与 `success` 一并视为成功态。 |
 | `Fetching`      | 请求中：与 `useMessageGroup` 在末尾用户消息后注入的 Loading 占位（`LOADING_MESSAGE_ID`）配合时，`ChatContainer` 会将传入输入区与列表底部的状态推导为该值，便于展示「停止」与禁止重复发送。 |
 
 ### InterruptReason

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -149,6 +149,9 @@ enum MessageStatus {
   // 已完成
   Complete = 'complete',
 
+  // 已完成（与 Complete 同义，兼容协议/后端返回的 completed）
+  Completed = 'completed',
+
   // 已禁用
   Disabled = 'disabled',
 
@@ -174,6 +177,8 @@ enum MessageStatus {
   Success = 'success',
 }
 ```
+
+完整取值与说明见 [常量枚举 · MessageStatus](./constants#messagestatus)。
 
 ## 具体消息类型
 

--- a/src/frontend/web/docs/api/chat-x/types.md
+++ b/src/frontend/web/docs/api/chat-x/types.md
@@ -16,12 +16,16 @@ enum MessageStatus {
   Streaming = 'streaming',
   /** 已完成 */
   Complete = 'complete',
+  /** 已完成（与 Complete 同义，兼容协议/后端返回的 completed） */
+  Completed = 'completed',
   /** 出错 */
   Error = 'error',
   /** 已停止 */
   Stop = 'stop',
 }
 ```
+
+> 库内常用 `complete`；`completed` 与之语义相同。`ToolcallRender` 将 `complete` / `completed` / `success` 一并视为「调用成功」。完整枚举（含 `Fetching`、`Success` 等）以 `@blueking/chat-x` 导出为准。
 
 ### MessageToolsStatus
 

--- a/src/frontend/web/docs/guide/core-features/chat-interaction.md
+++ b/src/frontend/web/docs/guide/core-features/chat-interaction.md
@@ -107,10 +107,13 @@ enum MessageStatus {
   Pending = 'pending',       // 等待中
   Streaming = 'streaming',   // 流式输出中
   Complete = 'complete',     // 已完成
+  Completed = 'completed',   // 已完成（与 Complete 同义，兼容协议返回）
   Error = 'error',           // 出错
   Stop = 'stop',             // 被用户停止
 }
 ```
+
+完整取值与说明见 [类型定义 · MessageStatus](/api/chat-x/types#messagestatus)。
 
 ## 内容渲染
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】兼容 MessageStatus.completed 并校准输入区控件尺寸样式
ID: 1070093903136852438

## 改动
- ag-ui/constants & ToolcallRender：新增 `MessageStatus.Completed`，与 complete/success 同为成功态；补充单测与状态色
- chat-input / model-selector：控件高度 32px、圆角 8px；快捷指令样式对齐
- chat-container / message-container：主区左右 padding 16px；消息容器左右 padding 清零
- assistant/user-message：本地 props interface，避免 Vue 将泛型 content 推断为 Object
- wikis / web docs：同步 Completed 说明，组件文档枚举改为链接常量文档
- playground：调试 mock 切到含 toolCalls 的 MOCK_MESSAGES

## 影响面
- 协议返回 `completed` 时 ToolCall 可正确展示成功态；输入区与消息区视觉尺寸调整
- props 类型声明调整为运行时兼容性修复，不改变对外消息数据结构

## 测试
- [ ] ToolCall 在 `completed` / `complete` / `success` 下展示「调用成功」及成功态样式
- [ ] 输入区模型选择器、快捷指令高度 32px、圆角 8px
- [ ] 主区左右留白 16px；消息容器左右无多余 padding
- [ ] 用户/助手消息渲染与编辑不受 props 声明调整影响
- [ ] 文档与类型说明中 Completed 描述正确

Made with [Cursor](https://cursor.com)