### PR TITLE
feat: 文件产物按 outputId 去重并优化侧栏 Tab 挂载 --story=136856569

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -14,6 +14,7 @@
       v-model:selected-model="selectedModel"
       v-model:selected-shortcut="selectedShortcut"
       :enable-selection="false"
+      :execution-tab-visible="true"
       :message-tools="customMessageTools"
       :messages="messages"
       :model-value="userInput"

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -392,7 +392,34 @@ export const mockArtifactClick = async (file: AIFileInfo): Promise<MockArtifactU
   };
 };
 
-// 带文件产物的会话消息，用于 playground 调试 artifacts 展示
+/** 第一轮产物：含 pdf / markdown / txt，后续轮次会复用部分 outputId 验证去重 */
+const MOCK_ARTIFACTS_ROUND1: AIFileInfo[] = [
+  MOCK_FILE_ARTIFACTS[0], // artifact-pdf
+  MOCK_FILE_ARTIFACTS[1], // artifact-markdown
+  MOCK_FILE_ARTIFACTS[5], // artifact-txt
+];
+
+/**
+ * 第二轮产物：复用 artifact-pdf / artifact-txt（同 outputId 应去重并保留本轮），
+ * 并新增 artifact-html；侧栏预期顺序按「最后一次出现」：markdown → pdf(新) → html → txt
+ */
+const MOCK_ARTIFACTS_ROUND2: AIFileInfo[] = [
+  {
+    name: '可观测平台立项说明书-v2.pdf',
+    outputId: 'artifact-pdf',
+    size: 312_320,
+    type: AIFileType.Pdf,
+  },
+  MOCK_FILE_ARTIFACTS[4], // artifact-html
+  {
+    name: '周例会纪要-0721-修订.txt',
+    outputId: 'artifact-txt',
+    size: MOCK_ARTIFACT_TXT_CONTENT.length + 32,
+    type: AIFileType.Txt,
+  },
+];
+
+// 带文件产物的会话消息，用于 playground 调试 artifacts 展示与 outputId 去重
 export const MOCK_ARTIFACTS_MESSAGES = [
   {
     id: 'mock-artifacts-user',
@@ -401,17 +428,40 @@ export const MOCK_ARTIFACTS_MESSAGES = [
     name: 'user',
     status: MessageStatus.Complete,
     messageId: 'mock-artifacts-user',
+    uid: 'mock-artifacts-user',
   },
   {
     id: 'mock-artifacts-assistant',
     role: MessageRole.Assistant,
-    content:
-      '已为你生成一组评审材料：立项 PDF、配置说明 Markdown、告警 JSON、巡检照片、大盘周报 HTML，以及周例会纪要 TXT。可点击卡片在侧栏预览或下载。',
+    content: '已整理第一版材料：立项 PDF、配置说明 Markdown、周例会纪要 TXT。可点击卡片在侧栏预览或下载。',
     name: 'react_agent',
     status: MessageStatus.Complete,
     messageId: 'mock-artifacts-assistant',
+    uid: 'mock-artifacts-assistant',
     property: {
-      artifacts: MOCK_FILE_ARTIFACTS,
+      artifacts: MOCK_ARTIFACTS_ROUND1,
+    },
+  },
+  {
+    id: 'mock-artifacts-user-2',
+    role: MessageRole.User,
+    content: '再补一版 PDF，并加上大盘周报 HTML；纪要也更新一下。',
+    name: 'user',
+    status: MessageStatus.Complete,
+    messageId: 'mock-artifacts-user-2',
+    uid: 'mock-artifacts-user-2',
+  },
+  {
+    id: 'mock-artifacts-assistant-2',
+    role: MessageRole.Assistant,
+    content:
+      '已更新：PDF / TXT 与上一轮同 outputId（侧栏应去重并保留本轮最新文件名），同时新增 HTML 周报。打开「文件产物」侧栏可验证去重与顺序。',
+    name: 'react_agent',
+    status: MessageStatus.Complete,
+    messageId: 'mock-artifacts-assistant-2',
+    uid: 'mock-artifacts-assistant-2',
+    property: {
+      artifacts: MOCK_ARTIFACTS_ROUND2,
     },
   },
 ] as Message[];
@@ -724,6 +774,8 @@ It converts "HTML", but keep intact partial entries like "xxxHTMLyyy" and so on.
               `;
 
 export const MOCK_MESSAGES = [
+  // 文件产物 + outputId 去重调试会话（侧栏「文件产物」）
+  ...MOCK_ARTIFACTS_MESSAGES,
   {
     id: 'cbba21f14f7847d98ff3240e69ef5c07',
     role: 'user',

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/file.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/file.ts
@@ -28,9 +28,9 @@ export enum AIFileType {
   Html = 'html',
   Jpg = 'jpg',
   Json = 'json',
+  Markdown = 'markdown',
   /** 后台扩展名别名，与 Markdown 等价 */
   Md = 'md',
-  Markdown = 'markdown',
   Pdf = 'pdf',
   Txt = 'txt',
 }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -30,6 +30,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { APPROVAL_STATUS, InterruptReason, MessageRole, MessageStatus } from '../../ag-ui/types';
 import { LOADING_MESSAGE_ID, RenderMode } from '../../common';
+import { useCustomTabProvider } from '../../composables/use-custom-tab';
 import ChatContainer, { type ChatContainerProps } from './chat-container.vue';
 
 import type { AssistantMessage, Message, UserMessage, UserQuestionInterrupt } from '../../ag-ui/types';
@@ -72,6 +73,12 @@ const mockExecutionGroupsRef = vi.hoisted(() => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const { ref: vueRef } = require('vue');
   return vueRef([]) as Ref<unknown[]>;
+});
+/** 供 useMessageGroup mock 注入会话级文件产物，验证 ensureCustomTab 静默挂载 */
+const mockSessionArtifactsRef = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { ref: vueRef } = require('vue');
+  return vueRef([]) as Ref<Array<{ name: string; outputId: string; size: number; type: string }>>;
 });
 const mockUseMessageGroup = vi.hoisted(() => vi.fn());
 const mockUseRenderModeProvider = vi.hoisted(() => vi.fn());
@@ -194,6 +201,7 @@ vi.mock('../../composables', () => ({
       return {
         messageGroups,
         executionGroups,
+        sessionArtifacts: computed(() => mockSessionArtifactsRef.value),
         activeUserQuestionInterrupt,
         pendingApprovalCount,
         pendingApprovalTipText,
@@ -257,10 +265,13 @@ vi.mock('../../composables/use-custom-tab', () => {
             ),
         );
 
-        const addCustomTab = vi.fn((tab: { label: string; name: string }) => {
+        const ensureCustomTab = vi.fn((tab: { label: string; name: string }) => {
           if (!tabs.value.find((t: { name: string }) => t.name === tab.name)) {
             tabs.value = [...tabs.value, tab];
           }
+        });
+        const addCustomTab = vi.fn((tab: { label: string; name: string }) => {
+          ensureCustomTab(tab);
           isCollapse.value = false;
         });
         const removeCustomTab = vi.fn((name: string) => {
@@ -281,6 +292,7 @@ vi.mock('../../composables/use-custom-tab', () => {
           displayTabs,
           selectedTab,
           addCustomTab,
+          ensureCustomTab,
           removeCustomTab,
           selectCustomTab,
           resetCustomTab,
@@ -292,6 +304,7 @@ vi.mock('../../composables/use-custom-tab', () => {
           selectedTab,
           isCollapse,
           addCustomTab,
+          ensureCustomTab,
           removeCustomTab,
           selectCustomTab,
           resetCustomTab,
@@ -620,6 +633,7 @@ describe('ChatContainer', () => {
     vi.clearAllMocks();
     mockMessageGroupsRef.value = [];
     mockExecutionGroupsRef.value = [];
+    mockSessionArtifactsRef.value = [];
   });
 
   afterEach(() => {
@@ -1310,6 +1324,35 @@ describe('ChatContainer', () => {
 
       expect(getSideTabRenderComponent).toHaveBeenCalled();
       expect(wrapper.find('.custom-tab-label').exists()).toBe(true);
+    });
+
+    it('有 sessionArtifacts 时应 ensureCustomTab 挂上文件产物且不展开、不抢选中', async () => {
+      mockSessionArtifactsRef.value = [
+        { name: '报告.pdf', outputId: 'out-1', size: 1024, type: 'pdf' },
+      ];
+      // 侧栏因执行情况可展开时，文件产物只应静默挂上
+      mockExecutionGroupsRef.value = [{ messages: [{ id: 't1' }], type: MessageRole.Tool, uid: 'exec-1' }];
+
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, messages: [createUserMessage('1', 'Hello')] },
+      });
+      await nextTick();
+
+      const providerApi = vi.mocked(useCustomTabProvider).mock.results.at(-1)?.value as {
+        addCustomTab: ReturnType<typeof vi.fn>;
+        ensureCustomTab: ReturnType<typeof vi.fn>;
+        isCollapse: { value: boolean };
+        selectedTab: { value: { name: string } };
+        tabs: { value: { name: string }[] };
+      };
+
+      expect(providerApi.ensureCustomTab).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'file-artifact', closable: false, order: -1 }),
+      );
+      expect(providerApi.addCustomTab).not.toHaveBeenCalled();
+      expect(providerApi.tabs.value.some(tab => tab.name === 'file-artifact')).toBe(true);
+      expect(providerApi.isCollapse.value).toBe(true);
+      expect(providerApi.selectedTab.value.name).toBe('execution');
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -478,33 +478,52 @@
 
   useCommonTippyProvider({ tippyOptions: computed(() => props.commonTippyOptions ?? {}) });
 
-  const { displayTabs, tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
-    useCustomTabProvider<CustomBkFlowTabData>({
-      executionTabVisible: () => props.executionTabVisible,
-      onTabChange: async tab => {
-        // 文件产物 Tab 由 FileArtifactPanel 自行通过 onArtifactClick 异步取链，无需走自定义 Tab 拉取
-        if (tab.name === FILE_ARTIFACT_TAB_NAME) {
-          return;
-        }
-        const tabProps = selectedTab.value.data?.props || {
-          loading: true,
-          data: {},
-        };
-        selectedTab.value.data = {
-          ...selectedTab.value.data,
-          props: tabProps,
-        };
-        const data = await props.onCustomTabChange?.(tab);
-        selectedTab.value.data = {
-          ...selectedTab.value.data,
-          props: {
-            ...tabProps,
-            loading: false,
-            data,
-          },
-        };
-      },
+  const {
+    displayTabs,
+    tabs,
+    selectedTab,
+    isCollapse,
+    addCustomTab,
+    ensureCustomTab,
+    removeCustomTab,
+    selectCustomTab,
+    resetCustomTab,
+  } = useCustomTabProvider<CustomBkFlowTabData>({
+    executionTabVisible: () => props.executionTabVisible,
+    onTabChange: async tab => {
+      // 文件产物 Tab 由 FileArtifactPanel 自行通过 onArtifactClick 异步取链，无需走自定义 Tab 拉取
+      if (tab.name === FILE_ARTIFACT_TAB_NAME) {
+        return;
+      }
+      const tabProps = selectedTab.value.data?.props || {
+        loading: true,
+        data: {},
+      };
+      selectedTab.value.data = {
+        ...selectedTab.value.data,
+        props: tabProps,
+      };
+      const data = await props.onCustomTabChange?.(tab);
+      selectedTab.value.data = {
+        ...selectedTab.value.data,
+        props: {
+          ...tabProps,
+          loading: false,
+          data,
+        },
+      };
+    },
+  });
+
+  /** 挂上「文件产物」Tab，不抢占当前选中（如执行情况） */
+  const ensureFileArtifactTab = () => {
+    ensureCustomTab({
+      closable: false,
+      label: t('文件产物'),
+      name: FILE_ARTIFACT_TAB_NAME,
+      order: -1,
     });
+  };
 
   const keyword = shallowRef('');
   const selectedUserMessages = deepRef<Message[]>([]);
@@ -553,13 +572,26 @@
     },
   });
 
-  // 会话切换 / 无文件产物时清理：移除 Tab 并重置命中态，避免残留
-  watch(sessionArtifacts, list => {
-    if (!list.length) {
-      removeCustomTab(FILE_ARTIFACT_TAB_NAME);
-      setActiveArtifactId('');
-    }
-  });
+  /**
+   * 有文件产物时挂上 Tab 并保证命中态有效；无产物时清理。
+   * ensure 不切换选中，避免从「执行情况」展开侧栏时被抢走焦点。
+   */
+  watch(
+    sessionArtifacts,
+    list => {
+      if (!list.length) {
+        removeCustomTab(FILE_ARTIFACT_TAB_NAME);
+        setActiveArtifactId('');
+        return;
+      }
+      ensureFileArtifactTab();
+      // 未命中或命中项已不在列表时，默认选中第一个
+      if (!list.some(item => item.outputId === activeArtifactId.value)) {
+        setActiveArtifactId(list[0].outputId);
+      }
+    },
+    { immediate: true },
+  );
 
   watch(isCollapse, newVal => {
     if (newVal) {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
@@ -33,7 +33,6 @@
     <MessageArtifacts
       v-if="artifacts && artifacts.length > 0"
       :artifacts="artifacts"
-      :message-uid="messageUid"
     />
   </div>
 </template>
@@ -61,8 +60,6 @@
   }
   const props = defineProps<AssistantMessageProps>();
   const artifacts = computed(() => props.property?.artifacts);
-  // 唯一消息标识：优先 uid，回退 id，供文件产物命中唯一文件与「在对话中定位」
-  const messageUid = computed(() => props.uid ?? (props.id != null ? String(props.id) : ''));
 </script>
 
 <style lang="scss">

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
@@ -155,18 +155,18 @@ describe('ArtifactFileCard', () => {
       expect(onPreview).toHaveBeenCalledWith(file);
     });
 
-    it('无 onPreview 时点击卡片应调用侧栏预览 openPreview 并透传定位信息', async () => {
+    it('无 onPreview 时点击卡片应调用侧栏预览 openPreview', async () => {
       const openPreview = vi.fn();
       const artifactPreview = createPreviewContext({ openPreview });
       const file = createFile();
       wrapper = mount(ArtifactFileCard, {
         global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: artifactPreview } },
-        props: { file, index: 2, messageUid: 'msg-a' },
+        props: { file },
       });
 
       await wrapper.find('.ai-artifact-file-card').trigger('click');
 
-      expect(openPreview).toHaveBeenCalledWith({ file, index: 2, messageUid: 'msg-a' });
+      expect(openPreview).toHaveBeenCalledWith({ file });
     });
 
     it('传入 onDownload 时点击下载应该调用回调而非默认下载', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
@@ -64,10 +64,6 @@
     // 侧栏列表选中态（variant=list 时使用）
     active?: boolean;
     file: AIFileInfo;
-    // 文件在所属消息 artifacts 中的下标，用于命中唯一文件（文件名不可靠）
-    index?: number;
-    // 所属 AssistantMessage 的 uid，用于命中唯一文件与「在对话中定位」
-    messageUid?: string;
     // 下载回调，传入时覆盖组件内置的默认下载行为
     onDownload?: (file: AIFileInfo) => void;
     // 点击卡片主体的回调（可选，优先于内置侧栏预览，便于外部自定义 / 测试）
@@ -102,11 +98,7 @@
       props.onPreview(props.file);
       return;
     }
-    artifactPreview?.openPreview({
-      file: props.file,
-      index: props.index ?? 0,
-      messageUid: props.messageUid ?? '',
-    });
+    artifactPreview?.openPreview({ file: props.file });
   };
 
   const handleDownload = async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
@@ -8,7 +8,6 @@ import { ARTIFACT_PREVIEW_TOKEN } from '../../../../../composables/use-artifact-
 import ArtifactPreviewHost from './artifact-preview-host.vue';
 
 import type { AIFileInfo } from '../../../../../ag-ui/types/file';
-import type { SessionArtifact } from '../../../../../composables/use-artifact-preview';
 
 vi.mock('bkui-vue', () => ({
   Button: defineComponent({
@@ -38,13 +37,6 @@ const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
   outputId: 'output-1',
   size: 1024,
   type: AIFileType.Pdf,
-  ...overrides,
-});
-
-const createSessionArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifact => ({
-  ...createFile(),
-  artifactId: 'message-1#0#output-1',
-  messageUid: 'message-1',
   ...overrides,
 });
 
@@ -95,15 +87,12 @@ describe('ArtifactPreviewHost', () => {
     expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/file.pdf');
   });
 
-  it('切换相同 outputId 和类型但 artifactId 不同的文件时应重新加载预览', async () => {
+  it('切换不同 outputId 的文件时应重新加载预览', async () => {
     const resolveArtifactUrls = vi.fn().mockResolvedValue({
       preview_url: 'https://example.com/file.pdf',
     });
-    const firstFile = createSessionArtifact();
-    const secondFile = createSessionArtifact({
-      artifactId: 'message-2#0#output-1',
-      messageUid: 'message-2',
-    });
+    const firstFile = createFile({ outputId: 'output-1' });
+    const secondFile = createFile({ outputId: 'output-2' });
     wrapper = mountHost(firstFile, createPreviewContext({ resolveArtifactUrls }));
     await flushPromises();
 
@@ -112,6 +101,21 @@ describe('ArtifactPreviewHost', () => {
 
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
     expect(resolveArtifactUrls).toHaveBeenLastCalledWith(secondFile);
+  });
+
+  it('切换相同 outputId 且类型不变时不应重新加载预览', async () => {
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      preview_url: 'https://example.com/file.pdf',
+    });
+    const firstFile = createFile({ name: 'a.pdf', outputId: 'same' });
+    const secondFile = createFile({ name: 'b.pdf', outputId: 'same' });
+    wrapper = mountHost(firstFile, createPreviewContext({ resolveArtifactUrls }));
+    await flushPromises();
+
+    await wrapper.setProps({ file: secondFile });
+    await flushPromises();
+
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
   });
 
   it('html 文件应使用 iframe srcdoc 展示下载内容', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -59,9 +59,8 @@
   import { useArtifactPreviewLoader } from './use-artifact-preview-loader';
 
   import type { AIFileInfo } from '../../../../../ag-ui/types/file';
-  import type { SessionArtifact } from '../../../../../composables/use-artifact-preview';
 
-  const props = defineProps<{ file?: AIFileInfo | SessionArtifact }>();
+  const props = defineProps<{ file?: AIFileInfo }>();
   const artifactPreview = useArtifactPreviewConsumer();
 
   const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
@@ -70,13 +69,9 @@
     resolveUrls: file => artifactPreview?.resolveArtifactUrls(file) ?? Promise.resolve({}),
   });
 
+  // 以 outputId 为唯一键；同文件类型变更时也需重新加载预览策略
   watch(
-    () => {
-      if (!props.file) {
-        return '';
-      }
-      return 'artifactId' in props.file ? props.file.artifactId : `${props.file.outputId}:${props.file.type}`;
-    },
+    () => (props.file ? `${props.file.outputId}:${props.file.type}` : ''),
     () => {
       load();
     },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
@@ -29,7 +29,7 @@ import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../../../../ag-ui/types/file';
-import { ARTIFACT_PREVIEW_TOKEN, buildArtifactId } from '../../../../composables/use-artifact-preview';
+import { ARTIFACT_PREVIEW_TOKEN } from '../../../../composables/use-artifact-preview';
 import FileArtifactPanel from './file-artifact-panel.vue';
 
 import type { SessionArtifact } from '../../../../composables/use-artifact-preview';
@@ -72,19 +72,13 @@ vi.mock('../../../message-loading/message-loading.vue', () => ({
   }),
 }));
 
-const createArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifact => {
-  const messageUid = overrides.messageUid ?? 'm1';
-  const outputId = overrides.outputId ?? 'o1';
-  return {
-    artifactId: buildArtifactId(messageUid, 0, outputId),
-    messageUid,
-    name: '项目立项书.pdf',
-    outputId,
-    size: 1024,
-    type: AIFileType.Pdf,
-    ...overrides,
-  };
-};
+const createArtifact = (overrides: Partial<SessionArtifact> = {}): SessionArtifact => ({
+  name: '项目立项书.pdf',
+  outputId: 'o1',
+  size: 1024,
+  type: AIFileType.Pdf,
+  ...overrides,
+});
 
 const createPreviewContext = (overrides: Record<string, unknown> = {}) => ({
   activeArtifactId: ref(''),
@@ -128,7 +122,7 @@ describe('FileArtifactPanel', () => {
 
   it('命中文件的列表项应带 is-active 态', () => {
     const artifacts = [createArtifact({ outputId: 'a' }), createArtifact({ outputId: 'b' })];
-    wrapper = mountPanel({ activeId: artifacts[1].artifactId, artifacts });
+    wrapper = mountPanel({ activeId: artifacts[1].outputId, artifacts });
 
     const items = wrapper.findAll('.ai-artifact-file-card.is-list');
     expect(items[0].classes()).not.toContain('is-active');
@@ -137,11 +131,11 @@ describe('FileArtifactPanel', () => {
 
   it('点击其它文件项应 emit select', async () => {
     const artifacts = [createArtifact({ outputId: 'a' }), createArtifact({ outputId: 'b' })];
-    wrapper = mountPanel({ activeId: artifacts[0].artifactId, artifacts });
+    wrapper = mountPanel({ activeId: artifacts[0].outputId, artifacts });
 
     await wrapper.findAll('.ai-artifact-file-card.is-list')[1].trigger('click');
 
-    expect(wrapper.emitted('select')?.[0]).toEqual([artifacts[1].artifactId]);
+    expect(wrapper.emitted('select')?.[0]).toEqual([artifacts[1].outputId]);
   });
 
   it('搜索应过滤文件列表', async () => {
@@ -160,7 +154,7 @@ describe('FileArtifactPanel', () => {
 
   it('未传 onArtifactClick 时预览区应展示无数据', async () => {
     const artifact = createArtifact();
-    wrapper = mountPanel({ activeId: artifact.artifactId, artifacts: [artifact] });
+    wrapper = mountPanel({ activeId: artifact.outputId, artifacts: [artifact] });
     await flushPromises();
 
     expect(wrapper.find('.ai-artifact-preview-host-empty').exists()).toBe(true);
@@ -176,7 +170,7 @@ describe('FileArtifactPanel', () => {
     });
     const artifact = createArtifact({ type: AIFileType.Pdf });
     wrapper = mountPanel(
-      { activeId: artifact.artifactId, artifacts: [artifact] },
+      { activeId: artifact.outputId, artifacts: [artifact] },
       createPreviewContext({ resolveArtifactUrls }),
     );
     await flushPromises();
@@ -200,7 +194,7 @@ describe('FileArtifactPanel', () => {
       type: AIFileType.Html,
     });
     wrapper = mountPanel(
-      { activeId: artifact.artifactId, artifacts: [artifact] },
+      { activeId: artifact.outputId, artifacts: [artifact] },
       createPreviewContext({ resolveArtifactUrls }),
     );
     await flushPromises();
@@ -219,7 +213,7 @@ describe('FileArtifactPanel', () => {
     });
     const artifact = createArtifact({ name: 'page.html', type: AIFileType.Html });
     wrapper = mountPanel(
-      { activeId: artifact.artifactId, artifacts: [artifact] },
+      { activeId: artifact.outputId, artifacts: [artifact] },
       createPreviewContext({ resolveArtifactUrls }),
     );
     await flushPromises();
@@ -238,7 +232,7 @@ describe('FileArtifactPanel', () => {
     );
     const artifact = createArtifact();
     wrapper = mountPanel(
-      { activeId: artifact.artifactId, artifacts: [artifact] },
+      { activeId: artifact.outputId, artifacts: [artifact] },
       createPreviewContext({ resolveArtifactUrls }),
     );
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
@@ -13,8 +13,8 @@
         <template v-if="filteredArtifacts.length">
           <ArtifactFileCard
             v-for="item in filteredArtifacts"
-            :key="item.artifactId"
-            :active="item.artifactId === activeId"
+            :key="item.outputId"
+            :active="item.outputId === activeId"
             :file="item"
             :on-preview="() => handleSelect(item)"
             variant="list"
@@ -85,9 +85,9 @@
   import type { SessionArtifact } from '../../../../composables/use-artifact-preview';
 
   const props = defineProps<{
-    // 命中的文件 id（messageUid#index#outputId）
+    // 命中的文件 outputId
     activeId: string;
-    // 当前会话全部文件产物
+    // 当前会话全部文件产物（已按 outputId 去重）
     artifacts: SessionArtifact[];
   }>();
 
@@ -112,13 +112,13 @@
     return props.artifacts.filter(item => item.name.toLowerCase().includes(kw));
   });
 
-  const activeArtifact = computed(() => props.artifacts.find(item => item.artifactId === props.activeId));
+  const activeArtifact = computed(() => props.artifacts.find(item => item.outputId === props.activeId));
 
   const handleSelect = (item: SessionArtifact) => {
-    if (item.artifactId === props.activeId) {
+    if (item.outputId === props.activeId) {
       return;
     }
-    emits('select', item.artifactId);
+    emits('select', item.outputId);
   };
 
   const handleDownload = async (file: SessionArtifact) => {
@@ -137,7 +137,7 @@
   };
 
   watch(
-    () => activeArtifact.value?.artifactId,
+    () => activeArtifact.value?.outputId,
     () => {
       downloadLoading.value = false;
     },

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.spec.ts
@@ -79,14 +79,13 @@ describe('MessageArtifacts', () => {
     expect(wrapper.find('.ai-artifact-file-card').exists()).toBe(false);
   });
 
-  it('应该向卡片透传 messageUid 与消息内下标 index，用于命中唯一文件', () => {
+  it('应该以 outputId 作为卡片 key 并透传 file', () => {
     const artifacts = [createFile({ outputId: 'a' }), createFile({ outputId: 'b' })];
 
-    wrapper = mount(MessageArtifacts, { props: { artifacts, messageUid: 'msg-1' } });
+    wrapper = mount(MessageArtifacts, { props: { artifacts } });
 
     const cards = wrapper.findAllComponents(ArtifactFileCard);
-    expect(cards[0].props('messageUid')).toBe('msg-1');
-    expect(cards[0].props('index')).toBe(0);
-    expect(cards[1].props('index')).toBe(1);
+    expect(cards[0].props('file')).toEqual(artifacts[0]);
+    expect(cards[1].props('file')).toEqual(artifacts[1]);
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/message-artifacts.vue
@@ -1,11 +1,9 @@
 <template>
   <div class="ai-message-artifacts">
     <ArtifactFileCard
-      v-for="(artifact, index) in artifacts"
+      v-for="artifact in artifacts"
       :key="artifact.outputId"
       :file="artifact"
-      :index="index"
-      :message-uid="messageUid"
       :on-download="onDownload"
       :on-preview="onPreview"
     />
@@ -19,8 +17,6 @@
   defineProps<{
     // AI 生成的文件产物列表
     artifacts: AIFileInfo[];
-    // 所属 AssistantMessage 的 uid，透传给卡片用于命中唯一文件与侧栏预览
-    messageUid?: string;
     // 下载回调，透传给卡片以覆盖默认下载行为
     onDownload?: (file: AIFileInfo) => void;
     // 点击卡片主体的回调（可选，优先于内置侧栏预览）

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
@@ -30,11 +30,7 @@ import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../ag-ui/types/file';
-import {
-  buildArtifactId,
-  useArtifactPreviewConsumer,
-  useArtifactPreviewProvider,
-} from './use-artifact-preview';
+import { useArtifactPreviewConsumer, useArtifactPreviewProvider } from './use-artifact-preview';
 
 import type { AIFileInfo, OnArtifactClick } from '../ag-ui/types/file';
 
@@ -47,17 +43,13 @@ const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
 });
 
 describe('use-artifact-preview', () => {
-  describe('buildArtifactId', () => {
-    it('应该按 messageUid#index#outputId 组合唯一 id', () => {
-      expect(buildArtifactId('m1', 2, 'o3')).toBe('m1#2#o3');
-    });
-  });
-
   describe('Provider / Consumer', () => {
-    const setup = (options: {
-      getOnArtifactClick?: () => OnArtifactClick | undefined;
-      onOpen?: ReturnType<typeof vi.fn>;
-    } = {}) => {
+    const setup = (
+      options: {
+        getOnArtifactClick?: () => OnArtifactClick | undefined;
+        onOpen?: ReturnType<typeof vi.fn>;
+      } = {},
+    ) => {
       const onOpen = options.onOpen ?? vi.fn();
       let providerApi: ReturnType<typeof useArtifactPreviewProvider> | undefined;
       let consumerCtx: ReturnType<typeof useArtifactPreviewConsumer>;
@@ -81,15 +73,14 @@ describe('use-artifact-preview', () => {
       return { consumerCtx, onOpen, providerApi, wrapper };
     };
 
-    it('openPreview 应命中文件并触发 onOpen', () => {
+    it('openPreview 应以 outputId 命中文件并触发 onOpen', () => {
       const { consumerCtx, onOpen, providerApi } = setup();
       const file = createFile({ outputId: 'o9' });
 
-      consumerCtx?.openPreview({ file, index: 1, messageUid: 'msg-a' });
+      consumerCtx?.openPreview({ file });
 
-      const expectedId = buildArtifactId('msg-a', 1, 'o9');
-      expect(providerApi?.activeArtifactId.value).toBe(expectedId);
-      expect(onOpen).toHaveBeenCalledWith(expectedId);
+      expect(providerApi?.activeArtifactId.value).toBe('o9');
+      expect(onOpen).toHaveBeenCalledWith('o9');
     });
 
     it('setActiveArtifactId 应直接更新命中态', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
@@ -37,24 +37,16 @@ export const FILE_ARTIFACT_TAB_NAME = 'file-artifact';
 export type OpenArtifactPreviewPayload = {
   /** 被点击的文件 */
   file: AIFileInfo;
-  /** 文件在所属消息 artifacts 中的下标 */
-  index: number;
-  /** 所属 AssistantMessage 的 uid */
-  messageUid: string;
 };
 
 /**
- * 会话级文件产物：在 AIFileInfo 基础上补充命中所需的唯一 id 与所属消息。
- * 由于同一会话可能出现「多个 AssistantMessage + 同名文件」，文件名不可作为唯一键，
- * 统一用 messageUid + 消息内下标 + outputId 组合出全局唯一 id。
+ * 会话级文件产物：以 outputId 为会话内唯一键（同 outputId 视为同一文件）。
+ * 拍平去重后即为 AIFileInfo，此处用别名标明语义。
  */
-export type SessionArtifact = AIFileInfo & {
-  artifactId: string;
-  messageUid: string;
-};
+export type SessionArtifact = AIFileInfo;
 
 type ArtifactPreviewContext = {
-  /** 当前命中的文件 id */
+  /** 当前命中的文件 outputId */
   activeArtifactId: Ref<string>;
   /** 是否具备异步取链能力（有 onArtifactClick 时下载按钮可见） */
   canResolveArtifactUrl: ComputedRef<boolean>;
@@ -62,13 +54,9 @@ type ArtifactPreviewContext = {
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
   /** 按 outputId 缓存并解析 download_url / preview_url */
   resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
-  /** 直接设置命中文件 id（侧栏列表内切换用） */
+  /** 直接设置命中文件 outputId（侧栏列表内切换用） */
   setActiveArtifactId: (id: string) => void;
 };
-
-/** 统一的文件产物唯一 id 生成规则，Provider 与文件卡片两侧必须一致 */
-export const buildArtifactId = (messageUid: string, index: number, outputId: string) =>
-  `${messageUid}#${index}#${outputId}`;
 
 /** 通过临时 <a> 触发浏览器下载 */
 export const triggerArtifactDownload = (url: string, fileName: string) => {
@@ -91,7 +79,7 @@ export const useArtifactPreviewProvider = (options: {
   /** 读取业务侧异步取链回调（用 getter 保持对 props 变更敏感） */
   getOnArtifactClick?: () => OnArtifactClick | undefined;
   /** 命中文件后触发：由容器负责 addCustomTab + 展开侧栏 + 选中 Tab */
-  onOpen: (artifactId: string) => void;
+  onOpen: (outputId: string) => void;
 }) => {
   const activeArtifactId = shallowRef('');
   // 已成功解析的 URL 缓存（key = outputId）
@@ -106,7 +94,7 @@ export const useArtifactPreviewProvider = (options: {
   };
 
   const openPreview = (payload: OpenArtifactPreviewPayload) => {
-    const id = buildArtifactId(payload.messageUid, payload.index, payload.file.outputId);
+    const id = payload.file.outputId;
     activeArtifactId.value = id;
     options.onOpen(id);
   };

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.spec.ts
@@ -129,6 +129,61 @@ describe('useCustomTab', () => {
       wrapper.unmount();
     });
 
+    it('ensureCustomTab 应挂上 Tab 但不展开、不切换选中', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+
+      const vm = wrapper.vm as unknown as {
+        providerResult: {
+          ensureCustomTab: (tab: { label: string; name: string }) => void;
+          isCollapse: { value: boolean };
+          selectedTab: { value: { name: string } };
+          tabs: { value: { name: string }[] };
+        };
+      };
+
+      vm.providerResult.ensureCustomTab({ label: '文件产物', name: 'file-artifact' });
+      await nextTick();
+
+      expect(vm.providerResult.tabs.value.some(tab => tab.name === 'file-artifact')).toBe(true);
+      expect(vm.providerResult.isCollapse.value).toBe(true);
+      expect(vm.providerResult.selectedTab.value.name).toBe(EXECUTION_TAB_NAME);
+
+      wrapper.unmount();
+    });
+
+    it('ensureCustomTab 同名应合并更新且仍不展开、不切换选中', async () => {
+      const Provider = createProviderComponent();
+      const wrapper = mount(Provider);
+
+      const vm = wrapper.vm as unknown as {
+        providerResult: {
+          ensureCustomTab: (tab: {
+            label: string;
+            name: string;
+            order?: number;
+            visible?: boolean;
+          }) => void;
+          isCollapse: { value: boolean };
+          selectedTab: { value: { name: string } };
+          tabs: { value: { label: string; name: string; order?: number }[] };
+        };
+      };
+
+      vm.providerResult.ensureCustomTab({ label: '文件产物', name: 'file-artifact', order: -1 });
+      await nextTick();
+      vm.providerResult.ensureCustomTab({ label: '文件产物-更新', name: 'file-artifact', order: -2 });
+      await nextTick();
+
+      const fileTabs = vm.providerResult.tabs.value.filter(tab => tab.name === 'file-artifact');
+      expect(fileTabs).toHaveLength(1);
+      expect(fileTabs[0]).toMatchObject({ label: '文件产物-更新', order: -2 });
+      expect(vm.providerResult.isCollapse.value).toBe(true);
+      expect(vm.providerResult.selectedTab.value.name).toBe(EXECUTION_TAB_NAME);
+
+      wrapper.unmount();
+    });
+
     it('同名 Tab 不应该重复添加', async () => {
       const Provider = createProviderComponent();
       const wrapper = mount(Provider);

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-custom-tab.ts
@@ -76,16 +76,29 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
       .sort((a, b) => (a.order ?? DEFAULT_TAB_ORDER) - (b.order ?? DEFAULT_TAB_ORDER)),
   );
 
-  const addCustomTab = (tab: CustomTab<T>) => {
+  /** 写入 / 合并 Tab 元信息，不改变展开态与当前选中 */
+  const upsertCustomTab = (tab: CustomTab<T>) => {
     const index = tabs.value.findIndex(item => item.name === tab.name);
     if (index === -1) {
       tabs.value = [...tabs.value, tab];
-    } else {
-      // 同名 Tab 合并更新，支持运行时调整 order / visible / label 等元信息
-      const next = tabs.value.slice();
-      next[index] = { ...next[index], ...tab };
-      tabs.value = next;
+      return;
     }
+    // 同名 Tab 合并更新，支持运行时调整 order / visible / label 等元信息
+    const next = tabs.value.slice();
+    next[index] = { ...next[index], ...tab };
+    tabs.value = next;
+  };
+
+  /**
+   * 确保 Tab 存在（可合并更新），不展开侧栏、不切换选中。
+   * 用于「侧栏已因执行情况打开时同步挂上文件产物」等场景。
+   */
+  const ensureCustomTab = (tab: CustomTab<T>) => {
+    upsertCustomTab(tab);
+  };
+
+  const addCustomTab = (tab: CustomTab<T>) => {
+    upsertCustomTab(tab);
     isCollapse.value = false;
     nextTick(() => {
       selectCustomTab(tabs.value.find(item => item.name === tab.name)!);
@@ -126,6 +139,7 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
     displayTabs,
     selectedTab,
     addCustomTab,
+    ensureCustomTab,
     removeCustomTab,
     selectCustomTab,
     resetCustomTab,
@@ -137,6 +151,7 @@ export function useCustomTabProvider<T extends Record<string, unknown>>(options:
     selectedTab,
     isCollapse,
     addCustomTab,
+    ensureCustomTab,
     removeCustomTab,
     selectCustomTab,
     resetCustomTab,
@@ -149,6 +164,7 @@ export const useCustomTabConsumer = <T extends Record<string, unknown>>() => {
     | {
         addCustomTab: (tab: CustomTab<T>) => void;
         displayTabs: ComputedRef<CustomTab<T>[]>;
+        ensureCustomTab: (tab: CustomTab<T>) => void;
         removeCustomTab: (tabName: CustomTab<T>['name']) => void;
         selectCustomTab: (tab: CustomTab<T>) => void;
         selectedTab: ShallowRef<CustomTab<T> | null>;

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -31,7 +31,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { APPROVAL_STATUS, InterruptReason, MessageContentType, MessageRole, MessageStatus } from '../ag-ui/types';
 import { AIFileType } from '../ag-ui/types/file';
 import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
-import { buildArtifactId } from './use-artifact-preview';
 import { useMessageGroup } from './use-message-group';
 
 import type { AssistantMessage, Message, ToolMessage, UserMessage } from '../ag-ui/types';
@@ -326,7 +325,7 @@ describe('useMessageGroup', () => {
       expect(sessionArtifacts.value).toEqual([]);
     });
 
-    it('应拍平所有 AssistantMessage 的 artifacts 并生成唯一 id', async () => {
+    it('应拍平所有 AssistantMessage 的 artifacts，并以 outputId 为唯一键', async () => {
       const messages: Message[] = [
         createAssistantMessage('a1', 'with files', {
           uid: 'msg-a',
@@ -341,12 +340,26 @@ describe('useMessageGroup', () => {
       const { sessionArtifacts } = setupMessageGroup(messages);
       await nextTick();
 
-      expect(sessionArtifacts.value.map(item => item.artifactId)).toEqual([
-        buildArtifactId('msg-a', 0, 'o1'),
-        buildArtifactId('msg-a', 1, 'o2'),
-        buildArtifactId('msg-b', 0, 'o3'),
-      ]);
-      expect(sessionArtifacts.value[0]?.messageUid).toBe('msg-a');
+      expect(sessionArtifacts.value.map(item => item.outputId)).toEqual(['o1', 'o2', 'o3']);
+    });
+
+    it('相同 outputId 应去重并保留最后一次出现（含相对顺序）', async () => {
+      const first = createFile({ name: '旧名.pdf', outputId: 'dup', size: 1 });
+      const middle = createFile({ outputId: 'keep' });
+      const last = createFile({ name: '新名.pdf', outputId: 'dup', size: 99 });
+      const messages: Message[] = [
+        createAssistantMessage('a1', 'first', {
+          property: { artifacts: [first, middle] },
+        }),
+        createAssistantMessage('a2', 'later', {
+          property: { artifacts: [last] },
+        }),
+      ];
+      const { sessionArtifacts } = setupMessageGroup(messages);
+      await nextTick();
+
+      expect(sessionArtifacts.value.map(item => item.outputId)).toEqual(['keep', 'dup']);
+      expect(sessionArtifacts.value[1]).toMatchObject({ name: '新名.pdf', outputId: 'dup', size: 99 });
     });
 
     it('仅统计 AssistantMessage 的 artifacts，忽略其它角色', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -39,7 +39,7 @@ import {
 import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
 import { t } from '../lang/lang';
 import { generateUUID } from '../utils';
-import { type SessionArtifact, buildArtifactId } from './use-artifact-preview';
+import { type SessionArtifact } from './use-artifact-preview';
 
 import type { BkFlowMessageContent } from '../ag-ui/types/contents';
 import type { InterruptMessage, UserQuestionInterrupt } from '../ag-ui/types/interrupt';
@@ -263,10 +263,11 @@ export const useMessageGroup = (options: {
   });
   /**
    * 会话级文件产物：拍平所有 AssistantMessage 的 property.artifacts，
-   * 用 messageUid + 消息内下标 + outputId 生成全局唯一 id（文件名可能重复，不可作唯一键）。
+   * 以 outputId 为唯一键去重，保留最后一次出现（列表顺序同最后一次出现的相对顺序）。
    */
   const sessionArtifacts = computed<SessionArtifact[]>(() => {
-    const list: SessionArtifact[] = [];
+    // delete + set：同 key 覆盖内容，并把该项挪到 Map 末尾，保证「最后出现」顺序
+    const byOutputId = new Map<string, SessionArtifact>();
     for (const message of options.messages.value) {
       if (message.role !== MessageRole.Assistant) {
         continue;
@@ -275,16 +276,14 @@ export const useMessageGroup = (options: {
       if (!artifacts?.length) {
         continue;
       }
-      const messageUid = message.uid ?? String(message.id);
-      artifacts.forEach((file, index) => {
-        list.push({
-          ...file,
-          artifactId: buildArtifactId(messageUid, index, file.outputId),
-          messageUid,
-        });
-      });
+      for (const file of artifacts) {
+        if (byOutputId.has(file.outputId)) {
+          byOutputId.delete(file.outputId);
+        }
+        byOutputId.set(file.outputId, file);
+      }
     }
-    return list;
+    return Array.from(byOutputId.values());
   });
 
   const activeUserQuestionInterrupt = computed(() => findActiveUserQuestion(options.messages.value));

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -5,7 +5,7 @@ kind: component
 domain: message
 description: 汇总当前会话全部文件产物，支持搜索、选中与分类型预览，挂载在 ChatContainer 侧栏「文件产物」Tab。
 aiSummary: >
-  汇总当前会话所有 AssistantMessage 的 artifacts，支持关键词搜索、列表选中与下载；
+  汇总当前会话所有 AssistantMessage 的 artifacts（按 outputId 去重），支持关键词搜索、列表选中与下载；
   预览区委托 ArtifactPreviewHost：按类型走 text_from_download（html / markdown / md / txt / json）
   或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 异步获取。
   源码位置：src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue。
@@ -26,17 +26,11 @@ sinceVersion: 0.0.20
 
   import { MOCK_FILE_ARTIFACTS, mockArtifactClick } from '../../../playground/mock'
   import FileArtifactPanelComp from '../../../src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue'
-  import { buildArtifactId, useArtifactPreviewProvider } from '../../../src/composables/use-artifact-preview'
+  import { useArtifactPreviewProvider } from '../../../src/composables/use-artifact-preview'
 
-  const DEMO_MESSAGE_UID = 'wiki-artifact-msg'
+  const demoArtifacts = MOCK_FILE_ARTIFACTS
 
-  const demoArtifacts = MOCK_FILE_ARTIFACTS.map((file, index) => ({
-    ...file,
-    artifactId: buildArtifactId(DEMO_MESSAGE_UID, index, file.outputId),
-    messageUid: DEMO_MESSAGE_UID,
-  }))
-
-  const activeArtifactId = shallowRef(demoArtifacts[0]?.artifactId ?? '')
+  const activeArtifactId = shallowRef(demoArtifacts[0]?.outputId ?? '')
 
   // 文档站单独挂载面板时需自行提供 Provider；业务侧由 ChatContainer 注入
   useArtifactPreviewProvider({
@@ -59,14 +53,14 @@ sinceVersion: 0.0.20
 
 > **导出说明**：内部侧栏面板组件，**通常不直接使用**；由 `ChatContainer` 在「文件产物」Tab 内自动挂载。预览加载与渲染为同目录下 `artifact-preview/` 内部实现，不单独导出。
 
-点击 AI 回复中的[文件卡片](/components/message/assistant-message)后，`ChatContainer` 侧栏会弹出固定的「文件产物」Tab，聚合展示当前会话**所有** `AssistantMessage` 的文件产物，并命中被点击的文件进行预览。
+点击 AI 回复中的[文件卡片](/components/message/assistant-message)后，`ChatContainer` 侧栏会弹出固定的「文件产物」Tab，聚合展示当前会话**所有** `AssistantMessage` 的文件产物（按 `outputId` 去重），并命中被点击的文件进行预览。
 
 面板左侧为可搜索的文件列表，右侧为预览区。通常不需要直接使用，由 `ChatContainer` 在侧栏内自动渲染。
 
 ## 核心能力
 
-- **会话级聚合**：拍平当前会话所有 `AssistantMessage.property.artifacts`，统一在一个列表内展示
-- **唯一命中**：同一会话可能出现多个消息 + 同名文件，文件名不可作唯一键，统一用 `messageUid#消息内下标#outputId` 生成全局唯一 id
+- **会话级聚合**：拍平当前会话所有 `AssistantMessage.property.artifacts`，以 `outputId` 去重后统一在一个列表内展示
+- **唯一命中**：以 `outputId` 作为会话内唯一键（同 `outputId` 视为同一文件）；文件名可能重复，不可作唯一键
 - **关键词搜索**：按文件名实时过滤列表
 - **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 缓存获取 `download_url` / `preview_url`
 - **职责拆分**：
@@ -91,24 +85,18 @@ sinceVersion: 0.0.20
 
 <script setup lang="ts">
   import { shallowRef } from 'vue'
-  import { buildArtifactId, useArtifactPreviewProvider } from '@blueking/chat-x'
+  import { useArtifactPreviewProvider } from '@blueking/chat-x'
   import type { AIFileInfo, SessionArtifact } from '@blueking/chat-x'
   // 内部组件：仅文档 / 调试；业务请用 ChatContainer 自动挂载
   import FileArtifactPanel from './message-artifacts/file-artifact-panel.vue'
 
-  const files: AIFileInfo[] = [
+  const sessionArtifacts: SessionArtifact[] = [
     { name: '周报.html', outputId: 'a-html', size: 10240, type: 'html' },
     { name: '说明.md', outputId: 'a-md', size: 8192, type: 'md' },
     { name: '纪要.txt', outputId: 'a-txt', size: 4096, type: 'txt' },
     { name: '配置.json', outputId: 'a-json', size: 2048, type: 'json' },
     { name: '立项.pdf', outputId: 'a-pdf', size: 204800, type: 'pdf' },
   ]
-
-  const sessionArtifacts: SessionArtifact[] = files.map((file, index) => ({
-    ...file,
-    artifactId: buildArtifactId('msg-1', index, file.outputId),
-    messageUid: 'msg-1',
-  }))
 
   useArtifactPreviewProvider({
     getOnArtifactClick: () => async file => {
@@ -119,7 +107,7 @@ sinceVersion: 0.0.20
     onOpen: () => {},
   })
 
-  const activeArtifactId = shallowRef(sessionArtifacts[0].artifactId)
+  const activeArtifactId = shallowRef(sessionArtifacts[0].outputId)
   const handleSelect = (id: string) => {
     activeArtifactId.value = id
   }
@@ -207,34 +195,32 @@ sinceVersion: 0.0.20
 
 ```
 ArtifactFileCard（点击文件卡片）
-  └─ useArtifactPreviewConsumer().openPreview({ file, index, messageUid })
+  └─ useArtifactPreviewConsumer().openPreview({ file })
        └─ useArtifactPreviewProvider（ChatContainer 内）
-            ├─ 记录命中文件 activeArtifactId
+            ├─ 记录命中文件 activeArtifactId = file.outputId
             └─ onOpen → addCustomTab('file-artifact') 展开并选中侧栏 Tab
                  └─ FileArtifactPanel
-                      ├─ 列表 @select → setActiveArtifactId
+                      ├─ 列表 @select → setActiveArtifactId(outputId)
                       ├─ 下载 → resolveArtifactUrls + triggerArtifactDownload
                       └─ ArtifactPreviewHost
                            ├─ useArtifactPreviewLoader（策略 + fetch / 取链，防竞态）
                            └─ HtmlPreview | MarkdownPreview | TxtPreview | UrlIframePreview
+
+sessionArtifacts 有产物时
+  └─ ensureCustomTab('file-artifact') 静默挂上，不抢当前选中（如执行情况）
 ```
 
 - 文件卡片通过 `useArtifactPreviewConsumer` 注入预览上下文，无 Provider 时卡片不可点击（兜底 `undefined`）
 - `ChatContainer` 通过 `useArtifactPreviewProvider` 提供上下文，并把「打开侧栏 Tab」这一副作用以 `onOpen` 注入，保持 composable 职责单一
 - 侧栏「文件产物」Tab 固定不可关闭，`order: -1` 排在「执行情况」之前；会话切换或无文件产物时自动移除
 
-## 唯一 id 规则
+## 唯一键规则
 
-同一会话可能存在多个 `AssistantMessage`，且不同消息里可能有同名文件，因此**文件名不可作为唯一键**。统一由 `buildArtifactId` 生成：
+会话内以 **`outputId`** 作为文件产物唯一键：
 
-```typescript
-import { buildArtifactId } from '@blueking/chat-x';
-
-// messageUid#消息内下标#outputId
-buildArtifactId('msg-a', 2, 'output-9'); // => 'msg-a#2#output-9'
-```
-
-Provider 侧聚合与文件卡片侧透传必须使用同一规则，保证命中一致。
+- 同一 `outputId` 在多条消息中出现时，聚合列表去重并保留最后一次出现的文件信息
+- `activeId`、列表 `:key`、`select` 事件参数均使用 `outputId`
+- 文件名可能重复，**不可**作为唯一键
 
 ## 预览机制
 
@@ -282,14 +268,14 @@ message-artifacts/
 
 | 属性名    | 类型                | 必填 | 说明                                   |
 | --------- | ------------------- | ---- | -------------------------------------- |
-| activeId  | `string`            | ✓    | 当前命中的文件 id（`messageUid#index#outputId`） |
-| artifacts | `SessionArtifact[]` | ✓    | 当前会话全部文件产物                   |
+| activeId  | `string`            | ✓    | 当前命中的文件 `outputId`              |
+| artifacts | `SessionArtifact[]` | ✓    | 当前会话全部文件产物（已按 `outputId` 去重） |
 
 ### Events
 
 | 事件名 | 参数              | 说明                       |
 | ------ | ----------------- | -------------------------- |
-| select | `(id: string)`    | 列表内切换选中文件，参数为文件 `artifactId` |
+| select | `(id: string)`    | 列表内切换选中文件，参数为文件 `outputId` |
 
 ### Slots / Expose
 
@@ -300,11 +286,8 @@ message-artifacts/
 ```typescript
 import type { AIFileInfo, SessionArtifact } from '@blueking/chat-x';
 
-// 会话级文件产物：在 AIFileInfo 基础上补充命中所需字段
-type SessionArtifact = AIFileInfo & {
-  artifactId: string; // 全局唯一 id：messageUid#index#outputId
-  messageUid: string; // 所属 AssistantMessage 的 uid
-};
+// 会话级文件产物：拍平去重后即为 AIFileInfo
+type SessionArtifact = AIFileInfo;
 
 type AIFileInfo = {
   name: string;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -562,9 +562,10 @@ ai-chat-container（:data-ai-size="size"）
 
 ### 内置「文件产物」Tab
 
-除「执行情况」外，容器内置一个按需出现的固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话所有 `AssistantMessage.property.artifacts`：
+除「执行情况」外，容器内置一个按需出现的固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话所有 `AssistantMessage.property.artifacts`（按 `outputId` 去重）：
 
-- **触发**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 命中该文件并 `addCustomTab` 弹出侧栏
+- **静默挂载**：会话已有文件产物时，容器通过 `ensureCustomTab` 挂上该 Tab，**不展开侧栏、不切换当前选中**（避免从「执行情况」展开时被抢走焦点），并保证命中态有效（默认第一个 `outputId`）
+- **主动打开**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 以 `outputId` 命中该文件，再 `addCustomTab` 展开侧栏并选中「文件产物」
 - **排序 / 关闭**：`order: -1` 排在「执行情况」之前，`closable: false` 不可关闭
 - **显隐解耦**：该 Tab 存在时，侧栏展示不再受「`executionGroups` 为空」约束（即使当前会话没有执行类消息，也能独立展示文件产物侧栏）；会话切换或无文件产物时自动移除并重置命中态
 - **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取。文本类（`html` / `markdown` / `md` / `txt` / `json`）拉 `download_url` 正文直渲染（`md` 与 `markdown` 等价）；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/index.md
@@ -15,9 +15,8 @@
 | `useMessageGroup`            | 消息分组逻辑；将 `Message[]` 转为 `MessageGroup[]`，处理 Tool 合并、Loading 注入、执行摘要过滤和分享模式                          | [查看](./use-message-group.md)    |
 | `useCustomTabProvider`       | 自定义 Tab 管理 Provider；用于 `ChatContainer` 侧边栏的 Tab 动态增删和切换                                                        | [查看](./use-custom-tab.md)       |
 | `useCustomTabConsumer`       | 自定义 Tab 管理 Consumer；在后代组件中注入并操作 Tab（添加/移除/选中）                                                            | [查看](./use-custom-tab.md)       |
-| `useArtifactPreviewProvider` | 文件产物预览 Provider；维护命中文件 id，通过 `onOpen` 触发侧栏「文件产物」Tab                                                     | [查看](./use-artifact-preview.md) |
+| `useArtifactPreviewProvider` | 文件产物预览 Provider；维护命中文件 `outputId`，通过 `onOpen` 触发侧栏「文件产物」Tab                                               | [查看](./use-artifact-preview.md) |
 | `useArtifactPreviewConsumer` | 文件产物预览 Consumer；在深层文件卡片中注入，点击触发 `openPreview`                                                               | [查看](./use-artifact-preview.md) |
-| `buildArtifactId`            | 生成文件产物全局唯一 id（`messageUid#index#outputId`）                                                                            | [查看](./use-artifact-preview.md) |
 | `useFullScreen`              | 浏览器原生全屏控制；嗅探标准/WebKit API，`isFullScreen` 与 ESC 退出同步；`ChatContainer` 侧栏全屏使用                               | [查看](./use-full-screen.md)      |
 | `useParentScrolling`         | 查找最近可滚动祖先并监听 `scroll`/`scrollend`；提供 `isScrolling` 状态，常用于滚动时隐藏浮层                                      | [查看](./use-parent-scrolling.md) |
 | `getScrollParent`            | 独立辅助函数；递归向上查找第一个 `overflowY` 可滚动的祖先元素                                                                     | [查看](./use-parent-scrolling.md) |
@@ -56,7 +55,6 @@ import {
   // 文件产物预览（Provider/Consumer）
   useArtifactPreviewProvider,
   useArtifactPreviewConsumer,
-  buildArtifactId,
   FILE_ARTIFACT_TAB_NAME,
 
   // 全屏控制
@@ -121,13 +119,17 @@ const { messageGroups, executionGroups, isShareMode, isAllSelected, onToggleShar
 
 ```typescript
 // Provider（容器组件）
-const { tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab } = useCustomTabProvider({
-  onTabChange: async tab => fetchData(tab.name),
-});
+const { tabs, selectedTab, isCollapse, addCustomTab, ensureCustomTab, removeCustomTab, selectCustomTab } =
+  useCustomTabProvider({
+    onTabChange: async tab => fetchData(tab.name),
+  });
 
 // Consumer（后代组件）
 const tabManager = useCustomTabConsumer();
+// 展开并选中
 tabManager?.addCustomTab({ name: 'detail', label: '详情', data: { component: DetailComp } });
+// 仅挂载，不抢焦点
+tabManager?.ensureCustomTab({ name: 'file-artifact', label: '文件产物', closable: false, order: -1 });
 ```
 
 ### useArtifactPreviewProvider / Consumer
@@ -140,7 +142,7 @@ const { activeArtifactId, setActiveArtifactId } = useArtifactPreviewProvider({
 
 // Consumer（文件卡片）
 const artifactPreview = useArtifactPreviewConsumer();
-artifactPreview?.openPreview({ file, index, messageUid });
+artifactPreview?.openPreview({ file });
 ```
 
 ### useParentScrolling

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -6,9 +6,9 @@ description: >-
   Provider/Consumer 模式的文件产物预览状态管理，用于 ChatContainer 侧栏「文件产物」Tab 的命中与切换。
   Provider 在 ChatContainer 中创建，Consumer 在深层文件卡片中注入使用。
 aiSummary: >
-  useArtifactPreviewProvider 维护 activeArtifactId，openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
+  useArtifactPreviewProvider 维护 activeArtifactId（值为 outputId），openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
   并通过 getOnArtifactClick 封装 resolveArtifactUrls（按 outputId 缓存 download_url / preview_url）；
-  useArtifactPreviewConsumer 在后代注入同一套 API。buildArtifactId 用 messageUid#index#outputId 生成唯一 id。
+  useArtifactPreviewConsumer 在后代注入同一套 API。SessionArtifact 即 AIFileInfo，会话内以 outputId 为唯一键。
   正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
 relatedComponents:
@@ -25,7 +25,7 @@ sinceVersion: 0.0.20
 
 > **分类**：composable
 
-Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatContainer` 中创建，负责维护当前命中的文件 id；Consumer 在深层 `ArtifactFileCard` 中注入，用于点击卡片触发预览。
+Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatContainer` 中创建，负责维护当前命中的文件 `outputId`；Consumer 在深层 `ArtifactFileCard` 中注入，用于点击卡片触发预览。
 
 **职责边界**：
 
@@ -41,7 +41,7 @@ function useArtifactPreviewProvider(options: {
   /** 读取业务侧异步取链回调（getter 保持对 props 变更敏感） */
   getOnArtifactClick?: () => OnArtifactClick | undefined;
   /** 命中文件后触发：由容器负责 addCustomTab + 展开侧栏 + 选中 Tab */
-  onOpen: (artifactId: string) => void;
+  onOpen: (outputId: string) => void;
 }): {
   activeArtifactId: ShallowRef<string>;
   canResolveArtifactUrl: ComputedRef<boolean>;
@@ -65,13 +65,6 @@ function useArtifactPreviewConsumer():
     };
 ```
 
-### buildArtifactId
-
-```typescript
-function buildArtifactId(messageUid: string, index: number, outputId: string): string;
-// => `${messageUid}#${index}#${outputId}`
-```
-
 ## 使用示例
 
 ### Provider（ChatContainer）
@@ -87,13 +80,14 @@ import {
 } from '@blueking/chat-x';
 import { t } from '@blueking/chat-x/lang';
 
-const { addCustomTab, removeCustomTab } = useCustomTabProvider({ /* ... */ });
+const { addCustomTab, ensureCustomTab, removeCustomTab } = useCustomTabProvider({ /* ... */ });
 
 // 会话级文件产物聚合已内聚在 useMessageGroup，直接消费
 const { sessionArtifacts } = useMessageGroup({ keyword, messages, selectedUserMessages });
 
 const { activeArtifactId, setActiveArtifactId } = useArtifactPreviewProvider({
   getOnArtifactClick: () => props.onArtifactClick,
+  // 点击文件卡片：展开侧栏并选中「文件产物」Tab
   onOpen: () => {
     addCustomTab({
       closable: false,
@@ -104,13 +98,23 @@ const { activeArtifactId, setActiveArtifactId } = useArtifactPreviewProvider({
   },
 });
 
-// 无文件产物时清理 Tab 与命中态
+// 有产物时静默挂上 Tab（不抢焦点）；无产物时清理
 watch(sessionArtifacts, list => {
   if (!list.length) {
     removeCustomTab(FILE_ARTIFACT_TAB_NAME);
     setActiveArtifactId('');
+    return;
   }
-});
+  ensureCustomTab({
+    closable: false,
+    label: t('文件产物'),
+    name: FILE_ARTIFACT_TAB_NAME,
+    order: -1,
+  });
+  if (!list.some(item => item.outputId === activeArtifactId.value)) {
+    setActiveArtifactId(list[0].outputId);
+  }
+}, { immediate: true });
 ```
 
 ### Consumer（ArtifactFileCard）
@@ -128,18 +132,14 @@ const handleCardClick = () => {
     props.onPreview(props.file);
     return;
   }
-  artifactPreview?.openPreview({
-    file: props.file,
-    index: props.index ?? 0,
-    messageUid: props.messageUid ?? '',
-  });
+  artifactPreview?.openPreview({ file: props.file });
 };
 ```
 
 ### 侧栏列表内切换命中文件
 
 ```typescript
-// FileArtifactPanel 列表点击 → emit select → 容器调用 setActiveArtifactId
+// FileArtifactPanel 列表点击 → emit select(outputId) → 容器调用 setActiveArtifactId
 // 右侧预览由面板内 ArtifactPreviewHost 消费 activeArtifact，自行取链并按类型渲染
 <FileArtifactPanel
   :active-id="activeArtifactId"
@@ -173,32 +173,27 @@ const onArtifactClick = async (file: AIFileInfo) => {
 
 | 属性/方法名         | 类型                                      | 说明                                                                 |
 | ------------------- | ----------------------------------------- | -------------------------------------------------------------------- |
-| activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 id（`messageUid#index#outputId`）                     |
+| activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 `outputId`                                            |
 | canResolveArtifactUrl | `ComputedRef<boolean>`                  | 是否具备异步取链能力（有 `onArtifactClick` 时为 true，下载按钮据此显隐） |
-| openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：计算 id、更新命中态、调用 `onOpen`             |
+| openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：以 `file.outputId` 更新命中态、调用 `onOpen`   |
 | resolveArtifactUrls | `(file: AIFileInfo) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 并按 `outputId` 缓存结果；并发请求去重 |
-| setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 id；侧栏列表内切换选中时使用                        |
+| setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 `outputId`；侧栏列表内切换选中时使用                |
 
 ## 类型定义
 
 ```typescript
 import type { AIFileInfo, ArtifactUrlResult, OnArtifactClick } from '@blueking/chat-x';
 
-/** 打开预览时的入参：文件 + 消息内下标 + 所属消息 uid */
+/** 打开预览时的入参 */
 type OpenArtifactPreviewPayload = {
   file: AIFileInfo;
-  index: number;
-  messageUid: string;
 };
 
 /**
- * 会话级文件产物：在 AIFileInfo 基础上补充命中所需的唯一 id 与所属消息。
- * 同一会话可能出现多个 AssistantMessage + 同名文件，文件名不可作唯一键。
+ * 会话级文件产物：以 outputId 为会话内唯一键（同 outputId 视为同一文件）。
+ * 拍平去重后即为 AIFileInfo，此处用别名标明语义。
  */
-type SessionArtifact = AIFileInfo & {
-  artifactId: string;
-  messageUid: string;
-};
+type SessionArtifact = AIFileInfo;
 
 /** onArtifactClick 返回值（snake_case） */
 type ArtifactUrlResult = {
@@ -207,28 +202,27 @@ type ArtifactUrlResult = {
 };
 ```
 
-## 唯一 id 规则
+## 唯一键规则
 
-同一会话可能存在多个 `AssistantMessage`，且不同消息里可能有同名文件，因此**文件名不可作为唯一键**。Provider 侧聚合与 Consumer 侧透传必须使用同一 `buildArtifactId` 规则：
+会话内以 **`outputId`** 作为文件产物唯一键：
 
-```typescript
-buildArtifactId('msg-a', 2, 'output-9'); // => 'msg-a#2#output-9'
-```
-
-- `messageUid`：所属 `AssistantMessage` 的 `uid`（回退 `String(id)`）
-- `index`：文件在所属消息 `property.artifacts` 数组中的下标
-- `outputId`：文件自身的 `AIFileInfo.outputId`
+- 同一 `outputId` 在多条 `AssistantMessage` 中出现时，`sessionArtifacts` 去重并保留**最后一次**出现的文件信息
+- `activeArtifactId`、列表 `:key`、`select` 事件参数均使用 `outputId`
+- 文件名可能重复，**不可**作为唯一键
 
 ## 完整触发链路
 
 ```
 ArtifactFileCard（点击）
-  └─ useArtifactPreviewConsumer().openPreview({ file, index, messageUid })
+  └─ useArtifactPreviewConsumer().openPreview({ file })
        └─ useArtifactPreviewProvider（ChatContainer）
-            ├─ activeArtifactId = buildArtifactId(...)
-            └─ onOpen(artifactId) → addCustomTab(FILE_ARTIFACT_TAB_NAME)
+            ├─ activeArtifactId = file.outputId
+            └─ onOpen(outputId) → addCustomTab(FILE_ARTIFACT_TAB_NAME) 展开并选中
                  └─ FileArtifactPanel（列表 + 下载头，@select → setActiveArtifactId）
                       └─ ArtifactPreviewHost（loader + 分类型 renderer）
+
+sessionArtifacts 变化（有产物）
+  └─ ensureCustomTab(FILE_ARTIFACT_TAB_NAME) 静默挂上，不抢当前选中（如执行情况）
 ```
 
 分类型预览策略见 [FileArtifactPanel 预览机制](../components/message/file-artifact-panel#预览机制)。
@@ -238,10 +232,11 @@ ArtifactFileCard（点击）
 - **职责单一**：composable 不直接调用 `useCustomTab`，侧栏 Tab 打开逻辑由 `onOpen` 注入；也不做正文 fetch / iframe 渲染
 - **ShallowRef 优先**：`activeArtifactId` 使用 `shallowRef`，避免不必要的深层响应式开销
 - **Consumer 兜底**：`useArtifactPreviewConsumer` 无 Provider 时返回 `undefined`，文件卡片在无容器上下文时自动不可点击
-- **与 useCustomTab 协作**：「文件产物」Tab 通过 `addCustomTab` 按需添加（`order: -1`、`closable: false`），会话无文件产物时由容器 `removeCustomTab` 清理
+- **与 useCustomTab 协作**：点击卡片走 `addCustomTab`（展开 + 选中）；会话已有产物时走 `ensureCustomTab`（只挂载，不抢焦点）；无文件产物时由容器 `removeCustomTab` 清理
 
 ## 关联组件
 
 - [ChatContainer](../components/setup/chat-container) — Provider 主场景，内置「文件产物」Tab
 - [FileArtifactPanel](../components/message/file-artifact-panel) — 侧栏列表与预览 Host 挂载
 - [AssistantMessage](../components/message/assistant-message) — 文件产物来源（`property.artifacts`）
+- [useCustomTab](./use-custom-tab) — `addCustomTab` / `ensureCustomTab` 分工

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-custom-tab.md
@@ -6,7 +6,8 @@ description: >-
   Provider/Consumer 模式的自定义 Tab 管理，用于 `ChatContainer` 侧边栏的 Tab 动态管理。Provider 在
   `ChatContainer` 中创建，Consumer 在任意后代组件中注入使用。
 aiSummary: >
-  useCustomTabProvider 返回 tabs、selectedTab、isCollapse 及 add/remove/selectCustomTab，并通过 provide 共享；可选 onTabChange 在切换时拉取数据。
+  useCustomTabProvider 返回 tabs、selectedTab、isCollapse 及 add/ensure/remove/selectCustomTab，并通过 provide 共享；可选 onTabChange 在切换时拉取数据。
+  ensureCustomTab 只挂载/合并元信息，不展开侧栏、不切换选中；addCustomTab 会展开并选中。
   useCustomTabConsumer 在后代注入同一套 API，常用于侧栏动态节点详情等。EXECUTION_TAB_NAME 标识默认「执行情况」Tab。
   ChatContainer 侧栏集成 Provider 与 Tab UI。
 relatedComponents:
@@ -36,6 +37,7 @@ function useCustomTabProvider<T extends Record<string, unknown>>(options: {
   selectedTab: Ref<CustomTab<T>>;
   isCollapse: ShallowRef<boolean>;
   addCustomTab: (tab: CustomTab<T>) => void;
+  ensureCustomTab: (tab: CustomTab<T>) => void;
   removeCustomTab: (tabName: string) => void;
   selectCustomTab: (tab: CustomTab<T>) => void;
   resetCustomTab: () => void;
@@ -52,6 +54,7 @@ function useCustomTabConsumer<T extends Record<string, unknown>>():
       displayTabs: ComputedRef<CustomTab<T>[]>;
       selectedTab: ShallowRef<CustomTab<T> | null>;
       addCustomTab: (tab: CustomTab<T>) => void;
+      ensureCustomTab: (tab: CustomTab<T>) => void;
       removeCustomTab: (tabName: string) => void;
       selectCustomTab: (tab: CustomTab<T>) => void;
       resetCustomTab: () => void;
@@ -65,7 +68,7 @@ function useCustomTabConsumer<T extends Record<string, unknown>>():
 ```typescript
 import { useCustomTabProvider, EXECUTION_TAB_NAME } from '@blueking/chat-x';
 
-const { tabs, selectedTab, isCollapse, addCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
+const { tabs, selectedTab, isCollapse, addCustomTab, ensureCustomTab, removeCustomTab, selectCustomTab, resetCustomTab } =
   useCustomTabProvider({
   onTabChange: async tab => {
     // Tab 切换时加载数据
@@ -82,7 +85,7 @@ import { useCustomTabConsumer } from '@blueking/chat-x';
 
 const tabManager = useCustomTabConsumer();
 
-// 添加一个自定义 Tab
+// 添加一个自定义 Tab（展开侧栏并选中）
 tabManager?.addCustomTab({
   name: 'node-detail-123',
   label: '节点详情',
@@ -90,6 +93,14 @@ tabManager?.addCustomTab({
     component: NodeDetailComponent,
     props: { nodeId: '123' },
   },
+});
+
+// 仅确保 Tab 存在（不展开、不切换选中）—— 如侧栏已因执行情况打开时同步挂上文件产物
+tabManager?.ensureCustomTab({
+  name: 'file-artifact',
+  label: '文件产物',
+  closable: false,
+  order: -1,
 });
 
 // 移除 Tab
@@ -112,7 +123,8 @@ tabManager?.removeCustomTab('node-detail-123');
 | displayTabs     | `ComputedRef<CustomTab[]>`  | Tab 栏实际展示列表：过滤 `visible === false`，按 `order` 升序稳定排序 |
 | selectedTab     | `Ref<CustomTab>`            | 当前选中的 Tab；选中项被隐藏时自动回退到首个可见 Tab |
 | isCollapse      | `ShallowRef<boolean>`       | 侧边栏折叠状态；`addCustomTab` 时自动设为 `false` |
-| addCustomTab    | `(tab: CustomTab) => void`  | 添加 Tab；同名 Tab 合并更新（可改 `order` / `visible` / `label`） |
+| addCustomTab    | `(tab: CustomTab) => void`  | 添加/合并 Tab，**展开侧栏并选中**目标 Tab |
+| ensureCustomTab | `(tab: CustomTab) => void`  | 添加/合并 Tab，**不展开、不切换选中**；用于静默挂载（如文件产物） |
 | removeCustomTab | `(tabName: string) => void` | 移除指定 Tab                                      |
 | selectCustomTab | `(tab: CustomTab) => void`  | 切换到指定 Tab，触发 `onTabChange` 回调           |
 | resetCustomTab  | `() => void`                  | 重置为仅保留「执行情况」Tab、折叠侧栏并选中默认 Tab；`ChatContainer` 在卸载时调用，避免残留自定义 Tab |
@@ -142,7 +154,9 @@ interface CustomTab<T = Record<string, unknown>> {
 - 排序为稳定排序，`order` 相同的 Tab 保持插入先后顺序
 - 选中的 Tab 被配置隐藏时，内容不再渲染，自动切换到首个可见 Tab
 - `addCustomTab` 同时展开侧边栏（`isCollapse = false`）并在 `nextTick` 后自动选中目标 Tab；同名 Tab 合并更新
+- `ensureCustomTab` 与 `addCustomTab` 共用合并逻辑，但不改 `isCollapse`、不切换 `selectedTab`；适合「侧栏已打开时同步挂上文件产物」等场景
 
 ## 关联组件
 
 - [ChatContainer](../components/setup/chat-container) — 侧栏 Tab 与自定义面板
+- [useArtifactPreview](./use-artifact-preview) — 文件产物 Tab：有产物时 `ensureCustomTab`，点击卡片时 `addCustomTab`

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -127,23 +127,28 @@ const isExecutionMessage = (m: Message): boolean => {
 
 ## sessionArtifacts 会话级文件产物
 
-`sessionArtifacts` 拍平当前会话所有 `AssistantMessage.property.artifacts`，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。由于同一会话可能出现「多个 AssistantMessage + 同名文件」，文件名不可作为唯一键，统一用 `messageUid`（回退 `String(id)`）+ 消息内下标 + `outputId` 通过 [`buildArtifactId`](./use-artifact-preview) 生成全局唯一 `artifactId`：
+`sessionArtifacts` 拍平当前会话所有 `AssistantMessage.property.artifacts`，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。以 **`outputId`** 为会话内唯一键去重（同 `outputId` 视为同一文件），保留最后一次出现的文件信息，列表顺序与「最后一次出现」的相对顺序一致：
 
 ```typescript
 const sessionArtifacts = computed(() => {
-  const list = [];
+  // delete + set：同 key 覆盖内容，并把该项挪到 Map 末尾，保证「最后出现」顺序
+  const byOutputId = new Map();
   for (const message of messages.value) {
     if (message.role !== MessageRole.Assistant) continue;
     const artifacts = message.property?.artifacts;
     if (!artifacts?.length) continue;
-    const messageUid = message.uid ?? String(message.id);
-    artifacts.forEach((file, index) => {
-      list.push({ ...file, artifactId: buildArtifactId(messageUid, index, file.outputId), messageUid });
-    });
+    for (const file of artifacts) {
+      if (byOutputId.has(file.outputId)) {
+        byOutputId.delete(file.outputId);
+      }
+      byOutputId.set(file.outputId, file);
+    }
   }
-  return list;
+  return Array.from(byOutputId.values());
 });
 ```
+
+> `SessionArtifact` 即为 `AIFileInfo` 别名；文件名可能重复，不可作唯一键。
 
 预览命中与取链见 [useArtifactPreview](./use-artifact-preview)；侧栏列表与分类型预览（`ArtifactPreviewHost`）见 [FileArtifactPanel](../components/message/file-artifact-panel)。
 
@@ -217,7 +222,7 @@ const {
 | ---------------- | ----------------------------- | --------------------------------------------------------------------------- |
 | messageGroups    | `Ref<MessageGroup[]>`         | 完整消息分组列表                                                            |
 | executionGroups  | `ComputedRef<MessageGroup[]>` | 仅包含执行类消息的分组（工具调用 + FlowAgent），自动提取 `userMessageTitle` |
-| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 拍平会话所有 AssistantMessage 文件产物，含全局唯一 `artifactId`         |
+| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 拍平会话所有 AssistantMessage 文件产物，按 `outputId` 去重（保留最后一次） |
 | pendingApprovalCount | `ComputedRef<number>`      | 当前消息中待审批 AI Dev 审批中断的数量                                      |
 | pendingApprovalTipText | `ComputedRef<string>`    | 待审批阻塞发送提示文案；无待审批时为空字符串                                |
 | isShareMode      | `ShallowRef<boolean>`         | 是否处于分享模式                                                            |


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物按 outputId 去重并优化侧栏 Tab 挂载
ID: 1070093903136856569

## 改动
- use-message-group: sessionArtifacts 按 outputId 去重，保留最后一次出现
- use-artifact-preview / artifacts UI: 命中键统一为 outputId，移除 buildArtifactId
- use-custom-tab / chat-container: 新增 ensureCustomTab，有产物挂 Tab 不抢占选中
- playground / wikis / 单测: 同步多轮去重与 API 说明

## 影响面
- chat-x 文件产物侧栏与预览命中逻辑；消费方若依赖旧 artifactId 复合键需适配
- 不影响无关业务逻辑

## 测试
- [ ] 同 outputId 多轮出现时侧栏只保留一条且为最后一次
- [ ] 卡片预览 / 侧栏切换 / 下载正常
- [ ] 执行情况已打开时出现产物不抢走选中
- [ ] 无产物时移除文件产物 Tab
- [ ] 相关单测通过（本次交付前未运行）

Made with [Cursor](https://cursor.com)