### PR TITLE
feat: 首条消息自动重命名成功后对外抛出 rename 事件

### DIFF
--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/SKILL.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/SKILL.md
@@ -3,7 +3,7 @@ name: ai-blueking-dev
 description: 蓝鲸 AI 小鲸组件开发指南。基于 @blueking/chat-x（UI 组件）和 @blueking/chat-helper（业务 SDK）开发 AI 聊天应用、智能体、对话界面。涵盖 ChatBot 独立使用、AIBlueking 完整集成、流式响应、快捷指令、划词选择、模型选择（Model Select）、自定义消息渲染（图表/表单/iframe）、HITL 人机协同（工具审批/用户提问/中断恢复）、流程化智能体节点重试跳过、渲染模式（chat/share/test 分享态）、字号主题、侧栏自定义与自定义 Tab、欢迎区 `#welcome` 插槽、消息工具栏扩展（messageTools/updateTools）、非 Vue 宿主挂载等。触发场景：开发 AI 小鲸、集成 AI Agent、使用 chat-x/chat-helper、构建 AI 对话 UI、实现流式聊天、模型热切换、自定义消息组件渲染、human-in-the-loop、interrupt/resume、flow agent、自定义欢迎页、自定义消息工具按钮。
 metadata:
   author: blueking
-  version: '5.7'
+  version: '5.8'
   packages:
     ai-blueking: 2.2.2-beta.1
     chat-x: 0.0.49-beta.1

--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/SKILL.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/SKILL.md
@@ -3,7 +3,7 @@ name: ai-blueking-dev
 description: 蓝鲸 AI 小鲸组件开发指南。基于 @blueking/chat-x（UI 组件）和 @blueking/chat-helper（业务 SDK）开发 AI 聊天应用、智能体、对话界面。涵盖 ChatBot 独立使用、AIBlueking 完整集成、流式响应、快捷指令、划词选择、模型选择（Model Select）、自定义消息渲染（图表/表单/iframe）、HITL 人机协同（工具审批/用户提问/中断恢复）、流程化智能体节点重试跳过、渲染模式（chat/share/test 分享态）、字号主题、侧栏自定义与自定义 Tab、欢迎区 `#welcome` 插槽、消息工具栏扩展（messageTools/updateTools）、非 Vue 宿主挂载等。触发场景：开发 AI 小鲸、集成 AI Agent、使用 chat-x/chat-helper、构建 AI 对话 UI、实现流式聊天、模型热切换、自定义消息组件渲染、human-in-the-loop、interrupt/resume、flow agent、自定义欢迎页、自定义消息工具按钮。
 metadata:
   author: blueking
-  version: '5.6'
+  version: '5.7'
   packages:
     ai-blueking: 2.2.2-beta.1
     chat-x: 0.0.49-beta.1

--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/architecture.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/architecture.md
@@ -171,9 +171,17 @@ class ChatBusinessManager {
     if (!this.sessionModule) return;
     if (this.messageModule.list.value.length !== 1) return;
     
-    this.sessionModule.renameSession(sessionCode).catch(error => {
-      console.error('[ChatBusinessManager] Auto rename failed:', error);
-    });
+    this.sessionModule.renameSession(sessionCode)
+      .then(() => {
+        const updated = this.sessionModule!.list.value.find(s => s.sessionCode === sessionCode);
+        if (updated?.sessionName) {
+          // 经 ChatBot emit('rename') → AIBlueking forwarders.rename，业务方可 @rename 监听
+          this.config.onSessionRenamed?.(updated.sessionName);
+        }
+      })
+      .catch(error => {
+        console.error('[ChatBusinessManager] Auto rename failed:', error);
+      });
   }
 }
 ```

--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/chat-x-api.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/chat-x-api.md
@@ -547,7 +547,7 @@ const {
 } = useUserQuestion(() => interrupt);
 ```
 
-- **`buildSkipResumePayload(interrupt?)`**：用户不走结构化选择、直接在 chat-input 打字回答时构造的 resume（`status:'cancelled'`，多题信息有损，统一作一条自由文本）。
+- **`buildSkipResumePayload(interrupt?)`**：用户不走结构化选择、直接在 chat-input 打字回答时构造的 resume（`status:'cancelled'` + `answers: []`）。业务层（ChatBot）原样透传，自由文本不进 `answers`，只经 `input` 传递。
 
 ### 中断协议类型（`ag-ui/types/interrupt.ts`）
 

--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/chatbot-api.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/chatbot-api.md
@@ -59,6 +59,7 @@
 | request-share     | -                                          | 请求进入分享模式               |
 | agent-action      | `(tool: IToolBtn, messages: Message[])`    | 自定义消息工具点击（非内置 cite/rebuild/delete/like/unlike） |
 | execution-panel-change | `(isCollapse: boolean)`               | 执行情况侧面板展开/折叠         |
+| rename            | `(newName: string)`                        | 首条消息后 AI 自动重命名成功（独立使用 ChatBot 时可直接监听；AIBlueking 会转发为自身 `@rename`） |
 
 ## Slots
 
@@ -216,7 +217,7 @@ AIHeader 是 AIBlueking 的 Header 区域组件，其事件会透传至 AIBlueki
 | `history-session-delete` | `(sessionCode: string)` | 历史面板中删除会话（V2 模式） |
 | `history-session-rename` | `(sessionCode: string, newName: string)` | 历史面板中重命名会话（V2 模式） |
 | `auto-generate-name` | 无 | 自动生成会话名称 |
-| `rename` | `(newName: string)` | 手动重命名会话 |
+| `rename` | `(newName: string)` | 会话重命名（手动改名，或首条消息后 AI 自动重命名成功） |
 | `help-click` | 无 | 点击转人工按钮 |
 | `share` | 无 | 点击分享按钮 |
 | `toggle-compression` | 无 | 切换面板压缩/展开 |
@@ -342,7 +343,7 @@ AIBlueking 是完整面板组件（Nimbus 悬浮球 + 浮窗 + 拖拽 + Header +
 | new-chat-created | `(session: { sessionCode, sessionName?, createdAt? })` | 新会话创建成功 |
 | history-click | `(event: Event)` | 点击历史会话按钮 |
 | auto-generate-name | 无 | 自动生成会话名 |
-| rename | `(newName: string)` | 手动重命名会话 |
+| rename | `(newName: string)` | 会话重命名（手动改名，或首条消息后 AI 自动重命名成功） |
 | help-click | 无 | 点击转人工按钮 |
 | share | 无 | 点击分享按钮 |
 

--- a/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/hitl.md
+++ b/src/frontend/ai-blueking/packages/ai-blueking/skills/ai-blueking-dev/references/hitl.md
@@ -430,7 +430,7 @@ const handleInterruptResume: OnInterruptResume = async (payload, interrupt) => {
 
 **方式 A：在提问浮层卡片作答** —— 逐题选择/填写后点「完成」（`buildResolvePayload` → `status: resolved`）或「跳过」（`buildSkipPayload` → `status: cancelled`）。
 
-**方式 B：直接在输入框输入** —— 用户不点卡片、直接在 `ChatInput` 打字发送。此时利用 `onSendMessage` 的**第三个参数**把普通发送转成一次「跳过原提问 + 用自由文本作答」的恢复：
+**方式 B：直接在输入框输入** —— 用户不点卡片、直接在 `ChatInput` 打字发送。此时利用 `onSendMessage` 的**第三个参数**把普通发送转成一次「用自由文本作答」的恢复：
 
 ```typescript
 // ChatInput 的 onSendMessage 现在支持第三参数
@@ -443,6 +443,16 @@ onSendMessage?: (
 // buildSkipResumePayload(interrupt) 生成 status:'cancelled' 的空答案负载，
 // ChatBot 内部据此在发送用户输入的同时恢复被中断的提问。
 ```
+
+⚠️ **自由文本不进 `answers`**：用户没有选择任何选项，`payload.answers` 必须保持 `[]`、`status` 保持 `'cancelled'`（等同跳过），文本只通过 `input` 传给后端。ChatBot 原样透传 chat-x 给的 skip payload，不做改写：
+
+```typescript
+// use-interrupt-resume.ts —— 自由文本恢复的最终负载
+{ interruptId, reason: InterruptReason.UserQuestion, status: 'cancelled', payload: { answers: [] } }
+// 同时 streamRequest({ sessionCode, resume, input: '用户输入的文本' })
+```
+
+后端据是否携带 `input` 区分「自由文本作答」与「纯跳过」。**不要**把自由文本包装成 `label:'others'` 的答案项——`others` 仅用于用户在卡片里主动选择「其他」并填写的场景。
 
 ChatBot / AIBlueking 已内置该旁路逻辑，业务无需处理；原子模式下如需支持「输入框作答」，在 `handleSend` 中检测当前是否有活跃 UserQuestion 中断（`useMessageGroup().activeUserQuestionInterrupt`），有则携带 `buildSkipResumePayload` 结果调用恢复。
 

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/ai-blueking.vue
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/ai-blueking.vue
@@ -101,6 +101,7 @@
             @receive-end="handleReceiveEnd"
             @receive-start="handleReceiveStart"
             @receive-text="handleReceiveText"
+            @rename="handleSessionRenamed"
             @request-share="handleShare"
             @send-message="(msg: string) => handleSendMessage(msg)"
             @session-switched="(session: ISession | null) => handleSessionSwitched(session)"
@@ -289,6 +290,7 @@
     handleAutoGenerateName,
     handleHelpClick,
     handleRename,
+    handleSessionRenamed,
     handleSessionSwitched,
     addNewSession,
     switchToSession,

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/__tests__/use-chatbot-init.spec.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/__tests__/use-chatbot-init.spec.ts
@@ -346,6 +346,12 @@ describe('useChatbotInit', () => {
       // 业务管理器的失败事件必须能汇入 error 出口，否则 chat-error / session-error 是死通道
       expect(vi.mocked(ChatBusinessManager).mock.calls[0][3]).toBe(errorReporterParams.managerErrorBridge);
       expect(vi.mocked(SessionBusinessManager).mock.calls[0][2]).toBe(errorReporterParams.managerErrorBridge);
+
+      // 自动重命名成功应经 onSessionRenamed → ChatBot emit('rename')
+      const chatConfig = vi.mocked(ChatBusinessManager).mock.calls[0][4] as { onSessionRenamed?: (name: string) => void };
+      expect(typeof chatConfig?.onSessionRenamed).toBe('function');
+      chatConfig.onSessionRenamed!('Auto Name');
+      expect(emit).toHaveBeenCalledWith('rename', 'Auto Name');
       wrapper.unmount();
     });
 

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/__tests__/use-interrupt-resume.spec.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/__tests__/use-interrupt-resume.spec.ts
@@ -137,7 +137,7 @@ describe('useInterruptResume', () => {
     });
   });
 
-  it('ask-user-question 直接输入应调用 streamRequest 并传入 input', async () => {
+  it('ask-user-question 直接输入应调用 streamRequest 并传入 input，resume 保持 cancelled + 空 answers', async () => {
     const params = createParams();
     const { resumeUserQuestionWithInput } = useInterruptResume(params);
 
@@ -163,16 +163,8 @@ describe('useInterruptResume', () => {
       input: '自由文本回答',
       resume: {
         interruptId: 'interrupt-1',
-        status: 'resolved',
-        payload: {
-          answers: [
-            {
-              question: '请补充说明',
-              multiSelect: false,
-              answer: [{ label: 'others', description: '自由文本回答' }],
-            },
-          ],
-        },
+        status: 'cancelled',
+        payload: { answers: [] },
       },
     });
   });

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/use-chatbot-init.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/use-chatbot-init.ts
@@ -216,6 +216,8 @@ export function useChatbotInit(params: UseChatbotInitParams): UseChatbotInitRetu
       openingRemark: props.helloText,
       predefinedQuestions: props.prompts,
       placeholder: props.placeholder,
+      // 首条消息自动重命名成功 → ChatBot rename → AIBlueking forwarders.rename
+      onSessionRenamed: (newName: string) => emit('rename', newName),
     });
 
     const shortcutMgr = new ShortcutManager(null, props.shortcuts || []);

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/use-interrupt-resume.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/components/composables/use-interrupt-resume.ts
@@ -17,15 +17,12 @@ import {
   type InterruptResume,
   type ToolApprovalResume,
   type UserMessage,
-  type UserQuestionInterrupt,
   type UserQuestionResume,
 } from '@blueking/chat-x';
 
 import type { IChatHelper } from '../../types';
 import type { ChatBotEmitFn } from './use-chatbot-init';
 import type { ReportChatBotError } from './use-error-reporter';
-
-const OTHERS_OPTION_LABEL = 'others';
 
 // ApprovalRefresh 无对应后端 userOperation，仅触发一次轮询拉取单据最新状态，故不在此映射内
 const USER_OPERATION_MAP: Partial<Record<InterruptResumeOperation, UserOperation>> = {
@@ -77,32 +74,6 @@ function toIResume(resume: UserQuestionResume): IResume {
     interruptId: resume.interruptId,
     status: toResumeStatus(resume.status),
     payload: resume.payload,
-  };
-}
-
-/**
- * 用户在 chat-input 直接输入时的自由文本 resume。
- * chat-x 第三参会携带 cancelled + 空答案的 skip payload，业务层需转为 resolved + Others 答案。
- */
-function buildFreeTextUserQuestionResume(
-  interrupt: UserQuestionInterrupt | undefined,
-  text: string,
-  baseResume: UserQuestionResume,
-): UserQuestionResume {
-  const firstQuestion = interrupt?.metadata?.questions?.[0]?.question ?? '';
-  return {
-    interruptId: baseResume.interruptId,
-    reason: InterruptReason.UserQuestion,
-    status: 'resolved',
-    payload: {
-      answers: [
-        {
-          question: firstQuestion,
-          multiSelect: false,
-          answer: [{ label: OTHERS_OPTION_LABEL, description: text }],
-        },
-      ],
-    },
   };
 }
 
@@ -208,13 +179,9 @@ export function useInterruptResume(params: UseInterruptResumeParams): UseInterru
         throw new Error('[ChatBot] User question free text input is empty');
       }
 
-      const resume = buildFreeTextUserQuestionResume(
-        options.interrupt as UserQuestionInterrupt | undefined,
-        input,
-        options.payload,
-      );
-
-      await handleUserQuestionResume(resume, input);
+      // 用户未做结构化选择：直接沿用 chat-x 的 skip payload（cancelled + 空 answers），
+      // 自由文本不塞进 answers，只通过 input 传给后端
+      await handleUserQuestionResume(options.payload, input);
     } catch (error) {
       reportError(error, 'Failed to resume user question with input');
     }

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/components/types.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/components/types.ts
@@ -47,6 +47,11 @@ export type ChatBotEmits = {
   'receive-end': [];
   'receive-start': [];
   'receive-text': [];
+  /**
+   * 会话名称变更（目前：首条消息后 AI 自动重命名成功）
+   * 与 AIBlueking / Header 的 rename 事件 payload 一致
+   */
+  rename: [newName: string];
   /** 请求进入分享模式事件（来自 message-tools 的 share 按钮） */
   'request-share': [];
   'send-message': [message: string];

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/composables/__tests__/use-session-handlers.spec.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/composables/__tests__/use-session-handlers.spec.ts
@@ -45,6 +45,17 @@ describe('useSessionHandlers error reporting', () => {
     expect(payload.source).toBe('business');
   });
 
+  it('forwards session renamed from ChatBot without calling updateSession', () => {
+    const params = createParams();
+    const { handleSessionRenamed, sessionName } = useSessionHandlers(params);
+
+    handleSessionRenamed('AI Generated Name');
+
+    expect(sessionName.value).toBe('AI Generated Name');
+    expect(params.forwarders.rename).toHaveBeenCalledWith('AI Generated Name');
+    expect(params.chatHelper.session.updateSession).not.toHaveBeenCalled();
+  });
+
   it('reports auto generate name failure with semantic apiName', async () => {
     const reportSdkError = vi.fn();
     const { handleAutoGenerateName } = useSessionHandlers(createParams(reportSdkError));

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/composables/use-session-handlers.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/composables/use-session-handlers.ts
@@ -161,6 +161,14 @@ export function useSessionHandlers(params: UseSessionHandlersParams) {
     forwarders.rename(newName);
   };
 
+  /**
+   * ChatBot 侧会话名已变更（如首条消息自动重命名），仅同步 UI 并对外抛 rename，不再调 updateSession
+   */
+  const handleSessionRenamed = (newName: string) => {
+    sessionName.value = newName;
+    forwarders.rename(newName);
+  };
+
   const handleSessionSwitched = (session: ISession | null) => {
     if (session) {
       sessionName.value = session.sessionName || '';
@@ -218,6 +226,7 @@ export function useSessionHandlers(params: UseSessionHandlersParams) {
     handleAutoGenerateName,
     handleHelpClick,
     handleRename,
+    handleSessionRenamed,
     handleSessionSwitched,
     addNewSession,
     switchToSession,

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/__tests__/chat-business-manager.spec.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/__tests__/chat-business-manager.spec.ts
@@ -79,16 +79,41 @@ describe('ChatBusinessManager', () => {
 
     it('should auto-rename session when first message', async () => {
       mocks.mockMessageModule.list = shallowRef([{ id: '1', role: MessageRole.User, content: 'hello' }]);
+      const onSessionRenamed = vi.fn();
+      mocks.mockSessionModule.renameSession = vi.fn().mockImplementation(async () => {
+        mocks.mockSessionModule.list.value = [{ sessionCode: 'session-1', sessionName: 'AI Generated Name' }];
+      });
       manager = new ChatBusinessManager(
         mocks.mockAgentModule as any,
         mocks.mockMessageModule as any,
         mocks.mockSessionModule as any,
         mocks.mockEventEmitter,
+        { onSessionRenamed },
       );
 
       await manager.sendMessage('hello', 'session-1');
+      await Promise.resolve();
 
       expect(mocks.mockSessionModule.renameSession).toHaveBeenCalledWith('session-1');
+      expect(onSessionRenamed).toHaveBeenCalledWith('AI Generated Name');
+    });
+
+    it('should not emit rename when auto-rename fails', async () => {
+      mocks.mockMessageModule.list = shallowRef([{ id: '1', role: MessageRole.User, content: 'hello' }]);
+      const onSessionRenamed = vi.fn();
+      mocks.mockSessionModule.renameSession = vi.fn().mockRejectedValue(new Error('rename failed'));
+      manager = new ChatBusinessManager(
+        mocks.mockAgentModule as any,
+        mocks.mockMessageModule as any,
+        mocks.mockSessionModule as any,
+        mocks.mockEventEmitter,
+        { onSessionRenamed },
+      );
+
+      await manager.sendMessage('hello', 'session-1');
+      await Promise.resolve();
+
+      expect(onSessionRenamed).not.toHaveBeenCalled();
     });
 
     it('should not auto-rename when more than one message exists', async () => {

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/chat-business-manager.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/chat-business-manager.ts
@@ -112,6 +112,7 @@ export class ChatBusinessManager {
   }
   /**
    * 自动重命名会话（当第一条消息发送成功后）
+   * 成功后通过 config.onSessionRenamed 通知上层，对外抛出与手动改名一致的 rename 事件
    * @param sessionCode 会话编码
    */
   private autoRenameSessionIfNeeded(sessionCode: string): void {
@@ -133,9 +134,19 @@ export class ChatBusinessManager {
       return;
     }
 
-    renameTask.catch((error: unknown) => {
-      console.error('[ChatBusinessManager] Auto rename session failed:', error);
-    });
+    renameTask
+      .then(() => {
+        const updated =
+          sessionModule.list.value.find(s => s.sessionCode === sessionCode) ??
+          (sessionModule.current?.value?.sessionCode === sessionCode ? sessionModule.current.value : null);
+        const newName = updated?.sessionName;
+        if (newName) {
+          this.config.onSessionRenamed?.(newName);
+        }
+      })
+      .catch((error: unknown) => {
+        console.error('[ChatBusinessManager] Auto rename session failed:', error);
+      });
   }
 
   /**

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/types.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/manager/business/types.ts
@@ -18,6 +18,11 @@ export type { IShortcut } from '../../types';
 export interface ChatBusinessConfig {
   /** 欢迎语 */
   openingRemark?: string;
+  /**
+   * 会话自动重命名成功回调（首条消息后 AI 生成名称）
+   * 用于向上抛出与手动改名一致的 rename 事件；Manager 自身的 eventEmitter 仅接错误桥，不会转发此事件
+   */
+  onSessionRenamed?: (newName: string) => void;
   /** 占位文本 */
   placeholder?: string;
   /** 预定义问题 */

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/types.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/types.ts
@@ -127,6 +127,7 @@ export interface AIBluekingEmits {
   (e: 'history-click', event: Event): void;
   (e: 'auto-generate-name'): void;
   (e: 'help-click'): void;
+  /** 会话重命名（手动改名或首条消息后 AI 自动重命名成功） */
   (e: 'rename', newName: string): void;
   (e: 'share'): void;
 }

--- a/src/frontend/ai-blueking/packages/ai-blueking/src/vue2.ts
+++ b/src/frontend/ai-blueking/packages/ai-blueking/src/vue2.ts
@@ -386,6 +386,7 @@ const chatBotEmitNames = [
   'execution-panel-change',
   'feedback',
   'agent-action',
+  'rename',
 ] as const;
 
 const chatBotExposeKeys = [

--- a/src/frontend/ai-blueking/packages/chat-x/docs/ask-user-question-protocol.md
+++ b/src/frontend/ai-blueking/packages/chat-x/docs/ask-user-question-protocol.md
@@ -153,7 +153,7 @@ sequenceDiagram
 | --- | --- | --- | --- |
 | `interruptId` | string | 是 | 对应下发中断的 `id`。 |
 | `status` | string | 是 | `"resolved"`=已回答；`"cancelled"`=已跳过/取消。 |
-| `payload.answers` | `UserQuestionAnswerItem[]` | 是 | 各题答案，与 `questions` 一一对应（跳过时为空数组项）。 |
+| `payload.answers` | `UserQuestionAnswerItem[]` | 是 | 各题答案，与 `questions` 一一对应；仅结构化作答时有内容，跳过与自由文本作答均为 `[]`。 |
 
 #### UserQuestionAnswerItem（单题答案）
 
@@ -252,7 +252,7 @@ sequenceDiagram
 | 普通聊天 / 首次触发问题 | 用户输入 | 不传 |
 | 结构化作答（点击「完成」） | 不传 | `status=resolved`，`answers` 为各题答案 |
 | 结构化跳过（点击「跳过」） | 不传 | `status=cancelled`，`answers=[]` |
-| chat-input 自由文本作答 | 用户文本 | `status=resolved`，`answers` 为单条 Others 答案（见 3.2） |
+| chat-input 自由文本作答 | 用户文本 | `status=cancelled`，`answers=[]`（见 3.2） |
 
 ### 3.2 两种作答路径
 
@@ -262,29 +262,23 @@ sequenceDiagram
 
 **路径 B：chat-input 自由文本作答**
 
-用户不操作卡片，直接在主输入框输入文本发送。前端将其转为：
+用户不操作卡片，直接在主输入框输入文本发送。用户并未做任何结构化选择，等同于放弃本次提问并转而自由表达，因此**不构造任何答案项**：
 
-- `status = "resolved"`
-- `input = 用户文本`（同时透传，便于持久化与上下文）
-- `payload.answers` 收敛为**单条** Others 答案，`question` 取首题 `question`：
+- `status = "cancelled"`（与「跳过」一致）
+- `input = 用户文本`（自由文本仅通过此字段传递）
+- `payload.answers = []`
 
 ```json
 {
   "interruptId": "interrupt_user_question_001",
-  "status": "resolved",
-  "payload": {
-    "answers": [
-      {
-        "question": "请选择你想要的冒泡排序算法方案",
-        "multiSelect": false,
-        "answer": [{ "label": "others", "description": "<用户自由文本>" }]
-      }
-    ]
-  }
+  "status": "cancelled",
+  "payload": { "answers": [] }
 }
 ```
 
-> ⚠️ 路径 B 在多题场景下信息有损：所有题目被合并为一条自由文本答案。后端需兼容「`answers` 数量与 `questions` 数量不一致」的情况。
+> ⚠️ 路径 B 与「跳过」的 resume 完全相同，区别仅在于是否携带 `input`：带 `input` 表示用户以自由文本作答，不带 `input` 表示纯跳过。
+>
+> 只有用户在卡片中选择了选项（含 Others 自定义输入）时，`answers` 才有内容；自由文本**不会**被包装成 `label="others"` 的答案项。
 
 ### 3.3 SSE 事件序列（AG-UI）
 
@@ -323,7 +317,7 @@ sequenceDiagram
 | 完成条件 | 「完成」按钮需**所有题目均已作答**才可点击；选中 Others 时要求输入非空。 |
 | 跳过 / 取消 | 回传 `status="cancelled"`，`payload.answers=[]`；回显显示「已取消」。 |
 | 过期 `expiresAt` | 字段已在协议中预留（ISO8601）；当前前端未做强制拦截，后端可据此判断是否拒绝过期 resume。 |
-| 多题自由文本作答 | 路径 B 会把多题合并为单条 Others 答案，`answers` 数量与 `questions` 不一致，后端需兼容。 |
+| 自由文本作答 | 路径 B 回传 `status="cancelled"` + `answers=[]`，文本只在 `input` 中，后端据是否有 `input` 区分「自由文本作答」与「纯跳过」。 |
 | 答案与问题对应 | 结构化作答时 `answers` 与 `questions` 一一对应且顺序一致；未作答题以 `{ question, answer: [] }` 兜底。 |
 | 回显数据来源 | 回显只依赖 `result.payload.answers`，与下发的 `questions` 解耦，因此回显态的中断 `metadata.questions` 可为空。 |
 | `responseSchema` | AG-UI 协议层 `IInterrupt` 预留了 `responseSchema`（JSON Schema），用于约束回答结构；当前 Ask User Question 走固定 `answers` 结构，未强依赖该字段。 |
@@ -336,7 +330,7 @@ sequenceDiagram
 2. **`id` 必须稳定**：`interrupts[].id` 是 resume 回传的唯一关联键，需保证同一中断在下发与回显中保持一致。
 3. **不要下发 `others` 选项**：保留 `label="others"` 作为前端自定义输入项语义，后端下发会被过滤。
 4. **接收 resume 的接口是 `chat_completion/`**：Ask User Question 的回答**不走** `user_operation/`（那是审批取消 / 流程节点重试跳过用的）。
-5. **兼容自由文本作答**：`answers` 可能只有 1 条 Others 答案（与题数不符），需要在后端做合并/兜底解析。
+5. **兼容自由文本作答**：`status="cancelled"` + `answers=[]` 且带 `input` 时，代表用户放弃选项、用自由文本回答，回答内容在 `input` 字段中，需要后端据此兜底解析。
 6. **回显两种触发方式都要支持**：`RUN_FINISHED(success)` 与 `TOOL_CALL_RESULT(content=resume JSON 字符串)` 二选一即可，前端均能处理。
 7. **`status` 仅两个枚举值**：`resolved` / `cancelled`，请勿扩展其它值。
 

--- a/src/frontend/web/docs/api/ai-blueking/aiblueking.md
+++ b/src/frontend/web/docs/api/ai-blueking/aiblueking.md
@@ -167,7 +167,7 @@ function openAI() {
 | `new-chat-created` | `({ sessionCode, sessionName?, createdAt? })` | 新会话创建完成 |
 | `history-click` | `(event: Event)` | 历史记录点击 |
 | `auto-generate-name` | — | 自动生成名称 |
-| `rename` | `(newName: string)` | 重命名 |
+| `rename` | `(newName: string)` | 会话重命名（手动改名，或首条消息后 AI 自动重命名成功） |
 | `share` | — | 分享 |
 | `help-click` | — | 帮助点击 |
 

--- a/src/frontend/web/docs/api/ai-blueking/chatbot.md
+++ b/src/frontend/web/docs/api/ai-blueking/chatbot.md
@@ -129,6 +129,7 @@ const chatHelper = useChatHelper({ requestData: { urlPrefix: '/api/ai' } });
 | --- | --- | --- |
 | `session-switched` | `(session: ISession \| null)` | 会话切换完成 |
 | `agent-info-loaded` | `(chatHelper: IChatHelper)` | 独立模式初始化完成（与 `whenReady` 成功时机一致，仅独立模式） |
+| `rename` | `(newName: string)` | 首条消息后 AI 自动重命名成功；AIBlueking 集成时会转发为自身 `@rename` |
 
 ### 快捷方式事件
 


### PR DESCRIPTION
业务方可通过已有 @rename 同时感知手动改名与 AI 自动重命名。