### PR TITLE
fix:修复工具调用无法通过用户态鉴权

### DIFF
--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -416,6 +416,8 @@ class BaseResourceManager(abc.ABC):
         )
 
     def construct_tool(self, tool_code: str, **kwargs) -> StructuredTool:
+        username = kwargs.pop("username", None) or self.username or None
+        executor_info = kwargs.pop("executor_info", None) or {}
         operation_name = "retrieve_tool" if kwargs.pop("appspace", True) else "appspace_retrieve_tool"
         client = self.get_client()
         operation = getattr(client.api, operation_name)
@@ -423,12 +425,32 @@ class BaseResourceManager(abc.ABC):
         result["data"]["tool_cn_name"] = result["data"]["tool_name"]
         if result["data"].get("credential_type", "") != CredentialType.NULL.value:
             tool = Tool.model_validate(result["data"])
-            tool.extra = ToolExtra(
-                header={
-                    "X-Bkapi-Authorization": json.dumps(
-                        {"bk_app_code": self.app_code, "bk_app_secret": self.app_secret}
-                    )
+
+            app_code = executor_info.get("app_code") or self.app_code
+            app_secret = executor_info.get("app_secret") or self.app_secret
+            access_token = executor_info.get("access_token") or self.resolve_access_token(username)
+
+            if access_token:
+                auth_info: dict = {"access_token": access_token}
+                if username:
+                    auth_info["bk_username"] = username
+            elif username:
+                auth_info = {
+                    "bk_app_code": app_code,
+                    "bk_app_secret": app_secret,
+                    "bk_username": username,
                 }
+            else:
+                auth_info = {"bk_app_code": app_code, "bk_app_secret": app_secret}
+
+            tool.extra = ToolExtra(header={"X-Bkapi-Authorization": json.dumps(auth_info)})
+
+            _logger.info(
+                f"[credential] construct_tool: tool_code={tool_code}, "
+                f"app_code={self.app_code}, rm_type={type(self).__name__}, "
+                f"has_executor_info={bool(executor_info)}, "
+                f"has_access_token={bool(access_token)}, "
+                f"username={username or ''}"
             )
             return make_structured_tool(tool)
         return make_structured_tool(Tool.model_validate(result["data"]))

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -436,14 +436,12 @@ class BaseResourceManager(abc.ABC):
 
             if access_token:
                 auth_info: dict = {"access_token": access_token}
-            elif username:
+            else:
                 auth_info = {
                     "bk_app_code": app_code,
                     "bk_app_secret": app_secret,
                     "bk_username": username,
                 }
-            else:
-                auth_info = {"bk_app_code": app_code, "bk_app_secret": app_secret}
 
             tool.extra = ToolExtra(header={"X-Bkapi-Authorization": json.dumps(auth_info)})
 

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -415,9 +415,13 @@ class BaseResourceManager(abc.ABC):
             "data", {}
         )
 
-    def construct_tool(self, tool_code: str, **kwargs) -> StructuredTool:
-        username = kwargs.pop("username", None) or self.username or None
-        executor_info = kwargs.pop("executor_info", None) or {}
+    def construct_tool(
+        self,
+        tool_code: str,
+        username: str | None = None,
+        executor_info: dict | None = None,
+        **kwargs,
+    ) -> StructuredTool:
         operation_name = "retrieve_tool" if kwargs.pop("appspace", True) else "appspace_retrieve_tool"
         client = self.get_client()
         operation = getattr(client.api, operation_name)
@@ -426,14 +430,12 @@ class BaseResourceManager(abc.ABC):
         if result["data"].get("credential_type", "") != CredentialType.NULL.value:
             tool = Tool.model_validate(result["data"])
 
-            app_code = executor_info.get("app_code") or self.app_code
-            app_secret = executor_info.get("app_secret") or self.app_secret
-            access_token = executor_info.get("access_token") or self.resolve_access_token(username)
+            app_code = (executor_info or {}).get("app_code") or self.app_code
+            app_secret = (executor_info or {}).get("app_secret") or self.app_secret
+            access_token = (executor_info or {}).get("access_token") or self.resolve_access_token(username)
 
             if access_token:
                 auth_info: dict = {"access_token": access_token}
-                if username:
-                    auth_info["bk_username"] = username
             elif username:
                 auth_info = {
                     "bk_app_code": app_code,

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -429,10 +429,11 @@ class BaseResourceManager(abc.ABC):
         result["data"]["tool_cn_name"] = result["data"]["tool_name"]
         if result["data"].get("credential_type", "") != CredentialType.NULL.value:
             tool = Tool.model_validate(result["data"])
-
+            # 归一化用户名来源：显式 username > self.username；
+            resolved_username = username or self.username or None
             app_code = (executor_info or {}).get("app_code") or self.app_code
             app_secret = (executor_info or {}).get("app_secret") or self.app_secret
-            access_token = (executor_info or {}).get("access_token") or self.resolve_access_token(username)
+            access_token = (executor_info or {}).get("access_token") or self.resolve_access_token(resolved_username)
 
             if access_token:
                 auth_info: dict = {"access_token": access_token}
@@ -440,8 +441,10 @@ class BaseResourceManager(abc.ABC):
                 auth_info = {
                     "bk_app_code": app_code,
                     "bk_app_secret": app_secret,
-                    "bk_username": username,
                 }
+                # 仅在用户名非空时携带 bk_username，与 construct_mcp 分支保持一致。
+                if resolved_username:
+                    auth_info["bk_username"] = resolved_username
 
             tool.extra = ToolExtra(header={"X-Bkapi-Authorization": json.dumps(auth_info)})
 
@@ -450,7 +453,7 @@ class BaseResourceManager(abc.ABC):
                 f"app_code={self.app_code}, rm_type={type(self).__name__}, "
                 f"has_executor_info={bool(executor_info)}, "
                 f"has_access_token={bool(access_token)}, "
-                f"username={username or ''}"
+                f"username={resolved_username or ''}"
             )
             return make_structured_tool(tool)
         return make_structured_tool(Tool.model_validate(result["data"]))

--- a/src/agent/aidev_agent/packages/resource_manager/registry.py
+++ b/src/agent/aidev_agent/packages/resource_manager/registry.py
@@ -81,7 +81,13 @@ class ResourceManagerProtocol(Protocol):
         """被调方校验主调方智能体调用权限，返回平台 ``data``（含 ``allowed`` 等字段）。"""
         ...
 
-    def construct_tool(self, tool_code: str, **kwargs) -> StructuredTool:
+    def construct_tool(
+        self,
+        tool_code: str,
+        username: str | None = None,
+        executor_info: dict | None = None,
+        **kwargs,
+    ) -> StructuredTool:
         """按 ``tool_code`` 装配 LangChain ``StructuredTool``（含凭证拼装）。"""
         ...
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1344,7 +1344,14 @@ class ChatAgentBuilder:
         else:
             tool_codes = config.tool_codes
         logger.info(f"ChatAgentBuilder: tool_codes->[{tool_codes}]")
-        tools = [self.ctx.resource_manager.construct_tool(tool_code) for tool_code in tool_codes] + mcp_result.tools
+        tools = [
+            self.ctx.resource_manager.construct_tool(
+                tool_code,
+                username=self.ctx.username,
+                executor_info=self._executor_info,
+            )
+            for tool_code in tool_codes
+        ] + mcp_result.tools
         self._apply_tool_approval_settings(tools)
         return tools
 

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -16,11 +16,13 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.tools.base import Tool, make_mcp_tools, make_structured_tool
+from aidev_agent.packages.resource_manager.agent import AgentResourceManager
 from aidev_agent.packages.resource_manager.registry import resource_manager
 from aidev_agent.pydantic_models import ExecuteKwargs
 from langchain_core.tools import StructuredTool
@@ -1109,3 +1111,82 @@ def test_make_mcp_tools_does_not_mutate_original_config(mock_mcp_client_class):
 
     # 原始配置不应被修改
     assert config == original_config
+
+
+# ================== construct_tool 的 X-Bkapi-Authorization 头部拼装 ==================
+
+
+def _rm_with_mocked_client(tool_data: dict, credential_type: str = "blueapps") -> AgentResourceManager:
+    """构造一个 client 已被 mock 的 AgentResourceManager，避免真实网络调用。"""
+    rm = AgentResourceManager(app_code="rm_app", app_secret="rm_secret")
+    data = {**tool_data, "credential_type": credential_type}
+    mock_client = MagicMock()
+    mock_client.api.retrieve_tool = MagicMock(return_value={"data": data})
+    mock_client.api.appspace_retrieve_tool = MagicMock(return_value={"data": data})
+    rm.get_client = MagicMock(return_value=mock_client)  # type: ignore[method-assign]
+    # 默认令 resolve_access_token 返回空串，避免依赖 bkoauth；具体用例可再单独 patch
+    rm.resolve_access_token = MagicMock(return_value="")  # type: ignore[method-assign]
+    return rm
+
+
+def _extract_auth_header(tool) -> str | None:
+    """从 StructuredTool 里取出 X-Bkapi-Authorization 头（未注入时返回 None）。
+
+    ``make_structured_tool`` 在 ``inject_context=True``（默认）时会把 ``ApiWrapper``
+    包在闭包 ``tool_func`` 里；关闭时 ``func`` 直接就是 ``ApiWrapper`` 实例。
+    这里兼容两种情况，先直接取 ``_extra``，取不到再从闭包里翻出来。
+    """
+    func = tool.func
+    api_wrapper = func if hasattr(func, "_extra") else None
+    if api_wrapper is None and getattr(func, "__closure__", None):
+        for cell in func.__closure__:
+            if hasattr(cell.cell_contents, "_extra"):
+                api_wrapper = cell.cell_contents
+                break
+    if api_wrapper is None:
+        return None
+    header = api_wrapper._extra.header or {}
+    return header.get("X-Bkapi-Authorization")
+
+
+def test_construct_tool_skips_header_when_credential_type_is_null(sample_weather_tool_data):
+    """credential_type=null 的工具不注入 X-Bkapi-Authorization。"""
+    rm = _rm_with_mocked_client(sample_weather_tool_data, credential_type="null")
+
+    tool = rm.construct_tool("weather-query")
+
+    assert _extract_auth_header(tool) is None
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_auth",
+    [
+        # 无 username / executor_info → 应用凭据
+        pytest.param(
+            {},
+            {"bk_app_code": "rm_app", "bk_app_secret": "rm_secret", "bk_username": None},
+            id="without_user_context",
+        ),
+        # 仅 username → 应用凭据 + bk_username
+        pytest.param(
+            {"username": "alice"},
+            {"bk_app_code": "rm_app", "bk_app_secret": "rm_secret", "bk_username": "alice"},
+            id="with_username",
+        ),
+        # executor_info 提供 access_token → 仅 access_token，忽略其他字段
+        pytest.param(
+            {"username": "alice", "executor_info": {"access_token": "exec_token"}},
+            {"access_token": "exec_token"},
+            id="with_access_token",
+        ),
+    ],
+)
+def test_construct_tool_injects_expected_authorization_header(sample_weather_tool_data, kwargs, expected_auth):
+    """按输入拼装 X-Bkapi-Authorization：应用凭据 / 用户凭据 / access_token 优先。"""
+    rm = _rm_with_mocked_client(sample_weather_tool_data)
+
+    tool = rm.construct_tool("weather-query", **kwargs)
+
+    auth_header = _extract_auth_header(tool)
+    assert auth_header is not None
+    assert json.loads(auth_header) == expected_auth

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -1118,7 +1118,7 @@ def test_make_mcp_tools_does_not_mutate_original_config(mock_mcp_client_class):
 
 def _rm_with_mocked_client(tool_data: dict, credential_type: str = "blueapps") -> AgentResourceManager:
     """构造一个 client 已被 mock 的 AgentResourceManager，避免真实网络调用。"""
-    rm = AgentResourceManager(app_code="rm_app", app_secret="rm_secret")
+    rm = AgentResourceManager(app_code="dummy_app", app_secret="dummy_credential")
     data = {**tool_data, "credential_type": credential_type}
     mock_client = MagicMock()
     mock_client.api.retrieve_tool = MagicMock(return_value={"data": data})
@@ -1164,19 +1164,19 @@ def test_construct_tool_skips_header_when_credential_type_is_null(sample_weather
         # 无 username / executor_info → 应用凭据
         pytest.param(
             {},
-            {"bk_app_code": "rm_app", "bk_app_secret": "rm_secret", "bk_username": None},
+            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": None},
             id="without_user_context",
         ),
         # 仅 username → 应用凭据 + bk_username
         pytest.param(
             {"username": "alice"},
-            {"bk_app_code": "rm_app", "bk_app_secret": "rm_secret", "bk_username": "alice"},
+            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": "alice"},
             id="with_username",
         ),
         # executor_info 提供 access_token → 仅 access_token，忽略其他字段
         pytest.param(
-            {"username": "alice", "executor_info": {"access_token": "exec_token"}},
-            {"access_token": "exec_token"},
+            {"username": "alice", "executor_info": {"access_token": "dummy_exec_value"}},
+            {"access_token": "dummy_exec_value"},
             id="with_access_token",
         ),
     ],

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -1159,31 +1159,57 @@ def test_construct_tool_skips_header_when_credential_type_is_null(sample_weather
 
 
 @pytest.mark.parametrize(
-    "kwargs, expected_auth",
+    "self_username, kwargs, expected_auth",
     [
-        # 无 username / executor_info → 应用凭据
+        # 无 username / self.username / executor_info → 纯应用凭据，不含 bk_username
         pytest.param(
+            "",
             {},
-            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": None},
+            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential"},
             id="without_user_context",
         ),
-        # 仅 username → 应用凭据 + bk_username
+        # 仅显式 username → 应用凭据 + bk_username
         pytest.param(
+            "",
             {"username": "alice"},
             {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": "alice"},
             id="with_username",
         ),
+        # 仅 self.username（未显式传参）→ 回退到 self.username 拼装 bk_username
+        pytest.param(
+            "bob",
+            {},
+            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": "bob"},
+            id="fallback_to_self_username",
+        ),
+        # 显式 username 覆盖 self.username → 使用显式值
+        pytest.param(
+            "bob",
+            {"username": "alice"},
+            {"bk_app_code": "dummy_app", "bk_app_secret": "dummy_credential", "bk_username": "alice"},
+            id="explicit_username_overrides_self_username",
+        ),
         # executor_info 提供 access_token → 仅 access_token，忽略其他字段
         pytest.param(
+            "",
             {"username": "alice", "executor_info": {"access_token": "dummy_exec_value"}},
             {"access_token": "dummy_exec_value"},
             id="with_access_token",
         ),
     ],
 )
-def test_construct_tool_injects_expected_authorization_header(sample_weather_tool_data, kwargs, expected_auth):
-    """按输入拼装 X-Bkapi-Authorization：应用凭据 / 用户凭据 / access_token 优先。"""
+def test_construct_tool_injects_expected_authorization_header(
+    sample_weather_tool_data, self_username, kwargs, expected_auth
+):
+    """按输入拼装 X-Bkapi-Authorization：应用凭据 / 用户凭据 / access_token 优先。
+
+    覆盖场景：
+    - 纯应用态（无任何 username 来源）不含 bk_username 字段；
+    - 仅显式 username / 仅 self.username 回退 / 显式 username 覆盖 self.username；
+    - executor_info.access_token 优先，其他字段被忽略。
+    """
     rm = _rm_with_mocked_client(sample_weather_tool_data)
+    rm.username = self_username
 
     tool = rm.construct_tool("weather-query", **kwargs)
 


### PR DESCRIPTION
原工具调用请求头只包含"bk_app_code"和"bk_app_secret"可以通过应用态鉴权，但无法通过用户态鉴权。
修改后采用和mcp工具相同的方式优先取access_token填X-Bkapi-Authorization进行鉴权，若access-token不存在再走应用态鉴权。