### PR TITLE
feat: UserQuestionCard 一次一题分页与已完成进度 --story=136860076

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/docs/ask-user-question-protocol.md
+++ b/src/frontend/ai-blueking/packages/chat-x/docs/ask-user-question-protocol.md
@@ -258,7 +258,7 @@ sequenceDiagram
 
 **路径 A：结构化作答（问题卡片）**
 
-用户在 `UserQuestionCard` 中逐题选择，点击「完成」必须全部题目均已作答；点击「跳过」回传 `status=cancelled` + 空答案。请求 **不带 `input`**，只带 `resume`。
+用户在 `UserQuestionCard` 中一次只看到一题，可通过标题栏 `< 当前题 / 总题数 >` 切换；单选预设选项作答后会自动跳到下一题，多选 / Others 需手动切换。点击「完成」必须全部题目均已作答；点击「跳过」回传 `status=cancelled` + 空答案。请求 **不带 `input`**，只带 `resume`。
 
 **路径 B：chat-input 自由文本作答**
 
@@ -318,6 +318,8 @@ sequenceDiagram
 | --- | --- |
 | Others 自定义输入 | 前端自动为每题追加 Others 项（`label="others"`），后端无需下发；用户输入文本写入 `description`。 |
 | 单选 / 多选 | 由题目 `multiSelect` 决定：单选 `answer` 长度恒为 0/1，多选可多项。`multiSelect` 不传则不渲染单选/多选标签。 |
+| 一次一题（UI） | 卡片正文只展示当前题；标题栏 `< 当前题 / 总题数 >` 切换。单选预设选项从未答→有效答时自动跳下一题；多选 / Others 不自动跳。 |
+| 已完成进度（UI） | Footer 左侧「已完成 N 题」，右侧「跳过」+「完成」。协议字段不变。 |
 | 完成条件 | 「完成」按钮需**所有题目均已作答**才可点击；选中 Others 时要求输入非空。 |
 | 跳过 / 取消 | 回传 `status="cancelled"`，`payload.answers=[]`；回显显示「已取消」。 |
 | 过期 `expiresAt` | 字段已在协议中预留（ISO8601）；当前前端未做强制拦截，后端可据此判断是否拒绝过期 resume。 |
@@ -352,4 +354,4 @@ sequenceDiagram
 | 中断原因枚举 | `InterruptReason.UserQuestion` | `src/ag-ui/types/constants.ts` |
 | SSE 事件 / Resume | `IUserQuestionInterrupt` / `IResume` | `chat-helper/src/event/type.ts` |
 | resume 回传逻辑 | `useInterruptResume` | `ai-blueking/src/components/composables/use-interrupt-resume.ts` |
-| 答案聚合 / payload 组装 | `useUserQuestion` | `chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts` |
+| 答案聚合 / 分页定位 / payload 组装 | `useUserQuestion` | `chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts` |

--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -184,7 +184,7 @@
     UserQuestionChoice,
   } from '../src';
   import CustomTabContent from './custom-tab-content.vue';
-  import { MOCK_INTERRUPT_MESSAGES } from './interrupt';
+  import { MOCK_USER_QUESTION_PENDING_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
   import { MOCK_MESSAGES, MOCK_MODELS, MOCK_PROMPTS, MOCK_RESOURCES, mockArtifactClick } from './mock';
   import { uploadFileToSession } from './upload-file';
@@ -206,8 +206,11 @@
   const handleModelChange = (model: IModelOption) => {
     console.log('model change:', model);
   };
-  // 使用含 toolCalls 的 mock，用于验证「执行情况」侧栏
-  const messages = deepRef<Message[]>([...(MOCK_MESSAGES as Message[])]);
+  // 含 toolCalls 的会话 mock + 待回答 UserQuestion，便于预览一次一题 / 分页切换
+  const messages = deepRef<Message[]>([
+    ...(MOCK_MESSAGES as Message[]),
+    ...MOCK_USER_QUESTION_PENDING_MESSAGES,
+  ]);
 
   const handleInterruptResume: OnInterruptResume = (payload, interrupt) => {
     // 取消审批与流程节点重试 / 跳过复用同一回调，业务侧按 payload.operation 分流处理

--- a/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/interrupt.ts
@@ -226,22 +226,36 @@ const unsupportedScenario = createInterruptScenario({
 });
 
 // —— 场景 8：用户回答问题（待回答，outcome.interrupt，渲染在 chat-input 上方）——
+// 对齐设计稿：3 题分页、单选长文案 A–D、多选语言题；不在 mock 中放 others（前端自动追加）
 const userQuestionInterrupt: UserQuestionInterrupt = {
   id: 'interrupt_user_question',
   reason: InterruptReason.UserQuestion,
   toolCallId: 'tool_call_user_question',
   message: '选择冒泡排序方案',
   metadata: {
-    // 注意：不在 mock 中放 others 选项，由前端为每题自动追加 Others 输入项
     questions: [
       {
         header: '选择冒泡排序方案',
         multiSelect: false,
         question: '请选择你想要的冒泡排序算法方案',
         options: [
-          { label: 'A', description: '方案1：基础冒泡排序 - 最经典实现，易于理解，适合教学演示' },
-          { label: 'B', description: '方案2：优化版冒泡排序 - 加入标志位提前终止，适合部分有序数据' },
-          { label: 'C', description: '方案3：双向冒泡排序（鸡尾酒排序）- 正向反向交替，适合数据分布在两端' },
+          {
+            label: 'A',
+            description: '方案1：基础冒泡排序- 最经典实现，易于理解，适合教学演示',
+          },
+          {
+            label: 'B',
+            description: '方案2：优化版冒泡排序-加入标志位提前终止，适合部分有序数据',
+          },
+          {
+            label: 'C',
+            description:
+              '方案3：双向冒泡排序（鸡尾酒排序）一正向反向交替，适合数据分布在两端鸡尾酒排序一正向反向交替，适合数据分布在两端',
+          },
+          {
+            label: 'D',
+            description: '方案4：递归冒泡排序 -用递归替代循环，适合函数式编程风格',
+          },
         ],
       },
       {
@@ -249,16 +263,21 @@ const userQuestionInterrupt: UserQuestionInterrupt = {
         multiSelect: true,
         question: '请选择语言（可多选）',
         options: [
-          { label: 'Java', description: 'Java' },
-          { label: 'Python', description: 'Python' },
-          { label: 'Go', description: 'Go' },
+          { label: 'Java', description: 'Java - 企业级后端与 Android 场景常用' },
+          { label: 'Python', description: 'Python - 适合教学演示与快速原型' },
+          { label: 'Go', description: 'Go - 高并发与云原生场景友好' },
+          { label: 'TypeScript', description: 'TypeScript - 前端与 Node 全栈场景' },
         ],
       },
       {
         header: '选择冒泡排序方案',
         multiSelect: false,
         question: '请选择实现方式',
-        options: [{ label: 'best', description: '最佳方案' }],
+        options: [
+          { label: 'A', description: '最佳方案 - 综合性能与可读性最优' },
+          { label: 'B', description: '教学方案 - 代码最短，便于讲解' },
+          { label: 'C', description: '工程方案 - 含单元测试与边界校验' },
+        ],
       },
     ],
   },
@@ -283,15 +302,21 @@ const userQuestionAnsweredResult: UserQuestionResume = {
       {
         question: '请选择你想要的冒泡排序算法方案',
         multiSelect: false,
-        answer: [{ label: 'B', description: '方案2：优化版冒泡排序 - 加入标志位提前终止，适合部分有序数据' }],
+        answer: [
+          {
+            label: 'C',
+            description:
+              '方案3：双向冒泡排序（鸡尾酒排序）一正向反向交替，适合数据分布在两端鸡尾酒排序一正向反向交替，适合数据分布在两端',
+          },
+        ],
       },
       // 多选：命中多个预设选项
       {
         question: '请选择语言（可多选）',
         multiSelect: true,
         answer: [
-          { label: 'Java', description: 'Java' },
-          { label: 'Python', description: 'Python' },
+          { label: 'Java', description: 'Java - 企业级后端与 Android 场景常用' },
+          { label: 'Python', description: 'Python - 适合教学演示与快速原型' },
         ],
       },
       // Others：用户自定义输入，label 为 others，description 为输入文本
@@ -316,6 +341,9 @@ const userQuestionAnsweredScenario = createInterruptScenario({
   outcome: { type: 'success' },
   result: userQuestionAnsweredResult,
 });
+
+/** 仅待回答 UserQuestion：便于 playground 预览分页 / Footer「已完成 N 题」等新交互 */
+export const MOCK_USER_QUESTION_PENDING_MESSAGES: Message[] = [...userQuestionScenario];
 
 /** playground 全量中断 mock：覆盖审批态 + resume 态 + 兜底态 + 用户回答问题 */
 export const MOCK_INTERRUPT_MESSAGES: Message[] = [

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
@@ -25,7 +25,7 @@
 - **消息分组**：内置 `useMessageGroup` 自动处理消息分组、Tool 合并、Loading 注入
 - **输入区状态推导**：传给 `MessageContainer` 与 `ChatInput` 的 `messageStatus` 为内部计算值 `inputStatus`：当分组中存在 id 为 `LOADING_MESSAGE_ID`（`'__loading__'`，由 `useMessageGroup` 注入的占位 Loading 消息）时，对内使用 `MessageStatus.Fetching`；否则使用外部传入的 `messageStatus`。用于在「已发用户消息、尚未流式」阶段与流式中一致地展示停止能力，并避免输入区重复发送
 - **待审批发送阻塞**：当消息中存在 `AIDevToolApproval` 且状态为 `pending` / `draft` 的中断项时，`useMessageGroup` 会返回待审批提示，容器在输入区上方展示提示并通过 `ChatInput.sendDisabledTip` 禁止继续发送
-- **用户问题中断**：当消息中存在待回答 `UserQuestion` 中断时，容器会在输入区上方挂载 `UserQuestionCard`；结构化作答走 `onInterruptResume`，用户在输入框直接发送时走 `onSendMessage` 并在第三参数附带 skip 用的 `payload`（`status: 'cancelled'`）与 `interrupt`，且不会自动清空输入框
+- **用户问题中断**：当消息中存在待回答 `UserQuestion` 中断时，容器会在输入区上方挂载 `UserQuestionCard`（一次一题、标题栏可切换）；结构化作答走 `onInterruptResume`，用户在输入框直接发送时走 `onSendMessage` 并在第三参数附带 skip 用的 `payload`（`status: 'cancelled'`）与 `interrupt`，且不会自动清空输入框
 - **执行摘要**：侧边栏展示工具调用 / FlowAgent 执行记录，支持关键词搜索和对话定位
 - **侧栏全屏**：Tab 栏右侧提供全屏/退出全屏按钮，基于 `useFullScreen` 将侧栏区域（`.ai-full-screen-wrapper`）以浏览器原生全屏展示；全屏时 Tippy 的 `appendTo` 自动切换为全屏容器，避免 tooltip 被遮挡
 - **自定义 Tab**：通过 `useCustomTabProvider` 支持动态添加自定义 Tab（如节点详情）
@@ -363,9 +363,9 @@ ai-chat-container（:data-ai-size="size"）
 
 ## 用户问题中断
 
-当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)。
+当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)（一次一题，标题栏可切换题目）。
 
-- **结构化作答**：用户在卡片内完成选择或点击「跳过」后，通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
+- **结构化作答**：用户在卡片内逐题选择（单选可自动跳下一题），点击「完成」或「跳过」后通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
 - **输入框发送**：用户也可在输入框直接点击发送；容器会调用 `onSendMessage(content, docSchema, options)`，其中 `options.interrupt` 为当前激活的 UserQuestion，`options.payload` 为 `buildSkipResumePayload` 生成的 skip resume（`status: 'cancelled'`，`answers: []`）。此时**不会自动清空**输入框，由业务侧在 `onSendMessage` 内决定如何处理 `content` 与中断恢复。
 
 ```vue

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-question-card.md
@@ -2,7 +2,7 @@
 
 > 能力域：Agent 能力 ｜ 导入：`import { UserQuestionCard } from '@blueking/chat-x'` ｜ since 1.0.0
 
-渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。 源码位置：src/components/chat-message/interrupt-message/user-question/user-question-card.vue。
+渲染 UserQuestion 中断的待回答面板；一次一题分页切换，支持单选/多选、Others、跳过与已完成进度。源码位置：src/components/chat-message/interrupt-message/user-question/user-question-card.vue。
 
 **关联**：interrupt-message（outcome.success 时挂载 UserQuestionAnsweredCard 回显回答）、chat-container（检测最近待回答 UserQuestion 并把 UserQuestionCard 放在输入区上方）、interrupt（定义 UserQuestionInterrupt 与 UserQuestionResume 协议）
 
@@ -13,7 +13,7 @@
 
 - **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-card.vue`
 - **能力域**：Agent 能力
-- **能力说明**：渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。
+- **能力说明**：渲染 UserQuestion 中断的待回答面板；一次一题分页切换，支持单选/多选、Others、跳过与已完成进度。
 
 > **能力域**：Agent 能力
 
@@ -21,6 +21,9 @@
 
 ## 交互能力
 
+- **一次一题**：正文只展示当前题；标题栏右侧提供 `< 当前题 / 总题数 >` 切换定位（单题为 `1 / 1`），首末题对应箭头禁用。
+- **自动跳转**：单选预设选项从未答变为有效答时，自动跳到下一题（最后一题停留）；多选与 Others 不自动跳，靠箭头切换。
+- **已完成进度**：Footer 左侧展示「已完成 N 题」；右侧为「跳过」+「完成」。
 - **单选 / 多选**：每道题通过 `multiSelect` 控制选择行为；未传时不展示单选/多选标签，默认仍按单选处理。
 - **Others 自由输入**：默认 [UserQuestionChoice](/components/agent/user-question-choice) 为每道题追加 `label: 'others'` 输入项，输入文本写入 `answer[].description`。
 - **自定义作答形态**：通过 `#question` slot 可替换默认选择题，渲染任意表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/interrupt.md
@@ -132,6 +132,7 @@ type UserQuestionOptionItem = {
 - 前端会为每道**选择题**追加 `label: 'others'` 的自由输入项；后端无需重复下发该选项。
 - 当用户选择 Others 时，`answer[].description` 为用户输入文本。
 - 业务可通过 `UserQuestionCard` 的 `#question` slot 渲染自定义表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
+- UI 一次只展示一题：标题栏 `< 当前题 / 总题数 >` 切换；单选预设选项作答后自动跳下一题，多选 / Others 需手动切换（协议字段不变）。
 
 ## Interrupt
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.spec.ts
@@ -1,0 +1,203 @@
+/*
+ * Tencent is pleased to support the open source community by making
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) available.
+ *
+ * Copyright (C) 2021 THL A29 Limited, a Tencent company.  All rights reserved.
+ *
+ * 蓝鲸智云PaaS平台 (BlueKing PaaS) is licensed under the MIT License.
+ *
+ * License for 蓝鲸智云PaaS平台 (BlueKing PaaS):
+ *
+ * ---------------------------------------------------
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of
+ * the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO
+ * THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { InterruptReason } from '../../../../ag-ui/types/constants';
+import { OTHERS_OPTION_LABEL, toLetter, useUserQuestion } from './use-user-question';
+
+import type { UserQuestionAnswerItem, UserQuestionInterrupt } from '../../../../ag-ui/types/interrupt';
+
+const buildInterrupt = (overrides?: Partial<UserQuestionInterrupt>): UserQuestionInterrupt => ({
+  id: 'uq-1',
+  reason: InterruptReason.UserQuestion,
+  toolCallId: 'tc-1',
+  message: '选择方案',
+  metadata: {
+    questions: [
+      {
+        header: '选择方案',
+        multiSelect: false,
+        question: 'Q1',
+        options: [{ label: 'A', description: 'a' }],
+      },
+      {
+        header: '选择方案',
+        multiSelect: true,
+        question: 'Q2',
+        options: [{ label: 'B', description: 'b' }],
+      },
+      {
+        header: '选择方案',
+        multiSelect: false,
+        question: 'Q3',
+        options: [{ label: 'C', description: 'c' }],
+      },
+    ],
+  },
+  ...overrides,
+});
+
+const buildAnswer = (
+  question: string,
+  options: UserQuestionAnswerItem['answer'],
+  multiSelect?: boolean,
+): UserQuestionAnswerItem => ({
+  question,
+  multiSelect,
+  answer: options,
+});
+
+describe('useUserQuestion', () => {
+  it('toLetter 应按索引映射 A-Z，超出后回退数字', () => {
+    expect(toLetter(0)).toBe('A');
+    expect(toLetter(25)).toBe('Z');
+    expect(toLetter(26)).toBe('27');
+  });
+
+  it('初始 currentIndex 为 0，边界箭头态正确', () => {
+    const { currentIndex, canGoPrev, canGoNext, totalCount, answeredCount, completed } = useUserQuestion(() =>
+      buildInterrupt(),
+    );
+
+    expect(currentIndex.value).toBe(0);
+    expect(totalCount.value).toBe(3);
+    expect(answeredCount.value).toBe(0);
+    expect(completed.value).toBe(false);
+    expect(canGoPrev.value).toBe(false);
+    expect(canGoNext.value).toBe(true);
+  });
+
+  it('goPrev / goNext 应按边界切换 currentIndex', () => {
+    const { currentIndex, canGoPrev, canGoNext, goPrev, goNext } = useUserQuestion(() => buildInterrupt());
+
+    goPrev();
+    expect(currentIndex.value).toBe(0);
+
+    goNext();
+    expect(currentIndex.value).toBe(1);
+    expect(canGoPrev.value).toBe(true);
+
+    goNext();
+    expect(currentIndex.value).toBe(2);
+    expect(canGoNext.value).toBe(false);
+
+    goNext();
+    expect(currentIndex.value).toBe(2);
+  });
+
+  it('单选从未答变为有效答时应自动跳到下一题', () => {
+    const { currentIndex, answeredCount, setAnswer } = useUserQuestion(() => buildInterrupt());
+
+    setAnswer(0, buildAnswer('Q1', [{ label: 'A', description: 'a' }], false));
+    expect(answeredCount.value).toBe(1);
+    expect(currentIndex.value).toBe(1);
+  });
+
+  it('最后一题单选作答后应停留，不越界', () => {
+    const { currentIndex, goNext, setAnswer } = useUserQuestion(() => buildInterrupt());
+
+    goNext();
+    goNext();
+    expect(currentIndex.value).toBe(2);
+
+    setAnswer(2, buildAnswer('Q3', [{ label: 'C', description: 'c' }], false));
+    expect(currentIndex.value).toBe(2);
+  });
+
+  it('多选作答后不应自动跳转', () => {
+    const { currentIndex, goNext, setAnswer, answeredCount } = useUserQuestion(() => buildInterrupt());
+
+    goNext();
+    setAnswer(1, buildAnswer('Q2', [{ label: 'B', description: 'b' }], true));
+    expect(answeredCount.value).toBe(1);
+    expect(currentIndex.value).toBe(1);
+  });
+
+  it('Others 有效作答后不应自动跳转', () => {
+    const { currentIndex, setAnswer, answeredCount } = useUserQuestion(() => buildInterrupt());
+
+    setAnswer(
+      0,
+      buildAnswer('Q1', [{ label: OTHERS_OPTION_LABEL, description: '自定义内容' }], false),
+    );
+    expect(answeredCount.value).toBe(1);
+    expect(currentIndex.value).toBe(0);
+  });
+
+  it('改选已答题不应再次自动跳转', () => {
+    const { currentIndex, goPrev, setAnswer } = useUserQuestion(() => buildInterrupt());
+
+    setAnswer(0, buildAnswer('Q1', [{ label: 'A', description: 'a' }], false));
+    expect(currentIndex.value).toBe(1);
+
+    goPrev();
+    setAnswer(0, buildAnswer('Q1', [{ label: 'A', description: '改选' }], false));
+    expect(currentIndex.value).toBe(0);
+  });
+
+  it('非当前题写入答案不应触发自动跳转', () => {
+    const { currentIndex, setAnswer } = useUserQuestion(() => buildInterrupt());
+
+    setAnswer(2, buildAnswer('Q3', [{ label: 'C', description: 'c' }], false));
+    expect(currentIndex.value).toBe(0);
+  });
+
+  it('全部作答后 completed 为 true，resolve payload 与题目一一对应', () => {
+    const interrupt = buildInterrupt();
+    const { setAnswer, completed, buildResolvePayload, goNext } = useUserQuestion(() => interrupt);
+
+    setAnswer(0, buildAnswer('Q1', [{ label: 'A', description: 'a' }], false));
+    setAnswer(1, buildAnswer('Q2', [{ label: 'B', description: 'b' }], true));
+    // 自动跳到 Q2 后需手动到 Q3
+    goNext();
+    setAnswer(2, buildAnswer('Q3', [{ label: 'C', description: 'c' }], false));
+
+    expect(completed.value).toBe(true);
+    const payload = buildResolvePayload();
+    expect(payload.status).toBe('resolved');
+    expect(payload.interruptId).toBe('uq-1');
+    expect(payload.payload.answers).toHaveLength(3);
+    expect(payload.payload.answers[0].answer[0].label).toBe('A');
+  });
+
+  it('skip payload 应为 cancelled 且空答案', () => {
+    const { buildSkipPayload } = useUserQuestion(() => buildInterrupt());
+    const payload = buildSkipPayload();
+    expect(payload.status).toBe('cancelled');
+    expect(payload.payload.answers).toEqual([]);
+  });
+
+  it('清空答案后 answeredCount 应回退', () => {
+    const { setAnswer, answeredCount, getAnswer } = useUserQuestion(() => buildInterrupt());
+
+    setAnswer(0, buildAnswer('Q1', [{ label: 'A', description: 'a' }], false));
+    expect(answeredCount.value).toBe(1);
+    setAnswer(0, undefined);
+    expect(answeredCount.value).toBe(0);
+    expect(getAnswer(0)).toBeUndefined();
+  });
+});

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/use-user-question.ts
@@ -48,9 +48,9 @@ export type NormalizedUserQuestionOption = UserQuestionOptionItem & {
 };
 
 /**
- * 用户回答问题（human-in-the-loop）的答案聚合与 resume payload 构建。
+ * 用户回答问题（human-in-the-loop）的答案聚合、题目分页与 resume payload 构建。
  *
- * 设计目标：composable 只负责「收集每题答案 + 完成态计算 + payload 组装」，
+ * 设计目标：composable 只负责「收集每题答案 + 完成态计算 + 分页定位 + payload 组装」，
  * 对「回答形态」（单选/多选/表单/任意自定义）零感知；
  * 各题如何作答与如何校验，全部下沉到对应的渲染组件（默认为选择题），
  * 渲染组件作答有效时回传已组装的 {@link UserQuestionAnswerItem}，无效时回传 undefined。
@@ -62,13 +62,8 @@ export const useUserQuestion = (getInterrupt: () => undefined | UserQuestionInte
 
   // 每题答案：questionIndex -> 已组装答案；undefined 代表该题未作答
   const answerMap = shallowRef<Record<number, undefined | UserQuestionAnswerItem>>({});
-
-  const getAnswer = (questionIndex: number): undefined | UserQuestionAnswerItem => answerMap.value[questionIndex];
-
-  /** 写入/清空某题答案：传 undefined 表示该题回到未作答态 */
-  const setAnswer = (questionIndex: number, answer: undefined | UserQuestionAnswerItem) => {
-    answerMap.value = { ...answerMap.value, [questionIndex]: answer };
-  };
+  // 当前展示题索引（一次只展示一题）
+  const currentIndex = shallowRef(0);
 
   const totalCount = computed(() => questions.value.length);
   const answeredCount = computed(() =>
@@ -76,6 +71,43 @@ export const useUserQuestion = (getInterrupt: () => undefined | UserQuestionInte
   );
   /** 全部问题均已作答方可「完成」 */
   const completed = computed(() => totalCount.value > 0 && answeredCount.value === totalCount.value);
+
+  const canGoPrev = computed(() => currentIndex.value > 0);
+  const canGoNext = computed(() => currentIndex.value < totalCount.value - 1);
+
+  const getAnswer = (questionIndex: number): undefined | UserQuestionAnswerItem => answerMap.value[questionIndex];
+
+  const goPrev = () => {
+    if (!canGoPrev.value) return;
+    currentIndex.value -= 1;
+  };
+
+  const goNext = () => {
+    if (!canGoNext.value) return;
+    currentIndex.value += 1;
+  };
+
+  /**
+   * 单选预设选项：从未答 → 有效答时自动跳下一题。
+   * 多选 / Others / 改选已答题：不自动跳，由标题栏箭头切换。
+   */
+  const tryAutoAdvance = (questionIndex: number, prev: undefined | UserQuestionAnswerItem, answer: UserQuestionAnswerItem) => {
+    if (prev) return;
+    if (questionIndex !== currentIndex.value) return;
+    if (questions.value[questionIndex]?.multiSelect === true) return;
+    if (answer.answer.some(item => item.label === OTHERS_OPTION_LABEL)) return;
+    if (!canGoNext.value) return;
+    currentIndex.value += 1;
+  };
+
+  /** 写入/清空某题答案：传 undefined 表示该题回到未作答态 */
+  const setAnswer = (questionIndex: number, answer: undefined | UserQuestionAnswerItem) => {
+    const prev = answerMap.value[questionIndex];
+    answerMap.value = { ...answerMap.value, [questionIndex]: answer };
+    if (answer) {
+      tryAutoAdvance(questionIndex, prev, answer);
+    }
+  };
 
   /** 组装各题答案；未作答题以空答案兜底，保证与问题一一对应 */
   const buildAnswers = (): UserQuestionAnswerItem[] =>
@@ -97,6 +129,11 @@ export const useUserQuestion = (getInterrupt: () => undefined | UserQuestionInte
     answeredCount,
     totalCount,
     completed,
+    currentIndex,
+    canGoPrev,
+    canGoNext,
+    goPrev,
+    goNext,
     getAnswer,
     setAnswer,
     buildResolvePayload,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
@@ -69,6 +69,10 @@ const buildInterrupt = (): UserQuestionInterrupt => ({
   },
 });
 
+/** 解析「已完成 N 题」进度文案中的数字 */
+const progressCount = (wrapper: VueWrapper) =>
+  wrapper.find('.ai-user-question-card__progress-num').text();
+
 describe('UserQuestionCard', () => {
   let wrapper: VueWrapper;
 
@@ -76,23 +80,85 @@ describe('UserQuestionCard', () => {
     wrapper?.unmount();
   });
 
-  it('初始渲染标题、计数与全部题目（每题末尾追加 Others 输入项）', () => {
+  it('初始渲染标题、页码与已完成进度；全部题目挂载但只展示当前题', () => {
     wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
 
     expect(wrapper.find('.ai-user-question-card__title').text()).toBe('请回答问题');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('0 / 2');
-    // Q1: A、B、Others = 3；Q2: C、Others = 2，共 5
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('0');
+    // Q1: A、B、Others = 3；Q2: C、Others = 2，共 5（v-show 保留全部挂载）
     expect(wrapper.findAll('.ai-user-question-option')).toHaveLength(5);
+    const questions = wrapper.findAll('.ai-user-question-card__question');
+    expect((questions[0].element as HTMLElement).style.display).not.toBe('none');
+    expect((questions[1].element as HTMLElement).style.display).toBe('none');
   });
 
-  it('选择选项后已答计数递增', async () => {
+  it('选择单选选项后已答计数递增，并自动跳到下一题', async () => {
     wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
 
     const options = wrapper.findAll('.ai-user-question-option');
     await options[0].trigger('click'); // Q1.A
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('1');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
+
+    await options[3].trigger('click'); // Q2.C（多选不自动跳）
+    expect(progressCount(wrapper)).toBe('2');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
+  });
+
+  it('标题栏左右箭头可切换题目，边界禁用', async () => {
+    wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
+
+    const navButtons = wrapper.findAll('.ai-user-question-card__nav-btn');
+    const prevBtn = navButtons[0];
+    const nextBtn = navButtons[1];
+
+    expect(prevBtn.attributes('disabled')).toBeDefined();
+    expect(nextBtn.attributes('disabled')).toBeUndefined();
+
+    await nextBtn.trigger('click');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
+    expect(nextBtn.attributes('disabled')).toBeDefined();
+
+    await prevBtn.trigger('click');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('1 / 2');
+    expect(prevBtn.attributes('disabled')).toBeDefined();
+  });
+
+  it('单题时页码为 1 / 1，左右箭头均禁用', () => {
+    const interrupt = buildInterrupt();
+    interrupt.metadata!.questions = [interrupt.metadata!.questions[0]];
+    wrapper = mount(UserQuestionCard, { props: { interrupt } });
+
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('1 / 1');
+    const navButtons = wrapper.findAll('.ai-user-question-card__nav-btn');
+    expect(navButtons[0].attributes('disabled')).toBeDefined();
+    expect(navButtons[1].attributes('disabled')).toBeDefined();
+  });
+
+  it('Footer 按钮顺序为跳过在前、完成在后，并展示已完成文案', () => {
+    wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
+
+    const actions = wrapper.find('.ai-user-question-card__actions');
+    const buttons = actions.findAllComponents(Button);
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0].classes()).toContain('ai-user-question-card__skip');
+    expect(buttons[1].classes()).toContain('ai-user-question-card__complete');
+    expect(wrapper.find('.ai-user-question-card__progress').text()).toContain('已完成');
+    expect(progressCount(wrapper)).toBe('0');
+  });
+
+  it('多选作答后不自动跳转', async () => {
+    wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
+
+    // 先手动切到多选题
+    await wrapper.findAll('.ai-user-question-card__nav-btn')[1].trigger('click');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
+
+    const options = wrapper.findAll('.ai-user-question-option');
     await options[3].trigger('click'); // Q2.C
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('2 / 2');
+    expect(progressCount(wrapper)).toBe('1');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
   });
 
   it('未答完时点击完成不触发 resume', async () => {
@@ -109,7 +175,7 @@ describe('UserQuestionCard', () => {
     wrapper = mount(UserQuestionCard, { props: { interrupt, onResume } });
 
     const options = wrapper.findAll('.ai-user-question-option');
-    await options[0].trigger('click'); // Q1.A
+    await options[0].trigger('click'); // Q1.A → 自动跳到 Q2
     await options[3].trigger('click'); // Q2.C
     await wrapper.find('.ai-user-question-card__complete').trigger('click');
 
@@ -174,10 +240,10 @@ describe('UserQuestionCard', () => {
     expect(wrapper.find('.ai-user-question-card__skip-icon').exists()).toBe(false);
   });
 
-  it('点击箭头可折叠，body 与 footer 通过 v-show 隐藏而非卸载', async () => {
+  it('点击收起按钮可折叠，body 与 footer 通过 v-show 隐藏而非卸载', async () => {
     wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
 
-    await wrapper.find('.ai-user-question-card__arrow').trigger('click');
+    await wrapper.find('.ai-user-question-card__collapse-btn').trigger('click');
     expect(wrapper.classes()).toContain('ai-user-question-card--collapsed');
     // v-show 保留 DOM，避免折叠时丢失勾选态
     const body = wrapper.find('.ai-user-question-card__body');
@@ -193,26 +259,30 @@ describe('UserQuestionCard', () => {
 
     const options = wrapper.findAll('.ai-user-question-option');
     await options[0].trigger('click');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('1');
+    // 单选自动跳到第 2 题，先回到第 1 题再折叠，便于断言选中态
+    await wrapper.findAll('.ai-user-question-card__nav-btn')[0].trigger('click');
 
-    await wrapper.find('.ai-user-question-card__arrow').trigger('click');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    await wrapper.find('.ai-user-question-card__collapse-btn').trigger('click');
+    expect(progressCount(wrapper)).toBe('1');
 
-    await wrapper.find('.ai-user-question-card__arrow').trigger('click');
+    await wrapper.find('.ai-user-question-card__collapse-btn').trigger('click');
     expect(wrapper.findAll('.ai-user-question-option')[0].classes()).toContain('ai-user-question-option--selected');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('1');
   });
 
-  it('选中 Others 但未输入文本不计为已答', async () => {
+  it('选中 Others 但未输入文本不计为已答，输入后也不自动跳转', async () => {
     wrapper = mount(UserQuestionCard, { props: { interrupt: buildInterrupt() } });
 
     const options = wrapper.findAll('.ai-user-question-option');
     // Q1 的 Others 为第 3 个（索引 2）
     await options[2].trigger('click');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('0 / 2');
+    expect(progressCount(wrapper)).toBe('0');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('1 / 2');
 
     await options[2].find('.ai-user-question-option__input').setValue('自定义');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('1');
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('1 / 2');
   });
 
   it('自定义 #question 表单 slot：通过 setAnswer 回传任意答案并驱动完成态', async () => {
@@ -234,12 +304,14 @@ describe('UserQuestionCard', () => {
     });
 
     const fillButtons = wrapper.findAll('.form-fill');
-    // 两题，需各自填写后才能完成
+    // 两题均挂载，需各自填写后才能完成
     expect(fillButtons).toHaveLength(2);
     await fillButtons[0].trigger('click');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('1 / 2');
+    expect(progressCount(wrapper)).toBe('1');
+    // Q1 为单选语义（multiSelect=false），自定义答案也会自动跳到 Q2
+    expect(wrapper.find('.ai-user-question-card__pager-text').text()).toBe('2 / 2');
     await fillButtons[1].trigger('click');
-    expect(wrapper.find('.ai-user-question-card__counter').text()).toBe('2 / 2');
+    expect(progressCount(wrapper)).toBe('2');
 
     await wrapper.find('.ai-user-question-card__complete').trigger('click');
     expect(onResume).toHaveBeenCalledTimes(1);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
@@ -15,20 +15,40 @@
         >
           {{ panelTitle }}
         </span>
-        <!-- <span
-          v-if="isCollapsed"
-          class="ai-user-question-card__tag"
-        >
-          {{ headerSelectText }}
-        </span> -->
       </div>
-      <div class="ai-user-question-card__counter-wrap">
-        <span class="ai-user-question-card__counter">{{ answeredCount }} / {{ totalCount }}</span>
-        <ArrowLeftIcon
-          class="ai-user-question-card__arrow"
-          :style="{ transform: isCollapsed ? 'rotate(180deg)' : 'rotate(-90deg)' }"
+      <div class="ai-user-question-card__header-actions">
+        <div class="ai-user-question-card__pager">
+          <button
+            class="ai-user-question-card__nav-btn"
+            :class="{ 'is-disabled': !canGoPrev }"
+            :disabled="!canGoPrev"
+            type="button"
+            @click.stop="goPrev"
+          >
+            <ArrowLeftIcon class="ai-user-question-card__nav-icon" />
+          </button>
+          <span class="ai-user-question-card__pager-text">{{ currentIndex + 1 }} / {{ totalCount }}</span>
+          <button
+            class="ai-user-question-card__nav-btn"
+            :class="{ 'is-disabled': !canGoNext }"
+            :disabled="!canGoNext"
+            type="button"
+            @click.stop="goNext"
+          >
+            <ArrowRightPreviewIcon class="ai-user-question-card__nav-icon" />
+          </button>
+        </div>
+        <span class="ai-user-question-card__divider" />
+        <button
+          class="ai-user-question-card__collapse-btn"
+          type="button"
           @click.stop="toggleCollapse"
-        />
+        >
+          <ArrowLeftIcon
+            class="ai-user-question-card__arrow"
+            :style="{ transform: isCollapsed ? 'rotate(180deg)' : 'rotate(-90deg)' }"
+          />
+        </button>
       </div>
     </header>
     <!-- 折叠用 v-show 而非 v-if：保留 UserQuestionChoice 及自定义 slot 的勾选态，避免卸载丢失选中 -->
@@ -36,8 +56,10 @@
       v-show="!isCollapsed"
       class="ai-user-question-card__body"
     >
+      <!-- 一次只展示一题；全部题目仍挂载以保留勾选 / Others 输入态 -->
       <div
         v-for="(question, qIndex) in questions"
+        v-show="qIndex === currentIndex"
         :key="qIndex"
         class="ai-user-question-card__question"
       >
@@ -76,34 +98,41 @@
       v-show="!isCollapsed"
       class="ai-user-question-card__footer"
     >
-      <Button
-        class="ai-user-question-card__complete"
-        :disabled="!completed || pendingAction === 'skip'"
-        :loading="pendingAction === 'complete'"
-        size="small"
-        theme="primary"
-        @click="handleComplete"
-      >
-        <EnterIcon
-          v-if="pendingAction !== 'complete'"
-          class="ai-user-question-card__enter-icon"
-        />
-        {{ t('完成') }}
-      </Button>
-      <Button
-        class="ai-user-question-card__skip"
-        :disabled="pendingAction === 'complete'"
-        :loading="pendingAction === 'skip'"
-        size="small"
-        text
-        @click="handleSkip"
-      >
-        <SkipIcon
-          v-if="pendingAction !== 'skip'"
-          class="ai-user-question-card__skip-icon"
-        />
-        {{ t('跳过') }}
-      </Button>
+      <span class="ai-user-question-card__progress">
+        {{ t('已完成') }}
+        <span class="ai-user-question-card__progress-num">{{ answeredCount }}</span>
+        {{ t('题') }}
+      </span>
+      <div class="ai-user-question-card__actions">
+        <Button
+          class="ai-user-question-card__skip"
+          :disabled="pendingAction === 'complete'"
+          :loading="pendingAction === 'skip'"
+          size="small"
+          text
+          @click="handleSkip"
+        >
+          <SkipIcon
+            v-if="pendingAction !== 'skip'"
+            class="ai-user-question-card__skip-icon"
+          />
+          {{ t('跳过') }}
+        </Button>
+        <Button
+          class="ai-user-question-card__complete"
+          :disabled="!completed || pendingAction === 'skip'"
+          :loading="pendingAction === 'complete'"
+          size="small"
+          theme="primary"
+          @click="handleComplete"
+        >
+          <EnterIcon
+            v-if="pendingAction !== 'complete'"
+            class="ai-user-question-card__enter-icon"
+          />
+          {{ t('完成') }}
+        </Button>
+      </div>
     </footer>
   </section>
 </template>
@@ -115,7 +144,7 @@
 
   import { useCommonTippyInject } from '../../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
-  import { ArrowLeftIcon, EnterIcon, HelpDocIcon, SkipIcon } from '../../../../icons';
+  import { ArrowLeftIcon, ArrowRightPreviewIcon, EnterIcon, HelpDocIcon, SkipIcon } from '../../../../icons';
   import { t } from '../../../../lang/lang';
   import { useUserQuestion } from './use-user-question';
   import UserQuestionChoice from './user-question-choice.vue';
@@ -156,6 +185,11 @@
     answeredCount,
     totalCount,
     completed,
+    currentIndex,
+    canGoPrev,
+    canGoNext,
+    goPrev,
+    goNext,
     getAnswer,
     setAnswer,
     buildResolvePayload,
@@ -163,10 +197,6 @@
   } = useUserQuestion(() => props.interrupt);
 
   const panelTitle = computed(() => props.interrupt.metadata?.questions?.[0]?.header || props.interrupt.message || '');
-  // 折叠态标题旁的 单选/多选 标签，取首题类型作近似展示
-  // const headerSelectText = computed(() =>
-  //   props.interrupt.metadata?.questions?.[0]?.multiSelect ? t('多选') : t('单选'),
-  // );
 
   const toggleCollapse = () => {
     isCollapsed.value = !isCollapsed.value;
@@ -259,33 +289,94 @@
       white-space: nowrap;
     }
 
-    &__counter-wrap {
+    &__header-actions {
       display: flex;
       flex: 0 0 auto;
+      gap: 12px;
+      align-items: center;
+    }
+
+    &__pager {
+      display: flex;
       gap: 4px;
       align-items: center;
     }
 
-    &__counter {
+    &__pager-text {
       font-family: Arial, sans-serif;
       font-size: var(--ai-font-size, 12px);
       line-height: var(--ai-line-height-compact, 20px);
       color: #979ba5;
+      white-space: nowrap;
     }
 
-    &__arrow {
-      width: 12px;
-      height: 12px;
+    &__nav-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      padding: 0;
       color: #979ba5;
       cursor: pointer;
+      background: transparent;
+      border: none;
+      border-radius: 2px;
+
+      &:hover:not(.is-disabled) {
+        color: #4d4f56;
+        background: #dcdee5;
+      }
+
+      &.is-disabled {
+        color: #c4c6cc;
+        cursor: not-allowed;
+        background: #eaebf0;
+      }
+    }
+
+    &__nav-icon {
+      width: 10px;
+      height: 10px;
 
       // stroke 图标的粗细由 stroke-width 控制，覆盖图标默认的 64
       path {
         stroke-width: 120;
       }
+    }
+
+    &__divider {
+      flex: 0 0 1px;
+      width: 1px;
+      height: 10px;
+      background: #dcdee5;
+    }
+
+    &__collapse-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 16px;
+      height: 16px;
+      padding: 0;
+      color: #979ba5;
+      cursor: pointer;
+      background: transparent;
+      border: none;
+      border-radius: 2px;
 
       &:hover {
         color: #4d4f56;
+      }
+    }
+
+    &__arrow {
+      width: 12px;
+      height: 12px;
+
+      // stroke 图标的粗细由 stroke-width 控制，覆盖图标默认的 64
+      path {
+        stroke-width: 120;
       }
     }
 
@@ -294,7 +385,7 @@
       flex-direction: column;
       gap: 8px;
       max-height: 320px; // 近似「不超过弹窗 2/3」，可按需调整
-      padding: 12px;
+      padding: 12px 12px 0;
       overflow-y: auto;
       scrollbar-color: #dcdee5 transparent;
       scrollbar-width: thin;
@@ -352,8 +443,26 @@
       display: flex;
       gap: 8px;
       align-items: center;
+      justify-content: space-between;
       padding: 12px;
       border-top: 1px solid #dcdee5;
+    }
+
+    &__progress {
+      font-size: var(--ai-font-size, 12px);
+      line-height: var(--ai-line-height-compact, 20px);
+      color: #4d4f56;
+      white-space: nowrap;
+    }
+
+    &__progress-num {
+      font-family: Arial, sans-serif;
+    }
+
+    &__actions {
+      display: flex;
+      gap: 20px;
+      align-items: center;
     }
 
     &__complete,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-choice.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-choice.vue
@@ -108,5 +108,6 @@
     display: flex;
     flex-direction: column;
     gap: 8px;
+    margin-bottom: 8px;
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -176,6 +176,8 @@ export const lang = {
   单选: 'Single',
   多选: 'Multiple',
   其他: 'Others',
+  已完成: 'Completed',
+  题: 'question(s)',
   回答内容: 'Answers',
   已回复: 'Replied',
   '请输入...': 'Please enter...',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
@@ -3,9 +3,10 @@ name: UserQuestionCard 用户问题中断
 slug: user-question-card
 kind: component
 domain: agent
-description: 渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。
+description: 渲染 UserQuestion 中断的待回答面板；一次一题分页切换，支持单选/多选、Others、跳过与已完成进度。
 aiSummary: >
-  渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。
+  渲染 UserQuestion 中断的待回答面板：一次只展示一题，标题栏提供题号切换，
+  Footer 展示已完成进度；支持单选自动跳下一题、多选/Others、完成与跳过。
   源码位置：src/components/chat-message/interrupt-message/user-question/user-question-card.vue。
 relatedComponents:
   - slug: interrupt-message
@@ -79,7 +80,7 @@ sinceVersion: 1.0.0
 
 - **源码位置**：`src/components/chat-message/interrupt-message/user-question/user-question-card.vue`
 - **能力域**：Agent 能力
-- **能力说明**：渲染 UserQuestion 中断的待回答面板，支持单选、多选、Others 与跳过。
+- **能力说明**：渲染 UserQuestion 中断的待回答面板；一次一题分页切换，支持单选/多选、Others、跳过与已完成进度。
 
 
 
@@ -89,6 +90,9 @@ sinceVersion: 1.0.0
 
 ## 交互能力
 
+- **一次一题**：正文只展示当前题；标题栏右侧提供 `< 当前题 / 总题数 >` 切换定位（单题为 `1 / 1`），首末题对应箭头禁用。
+- **自动跳转**：单选预设选项从未答变为有效答时，自动跳到下一题（最后一题停留）；多选与 Others 不自动跳，靠箭头切换。
+- **已完成进度**：Footer 左侧展示「已完成 N 题」；右侧为「跳过」+「完成」。
 - **单选 / 多选**：每道题通过 `multiSelect` 控制选择行为；未传时不展示单选/多选标签，默认仍按单选处理。
 - **Others 自由输入**：默认 [UserQuestionChoice](/components/agent/user-question-choice) 为每道题追加 `label: 'others'` 输入项，输入文本写入 `answer[].description`。
 - **自定义作答形态**：通过 `#question` slot 可替换默认选择题，渲染任意表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
@@ -221,7 +225,7 @@ const payload = {
 />
 ```
 
-- 卡片内「完成 / 跳过」→ `onInterruptResume(payload, interrupt)`
+- 卡片内「跳过 / 完成」→ `onInterruptResume(payload, interrupt)`（Footer 右置，跳过在前、完成在后）
 - 输入框直接发送 → `onSendMessage(content, docSchema, { interrupt, payload })`，其中 `payload` 由 `buildSkipResumePayload(interrupt)` 生成（`status: 'cancelled'`）
 
 ## 工具函数 buildSkipResumePayload

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/index.md
@@ -105,7 +105,7 @@ aiSummary: >
 | [ToolcallRender](./agent/toolcall-render.md) | 工具调用渲染器。 |
 | [ToolApprovalCard](./agent/tool-approval-card.md) | 工具审批卡片。 |
 | [InterruptMessage](./agent/interrupt-message.md) | 中断消息渲染器。 |
-| [UserQuestionCard](./agent/user-question-card.md) | 用户问题中断交互面板。 |
+| [UserQuestionCard](./agent/user-question-card.md) | 用户问题中断交互面板（一次一题分页）。 |
 | [UserQuestionChoice](./agent/user-question-choice.md) | 用户问题默认选择题渲染。 |
 | [UserQuestionAnsweredCard](./agent/user-question-answered-card.md) | 用户问题回答回显。 |
 | [UserQuestionOption](./agent/user-question-option.md) | 用户问题选项行。 |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/inventory.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/inventory.md
@@ -24,7 +24,7 @@ aiSummary: >
 | [ToolApprovalCard 工具审批卡片](/components/agent/tool-approval-card) | Agent 能力 | `src/components/chat-message/interrupt-message/tool-approval-card.vue` | 已覆盖 |
 | [ToolcallRender 工具调用渲染器](/components/agent/toolcall-render) | Agent 能力 | `src/components/tool-call/toolcall-render/toolcall-render.vue` | 已覆盖 |
 | [UserQuestionAnsweredCard 用户问题回答回显](/components/agent/user-question-answered-card) | Agent 能力 | `src/components/chat-message/interrupt-message/user-question/user-question-answered-card.vue` | 已覆盖 |
-| [UserQuestionCard 用户问题中断](/components/agent/user-question-card) | Agent 能力 | `src/components/chat-message/interrupt-message/user-question/user-question-card.vue` | 已覆盖 |
+| [UserQuestionCard 用户问题中断](/components/agent/user-question-card) | Agent 能力 | `src/components/chat-message/interrupt-message/user-question/user-question-card.vue`（一次一题分页） | 已覆盖 |
 | [UserQuestionChoice 用户问题选择题](/components/agent/user-question-choice) | Agent 能力 | `src/components/chat-message/interrupt-message/user-question/user-question-choice.vue` | 已覆盖 |
 | [UserQuestionOption 用户问题选项](/components/agent/user-question-option) | Agent 能力 | `src/components/chat-message/interrupt-message/user-question/user-question-option.vue` | 已覆盖 |
 | [DeleteTool 删除确认按钮](/components/feedback/delete-tool) | 工具与反馈 | `src/components/message-tools/delete-tool/delete-tool.vue` | 已覆盖 |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -856,9 +856,9 @@ ai-chat-container（:data-ai-size="size"）
 
 ## 用户问题中断
 
-当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)。
+当会话中最近一条待处理 interrupt 包含 `InterruptReason.UserQuestion` 时，`ChatContainer` 会在 `ChatInput` 上方显示 [UserQuestionCard](/components/agent/user-question-card)（一次一题，标题栏可切换题目）。
 
-- **结构化作答**：用户在卡片内完成选择或点击「跳过」后，通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
+- **结构化作答**：用户在卡片内逐题选择（单选可自动跳下一题），点击「完成」或「跳过」后通过 `onInterruptResume(payload, interrupt)` 回传 `UserQuestionResume`。
 - **输入框发送**：用户也可在输入框直接点击发送；容器会调用 `onSendMessage(content, docSchema, options)`，其中 `options.interrupt` 为当前激活的 UserQuestion，`options.payload` 为 `buildSkipResumePayload` 生成的 skip resume（`status: 'cancelled'`，`answers: []`）。此时**不会自动清空**输入框，由业务侧在 `onSendMessage` 内决定如何处理 `content` 与中断恢复。
 
 ```vue

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/interrupt.md
@@ -145,6 +145,7 @@ type UserQuestionOptionItem = {
 - 前端会为每道**选择题**追加 `label: 'others'` 的自由输入项；后端无需重复下发该选项。
 - 当用户选择 Others 时，`answer[].description` 为用户输入文本。
 - 业务可通过 `UserQuestionCard` 的 `#question` slot 渲染自定义表单；作答有效时调用 `setAnswer` 回传 `UserQuestionAnswerItem`，无效时传 `undefined`。
+- UI 一次只展示一题：标题栏 `< 当前题 / 总题数 >` 切换；单选预设选项作答后自动跳下一题，多选 / Others 需手动切换（协议字段不变）。
 
 ## Interrupt
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】UserQuestionCard 一次一题分页交互与已完成进度
ID: 1070093903136860076

## 改动
- user-question/use-user-question：增加 currentIndex 分页与单选自动跳下一题
- user-question/user-question-card：一次一题 UI、页码切换、Footer「已完成 N 题」
- user-question 单测：覆盖分页、自动跳转、Others/多选不跳转、payload
- playground：待回答 UserQuestion mock 与预览入口
- docs / skills / wikis：同步一次一题与进度交互说明；补充 i18n

## 影响面
- 影响 UserQuestion 待回答卡片交互与展示；resume / skip 协议字段不变

## 测试
- [ ] 多题时正文只显示当前题，页码与箭头边界正确
- [ ] 单选预设选项作答后自动进入下一题；最后一题停留
- [ ] 多选 / Others / 改选已答题不自动跳转
- [ ] Footer「已完成 N 题」随作答变化；全部作答后可「完成」
- [ ] resume payload / skip 行为与协议一致
- [ ] 相关单测通过（交付时未运行，需本地/CI 验证）

Made with [Cursor](https://cursor.com)