### PR TITLE
fix: MESSAGES_SNAPSHOT 多模态 content 解析为数组 --bug=161908798

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/utils.py
+++ b/src/agent/aidev_agent/core/ag_ui/utils.py
@@ -140,6 +140,23 @@ def stringify_if_needed(item: Any) -> str:
     return json.dumps(item)
 
 
+def parse_multimodal_content(content: Any) -> list[dict[str, Any]] | None:
+    """将多模态 content 归一化为 dict 列表；无法识别时返回 None。"""
+    if isinstance(content, list):
+        if content and all(isinstance(item, dict) for item in content):
+            return content
+        return None
+
+    if isinstance(content, str) and content.lstrip().startswith("["):
+        try:
+            parsed = json.loads(content)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if isinstance(parsed, list) and parsed and all(isinstance(item, dict) for item in parsed):
+            return parsed
+    return None
+
+
 def convert_langchain_multimodal_to_agui(
     content: list[dict[str, Any]],
 ) -> list[TextInputContent | BinaryInputContent]:
@@ -149,6 +166,17 @@ def convert_langchain_multimodal_to_agui(
         if isinstance(item, dict):
             if item.get("type") == "text":
                 agui_content.append(TextInputContent(type="text", text=item.get("text", "")))
+            elif item.get("type") == "binary":
+                agui_content.append(
+                    BinaryInputContent(
+                        type="binary",
+                        mime_type=item.get("mime_type") or "application/octet-stream",
+                        url=item.get("url"),
+                        data=item.get("data"),
+                        filename=item.get("filename"),
+                        id=item.get("id"),
+                    )
+                )
             elif item.get("type") == "image_url":
                 image_url_data = item.get("image_url", {})
                 url = image_url_data.get("url", "") if isinstance(image_url_data, dict) else image_url_data
@@ -179,8 +207,9 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
     for message in messages:
         if isinstance(message, HumanMessage):
             # Handle multimodal content
-            if isinstance(message.content, list):
-                content = convert_langchain_multimodal_to_agui(message.content)
+            multimodal = parse_multimodal_content(message.content)
+            if multimodal is not None:
+                content = convert_langchain_multimodal_to_agui(multimodal)
             else:
                 content = stringify_if_needed(resolve_message_content(message.content))
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -33,6 +33,7 @@ from aidev_agent.core.ag_ui.utils import (
     get_schema_keys,
     get_stream_payload_input,
     langchain_messages_to_agui,
+    parse_multimodal_content,
 )
 from aidev_agent.core.tools.a2a_tools.types import AgentBackendType, AgentSpec
 from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
@@ -1049,10 +1050,15 @@ class ChatCompletionAgent(BaseModel):
             bp = each.builtin_property or {}
             match each.role:
                 case PromptRole.USER.value:
+                    multimodal = parse_multimodal_content(each.content)
+                    if multimodal is not None:
+                        each.content = multimodal
                     if isinstance(each.content, list):
                         new_content = []
                         for each_content in each.content:
-                            if each_content.get("url"):
+                            if each_content.get("type") == "binary":
+                                new_content.append(each_content)
+                            elif each_content.get("url"):
                                 new_content.append({"type": "image_url", "image_url": {"url": each_content.get("url")}})
                             else:
                                 new_content.append(each_content)

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_multimodal.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_multimodal.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""MESSAGES_SNAPSHOT 多模态 content 格式单测。"""
+
+import json
+
+from unittest.mock import MagicMock
+
+import pytest
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+from langchain_core.messages import HumanMessage
+
+from aidev_agent.core.ag_ui.types import MessageSnapshotEventExtend
+from aidev_agent.core.ag_ui.utils import langchain_messages_to_agui, parse_multimodal_content
+from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+
+MULTIMODAL_CONTENT = [
+    {
+        "filename": "upload_file_1785756353687_fjdwe7.jpeg",
+        "mime_type": "image/jpeg",
+        "type": "binary",
+        "url": "https://example.com/files/upload_file.jpeg/",
+    },
+    {"type": "text", "text": "图片内容是啥"},
+]
+
+
+@pytest.mark.parametrize(
+    "raw_content",
+    [
+        MULTIMODAL_CONTENT,
+        json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False),
+    ],
+    ids=["list", "json_string"],
+)
+def test_langchain_messages_to_agui_keeps_multimodal_array(raw_content):
+    """历史多模态消息转换后 content 必须为数组，不能是 JSON 字符串。"""
+    message = HumanMessage(id="user-1", content=raw_content)
+    agui_message = langchain_messages_to_agui([message])[0]
+
+    assert isinstance(agui_message.content, list)
+    assert agui_message.content[0].type == "binary"
+    assert agui_message.content[0].filename == "upload_file_1785756353687_fjdwe7.jpeg"
+    assert agui_message.content[0].mime_type == "image/jpeg"
+    assert agui_message.content[1].type == "text"
+    assert agui_message.content[1].text == "图片内容是啥"
+
+
+def test_messages_snapshot_sse_encodes_multimodal_as_array():
+    """MESSAGES_SNAPSHOT SSE 载荷中 user content 应为结构化数组。"""
+    agui_messages = langchain_messages_to_agui(
+        [HumanMessage(id="user-1", content=json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False))]
+    )
+    encoded = EventEncoder().encode(
+        MessageSnapshotEventExtend(type=EventType.MESSAGES_SNAPSHOT, messages=agui_messages)
+    )
+    payload = json.loads(encoded.removeprefix("data: ").strip())
+
+    user_message = payload["messages"][0]
+    assert user_message["role"] == "user"
+    assert isinstance(user_message["content"], list)
+    assert user_message["content"][0]["type"] == "binary"
+    assert user_message["content"][0]["filename"] == "upload_file_1785756353687_fjdwe7.jpeg"
+    assert user_message["content"][1]["type"] == "text"
+
+
+def test_chat_history_to_langchain_parses_json_string_multimodal():
+    """DB 落库的 JSON 字符串多模态 content 应在历史转换时被解析。"""
+    chat_prompt = ChatPrompt(
+        id="1",
+        role="user",
+        content=json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False),
+    )
+    agent = MagicMock()
+    messages = ChatCompletionAgent._chat_history_to_langchain_messages(agent, [chat_prompt])
+
+    assert isinstance(messages[0].content, list)
+    assert messages[0].content[0]["type"] == "binary"
+
+
+def test_parse_multimodal_content_rejects_plain_text():
+    assert parse_multimodal_content("纯文本") is None


### PR DESCRIPTION
## Summary

- 修复 Workbench 会话 SSE 首帧 `MESSAGES_SNAPSHOT` 中 user 多模态 `content` 被序列化为 JSON 字符串的问题，还原为 AG-UI 结构化数组（`type: binary` + `type: text`）
- 新增 `parse_multimodal_content` 统一解析 list / JSON 字符串；`convert_langchain_multimodal_to_agui` 补充 `type: binary` 识别，保留 `filename` / `mime_type`
- 补充单测覆盖历史转换、AG-UI 转换及 SSE 编码路径

## 根因

DB 落库时多模态 content 为 JSON 字符串，SDK `_chat_history_to_langchain_messages` 与 `langchain_messages_to_agui` 未解析，走 `str()` / `stringify_if_needed` 降级为纯文本。

## 影响范围

- 仅影响 `role=user` 的多模态历史还原
- 不影响 assistant 产物（`property.artifacts`）及 `artifacts_generated` 事件

## Test plan

- [x] `pytest tests/core/ag_ui/test_messages_snapshot_multimodal.py`（5 passed）
- [ ] Staging 验证：带图片的用户消息续连 SSE，首帧 MESSAGES_SNAPSHOT content 为数组且图片可渲染


Made with [Cursor](https://cursor.com)