### PR TITLE
fix: 【chat-x】文件产物预览常规取链勿传 undefined --bug=161913646

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.spec.ts
@@ -187,15 +187,17 @@ describe('ArtifactFileCard', () => {
       const resolveArtifactUrls = vi.fn().mockResolvedValue({
         download_url: 'https://example.com/download',
       });
+      const file = createFile();
       wrapper = mount(ArtifactFileCard, {
         global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: createPreviewContext({ resolveArtifactUrls }) } },
-        props: { file: createFile() },
+        props: { file },
       });
 
       await wrapper.find('.ai-artifact-file-card-download').trigger('click');
       await flushPromises();
 
       expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
+      expect(resolveArtifactUrls).toHaveBeenCalledWith(file);
       expect(clickSpy).toHaveBeenCalledTimes(1);
       clickSpy.mockRestore();
     });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
@@ -81,10 +81,24 @@ describe('ArtifactPreviewHost', () => {
     const resolveArtifactUrls = vi.fn().mockResolvedValue({
       preview_url: 'https://example.com/file.pdf',
     });
-    wrapper = mountHost(createFile(), createPreviewContext({ resolveArtifactUrls }));
+    const file = createFile();
+    wrapper = mountHost(file, createPreviewContext({ resolveArtifactUrls }));
     await flushPromises();
 
+    // 常规加载只传 file，不传第二参（避免 (file, undefined)）
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
+    expect(resolveArtifactUrls).toHaveBeenCalledWith(file);
     expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/file.pdf');
+  });
+
+  it('无取链能力时应展示空态', async () => {
+    wrapper = mountHost(
+      createFile(),
+      createPreviewContext({ canResolveArtifactUrl: computed(() => false) }),
+    );
+    await flushPromises();
+
+    expect(wrapper.find('.ai-artifact-preview-host-empty').exists()).toBe(true);
   });
 
   it('切换不同 outputId 的文件时应重新加载预览', async () => {
@@ -100,6 +114,7 @@ describe('ArtifactPreviewHost', () => {
     await flushPromises();
 
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
+    expect(resolveArtifactUrls).toHaveBeenNthCalledWith(1, firstFile);
     expect(resolveArtifactUrls).toHaveBeenLastCalledWith(secondFile);
   });
 
@@ -116,6 +131,25 @@ describe('ArtifactPreviewHost', () => {
     await flushPromises();
 
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
+  });
+
+  it('相同 outputId 但 type 变更时应重新加载预览', async () => {
+    const resolveArtifactUrls = vi.fn()
+      .mockResolvedValueOnce({ preview_url: 'https://example.com/a.pdf' })
+      .mockResolvedValueOnce({ download_url: 'https://example.com/a.txt' });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('txt') }));
+    const firstFile = createFile({ name: 'a.pdf', outputId: 'same', type: AIFileType.Pdf });
+    const secondFile = createFile({ name: 'a.txt', outputId: 'same', type: AIFileType.Txt });
+    wrapper = mountHost(firstFile, createPreviewContext({ resolveArtifactUrls }));
+    await flushPromises();
+
+    await wrapper.setProps({ file: secondFile });
+    await flushPromises();
+
+    expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
+    expect(resolveArtifactUrls).toHaveBeenNthCalledWith(1, firstFile);
+    expect(resolveArtifactUrls).toHaveBeenLastCalledWith(secondFile);
+    expect(wrapper.find('.ai-artifact-txt-preview').text()).toBe('txt');
   });
 
   it('html 文件应使用 iframe srcdoc 展示下载内容', async () => {
@@ -148,6 +182,22 @@ describe('ArtifactPreviewHost', () => {
 
     expect(fetchSpy).toHaveBeenCalledWith('https://example.com/file.txt', expect.any(Object));
     expect(wrapper.find('.ai-artifact-txt-preview').text()).toBe('文本预览内容');
+  });
+
+  it('json 文件应按 txt 直渲染下载内容', async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{"a":1}') });
+    vi.stubGlobal('fetch', fetchSpy);
+    const resolveArtifactUrls = vi.fn().mockResolvedValue({
+      download_url: 'https://example.com/file.json',
+    });
+    wrapper = mountHost(
+      createFile({ name: 'file.json', type: AIFileType.Json }),
+      createPreviewContext({ resolveArtifactUrls }),
+    );
+    await flushPromises();
+
+    expect(fetchSpy).toHaveBeenCalledWith('https://example.com/file.json', expect.any(Object));
+    expect(wrapper.find('.ai-artifact-txt-preview').text()).toBe('{"a":1}');
   });
 
   it('markdown 文件应将下载内容传给 MarkdownContent', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -66,7 +66,10 @@
   const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
     canResolve: () => !!artifactPreview?.canResolveArtifactUrl.value,
     getFile: () => props.file,
-    resolveUrls: (file, options) => artifactPreview?.resolveArtifactUrls(file, options) ?? Promise.resolve({}),
+    // 无 options 时不传第二参，避免 mock 断言收到 (file, undefined)
+    resolveUrls: (file, options) =>
+      (options ? artifactPreview?.resolveArtifactUrls(file, options) : artifactPreview?.resolveArtifactUrls(file)) ??
+      Promise.resolve({}),
   });
 
   // 以 outputId 为唯一键；同文件类型变更时也需重新加载预览策略

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
@@ -7,6 +7,7 @@ import { AIFileType } from '../../../../../ag-ui/types/file';
 import { useArtifactPreviewLoader } from './use-artifact-preview-loader';
 
 import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
+import type { ResolveArtifactUrlsOptions } from '../../../../../composables/use-artifact-preview';
 
 const createFile = (type: AIFileType, name = `a.${type}`): AIFileInfo => ({
   name,
@@ -35,7 +36,7 @@ describe('use-artifact-preview-loader', () => {
   const mountLoader = (opts: {
     canResolve?: boolean;
     file: AIFileInfo | undefined;
-    resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
+    resolveUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
   }) => {
     let api: ReturnType<typeof useArtifactPreviewLoader> | undefined;
     const fileRef = shallowRef(opts.file);
@@ -159,6 +160,61 @@ describe('use-artifact-preview-loader', () => {
     await api.load();
 
     expect(api.status.value).toBe('error');
+    wrapper.unmount();
+  });
+
+  it('缺 preview_url 时应为 empty', async () => {
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Pdf),
+      resolveUrls: vi.fn().mockResolvedValue({}),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('empty');
+    wrapper.unmount();
+  });
+
+  it('缺 download_url 的文本类文件时应为 empty', async () => {
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Txt),
+      resolveUrls: vi.fn().mockResolvedValue({ preview_url: 'https://example.com/a.pdf' }),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('empty');
+    wrapper.unmount();
+  });
+
+  it('json 应按 txt 直渲染', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, text: () => Promise.resolve('{"ok":true}') }),
+    );
+    const { api, wrapper } = mountLoader({
+      file: createFile(AIFileType.Json, 'a.json'),
+      resolveUrls: vi.fn().mockResolvedValue({ download_url: 'https://example.com/a.json' }),
+    });
+
+    await api.load();
+
+    expect(api.status.value).toBe('ready');
+    expect(api.content.value).toBe('{"ok":true}');
+    expect(api.renderer.value).toBe('txt');
+    wrapper.unmount();
+  });
+
+  it('load() 默认只向 resolveUrls 传 file', async () => {
+    const file = createFile(AIFileType.Pdf);
+    const resolveUrls = vi.fn().mockResolvedValue({ preview_url: 'https://example.com/a.pdf' });
+    const { api, wrapper } = mountLoader({ file, resolveUrls });
+
+    await api.load();
+
+    expect(resolveUrls).toHaveBeenCalledTimes(1);
+    expect(resolveUrls).toHaveBeenCalledWith(file);
+    expect(resolveUrls.mock.calls[0]).toHaveLength(1);
     wrapper.unmount();
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.spec.ts
@@ -179,6 +179,7 @@ describe('FileArtifactPanel', () => {
     expect(iframe.attributes('src')).toBe('https://example.com/x.pdf');
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(1);
+    expect(resolveArtifactUrls).toHaveBeenCalledWith(artifact);
     vi.unstubAllGlobals();
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
@@ -629,7 +629,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 | `html` / `markdown` / `md` / `txt` / `json` | `download_url` | 正文直渲染（srcdoc / MarkdownContent / `<pre>`） |
 | `pdf` / `jpg` 等 | `preview_url` | iframe（一般为后台转好的 PDF） |
 
-`md` 与 `markdown` 等价（见 `AIFileType.Md` / `AIFileType.Markdown`）。
+`md` 与 `markdown` 等价（见 `AIFileType.Md` / `AIFileType.Markdown`）。预览重载、`force` 重试与取链约定见 [FileArtifactPanel 预览机制](/components/message/file-artifact-panel#预览机制)。
 
 ```vue
 <template>

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -7,7 +7,8 @@ description: 汇总当前会话全部文件产物，支持搜索、选中与分�
 aiSummary: >
   汇总当前会话所有 AssistantMessage 的 artifacts（按 outputId 去重），支持关键词搜索、列表选中与下载；
   预览区委托 ArtifactPreviewHost：按类型走 text_from_download（html / markdown / md / txt / json）
-  或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 异步获取。
+  或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 异步获取（TTL 缓存，重试 force）；
+  预览重载键为 outputId:type；常规 resolveArtifactUrls 只传 file。
   源码位置：src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue。
 relatedComponents:
   - slug: assistant-message
@@ -244,7 +245,14 @@ sessionArtifacts 有产物时
 | `empty` | 「暂无可预览的文件」（无文件 / 未传 `onArtifactClick` / 缺所需 URL） |
 | `error` | 「预览加载失败」+ 重试按钮 |
 
-切换文件时 `useArtifactPreviewLoader` 用 `loadSeq` + `AbortController` 中断上一次 `fetch`，避免竞态覆盖。下载图标仍由面板用 bkui `Loading` spin 单独表达。
+### 重载与取链约定
+
+- **重载键**：`ArtifactPreviewHost` 以 `` `${outputId}:${type}` `` 监听文件变化；`outputId` 或 `type` 任一变化会重新 `load()`，仅改文件名等其它字段不会
+- **常规取链**：`resolveArtifactUrls(file)`，只传文件，不传第二参
+- **重试 / 强刷**：错误态点击重试走 `load({ force: true })` → `resolveArtifactUrls(file, { force: true })`，绕过 TTL 缓存重新取链
+- **竞态**：切换文件时 `useArtifactPreviewLoader` 用 `loadSeq` + `AbortController` 中断上一次 `fetch`，避免过期结果覆盖最新内容
+
+下载图标仍由面板用 bkui `Loading` spin 单独表达。
 
 ## 内部结构（不导出）
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -568,8 +568,8 @@ ai-chat-container（:data-ai-size="size"）
 - **主动打开**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 以 `outputId` 命中该文件，再 `addCustomTab` 展开侧栏并选中「文件产物」
 - **排序 / 关闭**：`order: -1` 排在「执行情况」之前，`closable: false` 不可关闭
 - **显隐解耦**：该 Tab 存在时，侧栏展示不再受「`executionGroups` 为空」约束（即使当前会话没有执行类消息，也能独立展示文件产物侧栏）；会话切换或无文件产物时自动移除并重置命中态
-- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取。文本类（`html` / `markdown` / `md` / `txt` / `json`）拉 `download_url` 正文直渲染（`md` 与 `markdown` 等价）；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）
-- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）；正文加载与分类型渲染由 Host 内部完成
+- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取。文本类（`html` / `markdown` / `md` / `txt` / `json`）拉 `download_url` 正文直渲染（`md` 与 `markdown` 等价）；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）。预览重载键为 `outputId:type`；失败重试会 `force` 绕过 URL 缓存
+- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）；正文加载与分类型渲染由 Host 内部完成；常规取链只传 `file`，勿传 `undefined` 作为第二参
 - **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
 
 详见 [FileArtifactPanel 文件产物预览](/components/message/file-artifact-panel) 与 [useArtifactPreview 文件产物预览](/composables/use-artifact-preview)。

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -7,9 +7,9 @@ description: >-
   Provider 在 ChatContainer 中创建，Consumer 在深层文件卡片中注入使用。
 aiSummary: >
   useArtifactPreviewProvider 维护 activeArtifactId（值为 outputId），openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
-  并通过 getOnArtifactClick 封装 resolveArtifactUrls（TTL 8 分钟缓存，force 可强制刷新，并发去重）；
+  并通过 getOnArtifactClick 封装 resolveArtifactUrls（TTL 8 分钟缓存；常规只传 file，force 可强制刷新，并发去重）；
   useArtifactPreviewConsumer 在后代注入同一套 API。SessionArtifact 即 AIFileInfo，会话内以 outputId 为唯一键。
-  正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成。
+  正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成（重载键 outputId:type）。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
 relatedComponents:
   - slug: chat-container
@@ -29,8 +29,8 @@ Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatCo
 
 **职责边界**：
 
-- **本 composable**：维护「命中文件」与「URL 解析」（TTL 缓存 + 并发去重，重试可 `force` 刷新）；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
-- **不在本 composable**：聚合会话文件列表、渲染预览面板、按类型 fetch 正文 / iframe 展示 —— 分别由 `useMessageGroup.sessionArtifacts`、`FileArtifactPanel`、内部 `ArtifactPreviewHost` + `useArtifactPreviewLoader` 承担
+- **本 composable**：维护「命中文件」与「URL 解析」（TTL 缓存 + 并发去重；常规 `resolveArtifactUrls(file)`，重试可 `force` 刷新）；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
+- **不在本 composable**：聚合会话文件列表、渲染预览面板、按类型 fetch 正文 / iframe 展示 —— 分别由 `useMessageGroup.sessionArtifacts`、`FileArtifactPanel`、内部 `ArtifactPreviewHost` + `useArtifactPreviewLoader` 承担（预览重载键为 `outputId:type`）
 
 ## 函数签名
 
@@ -176,7 +176,7 @@ const onArtifactClick = async (file: AIFileInfo) => {
 | activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 `outputId`                                            |
 | canResolveArtifactUrl | `ComputedRef<boolean>`                  | 是否具备异步取链能力（有 `onArtifactClick` 时为 true，下载按钮据此显隐） |
 | openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：以 `file.outputId` 更新命中态、调用 `onOpen`   |
-| resolveArtifactUrls | `(file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 取链；成功结果按 `outputId` 缓存 8 分钟；`force` 绕过缓存；并发去重 |
+| resolveArtifactUrls | `(file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 取链；成功结果按 `outputId` 缓存 8 分钟；**常规调用只传 `file`**，仅预览重试 / 强刷传 `{ force: true }`（不要传 `undefined` 作为第二参）；并发去重 |
 | setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 `outputId`；侧栏列表内切换选中时使用                |
 
 ## 类型定义


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物预览常规取链勿传 undefined 并补齐单测文档
ID: 1070093903161913646

## 改动
- artifact-preview-host.vue: 无 options 时不向 resolveArtifactUrls 传第二参
- artifact-preview-host / use-artifact-preview-loader / file-artifact-panel / artifact-file-card 单测: 补单参、type 变更重载、json、空态等
- wikis (use-artifact-preview / file-artifact-panel / chat-container / assistant-message): 补充重载键、force 重试与取链约定

## 影响面
- 仅影响文件产物预览取链调用形态与测试/文档；业务取链结果不变

## 测试
- [ ] artifact-preview-host 常规加载只传 file，不出现 (file, undefined)
- [ ] 切换不同 outputId / 同 outputId 不同 type 会重新加载；重试传 { force: true }
- [ ] use-artifact-preview-loader 缺 URL 为空态；json 走 txt 直渲染
- [ ] wiki 约定与实现一致

Made with [Cursor](https://cursor.com)