### PR TITLE
fix: 修复了 ask_user_question 的问题

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -488,7 +488,7 @@ class LangGraphAgent:
                 yield ev
 
     async def _handle_on_chat_model_stream_event(self, event: Any) -> AsyncGenerator[BaseEvent, None]:
-        """协调器：解析 chunk → ctx + thinking/PredictState + 按 event 类型分发到子方法（D-02）。"""
+        """协调器：解析 chunk → ctx + thinking/PredictState + 按 event 类型分发到子方法。"""
         # 当 front_end_display 为 False 时，跳过OnChatModelStream事件
         if not self.front_end_display:
             return
@@ -546,7 +546,7 @@ class LangGraphAgent:
             and not is_tool_call_start_event
         )
 
-        # thinking 逻辑保留在协调器（D-02：不拆分）
+        # thinking 逻辑保留在协调器（不拆分）
         if reasoning_data:
             for each in self.handle_thinking_event(reasoning_data):
                 yield each
@@ -561,7 +561,7 @@ class LangGraphAgent:
             )
             self.active_run["thinking_process"] = None
 
-        # PredictState 逻辑保留在协调器（D-02：不拆分）
+        # PredictState 逻辑保留在协调器（不拆分）
         if tool_call_used_to_predict_state:
             yield CustomEvent(
                 type=EventType.CUSTOM,
@@ -602,7 +602,7 @@ class LangGraphAgent:
                 yield ev
 
     async def _handle_tool_call_end_stream_event(self, event: Any, ctx: dict) -> AsyncGenerator[BaseEvent, None]:
-        """tool_call_end 分支（D-02 拆分自 _handle_on_chat_model_stream_event）。"""
+        """tool_call_end 分支（ 拆分自 _handle_on_chat_model_stream_event）。"""
         current_stream = ctx["current_stream"]
         yield ToolCallEndEvent(
             type=EventType.TOOL_CALL_END,
@@ -612,7 +612,7 @@ class LangGraphAgent:
         self.messages_in_process[self.active_run["id"]] = None
 
     async def _handle_message_end_stream_event(self, event: Any, ctx: dict) -> AsyncGenerator[BaseEvent, None]:
-        """message_end 分支（D-02 拆分自 _handle_on_chat_model_stream_event）。"""
+        """message_end 分支（ 拆分自 _handle_on_chat_model_stream_event）。"""
         current_stream = ctx["current_stream"]
         yield TextMessageEndEvent(
             type=EventType.TEXT_MESSAGE_END,
@@ -622,7 +622,7 @@ class LangGraphAgent:
         self.messages_in_process[self.active_run["id"]] = None
 
     async def _handle_tool_call_start_stream_event(self, event: Any, ctx: dict) -> AsyncGenerator[BaseEvent, None]:
-        """tool_call_start 分支（D-02 拆分自 _handle_on_chat_model_stream_event）。"""
+        """tool_call_start 分支（ 拆分自 _handle_on_chat_model_stream_event）。"""
         current_stream = ctx["current_stream"]
         has_current_stream = ctx["has_current_stream"]
         is_parallel_tool_switch = ctx["is_parallel_tool_switch"]
@@ -666,7 +666,7 @@ class LangGraphAgent:
             )
 
     async def _handle_tool_call_args_stream_event(self, event: Any, ctx: dict) -> AsyncGenerator[BaseEvent, None]:
-        """tool_call_args 分支（D-02 拆分自 _handle_on_chat_model_stream_event）。"""
+        """tool_call_args 分支（ 拆分自 _handle_on_chat_model_stream_event）。"""
         current_stream = ctx["current_stream"]
         tool_call_data = ctx["tool_call_data"]
         yield ToolCallArgsEvent(
@@ -677,7 +677,7 @@ class LangGraphAgent:
         )
 
     async def _handle_message_content_stream_event(self, event: Any, ctx: dict) -> AsyncGenerator[BaseEvent, None]:
-        """message_content 分支（D-02 拆分自 _handle_on_chat_model_stream_event）。"""
+        """message_content 分支（ 拆分自 _handle_on_chat_model_stream_event）。"""
         current_stream = ctx["current_stream"]
         message_content = ctx["message_content"]
 

--- a/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
@@ -29,7 +29,6 @@ from .agent import LangGraphAGUIAgent
 from .approval import ApprovalOutcomeBuilder, ApproveResultLiteral
 from .ask_user_question import AskUserQuestionOutcomeBuilder
 from .event_builders import (
-    TOOL_CALLING_PLACEHOLDER,
     build_tool_result_event,
     enhance_tool_call,
     is_tool_approval_required,
@@ -47,6 +46,9 @@ from .types import (
     serialize_run_finished_outcome,
 )
 from .utils import langchain_messages_to_streaming_events
+
+ASK_USER_QUESTION_TOOL_NAME = "ask_user_question"
+
 
 logger = getLogger(__name__)
 
@@ -217,15 +219,6 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             except Exception:
                 logger.exception("[Resume] Failed to emit resume event")
 
-            # ask_user_question 续流：推送 MESSAGES_SNAPSHOT 让前端渲染 interrupt 卡片终态
-            if self._ask_user_question_interrupts:
-                try:
-                    snapshot = self._build_updated_messages_snapshot(input, resume_event)
-                    if snapshot is not None:
-                        yield event_encoder.encode(snapshot)
-                except Exception:
-                    logger.exception("[Resume] Failed to emit MESSAGES_SNAPSHOT for ask_user_question")
-
     def _build_resume_finished_event(self, input: RunAgentInput) -> RunFinishedEvent | None:
         """构造续流首条"终态形态"事件（支持 approval 和 ask_user_question）。
 
@@ -243,76 +236,6 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             return self._build_resume_ask_user_question_finished_event(input)
 
         return None
-
-    def _build_updated_messages_snapshot(
-        self, input: RunAgentInput, resume_event: RunFinishedEvent
-    ) -> MessageSnapshotEventExtend | None:
-        """构造续流后的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态形态。
-
-        前端 handleRunFinishedEvent 只标记 loading 完成，不更新消息列表中 interrupt 卡片的 content。
-        前端依赖 MESSAGES_SNAPSHOT 的覆盖式语义（list.value = messages.map(...)）来触发 Vue 响应式更新，
-        渲染 interrupt 卡片的 resolved 终态（outcome.type=success + result.payload.answers）。
-
-        从 input.messages 中找到 role=interrupt 的消息，替换其 content 为 RunFinishedEvent 的终态 content（outcome + result），其余消息不变。
-
-        仅 ask_user_question 路径调用；approval 路径的 DB 已在后台 worker 写好，
-        input.messages 中的 interrupt 记录已是 resolved 终态，无需额外处理。
-        """
-        messages = list(getattr(input, "messages", []) or [])
-        if not messages:
-            return None
-
-        # 从 RunFinishedEvent 提取终态 outcome / result
-        outcome = getattr(resume_event, "outcome", None)
-        result = getattr(resume_event, "result", None)
-        if outcome is None:
-            return None
-
-        # 序列化为 dict（与 MESSAGES_SNAPSHOT 的 API 格式一致）
-        if hasattr(outcome, "model_dump"):
-            outcome_dict = outcome.model_dump(mode="json", by_alias=True, exclude_none=True)
-        else:
-            outcome_dict = outcome if isinstance(outcome, dict) else {}
-        if hasattr(result, "model_dump"):
-            result_dict = result.model_dump(mode="json", by_alias=True, exclude_none=True)
-        else:
-            result_dict = result if isinstance(result, dict) else {}
-
-        # 构造与 DB 中 upgrade_content_to_success 输出一致的终态 content：
-        # {"outcome": {type, interrupts}, "result": {id, interruptId, status, payload, ...}}
-        # 注意：result 是单个 dict（不是 list），与 DB 落库格式一致。
-        terminal_content = {
-            "outcome": outcome_dict,
-            "result": result_dict,
-        }
-
-        # 替换 interrupt 消息的 content
-        updated_messages = []
-        found_interrupt = False
-        for msg in messages:
-            msg_dict = msg if isinstance(msg, dict) else (msg.model_dump() if hasattr(msg, "model_dump") else dict(msg))
-            if msg_dict.get("content") == TOOL_CALLING_PLACEHOLDER:
-                msg_dict["content"] = ""
-            if not found_interrupt and msg_dict.get("role") == "interrupt":
-                msg_dict = dict(msg_dict)
-                msg_dict["content"] = terminal_content
-                msg_dict["status"] = "complete"
-                # 补充 DB 中断消息的顶层字段（前端可能依赖这些字段渲染卡片）
-                interrupts = outcome_dict.get("interrupts", [])
-                if interrupts:
-                    first = interrupts[0]
-                    msg_dict["reason"] = first.get("reason", "")
-                    msg_dict["interrupt_id"] = first.get("id", "")
-                found_interrupt = True
-            updated_messages.append(msg_dict)
-
-        if not found_interrupt:
-            return None
-
-        return MessageSnapshotEventExtend(
-            type=EventType.MESSAGES_SNAPSHOT,
-            messages=updated_messages,
-        )
 
     def _resolve_resume_context(self, input: RunAgentInput) -> tuple[str, list]:
         """从 input.resume / forwarded_props 解析 (interruptId, answers)。
@@ -442,7 +365,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         run_id = agent_input.run_id or uuid.uuid4().hex
 
         # 1) 审批中断恢复：先回放终态 RUN_FINISHED，让前端把原中断卡片更新为最终状态
-        #    （approved / rejected / cancelled），与 AidevAGUIAgent.run 续流首条事件同源。
+        #   （approved / rejected / cancelled），与 AidevAGUIAgent.run 续流首条事件同源。
         try:
             if self._should_emit_resume_approval_finished():
                 yield encoder.encode(self._build_resume_approval_finished_event(agent_input))
@@ -455,7 +378,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         )
 
         # 3) 把 checkpoint 「片段」消息逐条转为流式增量事件下发，补齐前端缺失的本轮 worker 续流内容。
-        #    转换器内部会跳过 Human/System/Interrupt/Activity 消息，只下发 AI/Tool 的可重放事件。
+        #   转换器内部会跳过 Human/System/Interrupt/Activity 消息，只下发 AI/Tool 的可重放事件。
         if replayable_messages:
             try:
                 event_count = 0
@@ -484,7 +407,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         )
 
     async def _handle_single_event(self, event: Any, state: State) -> AsyncGenerator[BaseEvent, None]:
-        """覆写：super + 拦截 TOOL_CALL_* yield，审批抑制 + 工具增强在构造侧完成（D-01）。
+        """覆写：super + 拦截 TOOL_CALL_* yield，审批抑制 + 工具增强在构造侧完成。
 
         MRO: AidevAGUIAgent → LangGraphAGUIAgent（PredictState 注入）→ LangGraphAgent（4 子方法分发）。
         super()._handle_single_event 执行完整链路后，拦截 yield 的 TOOL_CALL_* 事件：
@@ -494,11 +417,20 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
 
         覆盖所有 TOOL_CALL 来源（_handle_*_stream_event 子方法 + _handle_on_chat_model_end_event + ManuallyEmitToolCall），
         不需覆写 3 个子方法。ManuallyEmitToolCall 的 tool_call_id 不在 _suppressed_tool_call_ids（手动发射不审批），透传。
+
+        ask_user_question 工具的 TOOL_CALL_START/ARGS/END 在续流场景下会被 ``_handle_on_tool_end_event``
+        重复补发（中断前的首次 run 已通过 OnChatModelStream 流式发到前端），此处直接按工具名抑制：
+        ask_user_question 工具只可能由 interrupt 路径触发，OnToolNodeFinish 路径会独立发出 TOOL_CALL_RESULT，
+        因此其 START/ARGS/END 三元组在续流场景下是冗余的。
         """
         async for ev in super()._handle_single_event(event, state):
             if isinstance(ev, ToolCallStartEvent):
                 if is_tool_approval_required(ev.tool_call_name, self._tool_mapping):
                     logger.info(f"[AidevAGUIAgent] 抑制需要审批的工具流式事件: {ev.tool_call_name} ({ev.tool_call_id})")
+                    self._suppressed_tool_call_ids.add(ev.tool_call_id)
+                    continue  # suppress
+                if ev.tool_call_name == ASK_USER_QUESTION_TOOL_NAME:
+                    logger.info(f"[AidevAGUIAgent] 抑制 ask_user_question 工具的 TOOL_CALL_START: {ev.tool_call_id}")
                     self._suppressed_tool_call_ids.add(ev.tool_call_id)
                     continue  # suppress
                 enhanced = enhance_tool_call(ev.tool_call_name, self._tool_mapping)
@@ -513,13 +445,13 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             yield ev
 
     async def _handle_on_custom_event(self, event: Any) -> AsyncGenerator[BaseEvent, None]:
-        """覆写：处理 OnToolNodeFinish/OnToolNodeImmediate/KnowledgeRag CUSTOM 转换（D-04）。
+        """覆写：处理 OnToolNodeFinish/OnToolNodeImmediate/KnowledgeRag CUSTOM 转换。
 
-        D-01 后子方法 yield Event（不 dispatch），_dispatch_event 由 _handle_stream_events 消费侧执行。
+         后子方法 yield Event（不 dispatch），_dispatch_event 由 _handle_stream_events 消费侧执行。
         原先在 _convert_event CUSTOM 分支中做的 CUSTOM→ToolCallResultEvent/透传转换，
         现在在构造侧（本覆写）完成，yield 转换后的 Event。
 
-        分支顺序与原 _convert_custom_event 保持一致：KNOWLEDGE_RAG_RESULT 优先（D-14 透传），
+        分支顺序与原 _convert_custom_event 保持一致：KNOWLEDGE_RAG_RESULT 优先（透传），
         OnToolNodeFinish/OnToolNodeImmediate 随后（→ ToolCallResultEvent），其余委托 super()。
         """
         name = event.get("name", "")

--- a/src/agent/aidev_agent/core/ag_ui/ask_user_question.py
+++ b/src/agent/aidev_agent/core/ag_ui/ask_user_question.py
@@ -18,6 +18,7 @@ import copy
 import json
 import uuid
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Any, Literal
 
 from pydantic import BaseModel
@@ -30,24 +31,36 @@ from aidev_agent.enums import PromptRole
 # ---------------------------------------------------------------------- #
 
 ASK_USER_QUESTION_REASON = "aidev:user_question"
-"""ask_user_question interrupt 的 reason 字符串（D-01, D-15）。
+"""ask_user_question interrupt 的 reason 字符串。
 
-与 ``TOOL_APPROVAL_REASON = "aidev:tool_approval"`` 对齐。必须显式设置，
-否则 ``_normalize_interrupt_value`` 会 fallback 到 ``"tool_call"``
-（研究报告 6.4 节风险点）。
+该字段是 AGUI 协议中断标识，用于区分 ask_user_question 与 ``tool_approval``，
+驱动路由分发与 DB 查询过滤。必须显式设置，否则 ``_normalize_interrupt_value``
+会 fallback 到 ``"tool_call"``（研究报告 6.4 节风险点）。
 """
 
-ASK_USER_QUESTION_STATE_KEY = "ask_user_question"
-"""ask_user_question 状态在 ``additional_kwargs`` 中的 key（D-10 旁路）。"""
 
-INTERRUPT_STATUS_PENDING = "pending"
-"""中断状态：待处理。"""
+class InterruptStatus(str, Enum):
+    """ask_user_question 中断三态。
 
-INTERRUPT_STATUS_RESOLVED = "resolved"
-"""中断状态：已解决。"""
+    与 ``approval.py`` 的 ``ApproveResult`` 三态设计对称（差异：ApproveResult
+    用普通类属性，InterruptStatus 用 Enum 以获得类型安全和成员枚举能力）。
+    继承 ``str`` 保证 ``InterruptStatus.PENDING == "pending"`` 为 ``True``，
+    Pydantic v2 序列化输出字符串值 ``"pending"``（非 ``"InterruptStatus.PENDING"``）。
+    """
 
-INTERRUPT_STATUS_CANCELLED = "cancelled"
-"""中断状态：已取消。"""
+    PENDING = "pending"
+    RESOLVED = "resolved"
+    CANCELLED = "cancelled"
+
+
+ASK_USER_QUESTION_SKIPPED_CONTENT = "用户未回答本次提问，已跳过；用户改为直接输入了新的消息。"
+"""用户跳过提问时的工具返回文案。
+
+用户忽略提问弹窗、直接输入新消息时（``resume`` 与 ``input`` 同时有值），
+本文案作为 ``ask_user_question`` 的工具返回值，让 LLM 明确知道问题未被回答
+且不应重复提问。与审批的 ``"工具审批未通过，已取消执行。`` 定位一致，
+差异：跳过不是错误（``status="success"``），审批拒绝是错误（``status="error"``）。
+"""
 
 
 # ---------------------------------------------------------------------- #
@@ -80,7 +93,7 @@ class AskUserQuestionMetadata(BaseModel):
     """
 
     type: Literal["ask_user_question"] = "ask_user_question"
-    status: Literal["pending", "resolved", "cancelled"] = INTERRUPT_STATUS_PENDING
+    status: InterruptStatus = InterruptStatus.PENDING
     questions: list[AskUserQuestionItem]
 
 
@@ -115,7 +128,7 @@ class AskUserQuestionOutcomeBuilder:
 
     @staticmethod
     def _build_result_from_first_interrupt(first_interrupt: dict) -> dict:
-        """将 ``interrupts[0]`` 扁平化为顶层 ``result`` 对象（D-06, D-07）。
+        """将 ``interrupts[0]`` 扁平化为顶层 ``result`` 对象。
 
         协议 success payload 的 ``payload.answers`` 从 interrupt metadata
         提取（DB-write 路径在用户回答后将 answers 写入 metadata，与
@@ -141,7 +154,7 @@ class AskUserQuestionOutcomeBuilder:
     def upgrade_content_to_success(
         cls,
         content: Any,
-        status: str = INTERRUPT_STATUS_RESOLVED,
+        status: str = InterruptStatus.RESOLVED.value,
         resume_answers: list | None = None,
     ) -> dict | None:
         """将 ask_user_question 中断 content 升级为"终态形态"。
@@ -220,7 +233,7 @@ class AskUserQuestionOutcomeBuilder:
         cls._apply_status_to_interrupt_metadata(safe_interrupts, status)
         outcome = {"type": "success", "interrupts": safe_interrupts}
         result = cls._build_result_from_first_interrupt(safe_interrupts[0]) if safe_interrupts else {}
-        # D-05: resume_answers 是用户刚提交答案的权威来源（首次中断入库时 metadata 无 answers，
+        # resume_answers 是用户刚提交答案的权威来源（首次中断入库时 metadata 无 answers，
         # answers 只走 resume payload），注入到 result["payload"]["answers"]，与 upgrade_content_to_success 对称。
         if resume_answers and isinstance(result, dict):
             result["payload"]["answers"] = list(resume_answers)
@@ -238,13 +251,18 @@ class AskUserQuestionHandler:
     作为独立类存在（不继承任何 ABC、不注册到 registry），供工具与测试
     直接实例化调用。
 
-    与审批 ``ApprovalOutcomeBuilder`` 的关键差异（D-06）：
+    对标 ``ApprovalStateHandler``（``aidev_agent/services/agent/approval.py``）
+    ——两者都是「中断/续流状态处理器」，方法一一对应（``extract_builtin_property``
+    对 ``_extract_builtin_property``、``hydrate_resume`` 对 ``hydrate_resume_payload``、
+    ``should_emit_resume_finished`` 对续流首帧回放判定）。关键协议差异：
 
     - ``hydrate_resume`` 仅补充 ``status``（来自 db_data），**不覆写 payload**
-      （答案由前端直接提交到 ``ResumeItem.payload``）。审批则会写
-      ``payload.approved``。
+      （答案由前端直接提交到 ``ResumeItem.payload``）。审批
+      ``ApprovalStateHandler.hydrate_resume_payload`` 则会写 ``payload.approved``。
+    - ``extract_builtin_property`` 不提取 ``callback_token`` / ``ticket_sn`` /
+      ``tool_name``（ask_user_question 无工单）。
     - ``build_payload`` 不创建 ITSM 工单，interrupt id 使用
-      ``uuid4().hex[:8]`` 而非 ``ticket_sn``（D-16）。
+      ``uuid4().hex[:8]`` 而非 ``ticket_sn``。
     """
 
     reason = ASK_USER_QUESTION_REASON
@@ -256,11 +274,11 @@ class AskUserQuestionHandler:
         tool_call_id: str,
         expires_at: str | None = None,
     ) -> dict[str, Any]:
-        """构造 ask_user_question interrupt payload（D-02, D-05, D-08, D-15, D-16）。
+        """构造 ask_user_question interrupt payload。
 
         顶层复用 AG-UI ``Interrupt`` 模型（``id`` / ``reason`` /
         ``toolCallId`` / ``message`` / ``metadata`` / ``expiresAt``），所有
-        ask_user_question 专属字段放入 ``metadata.questions``（D-08）。
+        ask_user_question 专属字段放入 ``metadata.questions``。
 
         Args:
             questions: 问题数组，每项为
@@ -273,14 +291,14 @@ class AskUserQuestionHandler:
         Returns:
             interrupt payload dict，顶层结构遵循 AG-UI ``Interrupt`` 模型。
         """
-        # D-16: id 格式 int-question-{tool_call_id}-{uuid_hex}
+        # id 格式 int-question-{tool_call_id}-{uuid_hex}
         interrupt_id = f"int-question-{tool_call_id}-{uuid.uuid4().hex[:8]}"
         metadata: dict[str, Any] = {
             "type": "ask_user_question",
-            "status": INTERRUPT_STATUS_PENDING,
+            "status": InterruptStatus.PENDING.value,
             "questions": questions,
         }
-        # D-05: expiresAt 顶层字段，未传入时自动生成 24h 后过期
+        # expiresAt 顶层字段，未传入时自动生成 24h 后过期
         if expires_at is None:
             expires_at = (datetime.now(timezone.utc) + timedelta(hours=24)).isoformat()
         return {
@@ -293,7 +311,7 @@ class AskUserQuestionHandler:
         }
 
     def hydrate_resume(self, resume_items: Any, db_data: Any) -> None:
-        """仅补充 status，不覆写 payload（D-06）。
+        """仅补充 status，不覆写 payload。
 
         与审批的差异：审批会写 ``payload.approved``，ask_user_question
         **不动 payload**（答案由前端直接提交到 ``ResumeItem.payload``）。
@@ -325,7 +343,7 @@ class AskUserQuestionHandler:
                     continue
 
     def should_emit_resume_finished(self, interrupt_result: Any, interrupt_interrupts: Any) -> bool:
-        """判断续流时是否需要 emit 首帧 ``RUN_FINISHED`` 回放（D-07）。
+        """判断续流时是否需要 emit 首帧 ``RUN_FINISHED`` 回放。
 
         ask_user_question 也需要首帧回放（与 approval 对称），触发条件（&，
         全部满足）：
@@ -346,7 +364,7 @@ class AskUserQuestionHandler:
         """从 ask_user_question interrupt 提取落库用的 ``builtin_property`` 字段。
 
         提取 ask_user_question 专属字段：``questions`` / ``options`` /
-        ``answers`` / ``multiSelect`` 等（D-02 字段名对齐协议）。与审批的差异：
+        ``answers`` / ``multiSelect`` 等（ 字段名对齐协议）。与审批的差异：
         不提取 ``callback_token`` / ``ticket_sn`` / ``tool_name``
         （ask_user_question 无工单）。
 
@@ -369,6 +387,79 @@ class AskUserQuestionHandler:
             "graph_thread_id": graph_thread_id or get_interrupt_value(interrupt, "threadId", "thread_id"),
         }
 
+    @staticmethod
+    def is_ask_user_resume(resume: Any) -> bool:
+        """判断 resume 是否为 ask_user_question 类型。
+
+        ask_user_question 的 resume payload 含 ``answers`` 字段；
+        approval 的 payload 是 ``{approved: bool}``，不含 answers。
+        兼容 list / dict 两种 resume 形态（_stream 归一化前可能为 dict）。
+        """
+        item = resume[0] if isinstance(resume, list) and resume else resume
+        if not isinstance(item, dict):
+            return False
+        payload = item.get("payload")
+        return isinstance(payload, dict) and "answers" in payload
+
+    @staticmethod
+    def validate_resume_consistency(resume: Any, interrupt: Any) -> None:
+        """校验 resume 与 chat_history 末尾 interrupt 的一致性。
+
+        ask_user_question resume 必须对应一条 pending 的末尾 INTERRUPT 记录，
+        且 id 一致、tool_call_id 必存在（无 tool_call_id 说明脏数据写入）：
+
+        - ``interrupt`` 不为 None 且 ``role == PromptRole.INTERRUPT.value``
+          （必须是 chat_history 的最后一条，避免已回答的 interrupt 被二次回答）
+        - ``interrupt.content`` 解析后 ``outcome.interrupts`` 仅一个元素
+        - 元素 ``id`` == resume 的 ``interruptId``
+        - 元素 ``metadata.status`` == pending
+        - ``interrupt.builtin_property.tool_call_id`` 必须存在且非空
+
+        不满足时抛 ``AgentException``，错误信息说明哪项校验失败。
+
+        Args:
+            resume: ExecuteKwargs.resume（list/dict 形态均可）。
+            interrupt: chat_history[-1]（已确保是末尾记录）。
+        """
+        from aidev_agent.exceptions import AgentException
+
+        item = resume[0] if isinstance(resume, list) and resume else resume
+        resume_id = item.get("interruptId") if isinstance(item, dict) else None
+
+        if interrupt is None:
+            raise AgentException(message="ask_user resume 缺少对应的 interrupt 记录")
+        role = getattr(interrupt, "role", None)
+        if role != PromptRole.INTERRUPT.value:
+            raise AgentException(message=f"ask_user resume 期望末尾为 INTERRUPT 记录，实际 role={role}")
+
+        content = getattr(interrupt, "content", None)
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except (TypeError, ValueError) as exc:
+                raise AgentException(message=f"ask_user resume 解析 interrupt content 失败: {exc}") from exc
+        if not isinstance(content, dict):
+            raise AgentException(message="ask_user resume 的 interrupt content 非合法 dict")
+
+        outcome = content.get("outcome") or {}
+        interrupts = outcome.get("interrupts") or []
+        if not isinstance(interrupts, list) or len(interrupts) != 1:
+            raise AgentException(
+                message=f"ask_user resume 期望 outcome.interrupts 仅一个元素，实际 {len(interrupts) if isinstance(interrupts, list) else '非 list'}"
+            )
+        first = interrupts[0] if isinstance(interrupts[0], dict) else {}
+        if first.get("id") != resume_id:
+            raise AgentException(
+                message=f"ask_user resume interruptId={resume_id} 与 chat_history interrupt id={first.get('id')} 不一致"
+            )
+        status = (first.get("metadata") or {}).get("status")
+        if status != InterruptStatus.PENDING.value:
+            raise AgentException(message=f"ask_user resume 期望 interrupt status=pending，实际 status={status}")
+
+        builtin = getattr(interrupt, "builtin_property", None) or {}
+        if not builtin.get("tool_call_id"):
+            raise AgentException(message="ask_user resume 的 interrupt 缺少 tool_call_id，存在脏数据")
+
     @property
     def outcome_builder(self) -> type:
         """返回 ``AskUserQuestionOutcomeBuilder``，用于构造续流首帧
@@ -381,38 +472,34 @@ class AskUserQuestionHandler:
 # ---------------------------------------------------------------------- #
 
 
-def find_pending_interrupt(contents: list[dict], interrupt_id: str) -> tuple[Any, dict, dict] | None:
-    """遍历 DB contents 找匹配的 pending ask_user_question interrupt 记录。
+def extract_message_id(upgraded: dict) -> str:
+    """从升级后的 content 提取 message_id（三元 fallback）。
 
-    逆序遍历（最新记录优先），双重过滤 ``role == PromptRole.INTERRUPT.value``
-    + ``status == "pending"``，解析 content JSON，匹配 ``interrupts[0].id``
-    且 ``reason == ASK_USER_QUESTION_REASON``。
-
-    Returns:
-        ``(content_id, raw_db_content, db_item)`` 元组，或 None（未找到）。
+    优先取 ``result.interruptId``，次取 ``outcome.interrupts[0].id``，兜底空串。
+    消除 bkplugin cancel/resolve 两处重复的三元表达式。
     """
-    for item in reversed(contents):
-        if not isinstance(item, dict):
-            continue
-        if item.get("role") != PromptRole.INTERRUPT.value:
-            continue
-        if item.get("status") != INTERRUPT_STATUS_PENDING:
-            continue
-        raw_content = item.get("content")
-        try:
-            parsed = json.loads(raw_content) if isinstance(raw_content, str) else raw_content
-        except (TypeError, ValueError):
-            continue
-        if not isinstance(parsed, dict):
-            continue
-        parsed_outcome = parsed.get("outcome") or {}
-        parsed_interrupts = parsed_outcome.get("interrupts") or []
-        if not parsed_interrupts:
-            continue
-        parsed_first = parsed_interrupts[0] if isinstance(parsed_interrupts[0], dict) else {}
-        if parsed_first.get("id") == interrupt_id and parsed_first.get("reason") == ASK_USER_QUESTION_REASON:
-            return item.get("id"), parsed, item
-    return None
+    return (
+        ((upgraded.get("result") or {}).get("interruptId"))
+        or ((upgraded.get("outcome") or {}).get("interrupts") or [{}])[0].get("id")
+        or ""
+    )
+
+
+def build_skipped_answers(questions: list) -> list[dict]:
+    """为每个 question 构造 skipped answer（标记 label="skipped"）。
+
+    消除 bkplugin cancel 内联的 list comprehension。过滤非 dict 元素，
+    缺失字段使用默认值（``question`` 默认 ``""``、``multiSelect`` 默认 ``False``）。
+    """
+    return [
+        {
+            "question": q.get("question", ""),
+            "multiSelect": q.get("multiSelect", False),
+            "answer": [{"label": "skipped", "description": ASK_USER_QUESTION_SKIPPED_CONTENT}],
+        }
+        for q in questions
+        if isinstance(q, dict)
+    ]
 
 
 def build_updated_builtin_property(db_item: dict, interrupt_id: str, status: str) -> dict:
@@ -503,16 +590,15 @@ def parse_resume_answers(resume_value: Any) -> Any:
 
 __all__ = [
     "ASK_USER_QUESTION_REASON",
-    "ASK_USER_QUESTION_STATE_KEY",
-    "INTERRUPT_STATUS_CANCELLED",
-    "INTERRUPT_STATUS_PENDING",
-    "INTERRUPT_STATUS_RESOLVED",
+    "ASK_USER_QUESTION_SKIPPED_CONTENT",
+    "InterruptStatus",
     "AskUserQuestionHandler",
     "AskUserQuestionItem",
     "AskUserQuestionOutcomeBuilder",
     "AskUserQuestionMetadata",
     "AskUserQuestionOption",
-    "find_pending_interrupt",
+    "extract_message_id",
+    "build_skipped_answers",
     "build_updated_builtin_property",
     "filter_ask_user_question_interrupts",
     "parse_resume_answers",

--- a/src/agent/aidev_agent/core/ag_ui/event_builders.py
+++ b/src/agent/aidev_agent/core/ag_ui/event_builders.py
@@ -59,7 +59,7 @@ def build_tool_result_event(tool_msg: Any, is_immediate: bool = False) -> Extend
 
     Returns:
         ExtendToolCallResultEvent 事件对象，携带 additional_metadata（完整 additional_kwargs dict 副本）
-        与 skip_db（is_immediate=True 时为 True，供 DB 侧跳过写入，per D-06/D-07）
+        与 skip_db（is_immediate=True 时为 True，供 DB 侧跳过写入，per /）
     """
     content = tool_msg.content
     if not isinstance(content, str):
@@ -183,7 +183,7 @@ def build_model_end_payload(output_message: Any, tools_mapping: dict[str, Any]) 
     """构造 ChatModelEnd CustomEvent.value 的扁平 dict payload。
 
     整合 build_tool_calls_with_approval_filter + resolve_content 的全部逻辑，SSE 侧调用此函数
-    构造 CustomEvent.value，DB 侧直接读 payload 不再二次推导（D-03/D-04）。
+    构造 CustomEvent.value，DB 侧直接读 payload 不再二次推导。
 
     Args:
         output_message: AIMessage（模型输出，OnChatModelEnd 事件的 data.output）

--- a/src/agent/aidev_agent/core/ag_ui/types.py
+++ b/src/agent/aidev_agent/core/ag_ui/types.py
@@ -51,6 +51,8 @@ class SessionPersistenceEventNames(str, Enum):
 
     ChatModelEnd = "aidev_session_chat_model_end"
     ArtifactsGenerated = "artifacts_generated"
+    AskUserQuestionFinalized = "ask_user_question_finalized"
+    UserInputSaved = "user_input_saved"
 
 
 class ArtifactPayload(TypedDict):

--- a/src/agent/aidev_agent/core/graphs/react/graph.py
+++ b/src/agent/aidev_agent/core/graphs/react/graph.py
@@ -60,6 +60,7 @@ from aidev_agent.core.nodes.tool import ToolNodeSettings, build_tool_node
 from aidev_agent.core.tools.a2a_tools.bkai_backend import BkaiBackend
 from aidev_agent.core.tools.a2a_tools.local_backend import LocalBackend
 from aidev_agent.core.tools.a2a_tools.provider import AgentBackendResolver, get_agent_tools
+from aidev_agent.core.tools.ask_user_question import ask_user_question as _ask_user_question_tool
 from aidev_agent.core.tools.knowledge import make_knowledge_retrieval_tool
 from aidev_agent.core.tools.runtime_tools import get_client_tools_with_runtime
 from aidev_agent.core.tools.runtime_tools.e2b_backend import E2BSandboxBackend
@@ -120,7 +121,7 @@ class DefaultState(TypedDict):
     knowledge_qa_content: list
     with_qa_response: list
     runtime_paas_sbx_pv: Annotated[list[dict], add_pv_info]
-    # ask_user_question 中断策略写入的用户答案（D-07），无 reducer 直接覆盖。
+    # ask_user_question 中断策略写入的用户答案，无 reducer 直接覆盖。
     # UserQuestionStrategy.interrupt 续流时写入 {tool_call_id: resolved_answer}，
     # ask_user_question 工具函数通过 InjectedState 读取。
     ask_user_question_answers: dict[str, Any]
@@ -404,11 +405,11 @@ class ReActAgentBuilder:
         return self
 
     def set_enable_ask_user_question_tool(self, enable: bool = True) -> "ReActAgentBuilder":
-        """启用/禁用 ask_user_question 工具（D-02, D-03）。
+        """启用/禁用 ask_user_question 工具。
 
         默认开启。业务侧可通过 ``builder.set_enable_ask_user_question_tool(False)``
         关闭。工具注册到 tool_node，LLM 调用时内部通过 ``interrupt()`` 暂停图执行，
-        等待用户回答（D-01）。
+        等待用户回答。
         """
         self._enable_ask_user_question_tool = bool(enable)
         return self
@@ -517,7 +518,6 @@ class ReActAgentBuilder:
             self._llm = options.llm
         if options.non_thinking_llm is not None:
             self._non_thinking_llm = options.non_thinking_llm
-            self._knowledge_llm = options.non_thinking_llm
         if options.fast_llm is not None:
             self._fast_llm = options.fast_llm
         if options.knowledge_llm is not None:
@@ -625,13 +625,33 @@ class ReActAgentBuilder:
                 knowledge_settings.enable_query_clarification = self._enable_query_clarification
         self._knowledge_query_options = knowledge_settings
 
+        # 若配置了知识库/知识项，则需要 knowledge_llm
+        # build() 入口已对 self._knowledge_llm 做回退（knowledge_llm or non_thinking_llm or llm），
+        # 此处校验回退后的值是否仍为空（即三者都未配置）
+        has_knowledge = bool(self._knowledge_query_options and self._knowledge_query_options.knowledge_bases) or bool(
+            self._knowledge_query_options and self._knowledge_query_options.knowledge_items
+        )
+        if has_knowledge and self._knowledge_llm is None:
+            raise ValueError("ReActAgentBuilder 构建失败：检测到知识库配置，但 knowledge_llm 为空")
+
+        # runtime_tool 合法性校验
+        if self._enable_runtime_tool and self._runtime_backend_resolver is None:
+            raise ValueError(
+                "ReActAgentBuilder 构建失败：启用了 runtime_tool 但未提供 runtime_backend_resolver，"
+                "请通过 AgentExecutorKwargs.runtime_backend_resolver 传入"
+            )
+
     def _prepare_agent_knowledge_node(
         self, *, knowledge_llm, knowledge_query_options: KnowledgeSettings | None, chat_history
     ):
         if knowledge_query_options is None:
             return None
+        # 判断使用哪种 RAG 模式：未启用 enable_knowledge_node 时不构造独立节点
+        if not knowledge_query_options.enable_knowledge_node:
+            return None
         has_knowledge = knowledge_query_options.knowledge_bases or knowledge_query_options.knowledge_items
         if has_knowledge:
+            logger.info("[ReActAgentBuilder] 两步RAG 模式已启用，使用独立的knowledge节点")
             return make_knowledge_node(
                 llm=knowledge_llm,
                 knowledge_query_options=knowledge_query_options,
@@ -724,6 +744,10 @@ class ReActAgentBuilder:
         middleware_tools = [t for m in langchain_middleware for t in getattr(m, "tools", [])]
         tools.extend(middleware_tools)
 
+        # ask_user_question 工具注入
+        if self._enable_ask_user_question_tool:
+            tools.append(_ask_user_question_tool)
+
         # 加载 SKILL 工具
         if self._enable_skills and self._skill_registry is not None:
             tools.append(self._skill_registry.get_activate_skill_tool())
@@ -772,7 +796,6 @@ class ReActAgentBuilder:
         - 将 activate_skill 工具与 prompt middleware 所需的 registry 写入 self._skill_registry
         - 为每个 skill 根据其 runtime 创建并注册独立 backend 到 self._runtime_backend_resolver
         """
-
         registry = SkillRegistry(self._skill_sources or [])
         self._skill_registry = registry
         resolver = self._runtime_backend_resolver
@@ -818,6 +841,42 @@ class ReActAgentBuilder:
         for backend_type_name, backend_cls in self._a2a_backend_types.items():
             resolver.register(backend_type_name, backend_cls)
         self._a2a_resolver = resolver
+
+    def _prepare_agent_pv_node(self):
+        """构造 PV Node，用于惰性创建/获取持久卷。
+
+        仅在启用 paas_sandbox runtime 时注入真实的 BkPaaSSandboxApi client；
+        否则仍返回 pv_node callable（无 PV 支持），保持图结构一致。
+
+        Returns:
+            pv_node callable
+        """
+        paas_client = None
+        paas_app_code = ""
+        if self._enable_runtime_tool and "paas_sandbox" in self._runtime_types:
+            executor_info = self._executor_info or {}
+            paas_app_code = executor_info.get("app_code", "")
+            if paas_app_code and self._resource_manager is not None:
+                paas_client = self._resource_manager.get_paas_sbx_client(executor_info)
+        return make_pv_node(
+            client=paas_client,
+            app_code=paas_app_code,
+            resource_manager=self._resource_manager,
+        )
+
+    def _prepare_agent_interrupt_node(self, *, tools: List[BaseTool]):
+        """构造中断检查节点 (approval_check)。
+
+        默认实现组合 ItsmApprovalStrategy + UserQuestionStrategy；
+        子类可重写以定制审批/中断策略，无需重写 _build_graph。
+
+        Args:
+            tools: 当前图绑定的工具列表，用于 ItsmApprovalStrategy 匹配 tool_call。
+
+        Returns:
+            由 make_interrupt_node 构造的可调用节点。
+        """
+        return make_interrupt_node([ItsmApprovalStrategy(tools), UserQuestionStrategy()])
 
     def _prepare_agent_tool_node(
         self,
@@ -898,28 +957,6 @@ class ReActAgentBuilder:
             return schemas[0]
         return _resolve_task_state_schema(schemas)
 
-    def _prepare_agent_pv_node(self):
-        """构造 PV Node，用于惰性创建/获取持久卷。
-
-        仅在启用 paas_sandbox runtime 时注入真实的 BkPaaSSandboxApi client；
-        否则仍返回 pv_node callable（无 PV 支持），保持图结构一致。
-
-        Returns:
-            pv_node callable
-        """
-        paas_client = None
-        paas_app_code = ""
-        if self._enable_runtime_tool and "paas_sandbox" in self._runtime_types:
-            executor_info = self._executor_info or {}
-            paas_app_code = executor_info.get("app_code", "")
-            if paas_app_code and self._resource_manager is not None:
-                paas_client = self._resource_manager.get_paas_sbx_client(executor_info)
-        return make_pv_node(
-            client=paas_client,
-            app_code=paas_app_code,
-            resource_manager=self._resource_manager,
-        )
-
     @staticmethod
     def _should_continue(state: dict) -> Literal["approval_check", "end"]:
         """条件路由函数：决定 model 节点后的下一步。
@@ -948,7 +985,6 @@ class ReActAgentBuilder:
     def _build_graph(
         self,
         *,
-        knowledge_settings: KnowledgeSettings,
         state_schema,
         callbacks: List,
         debug: bool,
@@ -962,6 +998,7 @@ class ReActAgentBuilder:
         model_node,
         tool_node,
         pv_node=None,
+        interrupt_node=None,
         tools: "List[BaseTool] | None" = None,
     ) -> Tuple["Runnable", RunnableConfig]:
         """构建 LangGraph 图。
@@ -972,7 +1009,6 @@ class ReActAgentBuilder:
         - 如果有工具: model → (条件) → pv_node / END, pv_node → tools → model
 
         Args:
-            knowledge_settings: 知识库检索配置
             state_schema: 状态模式
             callbacks: 回调列表
             debug: 是否开启调试模式
@@ -986,6 +1022,7 @@ class ReActAgentBuilder:
             model_node: 模型节点
             tool_node: 工具节点
             pv_node: PV 节点 callable，由 _prepare_agent_pv_node 构造
+            interrupt_node: 中断检查节点 callable，由 _prepare_agent_interrupt_node 构造
 
         Returns:
             (CompiledGraph, RunnableConfig) 元组
@@ -1012,8 +1049,7 @@ class ReActAgentBuilder:
         if tool_node:
             graph.add_node("pv_node", pv_node)
             graph.add_node("tools", tool_node)
-            approval_check_func = make_interrupt_node([ItsmApprovalStrategy(tools), UserQuestionStrategy()])
-            graph.add_node("approval_check", approval_check_func)
+            graph.add_node("approval_check", interrupt_node)
             # model → (should_continue) → approval_check / end
             graph.add_conditional_edges(
                 "model",
@@ -1058,52 +1094,21 @@ class ReActAgentBuilder:
             raise ValueError("ReActAgentBuilder 构建失败：缺少 llm，请先调用 set_llm(...) 或 set_bkai_options(...)")
         callbacks = list(self._callbacks or [])
         non_thinking_llm = self._non_thinking_llm or self._llm
-        # 判断 LLM：仅使用显式配置的 fast_llm；未配置时为 None（fail-open）。
-        # 不回退到 non_thinking_llm/llm——判断模型是独立的轻量模型，
-        # 回退到主模型会导致每次正常响应多一次主模型调用。
-        judge_llm = self._fast_llm
+        # judge_llm 回退到 non_thinking_llm / 主 llm，未配置 non_thinking_llm 时使用主 llm
+        judge_llm = self._fast_llm or self._non_thinking_llm or self._llm
+        # knowledge_llm 回退链：显式配置 -> non_thinking_llm -> llm
+        # 模型配置集中在 build 入口，便于排查问题
+        self._knowledge_llm = self._knowledge_llm or self._non_thinking_llm or self._llm
 
         self._prepare_agent_options()
 
-        # 若配置了知识库/知识项，则需要 knowledge_llm
-        has_knowledge = bool(self._knowledge_query_options and self._knowledge_query_options.knowledge_bases) or bool(
-            self._knowledge_query_options and self._knowledge_query_options.knowledge_items
-        )
-        if has_knowledge and self._knowledge_llm is None:
-            raise ValueError("ReActAgentBuilder 构建失败：检测到知识库配置，但 knowledge_llm 为空")
-
         # Skills / runtime tools setup (must run before preparing tools)
-        self._skill_registry = None
-
-        if self._enable_runtime_tool and self._runtime_backend_resolver is None:
-            raise ValueError(
-                "ReActAgentBuilder 构建失败：启用了 runtime_tool 但未提供 runtime_backend_resolver，"
-                "请通过 AgentExecutorKwargs.runtime_backend_resolver 传入"
-            )
-
         if self._enable_skills:
             self._prepare_skills()
 
         # A2A 后端注册（必须在工具注入之前执行）
         if self._enable_a2a_tool:
             self._prepare_a2a()
-
-        # 判断使用哪种RAG模式
-        knowledge_query_options = self._knowledge_query_options
-        enable_knowledge_node = (
-            knowledge_query_options.enable_knowledge_node if knowledge_query_options is not None else False
-        )
-
-        # ask_user_question 工具注入（D-01/D-02）。局部 import 避免模块加载时
-        # 的循环 import（graph.py 在模块依赖图中较早被导入）。
-        if self._enable_ask_user_question_tool:
-            from aidev_agent.core.tools.ask_user_question import (
-                ask_user_question as _ask_user_question_tool,
-            )
-
-            if self._extra_tools is None:
-                self._extra_tools = []
-            self._extra_tools.append(_ask_user_question_tool)
 
         # 统一处理 tools
         tool_ignore_errors = self._compute_use_structured_response()
@@ -1113,16 +1118,12 @@ class ReActAgentBuilder:
             langchain_middleware=self._langchain_middleware,
         )
 
-        # 两步RAG模式：创建独立的knowledge_node
-        if enable_knowledge_node:
-            knowledge_node = self._prepare_agent_knowledge_node(
-                knowledge_llm=self._knowledge_llm,
-                knowledge_query_options=self._knowledge_query_options,
-                chat_history=self._chat_history,
-            )
-            logger.info("[ReActAgentBuilder] 两步RAG 模式已启用，使用独立的knowledge节点")
-        else:
-            knowledge_node = None
+        # 两步RAG模式：根据 enable_knowledge_node 决定是否创建独立的 knowledge_node
+        knowledge_node = self._prepare_agent_knowledge_node(
+            knowledge_llm=self._knowledge_llm,
+            knowledge_query_options=self._knowledge_query_options,
+            chat_history=self._chat_history,
+        )
 
         # 统一处理 model_node
         model_node = self._prepare_agent_model_node(
@@ -1131,6 +1132,12 @@ class ReActAgentBuilder:
             judge_llm=judge_llm,
             tools=tools,
         )
+
+        # 中断检查节点 (approval_check)
+        interrupt_node = self._prepare_agent_interrupt_node(tools=tools)
+
+        # 构造 PV Node
+        pv_node = self._prepare_agent_pv_node()
 
         # 统一处理 tool_node
         tool_node = self._prepare_agent_tool_node(
@@ -1141,9 +1148,6 @@ class ReActAgentBuilder:
 
         # 初始化 Store
         store = self._prepare_store(store=self._store, file_store=self._file_store)
-
-        # 构造 PV Node
-        pv_node = self._prepare_agent_pv_node()
 
         # 定义 _TaskState（如需）——仅在 task/team/a2a 分支中使用
         if self._enable_task or self._a2a_specs or self._enable_team:
@@ -1156,7 +1160,6 @@ class ReActAgentBuilder:
 
         # 构建图
         compile_graph, cfg = self._build_graph(
-            knowledge_settings=self._knowledge_query_options,
             state_schema=state_schema,
             callbacks=callbacks,
             debug=self._debug,
@@ -1170,6 +1173,7 @@ class ReActAgentBuilder:
             model_node=model_node,
             tool_node=tool_node,
             pv_node=pv_node,
+            interrupt_node=interrupt_node,
             tools=tools if tools else None,
         )
 

--- a/src/agent/aidev_agent/core/nodes/interrupt/user_question.py
+++ b/src/agent/aidev_agent/core/nodes/interrupt/user_question.py
@@ -23,11 +23,11 @@ ASK_USER_QUESTION_TOOL_NAME = "ask_user_question"
 class UserQuestionStrategy:
     """ask_user_question 中断策略 —— 封装「向用户提问」的中断全流程。
 
-    中断从 tools 节点 wrapper 移到 ``approval_check`` 节点统一处理（D-02）。
+    中断从 tools 节点 wrapper 移到 ``approval_check`` 节点统一处理。
     续流后写 state 返回 ``Command(goto="pv_node")``，让 ToolNode 执行
-    ask_user_question 工具函数产生工具返回值（D-06 + D-08）。
+    ask_user_question 工具函数产生工具返回值（ + ）。
 
-    策略实例无 ``__init__``，所有中间变量为 ``interrupt`` 方法内局部变量（D-09）。
+    策略实例无 ``__init__``，所有中间变量为 ``interrupt`` 方法内局部变量。
     """
 
     reason = ASK_USER_QUESTION_REASON  # "aidev:user_question"
@@ -35,7 +35,7 @@ class UserQuestionStrategy:
     def interrupt(self, state: dict, config: RunnableConfig) -> Command | None:
         """ask_user_question 中断策略主入口。
 
-        ``make_interrupt_node`` 已做 D-04 前置检查（messages 非空且末尾
+        ``make_interrupt_node`` 已做  前置检查（messages 非空且末尾
         为含 tool_calls 的 AIMessage）。
 
         Returns:
@@ -87,10 +87,10 @@ class UserQuestionStrategy:
             str(resolved_answer)[:200] if resolved_answer else "None",
         )
 
-        # D-07：写入 state 供 ask_user_question 工具函数读取（不再直接返回工具消息，D-06）
+        # 写入 state 供 ask_user_question 工具函数读取（不再直接返回工具消息，）
         return Command(
             update={"ask_user_question_answers": {tool_call_id: resolved_answer}},
-            goto="pv_node",  # D-06：走 pv_node → tools 让 ToolNode 执行工具函数入库
+            goto="pv_node",  # 走 pv_node → tools 让 ToolNode 执行工具函数入库
         )
 
 

--- a/src/agent/aidev_agent/core/nodes/model/quality_gate.py
+++ b/src/agent/aidev_agent/core/nodes/model/quality_gate.py
@@ -22,7 +22,7 @@ import enum
 import logging
 
 from langchain_core.language_models.chat_models import BaseChatModel
-from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain_core.messages import AIMessage, AnyMessage, BaseMessage, HumanMessage
 
 from aidev_agent.packages.langgraph.streaming.utils import conditional_dispatch_custom_event
 
@@ -107,27 +107,55 @@ class QualityGate:
     """
 
     # 判断系统提示词——类属性，子类可重写
-    judgment_sys_prompt: str = """你是一个任务完成度判断器。我会给你以下信息：
+    judgment_sys_prompt: str = """
+## 角色
+你是一个任务完成度判断器。你需要判断智能助手在本轮交互中，是否已经完成用户最后一条输入所提出的任务。
+你会获得以下信息：
 1. 用户的最后一条输入
-2. 智能助手回答过程中调用的工具及其参数（如有）
+2. 智能助手回答过程中调用的工具及其参数
 3. 智能助手的最后一条输出
-
-你需要判断智能助手的输出是否实际完成了用户输入中要求的任务，以便于放行用户继续提问
-完成任务的情况如下：
-1. 输出详细的报告，回答了用户的问题，或者完成了用户的任务
-2. 要求用户补充相关信息，澄清问题等回复
-3. 明确指出不能完成用户任务，例如：根据已有知识不能回答问题
-4. 其他你认为完成任务了的情况
-
-判断规则：
-- 如果助手的输出明确回答了用户的问题或完成了用户要求的任务，判断为"已完成"
-- 如果助手的输出明显未完成用户任务（如答非所问、拒绝回答、输出不完整、仅重复用户输入等），判断为"未完成"
-- 如果无法确定助手是否完成了任务，判断为"不确定"
+## 任务要求
+以下情况判断为“已完成”：
+1. 智能助手已经明确回答用户的问题
+2. 智能助手已经执行用户要求的动作，并且最终回复了用户的要求
+3. 智能助手要求用户补充完成任务所必需的信息，或提出合理的澄清问题
+4. 智能助手明确说明由于能力、权限或信息限制而无法完成
+5. 核心任务已经完成，但助手又附加了说明、建议、追问或其他内容
+以下情况判断为“未完成”：
+1. 智能助手没有回答或执行用户要求的核心任务
+2. 输出答非所问，且工具调用也没有完成任务
+3. 仅复述用户输入，没有产生实际回答或动作
+4. 声称将要执行任务，但实际上没有回答，也没有调用工具执行
+5. 输出明显中断，核心结果缺失
+以下情况判断为“不确定”：
+1. 无法从工具参数或输出中判断工具是否实际实现了用户要求
+2. 用户需求本身存在关键歧义，无法判断当前行为是否满足要求
+3. 提供的信息不足以确定任务是否完成
+特别规则:
+1. 判断“是否完成”时，应关注用户原始要求中的最小核心目标
+2. 不要把助手自行扩展出来的后续任务，当成用户原始任务的一部分
+3. 不要要求用户必须回答助手提出的问题，才认为“提出问题”这一任务完成
+4. 如果工具调用与最后文本输出冲突，应优先判断用户要求的核心动作是否已在工具调用中完成
+5. 输出质量一般、存在冗余或包含无关内容，不等于任务未完成；只有核心任务没有实现时，才判断为“未完成”
 
 请只返回以下三个词中的一个，不要返回任何其他内容：
 - 已完成
 - 未完成
-- 不确定"""
+- 不确定
+
+## 输入
+用户最后一条输入： 
+```
+{last_user_input}
+```
+
+{tool_calls_text}
+
+智能助手最后一条输出：
+```
+{last_model_output}
+```
+"""
 
     def __init__(
         self,
@@ -220,16 +248,9 @@ class QualityGate:
                 tool_lines.append(f"- {tc['name']}({tc['args']})")
             tool_calls_text = "调用的工具及参数：\n" + "\n".join(tool_lines) + "\n\n"
 
-        usr_prompt = (
-            f"用户最后一条输入：\n```\n{last_user_input}\n```\n\n"
-            f"{tool_calls_text}"
-            f"智能助手最后一条输出：\n```\n{last_model_output}\n```\n\n"
-            f"请判断智能助手是否完成了用户的任务。"
+        prompt = self.judgment_sys_prompt.format(
+            last_user_input=last_user_input, tool_calls_text=tool_calls_text, last_model_output=last_model_output
         )
-        messages = [
-            SystemMessage(content=self.judgment_sys_prompt),
-            HumanMessage(content=usr_prompt),
-        ]
         # 判断 LLM 调用期间关闭前端显示/DB 写入，避免判断输出污染会话流。
         # 使用 try/finally 确保异常路径下也恢复 front_end_display=True。
         conditional_dispatch_custom_event(
@@ -238,7 +259,7 @@ class QualityGate:
             enable_custom_event=enable_custom_event,
         )
         try:
-            resp = judgment_llm.invoke(messages)
+            resp = judgment_llm.invoke(prompt)
             result = (resp.content or "").strip()
             # fail-open：只有明确"未完成"才返回 False
             return "未完成" not in result

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -27,6 +27,7 @@ class ExecuteKwargs(BaseModel):
     thread_id: str | None = Field(default=None, description="Thread ID，用于APIGW调用时自动管理会话")
     version: str | None = Field(default=None, description="agent 配置版本；为空则使用最新版本")
     turn_id: str = Field(default="", description="同一次 user-ai 回复的轮次 ID")
+    input: str = Field(default="", description="用户本轮输入文本；为空串表示无输入")
 
     # 执行配置
     legacy_streaming: bool = Field(default=False, description="是否使用 legacy streaming protocol")

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -7,7 +7,7 @@ from importlib.metadata import version as pkg_version
 from logging import getLogger
 from typing import Any, Callable, ClassVar, Generator, List, Optional
 
-from ag_ui.core import BaseEvent
+from ag_ui.core import BaseEvent, CustomEvent, EventType
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, RemoveMessage, SystemMessage, ToolMessage
@@ -22,11 +22,21 @@ from pydantic import BaseModel, Field
 from aidev_agent.api.bk_agent import BkAgentApi
 from aidev_agent.config import settings
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
-from aidev_agent.core.ag_ui.ask_user_question import filter_ask_user_question_interrupts
+from aidev_agent.core.ag_ui.ask_user_question import (
+    ASK_USER_QUESTION_SKIPPED_CONTENT,
+    AskUserQuestionHandler,
+    AskUserQuestionOutcomeBuilder,
+    InterruptStatus,
+    build_skipped_answers,
+    filter_ask_user_question_interrupts,
+    parse_resume_answers,
+)
+from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
     InterruptMessage,
     SchemaKeys,
+    SessionPersistenceEventNames,
 )
 from aidev_agent.core.ag_ui.utils import (
     agui_messages_to_langchain,
@@ -204,8 +214,190 @@ class ChatCompletionAgent(BaseModel):
             self.event_handler = ctx.event_handler
         return self
 
+    def _prepare_pre_run_history(self, execute_kwargs: ExecuteKwargs) -> None:
+        """agent 运行前的对话预处理：resume / input 三态分流 + chat_history 镜像 patch。
+
+        在 ``convert_history_to_messages`` 之前调用。build 期 DB 读已先发生，
+        这里把本轮 user / tool 记录手工 patch 进 ``self.chat_history``，
+        让 ``convert_history_to_messages`` 消费到最新记录，并派发对应 DB 回写事件
+        （由 ``AGUISessionWriter`` 的 handler 落库）。
+
+        - resume + (input 或空 answers)（跳过）：补 tool + user 两条，派发 skipped + user 事件，清空 resume。
+        - resume + 非空 answers（答题）：改写 interrupt 记录为 resolved，派发 resolved 事件。
+        - 无 resume + input（普通新对话）：补 user 一条，派发 user 事件。
+        - 无 resume + 无 input：无事可做。
+
+        input 是独立维度，不绑 resume：跳过判别条件是 ``input 或 answers 为空``，
+        因此 ``resume + 无 input + 空 answers`` 也走跳过（仅取消 interrupt，不补 user）。
+        """
+        if not isinstance(self.event_handler, BaseSessionWriter):
+            return
+        resume = execute_kwargs.resume
+        input_text = execute_kwargs.input
+        turn_id = execute_kwargs.turn_id
+
+        # 仅 ask_user_question 中断的 resume 走 ask_user 回写逻辑；审批中断由审批路径处理。
+        # 判别依据是 resume.payload.answers 是否存在（approval 的 payload 是 {approved: bool}）。
+        # 注意：不在此处 return —— input 是独立维度，非 ask_user 的 resume 仍需走步骤 7 派发 user 事件。
+        is_ask_user_resume = not resume or AskUserQuestionHandler.is_ask_user_resume(resume)
+
+        if resume and is_ask_user_resume:
+            # 严格取 chat_history 末尾：必须是 INTERRUPT（避免已回答的 interrupt 被二次回答）。
+            interrupt = self.chat_history[-1] if self.chat_history else None
+            AskUserQuestionHandler.validate_resume_consistency(resume, interrupt)
+            answers = parse_resume_answers(resume) or []
+            # 跳过判别：input 或空 answers 视为跳过（input 独立于 resume）。
+            if input_text or not answers:
+                self._handle_skip_path(interrupt, turn_id)
+                execute_kwargs.resume = None
+            else:
+                self._handle_answer_path(interrupt, answers, turn_id)
+
+        # 步骤 7：独立的 user 事件分发（跳过路径 resume 已清空 / 普通新对话 / 审批 resume 都走这里）。
+        if input_text:
+            self.chat_history.append(ChatPrompt(role=PromptRole.USER.value, content=input_text))
+            self._dispatch_custom(
+                CustomEvent(
+                    type=EventType.CUSTOM,
+                    name=SessionPersistenceEventNames.UserInputSaved.value,
+                    value={"content": input_text, "turn_id": turn_id},
+                )
+            )
+
+    def _handle_skip_path(self, interrupt: ChatPrompt, turn_id: str) -> None:
+        """跳过路径：补 tool → 改写 interrupt 为 CANCELLED → 派发 finalize 事件。
+
+        tool_call_id 已由 ``validate_resume_consistency`` 校验必存在，这里无条件补 tool 记录。
+        user 事件分发由调用方 ``_prepare_pre_run_history`` 的独立收尾步骤处理
+        （仅当 input_text 存在时派发，允许 ``resume + 空 answers + 无 input`` 纯取消 case）。
+
+        upgrade 失败时不派发 finalize 事件（与 handler 原本"upgrade 返回 None 不写 DB"等价）。
+        """
+        builtin = interrupt.builtin_property or {}
+        tool_call_id = builtin.get("tool_call_id", "")
+        questions = builtin.get("questions") or []
+        skipped_answers = build_skipped_answers(questions)
+
+        self.chat_history.append(
+            ChatPrompt(
+                role=PromptRole.TOOL.value,
+                content=ASK_USER_QUESTION_SKIPPED_CONTENT,
+                builtin_property={"tool_call_id": tool_call_id},
+            )
+        )
+        self._dispatch_custom(
+            ExtendToolCallResultEvent(
+                type=EventType.TOOL_CALL_RESULT,
+                tool_call_id=tool_call_id,
+                message_id=tool_call_id,
+                content=ASK_USER_QUESTION_SKIPPED_CONTENT,
+                role="tool",
+                duration=None,
+                is_error=False,
+                additional_metadata={},
+                skip_db=False,
+            )
+        )
+
+        # 先 upgrade，拿到终态 content；失败则不派发 finalize（与 handler upgrade None 行为等价）。
+        upgraded = self._resolve_chat_history_interrupt(
+            interrupt,
+            answers=skipped_answers,
+            status=InterruptStatus.CANCELLED.value,
+        )
+        if upgraded is None:
+            logger.warning(
+                "[AskUserQuestion] skip path upgrade 失败, content_id=%s, 不派发 finalize",
+                interrupt.id,
+            )
+            return
+        self._dispatch_custom(
+            CustomEvent(
+                type=EventType.CUSTOM,
+                name=SessionPersistenceEventNames.AskUserQuestionFinalized.value,
+                value={
+                    "turn_id": turn_id,
+                    "status": InterruptStatus.CANCELLED.value,
+                    "answers": skipped_answers,
+                    "content_id": interrupt.id,
+                    "content": upgraded,
+                    "builtin_property": builtin,
+                },
+            )
+        )
+
+    def _handle_answer_path(self, interrupt: ChatPrompt, answers: list, turn_id: str) -> None:
+        """答题路径：改写 interrupt 为 RESOLVED → 派发 finalize 事件（携带终态 content）。
+
+        upgrade 失败时不派发 finalize 事件（与 skip 路径对称）。
+        """
+        upgraded = self._resolve_chat_history_interrupt(interrupt, answers=answers)
+        if upgraded is None:
+            logger.warning(
+                "[AskUserQuestion] answer path upgrade 失败, content_id=%s, 不派发 finalize",
+                interrupt.id,
+            )
+            return
+        self._dispatch_custom(
+            CustomEvent(
+                type=EventType.CUSTOM,
+                name=SessionPersistenceEventNames.AskUserQuestionFinalized.value,
+                value={
+                    "turn_id": turn_id,
+                    "answers": answers,
+                    "status": InterruptStatus.RESOLVED.value,
+                    "content_id": interrupt.id,
+                    "content": upgraded,
+                    "builtin_property": interrupt.builtin_property or {},
+                },
+            )
+        )
+
+    def _resolve_chat_history_interrupt(
+        self,
+        interrupt: ChatPrompt,
+        *,
+        answers: list,
+        status: str = InterruptStatus.RESOLVED.value,
+    ) -> dict | None:
+        """把传入的 chat_history 末尾 interrupt 记录改写为终态，返回 upgraded content。
+
+        build 期 DB 读（chat_history）已先于本轮的 resolved/skipped 事件发生，若不改写，
+        ``convert_history_to_messages`` 产出的首帧 MESSAGES_SNAPSHOT 里 interrupt
+        卡片仍是 pending，前端无法关闭弹窗。这里把传入的 interrupt 记录 content 升级为
+        ``{"outcome": {type: success, ...}, "result": {...}}``（与 DB 的
+        upgrade_content_to_success 输出一致）。
+
+        调用方必须保证 ``interrupt`` 是 ``chat_history[-1]`` 且 role == INTERRUPT
+        （由 ``AskUserQuestionHandler.validate_resume_consistency`` 校验），
+        避免反向遍历改写到更早的、已终态的 interrupt 记录。
+
+        返回 upgraded content dict 供调用方透传给 finalize 事件（避免 handler 重复
+        调用 ``upgrade_content_to_success``）；结构不识别时返回 None，调用方应跳过
+        finalize 事件派发。
+
+        答题续流用 RESOLVED 状态；跳过路径用 CANCELLED 状态，与 DB 侧 finalize 状态保持一致。
+        """
+        upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
+            interrupt.content,
+            status,
+            resume_answers=answers,
+        )
+        if upgraded is not None:
+            interrupt.content = upgraded
+        return upgraded
+
+    def _dispatch_custom(self, event: BaseEvent) -> None:
+        """直调 event_handler 派发已构造好的事件（绕开 SSE 编码循环）。
+
+        事件构造由调用方负责，本方法仅做类型守卫与转发。
+        """
+        if isinstance(self.event_handler, BaseSessionWriter):
+            self.event_handler(event)
+
     def execute(self, execute_kwargs: ExecuteKwargs) -> Generator[str, None, None] | str:
         self.migration_v1()
+        self._prepare_pre_run_history(execute_kwargs)
         if not self.messages:
             self.messages = self.convert_history_to_messages()
         messages = self.messages
@@ -758,7 +950,7 @@ class ChatCompletionAgent(BaseModel):
         # 1. agent_state
         agent_state = agent_e.get_state(cfg)
 
-        # 2. schema_keys — 直接调 utils.py 函数（不依赖 agui_entry）（D-01）
+        # 2. schema_keys — 直接调 utils.py 函数（不依赖 agui_entry）
         schema_keys = get_schema_keys(agent_e, cfg, ["messages", "tools", "copilotkit"])
 
         # 3. forwarded_props 构造（在预处理前）
@@ -766,7 +958,7 @@ class ChatCompletionAgent(BaseModel):
         if execute_kwargs.resume:
             forwarded_props = {"command": {"resume": execute_kwargs.resume}}
 
-        # 4. 预处理（在 agent_input 构造前）（D-02, D-03）
+        # 4. 预处理（在 agent_input 构造前）
         # 11.8: tools/context 不在 _stream 作用域内，原 AgentInput.tools/context 默认为 []（body 不含）
         # tools 通过 AidevAGUIAgent 构造函数传入（graph 挂载），不通过 state 传递
         agui_messages = langchain_messages_to_agui(messages)
@@ -781,7 +973,7 @@ class ChatCompletionAgent(BaseModel):
             schema_keys,
         )
 
-        # 5. body 构造（合并后的 state 直接放进 body["state"]）（D-03）
+        # 5. body 构造（合并后的 state 直接放进 body["state"]）
         body = {
             "thread_id": self.thread_id,
             "run_id": messages[-1].id or uuid.uuid4().hex,
@@ -795,7 +987,7 @@ class ChatCompletionAgent(BaseModel):
         # 6. agent_input 构造（不需要 model_copy）
         agent_input = AgentInput(**body)
 
-        # 7. config 构造：fork merge 到 cfg（D-04）
+        # 7. config 构造：fork merge 到 cfg
         fork = preprocessed["fork"]
         if fork:
             merged_cfg = {
@@ -1541,11 +1733,11 @@ class ChatAgentBuilder:
         # 理由：
         # - member 模式依赖 LangGraph checkpointer + thread_id 续接多轮对话
         # - 若子 Agent 每次新建 MemorySaver，每次 chat_completion 构建的 child 只能看到
-        #   自己这一个 MemorySaver 的历史；而真正的期望是「同一 thread_id 跨父子/成员的
-        #   state 在同一 checkpointer 存取」
+        #  自己这一个 MemorySaver 的历史；而真正的期望是「同一 thread_id 跨父子/成员的
+        #  state 在同一 checkpointer 存取」
         # - 父 ctx.chat.checkpointer 在 factory.py:170 处一定非空（fallback 到 MemorySaver），
-        #   此处直接复用；仅在极端情况下（ctx.chat 为 None 或 checkpointer 缺失）
-        #   fallback，新建实例也仅对当前这一批 subagents 生效
+        #  此处直接复用；仅在极端情况下（ctx.chat 为 None 或 checkpointer 缺失）
+        #  fallback，新建实例也仅对当前这一批 subagents 生效
         parent_chat = self.ctx.chat
         shared_checkpointer = parent_chat.checkpointer
         specs: list[Any] = []
@@ -1597,7 +1789,7 @@ class ChatAgentBuilder:
                 child_config = child_config.model_copy(update={"related_agents": []})
 
                 # 3. 构造子 ChatBuildExtras：与父共享 agent_cls/auth_headers/checkpointer；
-                #    仅 callbacks 隔离避免事件双发
+                #   仅 callbacks 隔离避免事件双发
                 child_chat = ChatBuildExtras(
                     agent_cls=parent_chat.agent_cls if parent_chat is not None else None,
                     callbacks=[],  # 子 Agent 不继承父 callbacks，避免事件双发
@@ -1607,7 +1799,7 @@ class ChatAgentBuilder:
                     checkpointer=shared_checkpointer,  # 共享父 checkpointer，使 member 模式可跨调用续接
                 )
 
-                # 4. 构造子 AgentBuildContext（D-05）
+                # 4. 构造子 AgentBuildContext
                 child_ctx = AgentBuildContext(
                     agent_code=child_agent_code,
                     agent_type=AgentType.CHAT,

--- a/src/agent/aidev_agent/services/event_handlers/agui_writer.py
+++ b/src/agent/aidev_agent/services/event_handlers/agui_writer.py
@@ -11,12 +11,6 @@ from logging import getLogger
 from typing import Any
 
 from aidev_agent.api.bk_aidev import Client
-from aidev_agent.core.ag_ui.ask_user_question import (
-    ASK_USER_QUESTION_REASON,
-    AskUserQuestionOutcomeBuilder,
-    build_updated_builtin_property,
-    find_pending_interrupt,
-)
 from aidev_agent.core.ag_ui.types import RunFinishedOutcomeType
 from aidev_agent.enums import ActivityType, PromptRole, SessionsStatus
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
@@ -159,8 +153,8 @@ class AGUISessionWriter(BaseSessionWriter):
     def handle_run_finished(self, event) -> None:
         """处理 RUN_FINISHED 事件，额外检测中断并触发后台续流。
 
-        ask_user_question 续流首帧 RunFinishedEvent（outcome.type=success）在非
-        interrupt 分支通过 _handle_ask_user_question_resume_finished 完成 DB 终态写入。
+        SSE 层不写 DB，ask_user_question 的 DB 终态由 agent 侧 ChatCompletionAgent.execute()
+        前置派发的会话回写事件负责，与 approval 路径一致。
         """
         super().handle_run_finished(event)
 
@@ -203,109 +197,6 @@ class AGUISessionWriter(BaseSessionWriter):
             return
 
         self._clear_pending_interrupt_context()
-
-        # ask_user_question 续流首帧 RunFinishedEvent（outcome.type=success）：
-        # 从 event.outcome.interrupts[0] 提取 interrupt_id，
-        # 从 event.result 提取 resume_answers，查 DB pending 记录并更新为 resolved 终态。
-        if outcome and outcome_type != "interrupt":
-            self._handle_ask_user_question_resume_finished(event)
-
-    def _handle_ask_user_question_resume_finished(self, event) -> None:
-        """ask_user_question 续流首帧 RunFinishedEvent 的 DB 终态写入。
-
-        从 event.outcome.interrupts[0].id 提取 interrupt_id，
-        从 event.result.payload.answers 提取 resume_answers，
-        查 DB pending 记录并更新为 resolved 终态。
-        """
-        # 1. 从 RunFinishedEvent 提取 interrupt_id + resume_answers
-        outcome = getattr(event, "outcome", None)
-        if isinstance(outcome, dict):
-            interrupts = outcome.get("interrupts") or []
-        else:
-            interrupts = getattr(outcome, "interrupts", []) if outcome else []
-        if not interrupts:
-            return
-        first_interrupt = interrupts[0] if isinstance(interrupts[0], dict) else {}
-        if first_interrupt.get("reason") != ASK_USER_QUESTION_REASON:
-            return  # 非 ask_user_question，跳过
-        interrupt_id = first_interrupt.get("id")
-        if not interrupt_id:
-            return
-        # resume_answers 从 event.result 提取（result 是 _build_result_from_first_interrupt 的 dict）
-        result = getattr(event, "result", None)
-        resume_answers = []
-        if isinstance(result, dict):
-            resume_answers = result.get("payload", {}).get("answers") or []
-
-        # 2. DB I/O：查询 session contents
-        headers = {"X-BKAIDEV-USER": self.username} if self.username else {}
-        try:
-            contents = (
-                self.client.api.get_chat_session_contents(
-                    params={"session_code": self.session_code},
-                    headers=headers,
-                ).get("data")
-                or []
-            )
-        except Exception:
-            logger.exception(
-                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 查询 session contents 失败: session_code=%s",
-                self.session_code,
-            )
-            return
-
-        # 3. 协议匹配：找 pending interrupt 记录（纯函数）
-        found = find_pending_interrupt(contents, interrupt_id)
-        if found is None:
-            logger.warning(
-                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 未找到 pending interrupt 记录, "
-                "message_id=%s, session_code=%s",
-                interrupt_id,
-                self.session_code,
-            )
-            return
-        content_id, raw_db_content, db_item = found
-
-        # 4. 调用已有 OutcomeBuilder（已在 core/ag_ui）
-        upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
-            raw_db_content, "resolved", resume_answers=resume_answers
-        )
-        if upgraded is None:
-            logger.warning(
-                "[AskUserQuestion] _handle_ask_user_question_resume_finished: upgrade_content_to_success 返回 None, content_id=%s",
-                content_id,
-            )
-            return
-
-        # 5. 构造 updated_builtin（纯函数）
-        updated_builtin = build_updated_builtin_property(db_item, interrupt_id, "resolved")
-
-        # 6. DB I/O：更新 content
-        try:
-            self._do_update_content(
-                content_id=content_id,
-                payload={
-                    "content": upgraded,
-                    "status": "complete",
-                    "property": {
-                        "builtin_property": updated_builtin,
-                        "turn_id": self.turn_id,
-                    },
-                },
-                headers=headers,
-            )
-            logger.info(
-                "[AskUserQuestion] interrupt 记录更新为 resolved: content_id=%s, message_id=%s, session_code=%s",
-                content_id,
-                interrupt_id,
-                self.session_code,
-            )
-        except Exception:
-            logger.exception(
-                "[AskUserQuestion] _handle_ask_user_question_resume_finished: 更新 interrupt 记录失败, content_id=%s, session_code=%s",
-                content_id,
-                self.session_code,
-            )
 
     def _ensure_session_property_cache(self) -> None:
         if self._cached_session_property is not None:

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -22,7 +22,13 @@ from typing import Any, Callable
 from ag_ui.core import BaseEvent, CustomEvent, EventType, RunErrorEvent
 from ag_ui.core.events import RawEvent, TextMessageContentEvent, TextMessageEndEvent, TextMessageStartEvent
 
-from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, AskUserQuestionHandler
+from aidev_agent.core.ag_ui.ask_user_question import (
+    ASK_USER_QUESTION_REASON,
+    AskUserQuestionHandler,
+    InterruptStatus,
+    build_updated_builtin_property,
+    extract_message_id,
+)
 from aidev_agent.core.ag_ui.event_builders import build_model_end_payload, should_switch_thinking_step
 from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
 from aidev_agent.core.ag_ui.types import (
@@ -214,6 +220,10 @@ class BaseSessionWriter(ABC):
             self.handle_model_end(event)
         elif event_name == SessionPersistenceEventNames.ArtifactsGenerated.value:
             self.handle_artifacts_generated(event)
+        elif event_name == SessionPersistenceEventNames.AskUserQuestionFinalized.value:
+            self.handle_ask_user_question_finalize(event)
+        elif event_name == SessionPersistenceEventNames.UserInputSaved.value:
+            self.handle_user_input_saved(event)
         elif event_name == CustomMessageType.KNOWLEDGE_RAG_RESULT.value:
             self.handle_reference_document(event)
         elif event_name == CustomMessageType.FLOW_AGENT_START.value:
@@ -222,6 +232,76 @@ class BaseSessionWriter(ABC):
             self.handle_flow_agent_result(event)
         elif event_name == CustomMessageType.FLOW_AGENT_END.value:
             self.handle_flow_agent_end(event)
+
+    def handle_ask_user_question_finalize(self, event) -> None:
+        """处理 ask_user_question 跳过/答题事件（终态由 chat.py 预构造后透传）。
+
+        所有决策与协议计算在 chat.py 完成：status（cancelled/resolved）、answers
+        （skipped answers 或用户答案）、终态 content（已由 chat.py 调
+        ``upgrade_content_to_success`` 升级）均经事件 value 传入。跳过路径的 tool
+        记录由 chat.py 显式派发 TOOL_CALL_RESULT 事件（handle_tool_call_result）写入，
+        本 handler 仅负责把 interrupt 记录 UPDATE 为指定终态（extract message_id →
+        build builtin_property → UPDATE），不再重复调用 upgrade_content_to_success。
+        """
+        value = event.value if isinstance(event.value, dict) else {}
+        bp = value.get("builtin_property") if isinstance(value.get("builtin_property"), dict) else {}
+        try:
+            content_id = value.get("content_id")
+            if content_id is None:
+                logger.warning(
+                    "[AskUserQuestion] finalize: 事件缺 content_id, 无法定位 interrupt, session=%s",
+                    self.session_code,
+                )
+                return
+            upgraded = value.get("content")
+            if not isinstance(upgraded, dict):
+                logger.warning(
+                    "[AskUserQuestion] finalize: 事件缺终态 content, content_id=%s",
+                    content_id,
+                )
+                return
+            status = value.get("status") or InterruptStatus.RESOLVED.value
+            message_id = extract_message_id(upgraded)
+            db_item_adapter = {"property": {"builtin_property": bp}}
+            updated_builtin = build_updated_builtin_property(db_item_adapter, message_id, status)
+            self._do_update_content(
+                content_id=content_id,
+                payload={
+                    "content": upgraded,
+                    "status": "complete",
+                    "property": {
+                        "builtin_property": updated_builtin,
+                        "turn_id": value.get("turn_id") or "",
+                    },
+                },
+                headers=self._get_headers(),
+            )
+            logger.info(
+                "[AskUserQuestion] finalize: content_id=%s, status=%s, message_id=%s, answers=%d",
+                content_id,
+                status,
+                message_id,
+                len(value.get("answers") or []),
+            )
+        except Exception:
+            logger.exception("[AskUserQuestion] finalize 失败: session=%s", self.session_code)
+
+    def handle_user_input_saved(self, event) -> None:
+        """处理 user 输入落库事件（所有带 input 路径）：直调 _do_create_content 写 user 记录。"""
+        value = event.value if isinstance(event.value, dict) else {}
+        try:
+            self._do_create_content(
+                payload={
+                    "session_code": self.session_code,
+                    "role": PromptRole.USER.value,
+                    "content": value.get("content") or "",
+                    "status": "success",
+                    "property": {"turn_id": value.get("turn_id") or ""},
+                },
+                headers=self._get_headers(),
+            )
+        except Exception:
+            logger.exception("[AskUserQuestion] user 落库失败: session=%s", self.session_code)
 
     # ---------- 事件处理方法 ----------
 
@@ -544,7 +624,7 @@ class BaseSessionWriter(ABC):
                 serialized_reason = serialized.get("reason")
 
                 if serialized_reason == ASK_USER_QUESTION_REASON:
-                    # ask_user_question 路径：启用 extract_builtin_property（D-02）
+                    # ask_user_question 路径：启用 extract_builtin_property
                     # 字段集：questions/options/answers/multiSelect（无 callback_token/ticket_sn/tool_name）
                     builtin_property = AskUserQuestionHandler().extract_builtin_property(
                         interrupt_id, interrupt, graph_thread_id=getattr(event, "thread_id", "")
@@ -597,8 +677,9 @@ class BaseSessionWriter(ABC):
                     builtin_property=builtin_property,
                 )
         elif outcome and outcome_type != "interrupt":
-            # ask_user_question 续流的 DB 写入由 AGUISessionWriter.handle_run_finished
-            # 的 _handle_ask_user_question_resume_finished 完成（消费 RunFinishedEvent）。
+            # ask_user_question 续流的 DB 终态写入由 agent 侧 ChatCompletionAgent.execute()
+            # 前置派发的会话回写事件负责（handle_ask_user_question_finalize），
+            # SSE 层不再承担 DB 写入职责（对齐"谁产生谁写入"原则）。
             # approval 的 interrupt 状态由审批回调 API 更新。
             logger.info(
                 "[handle_run_finished] outcome != interrupt, session_code=%s, outcome_type=%s",

--- a/src/agent/tests/core/ag_ui/test_agent_sync.py
+++ b/src/agent/tests/core/ag_ui/test_agent_sync.py
@@ -9,10 +9,15 @@
 """
 
 import os
+import subprocess
 from unittest.mock import MagicMock
 
 import pytest
+from aidev_agent.core.ag_ui.agent import LangGraphAgent
 from langchain_core.messages import AIMessage, HumanMessage, RemoveMessage, SystemMessage
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, START, StateGraph, add_messages
+from typing_extensions import Annotated, TypedDict
 
 # 读取 chat.py 源码（避免 import 触发 ag_ui 等不可用依赖）
 _CHAT_PY_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "..", "aidev_agent", "services", "agent", "chat.py")
@@ -209,11 +214,6 @@ class TestPVStatePersistence:
     @pytest.mark.asyncio
     async def test_pv_state_survives_across_invocations(self):
         """使用稳定的 thread_id，runtime_paas_sbx_pv 应在检查点状态中持久化。"""
-        from typing import Annotated
-
-        from langgraph.checkpoint.memory import MemorySaver
-        from langgraph.graph import END, START, StateGraph, add_messages
-        from typing_extensions import TypedDict
 
         class TestState(TypedDict):
             messages: Annotated[list, add_messages]
@@ -254,16 +254,12 @@ class TestPVStatePersistence:
         assert pv_list2[0]["volume_id"] == "test-vol"
 
     def test_fork_time_travel_not_latest_checkpoint(self):
-        """D-05: fork 后又有新 checkpoint，时间旅行应从 fork checkpoint C 开始而非最新 D。
+        """fork 后又有新 checkpoint，时间旅行应从 fork checkpoint C 开始而非最新 D。
 
         Phase 11.5 CR2 修复的 bug：kwargs.update(fork) 不正确，应 merge fork 的
         configurable 到 config.configurable。本测试验证改 sync 后 update_state
         返回的 RunnableConfig 仍被 _stream 正确 merge 到 merged_cfg。
         """
-        from langgraph.checkpoint.memory import MemorySaver
-        from langgraph.graph import END, START, StateGraph
-        from langgraph.graph.message import add_messages
-        from typing_extensions import Annotated, TypedDict
 
         class TestState(TypedDict):
             messages: Annotated[list, add_messages]
@@ -322,7 +318,7 @@ class TestPVStatePersistence:
         graph.invoke({"messages": [HumanMessage(content="regen-msg", id="regen-1")]}, merged_cfg)
 
         # Step 7: 断言从 fork checkpoint C 开始（agent 看到的是 C 的消息 + regen-msg，
-        #         而非 D 的 msg-3）
+        #        而非 D 的 msg-3）
         # C 的状态是 user-msg-1（checkpoint A 之后），所以 agent 收到的消息序列应含 msg-1 + regen-msg
         # 而非 msg-3
         assert "regen-msg" in call_log[-1], f"agent 应收到 regen-msg，实际收到: {call_log[-1]}"
@@ -440,7 +436,7 @@ class TestMessagesProcessingLocation:
         """11.8 回归测试：get_stream_kwargs 不再接受 fork 参数（fork merge 移到 chat.py _stream）。
 
         11.5 CR2: fork merge 从 kwargs.update(fork) 改为 merge fork 的 configurable 到 config.configurable
-        11.8 D-04: fork merge 逻辑从 agent.py get_stream_kwargs 移到 chat.py _stream（merged_cfg）
+        11.8 fork merge 逻辑从 agent.py get_stream_kwargs 移到 chat.py _stream（merged_cfg）
         此测试验证 get_stream_kwargs 不接受 fork 参数（传 fork 应 TypeError）。
         """
         source = _read_agent_py()
@@ -455,8 +451,6 @@ class TestMessagesProcessingLocation:
         assert "if fork:" not in kwargs_source, "get_stream_kwargs 不应有 if fork: 分支（11.8）"
 
         # 验证 get_stream_kwargs 不接受 fork 参数
-        from aidev_agent.core.ag_ui.agent import LangGraphAgent
-
         mock_graph = MagicMock()
         agent = LangGraphAgent.__new__(LangGraphAgent)
         agent.graph = mock_graph
@@ -473,8 +467,6 @@ class TestMessagesProcessingLocation:
 
     def test_fork_merge_preserves_existing_configurable_fields(self):
         """11.8 回归测试：get_stream_kwargs 不接受 fork 参数，config 直接透传（fork merge 在 chat.py）。"""
-        from aidev_agent.core.ag_ui.agent import LangGraphAgent
-
         mock_graph = MagicMock()
         agent = LangGraphAgent.__new__(LangGraphAgent)
         agent.graph = mock_graph
@@ -796,8 +788,6 @@ class TestMessagesProcessingLocation:
 
         排除 __pycache__ 和本测试文件（断言字符串字面量自身包含标识符）。
         """
-        import subprocess
-
         result = subprocess.run(
             [
                 "grep",

--- a/src/agent/tests/core/ag_ui/test_ask_user_question_protocol.py
+++ b/src/agent/tests/core/ag_ui/test_ask_user_question_protocol.py
@@ -1,149 +1,26 @@
 # -*- coding: utf-8 -*-
 """ask_user_question 协议层纯函数单元测试。
 
-覆盖 Phase 14.1 D-01/D-03/D-04 抽出的 4 个纯函数的边界值：
-find_pending_interrupt / build_updated_builtin_property /
-filter_ask_user_question_interrupts / parse_resume_answers。
+覆盖 抽出的纯函数的边界值：
+build_updated_builtin_property / build_skipped_answers /
+filter_ask_user_question_interrupts / parse_resume_answers / extract_message_id。
 """
 
 import json
 from types import SimpleNamespace
 
+import pytest
 from aidev_agent.core.ag_ui.ask_user_question import (
     ASK_USER_QUESTION_REASON,
+    ASK_USER_QUESTION_SKIPPED_CONTENT,
+    AskUserQuestionMetadata,
+    InterruptStatus,
+    build_skipped_answers,
     build_updated_builtin_property,
+    extract_message_id,
     filter_ask_user_question_interrupts,
-    find_pending_interrupt,
     parse_resume_answers,
 )
-from aidev_agent.enums import PromptRole
-
-# ------------------------------------------------------------------ #
-# find_pending_interrupt
-# ------------------------------------------------------------------ #
-
-
-def test_find_pending_interrupt_empty():
-    assert find_pending_interrupt([], "int-1") is None
-
-
-def test_find_pending_interrupt_match():
-    raw_content = {
-        "outcome": {
-            "interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}],
-        },
-    }
-    item = {
-        "id": 42,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_content),
-    }
-    result = find_pending_interrupt([item], "int-1")
-    assert result is not None
-    content_id, raw_db_content, db_item = result
-    assert content_id == 42
-    assert raw_db_content["outcome"]["interrupts"][0]["id"] == "int-1"
-    assert db_item is item
-
-
-def test_find_pending_interrupt_wrong_role():
-    item = {
-        "id": 42,
-        "role": "activity",
-        "status": "pending",
-        "content": "{}",
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
-
-def test_find_pending_interrupt_wrong_status():
-    item = {
-        "id": 42,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "complete",
-        "content": "{}",
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
-
-def test_find_pending_interrupt_wrong_id():
-    raw_content = {
-        "outcome": {
-            "interrupts": [{"id": "int-other", "reason": ASK_USER_QUESTION_REASON}],
-        },
-    }
-    item = {
-        "id": 42,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_content),
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
-
-def test_find_pending_interrupt_reversed_order():
-    """逆序遍历，最新记录优先。"""
-    raw_old = {
-        "outcome": {"interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}]},
-    }
-    raw_new = {
-        "outcome": {"interrupts": [{"id": "int-1", "reason": ASK_USER_QUESTION_REASON}]},
-    }
-    old_item = {
-        "id": 1,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_old),
-    }
-    new_item = {
-        "id": 2,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_new),
-    }
-    result = find_pending_interrupt([old_item, new_item], "int-1")
-    assert result is not None
-    content_id, _, _ = result
-    assert content_id == 2  # 逆序，new_item 先匹配
-
-
-def test_find_pending_interrupt_reason_not_ask_user_question():
-    """匹配 id 但 reason 非 ASK_USER_QUESTION_REASON 时不返回。"""
-    raw_content = {
-        "outcome": {"interrupts": [{"id": "int-1", "reason": "aidev:tool_approval"}]},
-    }
-    item = {
-        "id": 42,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_content),
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
-
-def test_find_pending_interrupt_content_not_json():
-    """content 非 JSON 字符串时跳过该记录。"""
-    item = {
-        "id": 1,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": "not json",
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
-
-def test_find_pending_interrupt_missing_interrupts_field():
-    """outcome 缺少 interrupts 字段时跳过该记录。"""
-    raw_content = {"outcome": {}}
-    item = {
-        "id": 1,
-        "role": PromptRole.INTERRUPT.value,
-        "status": "pending",
-        "content": json.dumps(raw_content),
-    }
-    assert find_pending_interrupt([item], "int-1") is None
-
 
 # ------------------------------------------------------------------ #
 # build_updated_builtin_property
@@ -329,3 +206,83 @@ def test_parse_resume_answers_scalar():
 def test_parse_resume_answers_empty_list():
     """空列表返回空列表（非 None）。"""
     assert parse_resume_answers([]) == []
+
+
+# ------------------------------------------------------------------ #
+# InterruptStatus
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "member, expected",
+    [
+        (InterruptStatus.PENDING, "pending"),
+        (InterruptStatus.RESOLVED, "resolved"),
+        (InterruptStatus.CANCELLED, "cancelled"),
+    ],
+)
+def test_interrupt_status_str_value(member, expected):
+    """(str, Enum) 成员的 str 值等于字面量。"""
+    assert member.value == expected
+    assert member == expected  # str 继承
+
+
+def test_interrupt_status_pydantic_serialization():
+    """Pydantic v2 序列化输出字符串值（非枚举名）— Pitfall 3 验证。"""
+    m = AskUserQuestionMetadata(questions=[])
+    assert m.status == InterruptStatus.PENDING
+    # model_dump_json 输出 "pending" 而非 "InterruptStatus.PENDING"
+    dumped = m.model_dump_json()
+    assert '"status":"pending"' in dumped
+
+
+# ------------------------------------------------------------------ #
+# extract_message_id ( ②)
+# ------------------------------------------------------------------ #
+
+
+@pytest.mark.parametrize(
+    "upgraded, expected",
+    [
+        ({"result": {"interruptId": "id-1"}, "outcome": {"interrupts": [{"id": "id-2"}]}}, "id-1"),
+        ({"result": {}, "outcome": {"interrupts": [{"id": "id-2"}]}}, "id-2"),
+        ({"result": {}, "outcome": {"interrupts": []}}, ""),
+        ({}, ""),
+    ],
+)
+def test_extract_message_id(upgraded, expected):
+    """result.interruptId 优先 → outcome.interrupts[0].id 次之 → 空串兜底。"""
+    assert extract_message_id(upgraded) == expected
+
+
+# ------------------------------------------------------------------ #
+# build_skipped_answers ( ③)
+# ------------------------------------------------------------------ #
+
+
+def test_build_skipped_answers_basic():
+    """正常构造：每个 question 生成 label="skipped" 的 answer。"""
+    questions = [{"question": "Q1", "multiSelect": False}]
+    result = build_skipped_answers(questions)
+    assert len(result) == 1
+    assert result[0]["question"] == "Q1"
+    assert result[0]["multiSelect"] is False
+    assert result[0]["answer"][0]["label"] == "skipped"
+    assert result[0]["answer"][0]["description"] == ASK_USER_QUESTION_SKIPPED_CONTENT
+
+
+def test_build_skipped_answers_empty():
+    assert build_skipped_answers([]) == []
+
+
+def test_build_skipped_answers_filters_non_dict():
+    """过滤非 dict 元素。"""
+    result = build_skipped_answers([{"question": "Q"}, "not-a-dict", None])
+    assert len(result) == 1
+    assert result[0]["question"] == "Q"
+
+
+def test_build_skipped_answers_question_missing():
+    """question 缺失默认空串。"""
+    result = build_skipped_answers([{"multiSelect": True}])
+    assert result[0]["question"] == ""

--- a/src/agent/tests/core/graphs/test_react.py
+++ b/src/agent/tests/core/graphs/test_react.py
@@ -4,18 +4,21 @@
 """
 
 from pathlib import Path
-from typing import List
+from typing import List, TypedDict, get_type_hints
 from unittest.mock import MagicMock, patch
 
 import pytest
 from aidev_agent.config import settings
-from aidev_agent.core.graphs.react.graph import ReActAgentBuilder
+from aidev_agent.core.graphs.react.graph import DefaultState, ReActAgentBuilder
 from aidev_agent.core.graphs.react.skill_middleware import SkillsPromptMiddleware, _extract_paas_params
+from aidev_agent.core.graphs.react.team_middleware import TeamPromptMiddleware
 from aidev_agent.core.nodes.interrupt import ItsmApprovalStrategy, make_interrupt_node
+from aidev_agent.core.nodes.model.pydantic_models import ModelNodeSettings
 from aidev_agent.core.nodes.tool import ToolNodeSettings
+from aidev_agent.core.tools.a2a_tools.types import AgentSpec
 from aidev_agent.packages.langchain_core.models import ChatModel
 from aidev_agent.packages.langgraph.streaming.streaming_protocol import AgentStreamAdapter
-from aidev_agent.pydantic_models import AgentExecutorKwargs, KnowledgeSettings
+from aidev_agent.pydantic_models import AgentExecutorKwargs, KnowledgeSettings, ModelContextSettings
 from langchain.agents.middleware.types import AgentMiddleware
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
@@ -376,18 +379,13 @@ class TestReActAgentBuilder:
             builder.build()
 
     def test_build_raises_when_knowledge_without_knowledge_llm(self):
-        """配置了知识库但未设置 knowledge_llm 时应抛出 ValueError"""
-        llm = MagicMock()
-        llm.model_name = "gpt-4o"
-        builder = ReActAgentBuilder().set_llm(llm).set_knowledge_bases([{"id": "kb1"}])
-        with (
-            patch("aidev_agent.core.graphs.react.graph.std_make_model_node", return_value=MagicMock()),
-            patch(
-                "aidev_agent.core.graphs.react.graph.ReActAgentBuilder._build_graph",
-                return_value=(MagicMock(), {}),
-            ),
-            pytest.raises(ValueError, match="knowledge_llm"),
-        ):
+        """配置了知识库但 llm/knowledge_llm 均为空时应抛出 ValueError。
+
+        新逻辑下 knowledge_llm 会回退到 non_thinking_llm / llm，
+        只有 llm 也为空时才会触发校验失败（由 build() 入口的 llm 校验兜底）。
+        """
+        builder = ReActAgentBuilder().set_knowledge_bases([{"id": "kb1"}])
+        with pytest.raises(ValueError, match="缺少 llm"):
             builder.build()
 
     def test_build_raises_when_knowledge_query_options_not_knowledgebase_settings(self):
@@ -844,7 +842,7 @@ class TestReActAgentBuilder:
             approval_state = updated_ai_message.additional_kwargs["tool_approval"]
             assert approval_state["call_1"]["status"] == "approved"
             assert approval_state["call_2"]["status"] == "rejected"
-            # 两个 target 各调一次 request_approval_decision（D-05 复刻 11.1 _check for 循环）
+            # 两个 target 各调一次 request_approval_decision（ 复刻 11.1 _check for 循环）
             assert mock_request.call_count == 2
         finally:
             calculator.metadata = original_metadata
@@ -1013,6 +1011,514 @@ class TestReActAgentBuilder:
         store = MagicMock()
         result = builder._prepare_store(store=store, file_store=None)
         assert result is store
+
+    # ----------------------------------------------------------------
+    # B (continued). _prepare_agent_options 校验测试
+    # ----------------------------------------------------------------
+
+    def test_prepare_agent_options_raises_when_runtime_tool_without_resolver(self):
+        """enable_runtime_tool=True 但未提供 runtime_backend_resolver 时应抛出 ValueError"""
+        builder = ReActAgentBuilder().set_llm(MagicMock(model_name="gpt-4o")).set_enable_runtime_tool(True)
+        # runtime_backend_resolver 默认为 None
+        with pytest.raises(ValueError, match="runtime_tool 但未提供 runtime_backend_resolver"):
+            builder._prepare_agent_options()
+
+    def test_prepare_agent_options_runtime_tool_passes_with_resolver(self):
+        """enable_runtime_tool=True 且提供了 runtime_backend_resolver 时应通过校验"""
+        resolver = MagicMock()
+        builder = ReActAgentBuilder().set_llm(MagicMock(model_name="gpt-4o")).set_enable_runtime_tool(True)
+        builder._runtime_backend_resolver = resolver
+        # 不应抛出异常
+        builder._prepare_agent_options()
+        assert builder._runtime_backend_resolver is resolver
+
+    def test_prepare_agent_options_raises_when_knowledge_configured_but_all_llm_none(self):
+        """配置了知识库但 knowledge_llm/non_thinking_llm/llm 全为 None 时应触发 has_knowledge 校验。
+
+        build() 入口会对 self._knowledge_llm 做 (knowledge_llm or non_thinking_llm or llm) 回退；
+        正常 build 流程下 llm 必非 None，故此校验在 build 中永不触发。
+        但回退逻辑若变动（例如改为不回退到 llm），此校验应能兜底拦截。
+        因此直接调用 _prepare_agent_options 并保持三者全 None 来覆盖该分支。
+        """
+        builder = ReActAgentBuilder().set_knowledge_bases([{"id": "kb1"}])
+        # 显式保持三者全 None（模拟回退逻辑变动后可能出现的场景）
+        assert builder._knowledge_llm is None
+        assert builder._non_thinking_llm is None
+        assert builder._llm is None
+        with pytest.raises(ValueError, match="knowledge_llm 为空"):
+            builder._prepare_agent_options()
+
+    # ----------------------------------------------------------------
+    # B (continued). _prepare_agent_pv_node 测试
+    # ----------------------------------------------------------------
+
+    def test_prepare_agent_pv_node_returns_callable_without_runtime(self):
+        """未启用 runtime_tool 时应返回 pv_node callable（无 PV 支持）"""
+        builder = ReActAgentBuilder()
+        pv_node = builder._prepare_agent_pv_node()
+        assert callable(pv_node)
+
+    def test_prepare_agent_pv_node_paas_sandbox_without_app_code(self):
+        """启用 paas_sandbox runtime 但 executor_info 无 app_code 时不应注入 client"""
+        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder._executor_info = {}  # 无 app_code
+        pv_node = builder._prepare_agent_pv_node()
+        assert callable(pv_node)
+
+    def test_prepare_agent_pv_node_paas_sandbox_with_app_code_and_resource_manager(self):
+        """启用 paas_sandbox runtime 且有 app_code + resource_manager 时应注入 client"""
+        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder._executor_info = {"app_code": "test-app"}
+        resource_manager = MagicMock()
+        expected_client = MagicMock()
+        resource_manager.get_paas_sbx_client.return_value = expected_client
+        builder._resource_manager = resource_manager
+
+        with patch("aidev_agent.core.graphs.react.graph.make_pv_node") as mock_make_pv_node:
+            mock_make_pv_node.return_value = MagicMock()
+            builder._prepare_agent_pv_node()
+            mock_make_pv_node.assert_called_once()
+            call_kwargs = mock_make_pv_node.call_args.kwargs
+            assert call_kwargs["client"] is expected_client
+            assert call_kwargs["app_code"] == "test-app"
+            assert call_kwargs["resource_manager"] is resource_manager
+
+    def test_prepare_agent_pv_node_paas_sandbox_with_app_code_but_no_resource_manager(self):
+        """启用 paas_sandbox runtime 有 app_code 但无 resource_manager 时 client 应为 None"""
+        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder._executor_info = {"app_code": "test-app"}
+        # _resource_manager 默认为 None
+        with patch("aidev_agent.core.graphs.react.graph.make_pv_node") as mock_make_pv_node:
+            mock_make_pv_node.return_value = MagicMock()
+            builder._prepare_agent_pv_node()
+            call_kwargs = mock_make_pv_node.call_args.kwargs
+            assert call_kwargs["client"] is None
+
+    # ----------------------------------------------------------------
+    # B (continued). _prepare_a2a 测试
+    # ----------------------------------------------------------------
+
+    def test_prepare_a2a_skips_when_no_backend_types(self):
+        """_a2a_backend_types 为空时应直接返回，不创建 resolver"""
+        builder = ReActAgentBuilder()
+        builder._prepare_a2a()
+        assert builder._a2a_resolver is None
+
+    def test_prepare_a2a_creates_resolver_with_local_backend(self):
+        """启用 local backend 时应创建 resolver 并注册 local 类型"""
+        builder = ReActAgentBuilder().enable_a2a_backend_local(True)
+        builder._prepare_a2a()
+        assert builder._a2a_resolver is not None
+        # 验证 local backend 已注册
+        assert "local" in builder._a2a_backend_types
+
+    def test_prepare_a2a_creates_resolver_with_bkai_backend(self):
+        """启用 bkai backend 时应创建 resolver 并注册 bkai 类型"""
+        builder = ReActAgentBuilder().enable_a2a_backend_bkai(True)
+        builder._prepare_a2a()
+        assert builder._a2a_resolver is not None
+        assert "bkai" in builder._a2a_backend_types
+
+    def test_prepare_a2a_creates_resolver_with_multiple_backends(self):
+        """同时启用 local + bkai 时应注册两种后端类型"""
+        builder = ReActAgentBuilder().enable_a2a_backend_local(True).enable_a2a_backend_bkai(True)
+        builder._prepare_a2a()
+        assert builder._a2a_resolver is not None
+        assert {"local", "bkai"}.issubset(set(builder._a2a_backend_types))
+
+    def test_build_calls_prepare_a2a_when_enable_a2a_tool(self):
+        """build() 在 enable_a2a_tool=True 时应调用 _prepare_a2a"""
+        llm = MagicMock()
+        llm.model_name = "gpt-4o"
+        builder = ReActAgentBuilder().set_llm(llm).enable_a2a_tool(True).enable_a2a_backend_local(True)
+        with (
+            patch("aidev_agent.core.graphs.react.graph.std_make_model_node", return_value=MagicMock()),
+            patch(
+                "aidev_agent.core.graphs.react.graph.ReActAgentBuilder._build_graph",
+                return_value=(MagicMock(), {}),
+            ),
+            patch.object(ReActAgentBuilder, "_prepare_a2a", wraps=builder._prepare_a2a) as mock_prepare_a2a,
+        ):
+            builder.build()
+        mock_prepare_a2a.assert_called_once()
+        assert builder._a2a_resolver is not None
+
+    # ----------------------------------------------------------------
+    # B (continued). _compute_use_structured_response 测试 (P0)
+    # ----------------------------------------------------------------
+
+    def test_compute_use_structured_response_deepseek_agent_type(self):
+        """model_context_options.llm_code_agent_type 含 'deepseek' 时应返回 True"""
+        builder = ReActAgentBuilder()
+        builder._model_context_options = ModelContextSettings(llm_code_agent_type="deepseek_r1")
+        assert builder._compute_use_structured_response() is True
+
+    def test_compute_use_structured_response_non_deepseek_agent_type(self):
+        """llm_code_agent_type 不含 'deepseek' 时应返回 False"""
+        builder = ReActAgentBuilder()
+        builder._model_context_options = ModelContextSettings(llm_code_agent_type="openai")
+        assert builder._compute_use_structured_response() is False
+
+    def test_compute_use_structured_response_no_model_context_options(self):
+        """无 model_context_options 时回退到 is_model_without_function_calling 检查"""
+        builder = ReActAgentBuilder()
+        # 无 llm_code_agent_type，回退分支：llm 为 None 时回退为 False
+        # （is_model_without_function_calling(None) 会 AttributeError，但 build() 入口会校验 llm 非空）
+        # 此处用一个普通模型 + 无 extra_tools 触发 and 短路返回 False
+        builder._llm = MagicMock(model_name="gpt-4o")
+        assert builder._compute_use_structured_response() is False
+
+    # ----------------------------------------------------------------
+    # B (continued). _prepare_agent_model_node 测试 (P0)
+    # ----------------------------------------------------------------
+
+    def test_prepare_agent_model_node_extracts_model_context_options(self):
+        """_prepare_agent_model_node 应从 model_context_options 提取 token_limit/token_margin/compress_thrd"""
+        builder = ReActAgentBuilder()
+        builder._llm = MagicMock(model_name="gpt-4o")
+        builder._model_context_options = ModelContextSettings(
+            llm_token_limit=8000,
+            token_limit_margin=200,
+            tool_output_compress_thrd=3000,
+        )
+        captured = {}
+
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
+            captured["node_options"] = node_options
+            return MagicMock()
+
+        llm = MagicMock(model_name="gpt-4o")
+        with patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node):
+            builder._prepare_agent_model_node(llm=llm, non_thinking_llm=llm, judge_llm=llm, tools=[])
+        node_options: ModelNodeSettings = captured["node_options"]
+        assert node_options.token_limit == 8000
+        assert node_options.token_margin == 200
+        assert node_options.tool_output_compress_thrd == 3000
+
+    def test_prepare_agent_model_node_no_model_context_options_uses_defaults(self):
+        """无 model_context_options 时 ModelNodeSettings 应使用默认值"""
+        builder = ReActAgentBuilder()
+        builder._llm = MagicMock(model_name="gpt-4o")
+        captured = {}
+
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
+            captured["node_options"] = node_options
+            return MagicMock()
+
+        llm = MagicMock(model_name="gpt-4o")
+        with patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node):
+            builder._prepare_agent_model_node(llm=llm, non_thinking_llm=llm, judge_llm=llm, tools=[])
+        node_options: ModelNodeSettings = captured["node_options"]
+        assert node_options.token_limit is None
+        # token_margin / tool_output_compress_thrd 有默认值
+        assert node_options.token_margin == 100
+        assert node_options.tool_output_compress_thrd == 5000
+
+    def test_prepare_agent_model_node_injects_team_prompt_middleware(self):
+        """配置了 a2a_specs 和 a2a_resolver 时应注入 TeamPromptMiddleware"""
+        builder = ReActAgentBuilder()
+        builder._llm = MagicMock(model_name="gpt-4o")
+        builder._a2a_specs = [AgentSpec(name="helper", description="d", backend_type="bkai")]
+        builder._a2a_resolver = MagicMock()
+        captured = {}
+
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
+            captured["node_options"] = node_options
+            return MagicMock()
+
+        llm = MagicMock(model_name="gpt-4o")
+        with patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node):
+            builder._prepare_agent_model_node(llm=llm, non_thinking_llm=llm, judge_llm=llm, tools=[])
+        middlewares = captured["node_options"].extra_template_middlewares
+        assert any(isinstance(m, TeamPromptMiddleware) for m in middlewares)
+
+    def test_prepare_agent_model_node_no_team_middleware_without_a2a(self):
+        """未配置 a2a_specs/a2a_resolver 时不应注入 TeamPromptMiddleware"""
+        builder = ReActAgentBuilder()
+        builder._llm = MagicMock(model_name="gpt-4o")
+        captured = {}
+
+        def _fake_make_model_node(*, llm, non_thinking_llm, judge_llm, tools, node_options):
+            captured["node_options"] = node_options
+            return MagicMock()
+
+        llm = MagicMock(model_name="gpt-4o")
+        with patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node):
+            builder._prepare_agent_model_node(llm=llm, non_thinking_llm=llm, judge_llm=llm, tools=[])
+        middlewares = captured["node_options"].extra_template_middlewares
+        assert not any(isinstance(m, TeamPromptMiddleware) for m in middlewares)
+
+    # ----------------------------------------------------------------
+    # B (continued). _prepare_agent_tools 测试 (P0)
+    # ----------------------------------------------------------------
+
+    def test_prepare_agent_tools_injects_task_tools_when_enabled(self):
+        """enable_task=True 时应注入 Task 工具"""
+        builder = ReActAgentBuilder().enable_task(True)
+        with patch(
+            "aidev_agent.core.graphs.react.graph.get_task_tools", return_value=[MagicMock(spec=BaseTool)]
+        ) as mock:
+            tools = builder._prepare_agent_tools(extra_tools=[], langchain_middleware=[])
+        assert mock.called
+        assert len(tools) >= 1
+
+    def test_prepare_agent_tools_no_task_tools_when_disabled(self):
+        """enable_task=False 时不应注入 Task 工具"""
+        builder = ReActAgentBuilder()
+        builder._enable_task = False
+        builder._enable_ask_user_question_tool = False
+        with patch("aidev_agent.core.graphs.react.graph.get_task_tools") as mock:
+            tools = builder._prepare_agent_tools(extra_tools=[], langchain_middleware=[])
+        mock.assert_not_called()
+        assert tools == []
+
+    def test_prepare_agent_tools_injects_a2a_tools_when_specs_and_resolver(self):
+        """配置了 a2a_specs 和 a2a_resolver 时应注入 A2A 工具"""
+        sentinel_tool = MagicMock(spec=BaseTool)
+        builder = ReActAgentBuilder()
+        builder._enable_ask_user_question_tool = False
+        builder._a2a_specs = [AgentSpec(name="helper", description="d", backend_type="bkai")]
+        builder._a2a_resolver = MagicMock()
+        with patch(
+            "aidev_agent.core.graphs.react.graph.get_agent_tools",
+            return_value=[sentinel_tool],
+        ) as mock:
+            tools = builder._prepare_agent_tools(extra_tools=[], langchain_middleware=[])
+        mock.assert_called_once_with(builder._a2a_specs, builder._a2a_resolver)
+        assert sentinel_tool in tools
+
+    def test_prepare_agent_tools_no_a2a_tools_without_resolver(self):
+        """有 a2a_specs 但无 a2a_resolver 时不应注入 A2A 工具"""
+        builder = ReActAgentBuilder()
+        builder._enable_ask_user_question_tool = False
+        builder._a2a_specs = [AgentSpec(name="helper", description="d", backend_type="bkai")]
+        # a2a_resolver 默认为 None
+        with patch("aidev_agent.core.graphs.react.graph.get_agent_tools") as mock:
+            tools = builder._prepare_agent_tools(extra_tools=[], langchain_middleware=[])
+        mock.assert_not_called()
+        assert tools == []
+
+    def test_prepare_agent_tools_sets_handle_error_when_ignore_errors(self):
+        """ignore_errors=True 时应为所有工具设置 handle_validation_error/handle_tool_error"""
+        t1 = MagicMock(spec=BaseTool)
+        t2 = MagicMock(spec=BaseTool)
+        builder = ReActAgentBuilder()
+        # 直接通过 extra_tools 传入，绕过其他注入路径
+        tools = builder._prepare_agent_tools(extra_tools=[t1, t2], ignore_errors=True, langchain_middleware=[])
+        for t in tools:
+            assert t.handle_validation_error is True
+            assert t.handle_tool_error is True
+
+    def test_prepare_agent_tools_no_handle_error_when_ignore_errors_false(self):
+        """ignore_errors=False 时不应修改工具的 handle_error 属性"""
+        t1 = MagicMock(spec=BaseTool)
+        t1.handle_validation_error = "original"
+        t1.handle_tool_error = "original"
+        builder = ReActAgentBuilder()
+        tools = builder._prepare_agent_tools(extra_tools=[t1], ignore_errors=False, langchain_middleware=[])
+        assert tools[0].handle_validation_error == "original"
+        assert tools[0].handle_tool_error == "original"
+
+    # ----------------------------------------------------------------
+    # P1. _prepare_agent_knowledge_node early return 测试
+    # ----------------------------------------------------------------
+
+    def test_prepare_agent_knowledge_node_returns_none_when_disabled(self):
+        """enable_knowledge_node=False 时应返回 None"""
+        builder = ReActAgentBuilder()
+        options = KnowledgeSettings(enable_knowledge_node=False, knowledge_bases=[{"id": "kb1"}])
+        result = builder._prepare_agent_knowledge_node(
+            knowledge_llm=MagicMock(), knowledge_query_options=options, chat_history=[]
+        )
+        assert result is None
+
+    def test_prepare_agent_knowledge_node_returns_none_when_no_knowledge(self):
+        """enable_knowledge_node=True 但无 knowledge_bases/items 时应返回 None"""
+        builder = ReActAgentBuilder()
+        options = KnowledgeSettings(enable_knowledge_node=True)
+        result = builder._prepare_agent_knowledge_node(
+            knowledge_llm=MagicMock(), knowledge_query_options=options, chat_history=[]
+        )
+        assert result is None
+
+    # ----------------------------------------------------------------
+    # P1. set_bkai_options 配置链路测试 (skills / subagent_specs)
+    # ----------------------------------------------------------------
+
+    def test_set_bkai_options_skills_chain_enables_skills_and_runtime(self):
+        """set_bkai_options 收到 skills 时应启用 skills + runtime_tool + paas_sandbox"""
+        rm = MagicMock()
+        opts = AgentExecutorKwargs(
+            resource_manager=rm,
+            skills=[{"skill_name": "demo", "id": 1}],
+        )
+        builder = ReActAgentBuilder().set_bkai_options(opts)
+        assert builder._enable_skills is True
+        assert builder._enable_runtime_tool is True
+        assert "paas_sandbox" in builder._runtime_types
+        # skill_sources 应包含一个 BkAiBackend 实例
+        assert len(builder._skill_sources) == 1
+
+    def test_set_bkai_options_subagent_specs_chain_enables_a2a_team_task(self):
+        """set_bkai_options 收到 subagent_specs 时应启用 a2a_tool/team/task 并注册后端"""
+        specs = [AgentSpec(name="helper", description="d", backend_type="bkai")]
+        opts = AgentExecutorKwargs(subagent_specs=specs)
+        builder = ReActAgentBuilder().set_bkai_options(opts)
+        assert builder._enable_a2a_tool is True
+        assert builder._enable_team is True
+        assert builder._enable_task is True
+        assert {"local", "bkai"}.issubset(set(builder._a2a_backend_types))
+        assert builder._a2a_specs == specs
+
+    # ----------------------------------------------------------------
+    # P2. setter enable=False 分支合并测试
+    # ----------------------------------------------------------------
+
+    def test_setters_disable_branches(self):
+        """合并覆盖各 setter 的 enable=False 分支"""
+        builder = (
+            ReActAgentBuilder()
+            .enable_team(True)
+            .enable_team(False)
+            .set_team_config({"k": "v"})
+            .enable_task(True)
+            .enable_task(False)
+            .enable_a2a_backend_local(True)
+            .enable_a2a_backend_local(False)
+            .enable_a2a_backend_bkai(True)
+            .enable_a2a_backend_bkai(False)
+        )
+        assert builder._enable_team is False
+        assert builder._enable_task is False
+        # enable_team(False) 不会清掉 _enable_task（仅 enable_team(True) 隐式启用）
+        assert builder._team_config == {"k": "v"}
+        assert "local" not in builder._a2a_backend_types
+        assert "bkai" not in builder._a2a_backend_types
+
+    # ----------------------------------------------------------------
+    # P2. set_bkai_options 各字段赋值合并测试
+    # ----------------------------------------------------------------
+
+    def test_set_bkai_options_maps_all_fields(self):
+        """合并覆盖 set_bkai_options 中未单独测试的字段赋值"""
+        non_thinking_llm = MagicMock()
+        fast_llm = MagicMock()
+        chat_history = [HumanMessage(content="hi")]
+        file_store = MagicMock()
+        checkpointer = MemorySaver()
+        executor_info = {"user": "admin"}
+        model_ctx = ModelContextSettings(llm_token_limit=12345)
+        opts = AgentExecutorKwargs(
+            non_thinking_llm=non_thinking_llm,
+            fast_llm=fast_llm,
+            chat_history=chat_history,
+            support_vision=True,
+            file_store=file_store,
+            checkpointer=checkpointer,
+            executor_info=executor_info,
+            model_context_options=model_ctx,
+        )
+        builder = ReActAgentBuilder().set_bkai_options(opts)
+        assert builder._non_thinking_llm is non_thinking_llm
+        assert builder._fast_llm is fast_llm
+        assert builder._chat_history == chat_history
+        assert builder._support_vision is True
+        assert builder._file_store is file_store
+        assert builder._checkpointer is checkpointer
+        assert builder._executor_info == executor_info
+        assert builder._model_context_options is model_ctx
+
+    # ----------------------------------------------------------------
+    # P2. _prepare_skills 的 paas_sandbox + resource_manager 分支
+    # ----------------------------------------------------------------
+
+    def test_prepare_skills_paas_sandbox_with_resource_manager(self, tmp_path, monkeypatch):
+        """paas_sandbox runtime skill + resource_manager 时应注入 client 到 params"""
+        monkeypatch.chdir(tmp_path)
+        skills_root = tmp_path / ".agent" / "skills"
+        _write_skill(skills_root, name="paas-skill", description="d", body="b", runtime="paas_sandbox")
+
+        rm = MagicMock()
+        expected_client = MagicMock()
+        rm.get_paas_sbx_client.return_value = expected_client
+
+        builder = (
+            ReActAgentBuilder()
+            .set_llm(MagicMock(model_name="gpt-4o"))
+            .set_enable_skills(True)
+            .set_skill_sources([str(skills_root)])
+            .set_enable_runtime_tool(True)
+            .enable_runtime_paas(True)
+        )
+        builder._resource_manager = rm
+        builder._runtime_backend_resolver = MagicMock()
+
+        # 捕获 register_runtime 收到的 params
+        captured_params = {}
+        builder._runtime_backend_resolver.register_runtime = lambda key, backend: captured_params.__setitem__(
+            key, backend
+        )
+
+        builder._prepare_skills()
+        # paas_sandbox_{skill_name} 应被注册，且 backend 持有 client
+        registered_key = next((k for k in captured_params if k.startswith("paas_sandbox_")), None)
+        assert registered_key is not None
+        rm.get_paas_sbx_client.assert_called_once()
+
+    # ----------------------------------------------------------------
+    # P2. _prepare_state_schema 用户自定义 schema 分支
+    # ----------------------------------------------------------------
+
+    def test_prepare_state_schema_appends_user_schema(self):
+        """用户设置 _state_schema 时应被追加到 schemas 列表"""
+        builder = ReActAgentBuilder()
+
+        class CustomState(TypedDict):
+            foo: str
+
+        builder.set_state_schema(CustomState)
+        # 默认不启用 task/team/a2a,只应有 DefaultState + 用户 schema
+        schema = builder._prepare_state_schema(None)
+        assert schema is not None
+        # 验证 _state_schema 被加入(通过 _resolve_task_state_schema 合并后返回)
+        # 简单断言:返回值有 foo 字段(说明 CustomState 被合并)
+        hints = get_type_hints(schema)
+        assert "foo" in hints
+
+    # ----------------------------------------------------------------
+    # P2. _build_graph 真实构造图(覆盖 knowledge_node 路径)
+    # ----------------------------------------------------------------
+
+    def test_build_graph_constructs_knowledge_node_path(self):
+        """_build_graph 在传入 knowledge_node 时应真实构造 knowledge 节点和边。
+
+        不 mock _build_graph,验证 1034/1042-1043 行被覆盖。
+        """
+        builder = ReActAgentBuilder()
+
+        # 构造一个最小的真实 graph:无工具,有 knowledge_node
+        knowledge_node = MagicMock()
+        model_node = MagicMock()
+        result_graph, cfg = builder._build_graph(
+            state_schema=DefaultState,
+            callbacks=[],
+            debug=False,
+            checkpointer=MemorySaver(),
+            store=None,
+            interrupt_before=None,
+            interrupt_after=None,
+            name="test-graph",
+            cache=None,
+            knowledge_node=knowledge_node,
+            model_node=model_node,
+            tool_node=None,
+            pv_node=MagicMock(),
+            interrupt_node=MagicMock(),
+            tools=None,
+        )
+        assert result_graph is not None
+        assert cfg["configurable"]["debug"] is False
+        assert cfg["recursion_limit"] == 1000
 
     # ----------------------------------------------------------------
     # B (continued). set_bkai_options 测试 (M1)

--- a/src/agent/tests/core/graphs/test_react_pv.py
+++ b/src/agent/tests/core/graphs/test_react_pv.py
@@ -10,6 +10,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Literal
 
 from aidev_agent.core.nodes.pv import add_pv_info
@@ -69,8 +70,6 @@ def test_should_continue_empty_messages():
 
 def _read_graph_source() -> str:
     """读取 graph.py 源码，避免直接导入带来环境兼容问题。"""
-    from pathlib import Path
-
     graph_path = Path(__file__).resolve().parents[3] / "aidev_agent" / "core" / "graphs" / "react" / "graph.py"
     return graph_path.read_text(encoding="utf-8")
 

--- a/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
+++ b/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
@@ -51,7 +51,7 @@ async def test_aidev_agent_run_exposes_messages_snapshot(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_handle_single_event_suppresses_approval_tool_call(monkeypatch):
-    """D-01: _handle_single_event 覆写抑制需要审批的 ToolCallStartEvent。"""
+    """_handle_single_event 覆写抑制需要审批的 ToolCallStartEvent。"""
 
     async def _fake_super(self, event, state):  # noqa: ARG001
         yield ToolCallStartEvent(
@@ -87,7 +87,7 @@ async def test_handle_single_event_suppresses_approval_tool_call(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_handle_single_event_enhances_non_approval_tool_call(monkeypatch):
-    """D-01: 非审批工具的 ToolCallStartEvent 被 enhance 后 yield ExtendToolCallStartEvent。"""
+    """非审批工具的 ToolCallStartEvent 被 enhance 后 yield ExtendToolCallStartEvent。"""
 
     async def _fake_super(self, event, state):  # noqa: ARG001
         yield ToolCallStartEvent(
@@ -116,7 +116,7 @@ async def test_handle_single_event_enhances_non_approval_tool_call(monkeypatch):
 
 # ---------------------------------------------------------------------------
 # 审批续流终态形态：ApprovalOutcomeBuilder.upgrade_content_to_success
-#                  / ApprovalOutcomeBuilder.build_run_finished_payload
+#                 / ApprovalOutcomeBuilder.build_run_finished_payload
 # ---------------------------------------------------------------------------
 
 
@@ -485,12 +485,15 @@ async def test_resume_ask_user_question_emits_first_frame_run_finished(monkeypat
     ]
     payloads = [json.loads(chunk[6:]) for chunk in chunks]
 
-    # Phase 14.2: 首条 MESSAGES_SNAPSHOT 之后紧跟 RUN_FINISHED（续流首帧回放），
-    # 然后是额外的 MESSAGES_SNAPSHOT（更新 interrupt 卡片终态），
-    # 最后是 SDK 的 RUN_STARTED / RUN_FINISHED
+    # 续流首帧回放：首条 MESSAGES_SNAPSHOT 之后紧跟 RUN_FINISHED（关闭前端弹窗），
+    # 随后是 SDK 的 RUN_STARTED / RUN_FINISHED。不再下发第二次 MESSAGES_SNAPSHOT，
+    # interrupt 卡片终态由 RUN_FINISHED 的 outcome/result 承载。
     types = [p["type"] for p in payloads]
     assert types[0] == EventType.MESSAGES_SNAPSHOT.value
     assert types[1] == EventType.RUN_FINISHED.value, f"首帧回放 RUN_FINISHED 未发出，types={types}"
+    assert types[2:] == [EventType.RUN_STARTED.value, EventType.RUN_FINISHED.value], (
+        f"RUN_FINISHED 之后应直接是 SDK 的 RUN_STARTED / RUN_FINISHED，types={types}"
+    )
 
     # RUN_FINISHED 事件：顶层 outcome / result / runId
     run_finished = payloads[1]
@@ -514,23 +517,6 @@ async def test_resume_ask_user_question_emits_first_frame_run_finished(monkeypat
     assert result["payload"]["answers"] == [{"question": "q", "answer": [{"label": "a", "description": "d"}]}], (
         "result.payload.answers 应来自 resume payload（用户刚提交的答案），而非空的 metadata.answers"
     )
-
-    # RUN_FINISHED 之后应推送额外的 MESSAGES_SNAPSHOT，将 interrupt 消息更新为终态
-    assert types[2] == EventType.MESSAGES_SNAPSHOT.value, f"RUN_FINISHED 后应推送 MESSAGES_SNAPSHOT，types={types}"
-    updated_snapshot = payloads[2]
-    updated_messages = updated_snapshot.get("messages", [])
-    interrupt_msgs = [m for m in updated_messages if m.get("role") == "interrupt"]
-    assert interrupt_msgs, "更新后的 MESSAGES_SNAPSHOT 应包含 interrupt 消息"
-    updated_interrupt = interrupt_msgs[0]
-    assert updated_interrupt["status"] == "complete", "interrupt 消息 status 应为 complete"
-    assert updated_interrupt["content"]["outcome"]["type"] == "success", (
-        "interrupt 消息 content.outcome.type 应为 success"
-    )
-    # MESSAGES_SNAPSHOT 的 content.outcome 也应含 interrupts
-    assert "interrupts" in updated_interrupt["content"]["outcome"], (
-        "MESSAGES_SNAPSHOT 的 outcome 也应含 interrupts 字段"
-    )
-    assert len(updated_interrupt["content"]["outcome"]["interrupts"]) > 0
 
 
 @pytest.mark.asyncio

--- a/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
@@ -9,7 +9,7 @@ import json
 
 import pytest
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
-from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, AskUserQuestionOutcomeBuilder
+from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
 )
@@ -91,86 +91,6 @@ class _RecordingSessionWriter(BaseSessionWriter):
 
     def set_streaming_finished(self):
         pass
-
-    def handle_run_finished(self, event) -> None:
-        """Phase 14.2: 重写以支持 ask_user_question 续流终态写入。
-
-        super().handle_run_finished(event) 处理流式消息回写 + interrupt 首次落库，
-        非 interrupt 分支调用 _handle_ask_user_question_resume_finished 完成 DB 更新。
-        """
-        super().handle_run_finished(event)
-
-        outcome = getattr(event, "outcome", None)
-        outcome_type = (
-            outcome.get("type") if isinstance(outcome, dict) else getattr(outcome, "type", None) if outcome else None
-        )
-        if outcome and outcome_type != "interrupt":
-            self._handle_ask_user_question_resume_finished(event)
-
-    def _handle_ask_user_question_resume_finished(self, event) -> None:
-        """Phase 14.2: 从 RunFinishedEvent outcome/result 提取数据更新 DB interrupt 记录。
-
-        替代原 handle_activity_snapshot（已删除），逻辑从 event.outcome.interrupts[0] +
-        event.result.payload.answers 提取数据，查 in-memory _db_records 更新。
-        """
-        outcome = getattr(event, "outcome", None)
-        if isinstance(outcome, dict):
-            interrupts = outcome.get("interrupts") or []
-        else:
-            interrupts = getattr(outcome, "interrupts", []) if outcome else []
-        if not interrupts:
-            return
-        first_interrupt = interrupts[0] if isinstance(interrupts[0], dict) else {}
-        if first_interrupt.get("reason") != ASK_USER_QUESTION_REASON:
-            return
-        interrupt_id = first_interrupt.get("id")
-        if not interrupt_id:
-            return
-        result = getattr(event, "result", None)
-        resume_answers = []
-        if isinstance(result, dict):
-            resume_answers = result.get("payload", {}).get("answers") or []
-
-        for content_id, rec in self._db_records.items():
-            if rec.get("role") != PromptRole.INTERRUPT.value:
-                continue
-            if rec.get("status") != "pending":
-                continue
-            raw_content = rec.get("content")
-            if isinstance(raw_content, str):
-                try:
-                    parsed = json.loads(raw_content)
-                except (TypeError, ValueError):
-                    continue
-            else:
-                parsed = raw_content
-            if not isinstance(parsed, dict):
-                continue
-            parsed_intrs = (parsed.get("outcome") or {}).get("interrupts") or []
-            if not parsed_intrs:
-                continue
-            parsed_first = parsed_intrs[0] if isinstance(parsed_intrs[0], dict) else {}
-            if parsed_first.get("id") != interrupt_id:
-                continue
-            upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
-                parsed, "resolved", resume_answers=resume_answers
-            )
-            if upgraded is None:
-                continue
-            updated_builtin = dict((rec.get("property") or {}).get("builtin_property") or {})
-            updated_builtin["status"] = "resolved"
-            self._do_update_content(
-                content_id=content_id,
-                payload={
-                    "content": upgraded,
-                    "status": "complete",
-                    "property": {
-                        "builtin_property": updated_builtin,
-                        "turn_id": self.turn_id,
-                    },
-                },
-                headers={},
-            )
 
 
 def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
@@ -476,27 +396,13 @@ async def test_resume_preserves_prior_messages_and_writes_final_reply():
         f"续流后未写入最终回复的 assistant 记录，roles={roles_after_resume}"
     )
 
-    # 关键断言：续流后 interrupt 记录应被更新为 resolved（status 从 pending → resolved）
-    # 检查 writer.updated 中是否有 interrupt 记录的更新
+    # SSE 层不再 UPDATE interrupt 记录（DB 终态由入口层 chat.py:138 负责）
     interrupt_updates = [
         u
         for u in writer.updated
         if isinstance(u.get("payload", {}).get("content"), dict)
         and u["payload"]["content"].get("outcome", {}).get("type") == "success"
     ]
-    assert interrupt_updates, (
-        f"续流后未更新 interrupt 记录为 resolved，updates={len(writer.updated)}\n"
-        f"  updated details: {[(u.get('content_id'), str(u.get('payload', {}).get('content', ''))[:80]) for u in writer.updated]}"
-    )
-    # 验证更新后的 content 是终态形态（outcome.type=success, result.payload.answers 非空且匹配 resume 提交的答案）
-    upgraded_content = interrupt_updates[0]["payload"]["content"]
-    assert upgraded_content["outcome"]["type"] == "success"
-    assert "result" in upgraded_content
-    db_answers = upgraded_content["result"].get("payload", {}).get("answers")
-    assert isinstance(db_answers, list), (
-        f"result.payload.answers 应为 list，实际 {type(db_answers).__name__}，content={upgraded_content}"
-    )
-    expected_answers = [{"question": "请选择部署环境", "answer": [{"label": "生产环境", "description": "prod"}]}]
-    assert db_answers == expected_answers, (
-        f"result.payload.answers 应等于 resume 提交的答案 {expected_answers}，实际 {db_answers}"
+    assert not interrupt_updates, (
+        f" 后 SSE 层不应再 UPDATE interrupt 记录为 resolved，updates={len(writer.updated)}"
     )

--- a/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
@@ -351,11 +351,21 @@ async def test_resume_with_frontend_dict_format_updates_interrupt():
         config=merged_cfg2,
         tools={},
         # 与 chat.py 主流程对称：从 graph state 查 ask_user_question interrupts，
-        # 使 _build_resume_ask_user_question_finished_event 能触发 ACTIVITY_SNAPSHOT 事件，
-        # 经 _dispatch_event 派发给 writer 的 handle_activity_snapshot
+        # 使 _build_resume_ask_user_question_finished_event 能触发 ACTIVITY_SNAPSHOT 事件推前端。
         ask_user_question_interrupts=_extract_ask_user_question_interrupts(graph, config),
     )
     chunks2 = [chunk async for chunk in agui2.run(agent_input2)]  # noqa: F841
+
+    # 验证续流事件流：不应出现重复的 TOOL_CALL_START/ARGS/END（中断前已发到前端），
+    # 只应出现 TOOL_CALL_RESULT（由 OnToolNodeFinish 路径独立产出）。
+    tool_call_starts = [c for c in chunks2 if '"type":"TOOL_CALL_START"' in c]
+    tool_call_args = [c for c in chunks2 if '"type":"TOOL_CALL_ARGS"' in c]
+    tool_call_ends = [c for c in chunks2 if '"type":"TOOL_CALL_END"' in c]
+    tool_call_results = [c for c in chunks2 if '"type":"TOOL_CALL_RESULT"' in c]
+    assert not tool_call_starts, f"续流不应有 TOOL_CALL_START，实际: {tool_call_starts}"
+    assert not tool_call_args, f"续流不应有 TOOL_CALL_ARGS，实际: {tool_call_args}"
+    assert not tool_call_ends, f"续流不应有 TOOL_CALL_END，实际: {tool_call_ends}"
+    assert len(tool_call_results) == 1, f"续流应有 1 条 TOOL_CALL_RESULT，实际: {len(tool_call_results)}"
 
     # 检查 DB 中 interrupt 记录是否被更新
     db_after_resume = list(mock_client.api._contents)
@@ -376,8 +386,11 @@ async def test_resume_with_frontend_dict_format_updates_interrupt():
     elif isinstance(content, str):
         print(f"  content (str): {content[:100]}")
 
-    assert interrupt_after[0]["status"] != "pending", (
-        f"interrupt 记录仍为 pending（未更新为 resolved），status={interrupt_after[0]['status']}"
+    # SSE 层不再承担 DB 写入职责，interrupt 终态由 agent 侧 ChatCompletionAgent.execute()
+    # 前置派发的会话回写事件（handle_ask_user_question_finalize）负责。
+    # 本 e2e 测试仅模拟 SSE 层（不经 execute()），因此 interrupt 记录应仍为 pending（SSE 层不写 DB）。
+    assert interrupt_after[0]["status"] == "pending", (
+        f"SSE 层不应更新 interrupt 终态，status 应仍为 pending，实际: {interrupt_after[0]['status']}"
     )
 
 

--- a/src/agent/tests/core/interrupt/test_ask_user_question_handler.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_handler.py
@@ -1,29 +1,32 @@
 # -*- coding: utf-8 -*-
-"""``AskUserQuestionHandler`` 单元测试 — 覆盖 D-01/D-02/D-04~D-07/D-15/D-16。
+"""``AskUserQuestionHandler`` 单元测试 — 覆盖以下行为用例。
 
 测试覆盖 7 个行为用例：
 
-1. ``ASK_USER_QUESTION_REASON == "aidev:user_question"``（D-01）
+1. ``ASK_USER_QUESTION_REASON == "aidev:user_question"``
 2. ``build_payload`` 基本字段（reason / id 前缀 / metadata.questions + expiresAt，无扩展字段）
-3. ``build_payload`` 带 options + multiSelect（D-02，options 在 question 项内）
-4. ``hydrate_resume`` 不覆写 payload（D-06 —— 只设置 status，不动 payload）
-5. ``hydrate_resume`` 从 db_data 设置 status（D-06 —— status 来自 db_data）
+3. ``build_payload`` 带 options + multiSelect（options 在 question 项内）
+4. ``hydrate_resume`` 不覆写 payload（只设置 status，不动 payload）
+5. ``hydrate_resume`` 从 db_data 设置 status（status 来自 db_data）
 6. ``AskUserQuestionOutcomeBuilder.build_run_finished_payload`` 终态形态构造（payload.answers + 顶层 status）
 """
 
+import pytest
 from aidev_agent.core.ag_ui.ask_user_question import (
     ASK_USER_QUESTION_REASON,
+    ASK_USER_QUESTION_SKIPPED_CONTENT,
     AskUserQuestionHandler,
     AskUserQuestionOutcomeBuilder,
+    parse_resume_answers,
 )
 
 
-# 测试 1：reason 常量（D-01）
+# 测试 1：reason 常量
 def test_ask_user_question_reason_constant():
     assert ASK_USER_QUESTION_REASON == "aidev:user_question"
 
 
-# 测试 2：build_payload 基本字段（D-02, D-04, D-05, D-15, D-16）
+# 测试 2：build_payload 基本字段
 def test_build_payload_basic_fields():
     handler = AskUserQuestionHandler()
     questions = [
@@ -37,15 +40,15 @@ def test_build_payload_basic_fields():
     payload = handler.build_payload(questions=questions, tool_call_id="call_123")
 
     assert payload["reason"] == "aidev:user_question"
-    # D-16: id 格式 int-question-{tool_call_id}-{uuid_hex}
+    # id 格式 int-question-{tool_call_id}-{uuid_hex}
     assert payload["id"].startswith("int-question-call_123-")
     assert payload["toolCallId"] == "call_123"
-    assert payload["expiresAt"] is not None  # D-05 新增
+    assert payload["expiresAt"] is not None
     metadata = payload["metadata"]
     assert metadata["type"] == "ask_user_question"
     assert metadata["status"] == "pending"
     assert metadata["questions"] == questions
-    # D-04 删除的字段不存在
+    # 删除的字段不存在
     assert "required" not in metadata
     assert "other_enabled" not in metadata
     assert "multi_select" not in metadata  # 已移入 question 项（multiSelect）
@@ -53,7 +56,7 @@ def test_build_payload_basic_fields():
     assert "placeholder" not in metadata
 
 
-# 测试 3：build_payload 带 options + multiSelect（D-02，options 在 question 项内）
+# 测试 3：build_payload 带 options + multiSelect（options 在 question 项内）
 def test_build_payload_with_options_and_multi_select():
     handler = AskUserQuestionHandler()
     questions = [
@@ -77,41 +80,31 @@ def test_build_payload_with_options_and_multi_select():
     ]
 
 
-# 测试 4：hydrate_resume 不覆写 payload（D-06 —— 只设置 status，不动 payload）
+# 测试 4：hydrate_resume 不覆写 payload（只设置 status，不动 payload）
 def test_hydrate_resume_does_not_modify_payload():
     handler = AskUserQuestionHandler()
     resume_items = [
         {
             "interruptId": "x",
             "status": "resolved",
-            "payload": {
-                "answers": [
-                    {"question": "Q", "answer": [{"label": "yes", "description": None}]}
-                ]
-            },
+            "payload": {"answers": [{"question": "Q", "answer": [{"label": "yes", "description": None}]}]},
         }
     ]
     handler.hydrate_resume(resume_items, db_data=None)
 
     # payload 保持为 answers 结构，不被覆写
     assert resume_items[0]["payload"] == {
-        "answers": [
-            {"question": "Q", "answer": [{"label": "yes", "description": None}]}
-        ]
+        "answers": [{"question": "Q", "answer": [{"label": "yes", "description": None}]}]
     }
 
 
-# 测试 5：hydrate_resume 从 db_data 设置 status（D-06 —— status 来自 db_data）
+# 测试 5：hydrate_resume 从 db_data 设置 status（status 来自 db_data）
 def test_hydrate_resume_sets_status_from_db_data():
     handler = AskUserQuestionHandler()
     resume_items = [
         {
             "interruptId": "x",
-            "payload": {
-                "answers": [
-                    {"question": "Q", "answer": [{"label": "yes", "description": None}]}
-                ]
-            },
+            "payload": {"answers": [{"question": "Q", "answer": [{"label": "yes", "description": None}]}]},
         }
     ]
     handler.hydrate_resume(resume_items, db_data="resolved")
@@ -136,23 +129,104 @@ def test_outcome_builder_build_run_finished_payload():
                     }
                 ],
                 # 模拟 DB 写回形态：用户回答后的 answers
-                "answers": [
-                    {"question": "Q", "answer": [{"label": "A", "description": "选项A"}]}
-                ],
+                "answers": [{"question": "Q", "answer": [{"label": "A", "description": "选项A"}]}],
             },
         }
     ]
-    outcome, result = AskUserQuestionOutcomeBuilder.build_run_finished_payload(
-        interrupts, "resolved"
-    )
+    outcome, result = AskUserQuestionOutcomeBuilder.build_run_finished_payload(interrupts, "resolved")
 
     assert outcome["type"] == "success"
     assert outcome["interrupts"][0]["metadata"]["status"] == "resolved"
     assert result["id"] == "x"
     assert result["interruptId"] == "x"
-    # D-06/D-07: payload.answers 结构（协议 success 格式，非 metadata 透传）
-    assert result["payload"]["answers"] == [
-        {"question": "Q", "answer": [{"label": "A", "description": "选项A"}]}
-    ]
+    # /payload.answers 结构（协议 success 格式，非 metadata 透传）
+    assert result["payload"]["answers"] == [{"question": "Q", "answer": [{"label": "A", "description": "选项A"}]}]
     # 顶层 status（协议新增）
     assert result["status"] == "resolved"
+
+
+# 测试 7：falsy bug 修复 — 空列表 answers 应被显式写入（不与 None 混淆）
+@pytest.mark.parametrize(
+    "resume_answers, expected_answers",
+    [
+        ([], []),  # 用户明确提交空 → 写入 []
+        (None, []),  # 跳过场景未提交 → 保留 builder 默认 []
+        (
+            [{"question": "Q", "answer": [{"label": "A", "description": None}]}],
+            [{"question": "Q", "answer": [{"label": "A", "description": None}]}],
+        ),
+    ],
+)
+def test_build_run_finished_payload_distinguishes_empty_list_from_none(resume_answers, expected_answers):
+    interrupts = [
+        {
+            "id": "x",
+            "reason": "aidev:user_question",
+            "metadata": {"status": "pending", "questions": []},
+        }
+    ]
+    _, result = AskUserQuestionOutcomeBuilder.build_run_finished_payload(
+        interrupts, "resolved", resume_answers=resume_answers
+    )
+    assert result["payload"]["answers"] == expected_answers
+
+
+# 测试 8：falsy bug 修复 — upgrade_content_to_success 同样区分 [] 与 None
+@pytest.mark.parametrize(
+    "resume_answers, expected_answers",
+    [
+        ([], []),
+        (None, []),
+        (
+            [{"question": "Q", "answer": [{"label": "A", "description": None}]}],
+            [{"question": "Q", "answer": [{"label": "A", "description": None}]}],
+        ),
+    ],
+)
+def test_upgrade_content_to_success_distinguishes_empty_list_from_none(resume_answers, expected_answers):
+    content = {
+        "outcome": {
+            "type": "interrupt",
+            "interrupts": [
+                {
+                    "id": "x",
+                    "reason": "aidev:user_question",
+                    "metadata": {"status": "pending", "questions": []},
+                }
+            ],
+        }
+    }
+    upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
+        content, "cancelled", resume_answers=resume_answers
+    )
+    assert upgraded["result"]["payload"]["answers"] == expected_answers
+    assert upgraded["outcome"]["interrupts"][0]["metadata"]["status"] == "cancelled"
+
+
+# 测试 9：ASK_USER_QUESTION_SKIPPED_CONTENT 常量存在且非空
+def test_skipped_content_constant_exists():
+    assert isinstance(ASK_USER_QUESTION_SKIPPED_CONTENT, str)
+    assert "已跳过" in ASK_USER_QUESTION_SKIPPED_CONTENT
+
+
+# 测试 10：parse_resume_answers 纯协议解析
+@pytest.mark.parametrize(
+    "resume_items, expected",
+    [
+        # list 形态（标准 ResumeItem）
+        (
+            [{"interruptId": "x", "payload": {"answers": [{"question": "Q", "answer": []}]}}],
+            [{"question": "Q", "answer": []}],
+        ),
+        # dict 形态（单条）
+        ({"interruptId": "x", "payload": {"answers": []}}, []),
+        # 空 answers
+        ([{"interruptId": "x", "payload": {"answers": []}}], []),
+        # None 入参
+        (None, None),
+        # 无 payload → 返回 first dict 本身
+        ([{"interruptId": "x"}], {"interruptId": "x"}),
+    ],
+)
+def test_parse_resume_answers(resume_items, expected):
+    assert parse_resume_answers(resume_items) == expected

--- a/src/agent/tests/core/interrupt/test_ask_user_question_interrupt.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_interrupt.py
@@ -4,7 +4,7 @@
 本文件证明：
 
 1. ask_user_question interrupt 端到端可用（outcome builder 构造正确、
-   hydrate 不动 payload D-06、完整往返 answer 一致）；
+   hydrate 不动 payload 、完整往返 answer 一致）；
 2. approval 行为零回归（ApprovalOutcomeBuilder 续流终态形态构造正确，
    approval 首帧回放仍触发）。
 
@@ -48,7 +48,7 @@ def _ask_user_question_interrupt_dict() -> dict:
         "reason": ASK_USER_QUESTION_REASON,  # "aidev:user_question"
         "message": "需要用户回答：What?",
         "toolCallId": "call1",
-        "expiresAt": "2026-06-01T23:59:59+08:00",  # D-05
+        "expiresAt": "2026-06-01T23:59:59+08:00",  #
         "metadata": {
             "type": "ask_user_question",
             "status": "pending",
@@ -117,7 +117,7 @@ def test_ask_user_question_outcome_builder_resolved():
     assert outcome["interrupts"][0]["metadata"]["status"] == "resolved"
     assert result["id"] == "int-question-call1-abc"
     assert result["interruptId"] == "int-question-call1-abc"
-    # D-06/D-07: payload.answers 结构（协议 success 格式，非 metadata 透传）
+    # /payload.answers 结构（协议 success 格式，非 metadata 透传）
     assert result["payload"]["answers"] == [{"question": "What?", "answer": [{"label": "A", "description": "选项A"}]}]
     # 顶层 status（协议新增）
     assert result["status"] == "resolved"
@@ -143,7 +143,7 @@ def test_ask_user_question_outcome_builder_cancelled():
 
 @pytest.mark.asyncio
 async def test_approval_resume_still_emits_first_frame_finished(monkeypatch):
-    """回归（D-14）：approval interrupt 续流仍发出首帧 RUN_FINISHED。"""
+    """回归：approval interrupt 续流仍发出首帧 RUN_FINISHED。"""
     monkeypatch.setattr(LangGraphAGUIAgent, "run", _fake_parent_run_normal)
 
     agent = AidevAGUIAgent(
@@ -198,12 +198,12 @@ async def test_unknown_reason_resume_does_not_emit_first_frame_finished(monkeypa
 
 
 # --------------------------------------------------------------------------- #
-# 测试 6：AskUserQuestionHandler.hydrate_resume 不动 payload（D-06）
+# 测试 6：AskUserQuestionHandler.hydrate_resume 不动 payload
 # --------------------------------------------------------------------------- #
 
 
 def test_ask_user_question_hydrate_preserves_payload():
-    """D-06：hydrate_resume 设置 status 但不触碰 payload，payload.answers 被保留。"""
+    """hydrate_resume 设置 status 但不触碰 payload，payload.answers 被保留。"""
     handler = AskUserQuestionHandler()
     items = [
         {
@@ -214,7 +214,7 @@ def test_ask_user_question_hydrate_preserves_payload():
     ]
     handler.hydrate_resume(items, "resolved")
 
-    # payload 未被触碰（D-06）
+    # payload 未被触碰
     assert items[0]["payload"]["answers"] == [
         {"question": "Pick one", "answer": [{"label": "A", "description": "选项A"}]}
     ]
@@ -227,7 +227,7 @@ def test_ask_user_question_hydrate_preserves_payload():
 
 
 def test_ask_user_question_extract_builtin_property():
-    """extract_builtin_property 返回 questions、options、answers、multiSelect 字段（D-02 字段名对齐）。"""
+    """extract_builtin_property 返回 questions、options、answers、multiSelect 字段（ 字段名对齐）。"""
     handler = AskUserQuestionHandler()
     interrupt = {
         "id": "int-question-c1-abc",
@@ -277,12 +277,12 @@ def test_ask_user_question_extract_builtin_property():
 
 
 def test_ask_user_question_full_roundtrip_preserves_answer():
-    """完整往返：answers 在整个管道中被保留（D-06 + D-07 + D-02）。
+    """完整往返：answers 在整个管道中被保留（ +  + ）。
 
     流程：
     1. handler.build_payload 构造 pending 态 interrupt（questions 数组）
     2. 前端提交 ResumeItem（payload.answers = [...]）
-    3. handler.hydrate_resume 仅补 status，不动 payload（D-06）
+    3. handler.hydrate_resume 仅补 status，不动 payload
     4. handler.outcome_builder.build_run_finished_payload 构造终态形态
     → answers 在 result.payload.answers 中被保留（协议 success 格式）
     """
@@ -308,7 +308,7 @@ def test_ask_user_question_full_roundtrip_preserves_answer():
     db_interrupt = copy.deepcopy(payload)
     db_interrupt["metadata"]["answers"] = submitted_answers
 
-    # 3. hydrate_resume 仅补 status，不动 payload（D-06）
+    # 3. hydrate_resume 仅补 status，不动 payload
     original_payload = copy.deepcopy(resume_items[0]["payload"])
     handler.hydrate_resume(resume_items, "resolved")
     assert resume_items[0]["payload"] == original_payload  # payload 未变
@@ -509,7 +509,7 @@ async def test_resume_first_frame_result_answers_from_resume_payload(monkeypatch
         f"({expected_answers})，实际: {result_dict.get('payload', {}).get('answers')}"
     )
 
-    # Phase 14.2: MESSAGES_SNAPSHOT 已取消（D-03），仅保留首帧 MESSAGES_SNAPSHOT
+    # Phase 14.2: MESSAGES_SNAPSHOT 已取消，仅保留首帧 MESSAGES_SNAPSHOT
     messages_snapshots = [p for p in payloads if p["type"] == EventType.MESSAGES_SNAPSHOT.value]
     assert len(messages_snapshots) >= 1, (
         f"应至少有 1 个 MESSAGES_SNAPSHOT（首帧），实际: {len(messages_snapshots)}"

--- a/src/agent/tests/core/nodes/model/test_quality_gate.py
+++ b/src/agent/tests/core/nodes/model/test_quality_gate.py
@@ -152,20 +152,6 @@ class TestTaskJudgment:
         ]
         assert gate._extract_last_human_input(messages) == "第二个问题"
 
-    def test_judge_think_block_stripped(self):
-        mock_llm = Mock()
-        mock_llm.invoke.return_value = AIMessage(content="已完成")
-        gate = QualityGate(judge_llm=mock_llm, enable_judge_response=True)
-        think_content = "<think>admiration</think>visible answer"
-        response = AIMessage(content=think_content)
-        ctx = _make_ctx(response)
-        gate.validate_response(ctx)
-        # 验证传给判断 LLM 的 HumanMessage 不含 think 块
-        call_args = mock_llm.invoke.call_args[0][0]
-        human_msg = next(m for m in call_args if isinstance(m, HumanMessage))
-        assert "admiration" not in human_msg.content
-        assert "visible answer" in human_msg.content
-
 
 class TestEnableJudgeResponseSwitch:
     """测试 enable_judge_response 开关。"""

--- a/src/agent/tests/services/event_handlers/test_agui_writer_ask_user_question.py
+++ b/src/agent/tests/services/event_handlers/test_agui_writer_ask_user_question.py
@@ -1,0 +1,292 @@
+# -*- coding: utf-8 -*-
+"""AGUISessionWriter 的 ask_user_question 三个事件 handler 与三个私有 DB 方法单测。
+
+使用 e2e 测试的 ``_MockBKAidevClient`` 有状态内存 DB 模式（Q2 模式 A），
+宿主为真实 ``AGUISessionWriter``，覆盖跳过/答题/user 落库三条路径及 D-16/D-17/D-19 关键行为。
+"""
+
+import json
+from unittest.mock import patch
+
+from ag_ui.core import CustomEvent, EventType
+from aidev_agent.core.ag_ui.ask_user_question import (
+    ASK_USER_QUESTION_REASON,
+    ASK_USER_QUESTION_SKIPPED_CONTENT,
+    AskUserQuestionOutcomeBuilder,
+    InterruptStatus,
+    build_skipped_answers,
+)
+from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
+from aidev_agent.core.ag_ui.types import SessionPersistenceEventNames
+from aidev_agent.enums import PromptRole
+from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+
+
+class _MockBKAidevClient:
+    """模拟 BKAidev API client，追踪 DB 读写。"""
+
+    def __init__(self):
+        self.api = _MockApi(self)
+
+
+class _MockApi:
+    def __init__(self, client):
+        self.client = client
+        self._contents: list[dict] = []
+        self._next_id = 1
+
+    def create_chat_session_content(self, json, headers):
+        content_id = self._next_id
+        self._next_id += 1
+        record = {
+            "id": content_id,
+            "role": json.get("role"),
+            "content": json.get("content"),
+            "status": json.get("status"),
+            "property": json.get("property", {}),
+        }
+        self._contents.append(record)
+        return {"data": {"id": content_id}}
+
+    def update_chat_session_content(self, path_params, json, headers):
+        content_id = path_params["id"]
+        for rec in self._contents:
+            if rec["id"] == content_id:
+                if "content" in json:
+                    rec["content"] = json["content"]
+                if "status" in json:
+                    rec["status"] = json["status"]
+                if "property" in json:
+                    rec["property"] = json["property"]
+                break
+        return {"data": {"id": content_id}}
+
+    def get_chat_session_contents(self, params, headers):
+        # 模拟生产环境：API 返回的 property 不含 builtin_property
+        stripped = []
+        for rec in self._contents:
+            rec_copy = dict(rec)
+            prop = rec_copy.get("property") or {}
+            if isinstance(prop, dict):
+                stripped_prop = {k: v for k, v in prop.items() if k != "builtin_property"}
+                rec_copy["property"] = stripped_prop
+            stripped.append(rec_copy)
+        return {"data": stripped}
+
+    def update_chat_session(self, path_params, json, headers):
+        return {"data": {}}
+
+    def retrieve_chat_session(self, path_params, headers):
+        return {"data": {"session_property": {}}}
+
+
+def _pending_interrupt_record(content_id: int = 1, tool_call_id: str = "call_auq_001") -> dict:
+    """构造一条 pending 的 ask_user_question interrupt 记录。"""
+    return {
+        "id": content_id,
+        "role": PromptRole.INTERRUPT.value,
+        "status": "pending",
+        "content": json.dumps(
+            {
+                "outcome": {
+                    "type": "interrupt",
+                    "interrupts": [
+                        {
+                            "id": "int-question-001",
+                            "reason": ASK_USER_QUESTION_REASON,
+                            "toolCallId": tool_call_id,
+                            "metadata": {
+                                "questions": [
+                                    {"question": "确认继续？", "multiSelect": False},
+                                ]
+                            },
+                        }
+                    ],
+                }
+            }
+        ),
+        "property": {"turn_id": "t1"},
+    }
+
+
+class TestAGUISessionWriterAskUserQuestionHandlers:
+    """AGUISessionWriter 的 ask_user_question 三个 handler 与私有 DB 方法。"""
+
+    def _make_writer(self, contents=None) -> AGUISessionWriter:
+        mock_client = _MockBKAidevClient()
+        if contents:
+            mock_client.api._contents = contents
+        return AGUISessionWriter(session_code="test-auq-1", client=mock_client, username="test", tools=[])
+
+    def _event(self, name, value):
+        return CustomEvent(type=EventType.CUSTOM, name=name, value=value)
+
+    def _skipped_event_value(self, record: dict) -> dict:
+        """构造与 chat.py `_handle_skip_path` 一致的富化跳过 finalize 事件 value。
+
+        chat.py 已调 ``upgrade_content_to_success`` 把 content 升级为终态 dict 后透传，
+        本 helper 同样预升级（模拟 chat.py 行为）。跳过路径的 tool 记录由 chat.py 单独派发
+        TOOL_CALL_RESULT 事件（handle_tool_call_result）写入，不在本 value 内。
+        """
+        parsed = json.loads(record["content"])
+        interrupts = (parsed.get("outcome") or {}).get("interrupts") or []
+        first = interrupts[0] if interrupts and isinstance(interrupts[0], dict) else {}
+        metadata = first.get("metadata") or {}
+        skipped_answers = build_skipped_answers(metadata.get("questions") or [])
+        upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
+            record["content"], InterruptStatus.CANCELLED.value, resume_answers=skipped_answers
+        )
+        bp = record.get("builtin_property") or {}
+        return {
+            "turn_id": (record.get("property") or {}).get("turn_id") or "",
+            "status": InterruptStatus.CANCELLED.value,
+            "content_id": record["id"],
+            "content": upgraded,
+            "answers": skipped_answers,
+            "builtin_property": bp,
+        }
+
+    def _resolved_event_value(self, record: dict, answers: list) -> dict:
+        """构造与 chat.py `_handle_answer_path` 一致的富化答题事件 value。
+
+        chat.py 已调 ``upgrade_content_to_success`` 把 content 升级为终态 dict 后透传，
+        本 helper 同样预升级（模拟 chat.py 行为）。
+        """
+        upgraded = AskUserQuestionOutcomeBuilder.upgrade_content_to_success(
+            record["content"], InterruptStatus.RESOLVED.value, resume_answers=answers
+        )
+        bp = record.get("builtin_property") or {}
+        return {
+            "turn_id": (record.get("property") or {}).get("turn_id") or "",
+            "answers": answers,
+            "status": InterruptStatus.RESOLVED.value,
+            "content_id": record["id"],
+            "content": upgraded,
+            "builtin_property": bp,
+        }
+
+    def test_dispatch_routes_to_skipped_handler(self):
+        writer = self._make_writer()
+        with patch.object(writer, "handle_ask_user_question_finalize") as h:
+            writer._dispatch_custom_event_direct(
+                self._event(SessionPersistenceEventNames.AskUserQuestionFinalized.value, {})
+            )
+            h.assert_called_once()
+
+    def test_dispatch_routes_to_resolved_handler(self):
+        writer = self._make_writer()
+        with patch.object(writer, "handle_ask_user_question_finalize") as h:
+            writer._dispatch_custom_event_direct(
+                self._event(SessionPersistenceEventNames.AskUserQuestionFinalized.value, {})
+            )
+            h.assert_called_once()
+
+    def test_dispatch_routes_to_user_input_handler(self):
+        writer = self._make_writer()
+        with patch.object(writer, "handle_user_input_saved") as h:
+            writer._dispatch_custom_event_direct(self._event(SessionPersistenceEventNames.UserInputSaved.value, {}))
+            h.assert_called_once()
+
+    def test_handle_user_input_saved_creates_user_record(self):
+        writer = self._make_writer()
+        with patch.object(writer, "_do_create_content") as create:
+            writer.handle_user_input_saved(self._event("user_input_saved", {"content": "你好", "turn_id": "t1"}))
+            payload = create.call_args.kwargs["payload"]
+            assert payload["role"] == PromptRole.USER.value
+            assert payload["status"] == "success"
+            assert payload["property"] == {"turn_id": "t1"}
+            assert "builtin_property" not in payload["property"]
+
+    def test_handle_user_input_saved_propagates_exception(self):
+        writer = self._make_writer()
+        with patch.object(writer, "_do_create_content", side_effect=RuntimeError("boom")):
+            writer.handle_user_input_saved(self._event("user_input_saved", {"content": "hi", "turn_id": "t1"}))
+
+    def test_handle_finalize_cancelled_finalizes_to_cancelled(self):
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        value = self._skipped_event_value(_pending_interrupt_record())
+        writer.handle_ask_user_question_finalize(
+            self._event(SessionPersistenceEventNames.AskUserQuestionFinalized.value, value)
+        )
+        # finalize handler 仅终态 interrupt，不写 tool 记录（tool 由 chat.py 派发 TOOL_CALL_RESULT 单独写入）
+        tool_records = [r for r in writer.client.api._contents if r["role"] == PromptRole.TOOL.value]
+        assert not tool_records
+        interrupt_after = [r for r in writer.client.api._contents if r["role"] == PromptRole.INTERRUPT.value]
+        builtin = (interrupt_after[0].get("property") or {}).get("builtin_property") or {}
+        assert builtin["status"] == "cancelled"
+
+    def test_handle_tool_call_result_writes_skipped_tool(self):
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        writer.handle_tool_call_result(
+            ExtendToolCallResultEvent(
+                type=EventType.TOOL_CALL_RESULT,
+                tool_call_id="call_auq_001",
+                message_id="call_auq_001",
+                content=ASK_USER_QUESTION_SKIPPED_CONTENT,
+                role="tool",
+                duration=None,
+                is_error=False,
+                additional_metadata={},
+                skip_db=False,
+            )
+        )
+        tool_records = [r for r in writer.client.api._contents if r["role"] == PromptRole.TOOL.value]
+        assert tool_records
+        assert tool_records[0]["content"] == ASK_USER_QUESTION_SKIPPED_CONTENT
+        tool_builtin = (tool_records[0].get("property") or {}).get("builtin_property") or {}
+        assert tool_builtin["tool_call_id"] == "call_auq_001"
+
+    def test_handle_skipped_finalize_failure_does_not_rollback(self):
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        value = self._skipped_event_value(_pending_interrupt_record())
+        with patch.object(writer, "_do_update_content", side_effect=RuntimeError("boom")):
+            writer.handle_ask_user_question_finalize(
+                self._event(SessionPersistenceEventNames.AskUserQuestionFinalized.value, value)
+            )
+        # finalize 失败只 log 不回滚（无 tool 记录，interrupt 仍 pending）
+        tool_records = [r for r in writer.client.api._contents if r["role"] == PromptRole.TOOL.value]
+        assert not tool_records
+
+    def test_handle_resolved_finalizes_to_resolved(self):
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        value = self._resolved_event_value(_pending_interrupt_record(), answers=[{"a": 1}])
+        writer.handle_ask_user_question_finalize(
+            self._event(SessionPersistenceEventNames.AskUserQuestionFinalized.value, value)
+        )
+        interrupt_after = [r for r in writer.client.api._contents if r["role"] == PromptRole.INTERRUPT.value]
+        builtin = (interrupt_after[0].get("property") or {}).get("builtin_property") or {}
+        assert builtin["status"] == "resolved"
+
+    def test_handle_resolved_missing_content_id_does_not_finalize(self):
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        writer.handle_ask_user_question_finalize(
+            self._event(
+                SessionPersistenceEventNames.AskUserQuestionFinalized.value,
+                {
+                    "turn_id": "t1",
+                    "answers": [{"a": 1}],
+                    "status": InterruptStatus.RESOLVED.value,
+                },
+            )
+        )
+        interrupt_after = [r for r in writer.client.api._contents if r["role"] == PromptRole.INTERRUPT.value]
+        builtin = (interrupt_after[0].get("property") or {}).get("builtin_property") or {}
+        assert builtin.get("status") != "resolved"
+
+    def test_handle_finalize_missing_upgraded_content_does_not_finalize(self):
+        """事件有 content_id 但缺终态 content（chat.py upgrade 失败未派发，防御性 case）→ 不写 DB。"""
+        writer = self._make_writer(contents=[_pending_interrupt_record()])
+        writer.handle_ask_user_question_finalize(
+            self._event(
+                SessionPersistenceEventNames.AskUserQuestionFinalized.value,
+                {
+                    "turn_id": "t1",
+                    "content_id": 1,
+                    "answers": [],
+                    "status": InterruptStatus.CANCELLED.value,
+                },
+            )
+        )
+        interrupt_after = [r for r in writer.client.api._contents if r["role"] == PromptRole.INTERRUPT.value]
+        builtin = (interrupt_after[0].get("property") or {}).get("builtin_property") or {}
+        assert builtin.get("status") != "cancelled"

--- a/src/agent/tests/services/test_build_subagents.py
+++ b/src/agent/tests/services/test_build_subagents.py
@@ -177,7 +177,7 @@ def test_ctx_is_agent_build_context():
 
 
 def test_child_related_agents_cleared():
-    """即使子 config 原本含 related_agents（嵌套），子 ctx.agent_config.related_agents 必须被清空（递归断开 D-06）。"""
+    """即使子 config 原本含 related_agents（嵌套），子 ctx.agent_config.related_agents 必须被清空（递归断开 ）。"""
     # mock 子 config 故意带 nested related_agents
     nested_child_config = _make_agent_config(
         agent_code="child_code",

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -5,10 +5,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
+from ag_ui.core import CustomEvent, EventType, RunErrorEvent, RunFinishedEvent
 from aidev_agent.config import settings
 from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
-from aidev_agent.core.ag_ui.types import CustomMessageType
+from aidev_agent.core.ag_ui.ask_user_question import ASK_USER_QUESTION_REASON, ASK_USER_QUESTION_SKIPPED_CONTENT
+from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
+from aidev_agent.core.ag_ui.types import CustomMessageType, SessionPersistenceEventNames
 from aidev_agent.core.nodes.tool.approval_wrapper import TOOL_APPROVAL_REASON
 from aidev_agent.enums import PromptRole
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
@@ -51,6 +53,23 @@ class _ConcreteWriter(BaseSessionWriter):
     def _do_create_content(self, payload: dict, headers: dict) -> int | None:
         self._created_contents.append(payload)
         return len(self._created_contents)
+
+    def _do_update_content(self, content_id: int, payload: dict, headers: dict) -> None:
+        pass
+
+
+class _RecordingEventWriter(BaseSessionWriter):
+    """记录收到的所有事件的测试 writer。"""
+
+    def __init__(self, session_code: str = "test_session", **kwargs):
+        super().__init__(session_code=session_code, **kwargs)
+        self.events: list[CustomEvent] = []
+
+    def __call__(self, event, **kwargs):
+        self.events.append(event)
+
+    def _do_create_content(self, payload: dict, headers: dict) -> int | None:
+        return 1
 
     def _do_update_content(self, content_id: int, payload: dict, headers: dict) -> None:
         pass
@@ -2337,3 +2356,272 @@ class TestTerminalResumeReplay:
         mock_replay.assert_not_called()
         mock_astream.assert_not_called()
         agui_entry.run.assert_not_called()
+
+
+class TestDispatchSessionPersistenceEvents:
+    """测试 execute() 前置的 ask_user_question 三态分发与 chat_history patch。"""
+
+    DEFAULT_INTERRUPT_ID = "int-q"
+
+    def _make_agent(self, interrupt_tool_call_id="call_auq_001", interrupt_id=None):
+        writer = _RecordingEventWriter()
+        interrupt_id = interrupt_id or self.DEFAULT_INTERRUPT_ID
+        chat_history = [
+            ChatPrompt(id="1", role="system", content="sys"),
+            ChatPrompt(role="assistant", content="提问", builtin_property={"tool_calls": [{"id": "c1"}]}),
+        ]
+        if interrupt_tool_call_id:
+            chat_history.append(
+                ChatPrompt(
+                    id="content-1",
+                    role=PromptRole.INTERRUPT.value,
+                    content={
+                        "outcome": {
+                            "type": "interrupt",
+                            "interrupts": [
+                                {
+                                    "id": interrupt_id,
+                                    "reason": ASK_USER_QUESTION_REASON,
+                                    "toolCallId": interrupt_tool_call_id,
+                                    "metadata": {"type": "ask_user_question", "status": "pending", "questions": []},
+                                }
+                            ],
+                        }
+                    },
+                    builtin_property={
+                        "tool_call_id": interrupt_tool_call_id,
+                        "reason": ASK_USER_QUESTION_REASON,
+                        "questions": [{"question": "Q", "multiSelect": False}],
+                    },
+                )
+            )
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"]),
+            checkpointer=MemorySaver(),
+            event_handler=writer,
+            chat_history=chat_history,
+        )
+        return agent, writer
+
+    def _make_agent_without_tail_interrupt(self):
+        """构造末尾非 INTERRUPT 的 agent（末尾是 user 记录，模拟已回答场景）。"""
+        writer = _RecordingEventWriter()
+        chat_history = [
+            ChatPrompt(id="1", role="system", content="sys"),
+            ChatPrompt(role="assistant", content="提问", builtin_property={"tool_calls": [{"id": "c1"}]}),
+            ChatPrompt(
+                id="content-1",
+                role=PromptRole.INTERRUPT.value,
+                content={
+                    "outcome": {
+                        "type": "interrupt",
+                        "interrupts": [
+                            {
+                                "id": self.DEFAULT_INTERRUPT_ID,
+                                "reason": ASK_USER_QUESTION_REASON,
+                                "toolCallId": "call_auq_001",
+                                "metadata": {"type": "ask_user_question", "status": "pending", "questions": []},
+                            }
+                        ],
+                    }
+                },
+                builtin_property={
+                    "tool_call_id": "call_auq_001",
+                    "reason": ASK_USER_QUESTION_REASON,
+                    "questions": [{"question": "Q", "multiSelect": False}],
+                },
+            ),
+            # 末尾是 user 记录（interrupt 已被回答过一次）
+            ChatPrompt(role=PromptRole.USER.value, content="之前的回答"),
+        ]
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"]),
+            checkpointer=MemorySaver(),
+            event_handler=writer,
+            chat_history=chat_history,
+        )
+        return agent, writer
+
+    def _ask_user_resume(self, interrupt_id=None, answers=None):
+        """构造 ask_user_question resume（payload.answers 存在即被识别为 ask_user）。"""
+        payload_answers = answers if answers is not None else []
+        return {
+            "interruptId": interrupt_id or self.DEFAULT_INTERRUPT_ID,
+            "status": "resolved",
+            "payload": {"answers": payload_answers},
+        }
+
+    def test_skip_path_patches_tool_and_user_and_clears_resume(self):
+        agent, writer = self._make_agent()
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(), input="hi", turn_id="t1")
+        agent._prepare_pre_run_history(kwargs)
+        roles = [p.role for p in agent.chat_history]
+        assert roles[-2:] == [PromptRole.TOOL.value, PromptRole.USER.value]
+        assert agent.chat_history[-2].builtin_property.get("tool_call_id") == "call_auq_001"
+        assert agent.chat_history[-1].content == "hi"
+        assert kwargs.resume is None
+        interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        outcome = interrupt_after.content.get("outcome") or {}
+        assert outcome.get("type") == "success"
+        assert (outcome.get("interrupts") or [{}])[0].get("metadata", {}).get("status") == "cancelled"
+        assert isinstance(writer.events[0], ExtendToolCallResultEvent)
+        assert writer.events[0].content == ASK_USER_QUESTION_SKIPPED_CONTENT
+        custom_names = [e.name for e in writer.events if isinstance(e, CustomEvent)]
+        assert custom_names == [
+            SessionPersistenceEventNames.AskUserQuestionFinalized.value,
+            SessionPersistenceEventNames.UserInputSaved.value,
+        ]
+
+    def test_answer_path_resolves_interrupt_and_resolved_event(self):
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        answers = [{"question": "Q", "answer": [{"label": "A"}]}]
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(answers=answers), input="", turn_id="t1")
+        agent._prepare_pre_run_history(kwargs)
+        assert len(agent.chat_history) == before
+        interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        outcome = interrupt_after.content.get("outcome") or {}
+        assert outcome.get("type") == "success"
+        assert (outcome.get("interrupts") or [{}])[0].get("metadata", {}).get("status") == "resolved"
+        assert interrupt_after.content.get("result", {}).get("payload", {}).get("answers") == answers
+        assert len(writer.events) == 1
+        event = writer.events[0]
+        assert event.name == SessionPersistenceEventNames.AskUserQuestionFinalized.value
+        assert event.value["answers"] == answers
+        assert event.value["status"] == "resolved"
+        assert event.value["content_id"] == "content-1"
+        assert event.value["builtin_property"]["tool_call_id"] == "call_auq_001"
+
+    def test_normal_input_patches_user_only(self):
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        kwargs = ExecuteKwargs(input="hi")
+        agent._prepare_pre_run_history(kwargs)
+        assert len(agent.chat_history) == before + 1
+        assert agent.chat_history[-1].role == PromptRole.USER.value
+        assert agent.chat_history[-1].content == "hi"
+        names = [e.name for e in writer.events]
+        assert names == [SessionPersistenceEventNames.UserInputSaved.value]
+
+    def test_no_resume_no_input_no_event(self):
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        agent._prepare_pre_run_history(ExecuteKwargs())
+        assert len(agent.chat_history) == before
+        assert writer.events == []
+
+    def test_approval_resume_with_input_blocked_by_guard(self):
+        """审批中断 resume（payload 不含 answers）：守卫拦截，不落 ask_user 记录。"""
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        # approval resume payload 是 {approved: bool}，不含 answers → 不被识别为 ask_user
+        approval_resume = {"interruptId": "x", "status": "resolved", "payload": {"approved": True}}
+        kwargs = ExecuteKwargs(resume=approval_resume, input="hi", turn_id="t1")
+        agent._prepare_pre_run_history(kwargs)
+        # 审批 resume 被守卫拦截，但 input 仍走独立的 user 事件分发步骤
+        assert len(agent.chat_history) == before + 1
+        assert agent.chat_history[-1].content == "hi"
+        assert kwargs.resume is not None
+        names = [e.name for e in writer.events]
+        assert names == [SessionPersistenceEventNames.UserInputSaved.value]
+
+    def test_approval_resume_without_input_blocked_by_guard(self):
+        """审批中断 + 仅 resume（无 input）：守卫拦截，不派发任何事件。"""
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        approval_resume = {"interruptId": "x", "status": "resolved", "payload": {"approved": False}}
+        agent._prepare_pre_run_history(ExecuteKwargs(resume=approval_resume, input=""))
+        assert len(agent.chat_history) == before
+        assert writer.events == []
+        interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        assert (interrupt_after.content.get("outcome") or {}).get("type") != "success"
+
+    def test_no_interrupt_resume_raises_on_validation(self):
+        """末尾非 INTERRUPT（已回答场景）+ ask_user resume：一致性校验抛 AgentException。"""
+        from aidev_agent.exceptions import AgentException
+
+        agent, writer = self._make_agent_without_tail_interrupt()
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(), input="hi", turn_id="t1")
+        with pytest.raises(AgentException, match="期望末尾为 INTERRUPT"):
+            agent._prepare_pre_run_history(kwargs)
+
+    def test_empty_chat_history_resume_raises_on_validation(self):
+        """chat_history 为空 + ask_user resume：一致性校验抛 AgentException。"""
+        from aidev_agent.exceptions import AgentException
+
+        writer = _RecordingEventWriter()
+        agent = ChatCompletionAgent(
+            chat_model=MockChatModel(responses=["ok"]),
+            checkpointer=MemorySaver(),
+            event_handler=writer,
+            chat_history=[],
+        )
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(), input="hi", turn_id="t1")
+        with pytest.raises(AgentException, match="缺少对应的 interrupt 记录"):
+            agent._prepare_pre_run_history(kwargs)
+
+    def test_validate_resume_consistency_raises_on_missing_tool_call_id(self):
+        """interrupt.builtin_property 缺 tool_call_id（脏数据）→ 抛异常。"""
+        from aidev_agent.exceptions import AgentException
+
+        agent, writer = self._make_agent()
+        interrupt_prompt = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        interrupt_prompt.builtin_property = {"reason": ASK_USER_QUESTION_REASON, "questions": []}
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(), input="hi", turn_id="t1")
+        with pytest.raises(AgentException, match="缺少 tool_call_id"):
+            agent._prepare_pre_run_history(kwargs)
+
+    def test_skip_path_when_answers_empty_and_no_input(self):
+        """resume + 空 answers + 无 input → 跳过路径，仅取消 interrupt，不派发 user 事件。"""
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(answers=[]), input="", turn_id="t1")
+        agent._prepare_pre_run_history(kwargs)
+        assert kwargs.resume is None
+        # 不补 user 记录（无 input），但补 tool 记录（有 tool_call_id）
+        assert len(agent.chat_history) == before + 1
+        assert agent.chat_history[-1].role == PromptRole.TOOL.value
+        interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        outcome = interrupt_after.content.get("outcome") or {}
+        assert (outcome.get("interrupts") or [{}])[0].get("metadata", {}).get("status") == "cancelled"
+        # 不派发 UserInputSaved 事件（仅派发 tool + finalize）
+        custom_names = [e.name for e in writer.events if isinstance(e, CustomEvent)]
+        assert SessionPersistenceEventNames.UserInputSaved.value not in custom_names
+        assert SessionPersistenceEventNames.AskUserQuestionFinalized.value in custom_names
+
+    def test_validate_resume_consistency_raises_on_id_mismatch(self):
+        """resume.interruptId 与 chat_history interrupt id 不一致 → 抛异常。"""
+        from aidev_agent.exceptions import AgentException
+
+        agent, writer = self._make_agent()
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(interrupt_id="wrong-id"), input="hi", turn_id="t1")
+        with pytest.raises(AgentException, match="不一致"):
+            agent._prepare_pre_run_history(kwargs)
+
+    def test_validate_resume_consistency_raises_on_status_not_pending(self):
+        """interrupt status 非 pending → 抛异常。"""
+        from aidev_agent.exceptions import AgentException
+
+        agent, writer = self._make_agent()
+        interrupt_prompt = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        # 改写 interrupt content 的 status 为 resolved
+        interrupt_prompt.content["outcome"]["interrupts"][0]["metadata"]["status"] = "resolved"
+        kwargs = ExecuteKwargs(resume=self._ask_user_resume(), input="hi", turn_id="t1")
+        with pytest.raises(AgentException, match="status=pending"):
+            agent._prepare_pre_run_history(kwargs)
+
+    def test_non_ask_user_resume_returns_early(self):
+        """resume payload 不含 answers（模拟 approval）→ 不走 ask_user 回写逻辑。"""
+        agent, writer = self._make_agent()
+        before = len(agent.chat_history)
+        approval_resume = {
+            "interruptId": self.DEFAULT_INTERRUPT_ID,
+            "status": "resolved",
+            "payload": {"approved": True},
+        }
+        agent._prepare_pre_run_history(ExecuteKwargs(resume=approval_resume, input=""))
+        assert len(agent.chat_history) == before
+        assert writer.events == []
+        # resume 未被清空（未走 ask_user 路径）
+        interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
+        assert (interrupt_after.content.get("outcome") or {}).get("type") != "success"

--- a/src/agent/tests/services/test_knowledge_rag_result_db.py
+++ b/src/agent/tests/services/test_knowledge_rag_result_db.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""KNOWLEDGE_RAG_RESULT 事件透传 + DB 写入回归测试（D-14/D-15/D-06）。
+"""KNOWLEDGE_RAG_RESULT 事件透传 + DB 写入回归测试。
 
 覆盖三个层次：
 a. SSE 侧：_dispatch_event 纯分发，CUSTOM 透传不转换（转换在 _handle_on_custom_event 覆写中）
@@ -65,30 +65,30 @@ class _ConcreteSessionWriter(BaseSessionWriter):
 # ---------- a. SSE 侧透传测试 ----------
 
 
-# ---------- a2. D-06 透传验证测试 ----------
+# ---------- a2. 透传验证测试 ----------
 
 
 class TestConvertEventD06Passthrough:
-    """D-06/D-02/13.6：验证已删除的转换方法确实不存在（回归防护）。
+    """验证已删除的转换方法确实不存在（回归防护）。
 
     _convert_event / _convert_raw_event / _convert_custom_event / _convert_tool_call_start
-    均已删除（Phase 13.6 D-01 + 前序阶段），_dispatch_event 简化为纯分发。
+    均已删除（前序阶段），_dispatch_event 简化为纯分发。
     """
 
     def test_convert_custom_event_method_deleted(self):
-        """D-06 后 CUSTOM 转换方法已删除（不存在于实例或类上）。"""
+        """CUSTOM 转换方法已删除（不存在于实例或类上）。"""
         assert not hasattr(AidevAGUIAgent, "_convert_custom_event")
         agent = AidevAGUIAgent.__new__(AidevAGUIAgent)
         assert not hasattr(agent, "_convert_custom_event")
 
     def test_convert_tool_call_start_method_deleted(self):
-        """D-02 后 _convert_tool_call_start 方法已删除。"""
+        """_convert_tool_call_start 方法已删除。"""
         assert not hasattr(AidevAGUIAgent, "_convert_tool_call_start")
         agent = AidevAGUIAgent.__new__(AidevAGUIAgent)
         assert not hasattr(agent, "_convert_tool_call_start")
 
     def test_convert_event_and_convert_raw_event_deleted(self):
-        """Phase 13.6 D-01：_convert_event + _convert_raw_event 方法已删除。"""
+        """_convert_event + _convert_raw_event 方法已删除。"""
         assert not hasattr(AidevAGUIAgent, "_convert_event")
         assert not hasattr(AidevAGUIAgent, "_convert_raw_event")
         agent = AidevAGUIAgent.__new__(AidevAGUIAgent)

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -200,3 +200,13 @@ class TestCommonQAAgentGetAgentExecutor:
         called_options = mock_builder.set_bkai_options.call_args.args[0]
         dumped = called_options.model_dump(exclude_none=True)
         assert dumped["custom_param"] == "custom_value"
+
+
+def test_execute_kwargs_input_default_empty():
+    assert ExecuteKwargs().input == ""
+
+
+def test_execute_kwargs_input_assignment_and_serialization():
+    kwargs = ExecuteKwargs(input="hi")
+    assert kwargs.input == "hi"
+    assert kwargs.model_dump()["input"] == "hi"

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_bkplugin.py
@@ -4,7 +4,7 @@
 公开用法::
 
     runner = build_bkplugin_runner(...)
-    output  = runner.execute()         # 同步：返回 Chat / Flow 输出
+    output  = runner.execute()  # 同步：返回 Chat / Flow 输出
     storage = runner.dispatch_async()  # 流式：投递 Celery 后返回 POLL storage
 
 文件结构：
@@ -171,7 +171,7 @@ class BkpluginAgentRunner(ABC):
         """子类实现：实际投递 Celery 任务。"""
 
     def execute(self) -> str:
-        """同步执行 Agent，返回最终 AI 回复字符串；异常时写回失败状态 (D-01)。"""
+        """同步执行 Agent，返回最终 AI 回复字符串；异常时写回失败状态 。"""
         try:
             return self._do_execute()
         except RetryableHeartbeatTimeoutError:
@@ -196,7 +196,7 @@ class BkpluginAgentRunner(ABC):
             raise
 
     def dispatch_async(self) -> dict:
-        """投递 Celery 后台任务并返回 POLL storage；投递失败时写回失败状态 (D-01)。"""
+        """投递 Celery 后台任务并返回 POLL storage；投递失败时写回失败状态 。"""
         try:
             return self._do_dispatch_async()
         except Exception as e:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
@@ -131,7 +131,7 @@ class AgentBuilder:
                 channel_type=channel_type,
             )
         except Exception:
-            # D-03: Agent 构建失败，尝试标记 session 为 FAILED
+            # Agent 构建失败，尝试标记 session 为 FAILED
             try:
                 self.session_manager.update_session_status(session_code, SessionsStatus.FAILED.value)
             except Exception:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -199,7 +199,7 @@ class AgentExecutor:
                     turn_id=turn_id,
                 )
             elif generator_failed:
-                # D-03: 生成器异常且无任何内容时，写入错误状态
+                # 生成器异常且无任何内容时，写入错误状态
                 self.session_manager.save_stream_failure(session_code, "Agent 执行异常，未能生成回复", turn_id=turn_id)
 
     @classmethod

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -67,7 +67,7 @@ class SessionManager:
     def get_or_create_by_thread_id(self, thread_id: str) -> str:
         """根据 ``thread_id`` 取回或创建 session_code（幂等）。
 
-        D-10: 使用平台 get_or_create 幂等接口，替代 retrieve+create 两步操作。
+        使用平台 get_or_create 幂等接口，替代 retrieve+create 两步操作。
         解决 falsy data 边界问题（原 retrieve 返回 data 为 null/空时跳过创建）。
         """
         session_code = self.generate_session_code(self.username, self.agent_code, thread_id)

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -8,6 +8,7 @@ from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import AgentInstanceFactory
 from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
 from aidev_agent.services.messages_handler import ConsumerPreemptedError, StreamCancelledError
+from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
 from blueapps.core.exceptions import ClientBlueException
 from django.http.response import StreamingHttpResponse
 from rest_framework.views import Response
@@ -123,9 +124,15 @@ class ChatCompletionViewSet(PluginViewSet):
             # session_code 必为真。保留显式校验仅作为不变式被破坏时的防御性兜底。
             if not session_code:
                 raise ClientBlueException(message="session_code or thread_id is required")
-            turn_id = self._save_user_input(session_code, username, _input, turn_id)
+            # ask_user_question interrupt resume 三态处理的 DB 写入已下沉到 agent 侧
+            # ChatCompletionAgent.execute()（提交 1），入口层只产出 turn_id 并透传 _input。
+            # 1. resume + input → 用户跳过提问（agent 侧补 tool + cancel interrupt，清空 resume）
+            # 2. resume + 无 input → 用户答了题（agent 侧 UPDATE interrupt 为 resolved）
+            # 3. 无 resume → 普通新对话（agent 侧补 user 记录）
+            turn_id = self._resolve_chat_turn_id(session_code, username, _input, turn_id)
             if hasattr(execute_kwargs, "turn_id"):
                 execute_kwargs.turn_id = turn_id
+            execute_kwargs.input = _input
             # 模型热更新持久化：model 非空时写回 session.resources.model，使 get session 反映当前模型
             # 写回失败不阻塞 chat 主流程（平台 5xx/网络抖动时仅记录日志）
             model = data.get("model", "")
@@ -266,6 +273,24 @@ class ChatCompletionViewSet(PluginViewSet):
             if resolved:
                 return resolved
         return ""
+
+    @staticmethod
+    def _resolve_chat_turn_id(session_code: str, username: str, _input: str, turn_id: str = "") -> str:
+        """产出本轮 user-ai 回复的 turn_id（三分支，必须保序）。
+
+        1. 已有 turn_id → 直接复用
+        2. 无输入（答题续流）→ 从最近一条 user 记录继承同轮 turn_id
+        3. 否则 → 新生成 uuid4
+
+        注意：本方法只产出 turn_id，不持久化 user 内容（与 ``_save_user_input``
+        不同）。user 落库由 agent 侧 ``ChatCompletionAgent.execute()`` 的
+        ``UserInputSaved`` 事件负责。
+        """
+        if turn_id:
+            return turn_id
+        if not _input:
+            return ChatCompletionViewSet._resolve_turn_id(session_code, username, turn_id)
+        return uuid.uuid4().hex
 
     def _handle_flow_agent(
         self,
@@ -441,12 +466,9 @@ class ChatCompletionViewSet(PluginViewSet):
             raise
         finally:
             # 注意：cancel 信号可能在 finally 之前就被清理了，因此需要先检查
-            if not _cancelled and session_code:
-                from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
-
-                if GeneratorStreamingHelper.is_cancelled(session_code):
-                    _cancelled = True
-                    logger.info(f"[WRAP_STATUS] Generator结束后检测到取消标志: session_code={session_code}")
+            if not _cancelled and session_code and GeneratorStreamingHelper.is_cancelled(session_code):
+                _cancelled = True
+                logger.info(f"[WRAP_STATUS] Generator结束后检测到取消标志: session_code={session_code}")
             if _stream_completed and not _preempted and not _client_disconnected and not _cancelled:
                 logger.info(f"[WRAP_STATUS] 流正常结束, 调用 set_streaming_finished: session_code={session_code}")
                 event_handler.set_streaming_finished()

--- a/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
@@ -2,13 +2,12 @@
 """``SessionManager`` 行为契约：哈希稳定性、幂等取建、save_content kwargs 透传。"""
 
 import pytest
+from aidev_bkplugin.services.agent_session import SessionManager
 from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION
 
 
 @pytest.fixture
 def session_manager():
-    from aidev_bkplugin.services.agent_session import SessionManager
-
     return SessionManager(username="alice", agent_code="bk-aidev")
 
 
@@ -20,8 +19,6 @@ def session_manager():
     ],
 )
 def test_generate_session_code_is_stable_md5(username, agent_code, thread_id, expected_len):
-    from aidev_bkplugin.services.agent_session import SessionManager
-
     code = SessionManager.generate_session_code(username, agent_code, thread_id)
     assert len(code) == expected_len
     assert SessionManager.generate_session_code(username, agent_code, thread_id) == code


### PR DESCRIPTION
1. 移除 aidev_agent/core/ag_ui 在 ask_user 第二次下发快照的问题
2. 在 aidev_agent/core/ag_ui/ask_user_question.py 中，添加了关于协议解析的部分
3. 移除了 aidev_agent/services/event_handlers 中，ask_user_question 回写 DB 的逻辑 现在 SSE 流不再回写 ask_user 的 interrupt 状态数据， 改为入口处处理
4. SessionManager(aidev_bkplugin) 添加了处理ask_question_interrupt的逻辑
5. chat.py(aidev_bkplugin) 添加了处理 ask_user_question interrupt 数据的逻辑
6. 修复了 loop 下的 prompt 和 judge_llm  回退逻辑