### PR TITLE
fix: 文件产物临时链接支持 TTL 缓存与重试强制刷新 --story=136862161

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -383,6 +383,7 @@ const getMockTextDownloadUrl = (outputId: string) => {
 export const MOCK_ARTIFACT_URL_MAP: Record<string, MockArtifactUrl> = MOCK_ARTIFACT_STATIC_URL;
 
 export const mockArtifactClick = async (file: AIFileInfo): Promise<MockArtifactUrl> => {
+  console.info('mockArtifactClick', file);
   await new Promise(resolve => setTimeout(resolve, 600));
   const staticUrls = MOCK_ARTIFACT_STATIC_URL[file.outputId] ?? {};
   const textDownloadUrl = getMockTextDownloadUrl(file.outputId);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
@@ -185,6 +185,9 @@ describe('ArtifactPreviewHost', () => {
     await flushPromises();
 
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
+    expect(resolveArtifactUrls).toHaveBeenLastCalledWith(expect.objectContaining({ outputId: 'output-1' }), {
+      force: true,
+    });
     expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/retry.pdf');
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -15,7 +15,7 @@
         size="small"
         text
         theme="primary"
-        @click="load"
+        @click="() => load({ force: true })"
       >
         {{ t('重试') }}
       </Button>
@@ -66,7 +66,7 @@
   const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
     canResolve: () => !!artifactPreview?.canResolveArtifactUrl.value,
     getFile: () => props.file,
-    resolveUrls: file => artifactPreview?.resolveArtifactUrls(file) ?? Promise.resolve({}),
+    resolveUrls: (file, options) => artifactPreview?.resolveArtifactUrls(file, options) ?? Promise.resolve({}),
   });
 
   // 以 outputId 为唯一键；同文件类型变更时也需重新加载预览策略

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
@@ -162,6 +162,20 @@ describe('use-artifact-preview-loader', () => {
     wrapper.unmount();
   });
 
+  it('load({ force: true }) 应向 resolveUrls 传 force', async () => {
+    const resolveUrls = vi.fn().mockResolvedValue({ preview_url: 'https://example.com/a.pdf' });
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Pdf),
+      resolveUrls,
+    });
+
+    await api.load({ force: true });
+
+    expect(resolveUrls).toHaveBeenCalledWith(expect.objectContaining({ type: AIFileType.Pdf }), { force: true });
+    expect(api.status.value).toBe('ready');
+    wrapper.unmount();
+  });
+
   it('dispose 后 abort 不应置为 error', async () => {
     const fetchMock = vi.fn(
       (_url: string, options: { signal: AbortSignal }) => new Promise((_resolve, reject) => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
@@ -28,6 +28,7 @@ import { onBeforeUnmount, shallowRef } from 'vue';
 import { getArtifactPreviewStrategy } from './preview-strategy';
 
 import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
+import type { ResolveArtifactUrlsOptions } from '../../../../../composables/use-artifact-preview';
 import type { ArtifactPreviewRendererKind } from './preview-strategy';
 
 export type ArtifactPreviewPayload = {
@@ -39,10 +40,12 @@ export type ArtifactPreviewPayload = {
 
 export type ArtifactPreviewStatus = 'empty' | 'error' | 'idle' | 'loading' | 'ready';
 
+export type ArtifactPreviewLoadOptions = ResolveArtifactUrlsOptions;
+
 export const useArtifactPreviewLoader = (options: {
   canResolve: () => boolean;
   getFile: () => AIFileInfo | undefined;
-  resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+  resolveUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
 }) => {
   const status = shallowRef<ArtifactPreviewStatus>('idle');
   const content = shallowRef('');
@@ -57,7 +60,7 @@ export const useArtifactPreviewLoader = (options: {
     previewUrl.value = '';
   };
 
-  const load = async () => {
+  const load = async (loadOptions?: ArtifactPreviewLoadOptions) => {
     const seq = ++loadSeq;
     abortController?.abort();
     abortController = undefined;
@@ -76,7 +79,10 @@ export const useArtifactPreviewLoader = (options: {
     renderer.value = strategy.renderer;
 
     try {
-      const urls = await options.resolveUrls(file);
+      // 重试传 force，绕过 TTL 缓存重新取链
+      const urls = loadOptions?.force
+        ? await options.resolveUrls(file, { force: true })
+        : await options.resolveUrls(file);
       if (seq !== loadSeq) {
         return;
       }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/info-message/info-message.vue
@@ -48,7 +48,7 @@
 
     &-content {
       max-width: 100%;
-      word-break: break-word;
+      word-break: break-all;
     }
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
@@ -27,10 +27,14 @@
 import { defineComponent, h } from 'vue';
 
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../ag-ui/types/file';
-import { useArtifactPreviewConsumer, useArtifactPreviewProvider } from './use-artifact-preview';
+import {
+  ARTIFACT_URL_CACHE_TTL_MS,
+  useArtifactPreviewConsumer,
+  useArtifactPreviewProvider,
+} from './use-artifact-preview';
 
 import type { AIFileInfo, OnArtifactClick } from '../ag-ui/types/file';
 
@@ -44,6 +48,14 @@ const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
 
 describe('use-artifact-preview', () => {
   describe('Provider / Consumer', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     const setup = (
       options: {
         getOnArtifactClick?: () => OnArtifactClick | undefined;
@@ -97,7 +109,7 @@ describe('use-artifact-preview', () => {
       expect(consumerCtx?.canResolveArtifactUrl.value).toBe(false);
     });
 
-    it('resolveArtifactUrls 应按 outputId 缓存结果且不重复请求', async () => {
+    it('resolveArtifactUrls 在 TTL 内应复用缓存', async () => {
       const onArtifactClick = vi.fn().mockResolvedValue({
         download_url: 'https://example.com/d',
         preview_url: 'https://example.com/p',
@@ -114,6 +126,50 @@ describe('use-artifact-preview', () => {
       });
       expect(second).toEqual(first);
       expect(onArtifactClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('resolveArtifactUrls 过期后应重新取链', async () => {
+      const onArtifactClick = vi
+        .fn()
+        .mockResolvedValueOnce({
+          download_url: 'https://example.com/d1',
+          preview_url: 'https://example.com/p1',
+        })
+        .mockResolvedValueOnce({
+          download_url: 'https://example.com/d2',
+          preview_url: 'https://example.com/p2',
+        });
+      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
+      const file = createFile({ outputId: 'cache-ttl' });
+
+      const first = await consumerCtx!.resolveArtifactUrls(file);
+      vi.advanceTimersByTime(ARTIFACT_URL_CACHE_TTL_MS + 1);
+      const second = await consumerCtx!.resolveArtifactUrls(file);
+
+      expect(first).toEqual({
+        download_url: 'https://example.com/d1',
+        preview_url: 'https://example.com/p1',
+      });
+      expect(second).toEqual({
+        download_url: 'https://example.com/d2',
+        preview_url: 'https://example.com/p2',
+      });
+      expect(onArtifactClick).toHaveBeenCalledTimes(2);
+    });
+
+    it('resolveArtifactUrls 传 force 时应绕过缓存重新取链', async () => {
+      const onArtifactClick = vi
+        .fn()
+        .mockResolvedValueOnce({ download_url: 'https://example.com/d1' })
+        .mockResolvedValueOnce({ download_url: 'https://example.com/d2' });
+      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
+      const file = createFile({ outputId: 'cache-force' });
+
+      await consumerCtx!.resolveArtifactUrls(file);
+      const forced = await consumerCtx!.resolveArtifactUrls(file, { force: true });
+
+      expect(forced).toEqual({ download_url: 'https://example.com/d2' });
+      expect(onArtifactClick).toHaveBeenCalledTimes(2);
     });
 
     it('并发 resolveArtifactUrls 应复用同一进行中请求', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
@@ -34,9 +34,18 @@ export const ARTIFACT_PREVIEW_TOKEN = Symbol('ARTIFACT_PREVIEW_TOKEN');
 /** 文件产物侧栏 Tab 的保留唯一标识（固定 Tab，不可关闭） */
 export const FILE_ARTIFACT_TAB_NAME = 'file-artifact';
 
+/** 临时链接缓存有效期（短于后端 token 常见 10 分钟时效） */
+export const ARTIFACT_URL_CACHE_TTL_MS = 8 * 60 * 1000;
+
 export type OpenArtifactPreviewPayload = {
   /** 被点击的文件 */
   file: AIFileInfo;
+};
+
+/** resolveArtifactUrls 可选参数 */
+export type ResolveArtifactUrlsOptions = {
+  /** 为 true 时跳过 TTL 缓存，强制重新取链（如预览重试） */
+  force?: boolean;
 };
 
 /**
@@ -52,10 +61,15 @@ type ArtifactPreviewContext = {
   canResolveArtifactUrl: ComputedRef<boolean>;
   /** 由文件卡片触发：命中文件并弹出/切换到文件产物侧栏 */
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
-  /** 按 outputId 缓存并解析 download_url / preview_url */
-  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+  /** 解析 download_url / preview_url：TTL 内复用缓存；force 时强制刷新；并发去重 */
+  resolveArtifactUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
   /** 直接设置命中文件 outputId（侧栏列表内切换用） */
   setActiveArtifactId: (id: string) => void;
+};
+
+type ArtifactUrlCacheEntry = {
+  expiresAt: number;
+  urls: ArtifactUrlResult;
 };
 
 /** 通过临时 <a> 触发浏览器下载 */
@@ -72,7 +86,7 @@ export const triggerArtifactDownload = (url: string, fileName: string) => {
 
 /**
  * 文件产物预览 Provider（在 ChatContainer 内使用）。
- * 维护「命中文件」状态，并封装 onArtifactClick 的 URL 解析与按 outputId 缓存；
+ * 维护「命中文件」状态，并封装 onArtifactClick 取链（TTL 缓存 + 并发去重）；
  * 打开侧栏 Tab 的副作用由外部 onOpen 注入。
  */
 export const useArtifactPreviewProvider = (options: {
@@ -82,8 +96,8 @@ export const useArtifactPreviewProvider = (options: {
   onOpen: (outputId: string) => void;
 }) => {
   const activeArtifactId = shallowRef('');
-  // 已成功解析的 URL 缓存（key = outputId）
-  const urlCache = new Map<string, ArtifactUrlResult>();
+  // 成功结果按 outputId 缓存，带过期时间
+  const urlCache = new Map<string, ArtifactUrlCacheEntry>();
   // 进行中的请求，避免同文件并发重复打接口
   const inflight = new Map<string, Promise<ArtifactUrlResult>>();
 
@@ -99,11 +113,19 @@ export const useArtifactPreviewProvider = (options: {
     options.onOpen(id);
   };
 
-  const resolveArtifactUrls = async (file: AIFileInfo): Promise<ArtifactUrlResult> => {
+  const resolveArtifactUrls = async (
+    file: AIFileInfo,
+    resolveOptions?: ResolveArtifactUrlsOptions,
+  ): Promise<ArtifactUrlResult> => {
     const key = file.outputId;
-    const cached = urlCache.get(key);
-    if (cached) {
-      return cached;
+
+    if (resolveOptions?.force) {
+      urlCache.delete(key);
+    } else {
+      const cached = urlCache.get(key);
+      if (cached && cached.expiresAt > Date.now()) {
+        return cached.urls;
+      }
     }
 
     const pending = inflight.get(key);
@@ -118,9 +140,13 @@ export const useArtifactPreviewProvider = (options: {
 
     const request = onArtifactClick(file)
       .then(result => {
-        urlCache.set(key, result ?? {});
+        const urls = result ?? {};
+        urlCache.set(key, {
+          expiresAt: Date.now() + ARTIFACT_URL_CACHE_TTL_MS,
+          urls,
+        });
         inflight.delete(key);
-        return urlCache.get(key)!;
+        return urls;
       })
       .catch(error => {
         inflight.delete(key);

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -62,7 +62,7 @@ sinceVersion: 0.0.20
 - **会话级聚合**：拍平当前会话所有 `AssistantMessage.property.artifacts`，以 `outputId` 去重后统一在一个列表内展示
 - **唯一命中**：以 `outputId` 作为会话内唯一键（同 `outputId` 视为同一文件）；文件名可能重复，不可作唯一键
 - **关键词搜索**：按文件名实时过滤列表
-- **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 缓存获取 `download_url` / `preview_url`
+- **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 获取 `download_url` / `preview_url`（TTL 8 分钟缓存；预览重试会 `force` 刷新）
 - **职责拆分**：
   - **面板本身**：列表、搜索、预览头（文件名 / 图标 / 下载）
   - **`ArtifactPreviewHost`**：按策略加载正文或预览 URL，分派到对应 renderer；展示 loading / empty / error（含重试）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -7,7 +7,7 @@ description: >-
   Provider 在 ChatContainer 中创建，Consumer 在深层文件卡片中注入使用。
 aiSummary: >
   useArtifactPreviewProvider 维护 activeArtifactId（值为 outputId），openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
-  并通过 getOnArtifactClick 封装 resolveArtifactUrls（按 outputId 缓存 download_url / preview_url）；
+  并通过 getOnArtifactClick 封装 resolveArtifactUrls（TTL 8 分钟缓存，force 可强制刷新，并发去重）；
   useArtifactPreviewConsumer 在后代注入同一套 API。SessionArtifact 即 AIFileInfo，会话内以 outputId 为唯一键。
   正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
@@ -29,7 +29,7 @@ Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatCo
 
 **职责边界**：
 
-- **本 composable**：维护「命中文件」与「URL 解析缓存」；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
+- **本 composable**：维护「命中文件」与「URL 解析」（TTL 缓存 + 并发去重，重试可 `force` 刷新）；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
 - **不在本 composable**：聚合会话文件列表、渲染预览面板、按类型 fetch 正文 / iframe 展示 —— 分别由 `useMessageGroup.sessionArtifacts`、`FileArtifactPanel`、内部 `ArtifactPreviewHost` + `useArtifactPreviewLoader` 承担
 
 ## 函数签名
@@ -46,7 +46,7 @@ function useArtifactPreviewProvider(options: {
   activeArtifactId: ShallowRef<string>;
   canResolveArtifactUrl: ComputedRef<boolean>;
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
-  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+  resolveArtifactUrls: (file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>;
   setActiveArtifactId: (id: string) => void;
 };
 ```
@@ -60,7 +60,7 @@ function useArtifactPreviewConsumer():
       activeArtifactId: Ref<string>;
       canResolveArtifactUrl: ComputedRef<boolean>;
       openPreview: (payload: OpenArtifactPreviewPayload) => void;
-      resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+      resolveArtifactUrls: (file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>;
       setActiveArtifactId: (id: string) => void;
     };
 ```
@@ -176,7 +176,7 @@ const onArtifactClick = async (file: AIFileInfo) => {
 | activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 `outputId`                                            |
 | canResolveArtifactUrl | `ComputedRef<boolean>`                  | 是否具备异步取链能力（有 `onArtifactClick` 时为 true，下载按钮据此显隐） |
 | openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：以 `file.outputId` 更新命中态、调用 `onOpen`   |
-| resolveArtifactUrls | `(file: AIFileInfo) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 并按 `outputId` 缓存结果；并发请求去重 |
+| resolveArtifactUrls | `(file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 取链；成功结果按 `outputId` 缓存 8 分钟；`force` 绕过缓存；并发去重 |
 | setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 `outputId`；侧栏列表内切换选中时使用                |
 
 ## 类型定义


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物临时链接支持 TTL 缓存与重试强制刷新
ID: 1070093903136862161

## 改动
- use-artifact-preview: 成功取链结果增加 8 分钟 TTL；支持 force 强制刷新；保留并发去重
- ArtifactPreviewHost / loader: 预览重试传 force: true 重新取链
- info-message: 内容区 word-break 调整为 break-all
- playground mock: 补充 mockArtifactClick 调试日志
- wikis: 同步 TTL 8 分钟与 force 行为说明
- 单测: 覆盖 TTL 过期、force、重试传参

## 影响面
- 影响文件产物预览/下载取链缓存策略；链接过期后可自动或通过重试刷新
- InfoMessage 长文本换行表现变化

## 测试
- [ ] TTL 内同 outputId 不重复请求（单测已写，本地未跑全量）
- [ ] 超过 TTL 后重新取链（单测已写，本地未跑全量）
- [ ] 预览重试 force 绕过缓存（单测已写，本地未跑全量）
- [ ] 并发 resolve 仍去重
- [ ] InfoMessage 长文本 break-all 显示正常

Made with [Cursor](https://cursor.com)