### PR TITLE
feat: 补充智能体测试命令 --story=1070093903136445404

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -39,11 +39,13 @@ ci-test:
 	$(eval maxfail ?= --maxfail=2)
 	$(eval warnings ?= --disable-pytest-warnings)
 	$(eval markers ?= not slow)
+	$(eval args ?= -n 4 --dist worksteal)
 	${pytest} ${path} \
 		-m "${markers}" \
 		--durations=30 \
 		--cov-config ${ROOT_DIR}/pyproject.toml \
-		--cov ${ROOT_DIR}/aidev_agent
+		--cov ${ROOT_DIR}/aidev_agent \
+		${args}
 
 .PHONY: build
 build:

--- a/src/agent/pyproject.toml
+++ b/src/agent/pyproject.toml
@@ -68,6 +68,7 @@ dev = [
     "faker>=37.0.0,<38.0.0",
     "pytest-mock<4.0.0,>=3.14.0",
     "pytest-dotenv<1.0.0,>=0.5.2",
+    "pytest-xdist<4.0.0,>=3.5.0",
     "responses<1.0.0,>=0.25.0",
     "loguru>=0.7.3",
 ]

--- a/src/agent/uv.lock
+++ b/src/agent/uv.lock
@@ -76,6 +76,7 @@ dev = [
     { name = "pytest-env" },
     { name = "pytest-mock" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
     { name = "responses" },
 ]
 
@@ -135,6 +136,7 @@ dev = [
     { name = "pytest-env", specifier = ">=1.1.3,<1.2.0" },
     { name = "pytest-mock", specifier = ">=3.14.0,<4.0.0" },
     { name = "pytest-timeout", specifier = "==2.3.1" },
+    { name = "pytest-xdist", specifier = ">=3.5.0,<4.0.0" },
     { name = "responses", specifier = ">=0.25.0,<1.0.0" },
 ]
 
@@ -490,6 +492,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7f/7c/db59db76a70254aa0f9de2b509379b09ab89b2c1fa309acb8daf02e06ec2/environs-14.3.0.tar.gz", hash = "sha256:20672d92db325ce8114872b1989104eb84f083486325b5a44bcddff56472a384", size = 34209, upload-time = "2025-08-01T15:56:54.39Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ad/e3/98d8567eb438c7856a4dcedd97a8a7c6707120a5ada6f7d84ace44fd8591/environs-14.3.0-py3-none-any.whl", hash = "sha256:91e4c4ea964be277855cdd83a588f6375f10fad9fa452660ecb9f503c230f26a", size = 16355, upload-time = "2025-08-01T15:56:52.897Z" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -1640,6 +1651,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/93/0d/04719abc7a4bdb3a7a1f968f24b0f5253d698c9cc94975330e9d3145befb/pytest-timeout-2.3.1.tar.gz", hash = "sha256:12397729125c6ecbdaca01035b9e5239d4db97352320af155b3f5de1ba5165d9", size = 17697, upload-time = "2024-03-07T21:04:01.069Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/27/14af9ef8321f5edc7527e47def2a21d8118c6f329a9342cc61387a0c0599/pytest_timeout-2.3.1-py3-none-any.whl", hash = "sha256:68188cb703edfc6a18fad98dc25a3c61e9f24d644b0b70f33af545219fc7813e", size = 14148, upload-time = "2024-03-07T21:03:58.764Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]

--- a/src/plugins/aidev_bkplugin/Makefile
+++ b/src/plugins/aidev_bkplugin/Makefile
@@ -1,6 +1,6 @@
 # 导入子目录中的 Makefile 文件
 ROOT_DIR?=$(shell git rev-parse --show-toplevel)/src/plugins/aidev_bkplugin
-pytest = uv run --no-sync pytest -c ${ROOT_DIR}/pyproject.toml
+pytest = uv run --no-sync pytest --ds=tests.settings -c ${ROOT_DIR}/pyproject.toml
 
 
 .PHONY: ALL

--- a/src/plugins/aidev_bkplugin/pyproject.toml
+++ b/src/plugins/aidev_bkplugin/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [dependency-groups]
 dev = [
     "pytest>=7.4.4,<9",
+    "pytest-cov>=4.1.0,<4.2.0",
     "pytest-mock>=3.14.0",
     "pytest-django>=4.7.0,<5.0",
     "djangorestframework>=3.16.1",

--- a/src/plugins/aidev_bkplugin/uv.lock
+++ b/src/plugins/aidev_bkplugin/uv.lock
@@ -65,6 +65,7 @@ dependencies = [
 dev = [
     { name = "djangorestframework" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-django" },
     { name = "pytest-mock" },
 ]
@@ -80,6 +81,7 @@ requires-dist = [
 dev = [
     { name = "djangorestframework", specifier = ">=3.16.1" },
     { name = "pytest", specifier = ">=7.4.4,<9" },
+    { name = "pytest-cov", specifier = ">=4.1.0,<4.2.0" },
     { name = "pytest-django", specifier = ">=4.7.0,<5.0" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
 ]
@@ -272,6 +274,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.15.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/45/78dbf9604ee5b3db24efbf26bed1cb58862fb40480cba821963c69348751/coverage-7.15.3.tar.gz", hash = "sha256:ae7ea5a4614acf399ef0483c4cb34f8f8f01df848d8fcbe7d3ce0865733f1c4d", size = 935592, upload-time = "2026-08-02T18:50:17.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/9c/c8a3a923c24f631695cea2d5e2f02e776bc0af6e03800626e13a6c05a615/coverage-7.15.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5f3f854ab4599d98f7799ac9b91e34e8ec9ebc9a6372ee8c1f3413a68cc8b5e9", size = 222328, upload-time = "2026-08-02T18:47:49.228Z" },
+    { url = "https://files.pythonhosted.org/packages/92/51/dda77f34cbd2513d6ffb898c901d19e9ca55f48c0cbc4a1eb173a97d157a/coverage-7.15.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:75268348fee1f199653b8a846262aec5581c6bb008c4f58824959fb708cc688f", size = 222832, upload-time = "2026-08-02T18:47:51.219Z" },
+    { url = "https://files.pythonhosted.org/packages/78/59/e0faafc4c6e23bd76c76148875ee9ec5781b8f1cd62cea2bc4ca0f0f0e5d/coverage-7.15.3-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:21081739f6264cc594cad2d42b62befbd17633824022866c68720eb0c4b8d6b4", size = 253250, upload-time = "2026-08-02T18:47:52.737Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/4b1e0eeb727ffb471e411c1bd3402184b5dd54a77a762b0e55e87cdf9ae3/coverage-7.15.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:718d366251b060c10731c7dd359de6caea72250036eb94576aa56dacbf830a11", size = 255160, upload-time = "2026-08-02T18:47:54.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/a602d2d48f9db9f795e578a86aa914f7b20008e9330902defcfb73d17b3a/coverage-7.15.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fa1bbaa502a6e877f3ee67cbac3eba2bb637f623e454e6c37b81b38896dbd48f", size = 257269, upload-time = "2026-08-02T18:47:56.157Z" },
+    { url = "https://files.pythonhosted.org/packages/22/fa/bf6db13df2fcee00d2671849fe58c99232ee79a01fec7478c2bf7839b9e1/coverage-7.15.3-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:494880c9e60782610683f4eb9b65cce4f886673596b8f3cb2dfa079fc551c743", size = 259231, upload-time = "2026-08-02T18:47:57.76Z" },
+    { url = "https://files.pythonhosted.org/packages/89/37/8118f13b17fa7d9a3aa2c301d93f2d5ffeef70fa7e27e639a74bdacd3fea/coverage-7.15.3-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3db264ea689f9e8f9fa4fb9005fee4048c3bff4a547f4cfa27f5086cb0804ec0", size = 253357, upload-time = "2026-08-02T18:47:59.261Z" },
+    { url = "https://files.pythonhosted.org/packages/97/6d/c7b94fb03962f4d6f0fe13d01c4eb9c4c6e2e714a20d074516ec7582b110/coverage-7.15.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4e869d4799674d67778e76ddbe2e26cf1673369262e231a8ec259421b1015fea", size = 254961, upload-time = "2026-08-02T18:48:00.901Z" },
+    { url = "https://files.pythonhosted.org/packages/87/f9/fe0bd415fa56e36b62b649017c8fc98330858be4c7593789efb78cd24178/coverage-7.15.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:696fc7a28bbf717aba8d2c6963d26702945c7832cb313ba3b323aa5b1afb3156", size = 253024, upload-time = "2026-08-02T18:48:02.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7c/ffa53506d63ba8a77f5b9557dd6f5a5a5ad85adc680d7857410138f82bd9/coverage-7.15.3-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:3fe9be1c527497d047f770d88a0110189714c36383bb88384508f750c302bffa", size = 256792, upload-time = "2026-08-02T18:48:04.377Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/c6/df42458e72c18a49fe87e40ccd3fb0314210915256cf4a5593e1b3250e04/coverage-7.15.3-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:2400591f4b2e33746c70846388f8bb4c7e33b820e31cb8c6cb2f25305310438b", size = 252744, upload-time = "2026-08-02T18:48:06.154Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/14/8bf18a4b10a44f8ba5f604b00e102f37daf49d581d66a37dc33fa267e1a6/coverage-7.15.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2e557178799282269412a672e5753f2179edfe1b3f0f19b0c98f8e72d482326a", size = 253652, upload-time = "2026-08-02T18:48:07.955Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e6/e530c9bb94e4155817cbd149034105b062a6913bc356ae08f454d155de53/coverage-7.15.3-cp311-cp311-win32.whl", hash = "sha256:68ea6c947375982ae907e19e9d2ef156bd6e68e11f3566dd568d7f4ec974e715", size = 224428, upload-time = "2026-08-02T18:48:09.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/98/0050c692d120988f1973a15196f52dee4ae221848b760281461a2005b613/coverage-7.15.3-cp311-cp311-win_amd64.whl", hash = "sha256:28743dad31622e8c474b17446118037361f5b1f4f2ecdf72d4f6fde246d64446", size = 224906, upload-time = "2026-08-02T18:48:11.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/ae/c0ef3e2ba3f35fc1c6985811a40edd9331e5b8978c9ecf84699de3edacbe/coverage-7.15.3-cp311-cp311-win_arm64.whl", hash = "sha256:c4398918c4fda32718191239e451fd86ac5ad1e8979b592f1921ee2d1f038965", size = 224448, upload-time = "2026-08-02T18:48:13.304Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e7/7069b3d6c018917f49ba2e1c5fb910e498c7fefa3a1b78cb1b79e61ff45d/coverage-7.15.3-py3-none-any.whl", hash = "sha256:da78fa6fc7dafe4212839173133ee85afcf42c5cd5f3e47fa7c1c210453b445e", size = 214297, upload-time = "2026-08-02T18:50:14.709Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
 ]
 
 [[package]]
@@ -1100,6 +1131,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-cov"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/15/da3df99fd551507694a9b01f512a2f6cf1254f33601605843c3775f39460/pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6", size = 63245, upload-time = "2023-05-24T18:44:56.845Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/4b/8b78d126e275efa2379b1c2e09dc52cf70df16fc3b90613ef82531499d73/pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a", size = 21949, upload-time = "2023-05-24T18:44:54.079Z" },
+]
+
+[[package]]
 name = "pytest-django"
 version = "4.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1417,6 +1461,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/db/a58e09687c1698a7c592e1038e01c206569b86a0377828d51635561f8ebf/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:508fa71810c0efdcd1b898fda574889ee62852989f7c1667414736bcb2b9a4bd", size = 1195080, upload-time = "2025-10-06T20:21:49.246Z" },
     { url = "https://files.pythonhosted.org/packages/9e/1b/a9e4d2bf91d515c0f74afc526fd773a812232dd6cda33ebea7f531202325/tiktoken-0.12.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a1af81a6c44f008cba48494089dd98cccb8b313f55e961a52f5b222d1e507967", size = 1255240, upload-time = "2025-10-06T20:21:50.274Z" },
     { url = "https://files.pythonhosted.org/packages/9d/15/963819345f1b1fb0809070a79e9dd96938d4ca41297367d471733e79c76c/tiktoken-0.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:3e68e3e593637b53e56f7237be560f7a394451cb8c11079755e80ae64b9e6def", size = 879422, upload-time = "2025-10-06T20:21:51.734Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]

--- a/src/plugins/aidev_wxbot/Makefile
+++ b/src/plugins/aidev_wxbot/Makefile
@@ -1,6 +1,7 @@
 # 导入子目录中的 Makefile 文件
-ROOT_DIR?=$(shell git rev-parse --show-toplevel)/src/agent
-pytest = uv run --no-sync pytest -c ${ROOT_DIR}/pyproject.toml
+REPO_ROOT?=$(shell git rev-parse --show-toplevel)
+ROOT_DIR?=${REPO_ROOT}/src/plugins/aidev_wxbot
+pytest = PYTHONPATH=${REPO_ROOT}/src/agent:${REPO_ROOT}/src/plugins/aidev_bkplugin:${ROOT_DIR}:$${PYTHONPATH} uv run --no-sync pytest -c ${ROOT_DIR}/pyproject.toml
 
 
 .PHONY: ALL
@@ -25,6 +26,19 @@ init: uv-install
 uv-install:
 	uv --version
 	uv sync --inexact
+
+.PHONY: test
+test:
+	$(eval path ?= ${ROOT_DIR}/tests)
+	$(eval maxfail ?= --maxfail=2)
+	$(eval warnings ?= --disable-pytest-warnings)
+	$(eval markers ?= not slow)
+	${pytest} ${path} \
+		-m "${markers}" \
+		${maxfail} \
+		${warnings} \
+		--durations=20 \
+		${args}
 
 
 build:

--- a/src/plugins/aidev_wxbot/Makefile
+++ b/src/plugins/aidev_wxbot/Makefile
@@ -1,7 +1,7 @@
 # 导入子目录中的 Makefile 文件
 REPO_ROOT?=$(shell git rev-parse --show-toplevel)
 ROOT_DIR?=${REPO_ROOT}/src/plugins/aidev_wxbot
-pytest = PYTHONPATH=${REPO_ROOT}/src/agent:${REPO_ROOT}/src/plugins/aidev_bkplugin:${ROOT_DIR}:$${PYTHONPATH} uv run --no-sync pytest -c ${ROOT_DIR}/pyproject.toml
+pytest = PYTHONPATH=${REPO_ROOT}/src/agent:${REPO_ROOT}/src/plugins/aidev_bkplugin:${ROOT_DIR}:$${PYTHONPATH} uv run --no-sync pytest --ds=aidev_wxbot.settings -c ${ROOT_DIR}/pyproject.toml
 
 
 .PHONY: ALL

--- a/src/plugins/aidev_wxbot/pyproject.toml
+++ b/src/plugins/aidev_wxbot/pyproject.toml
@@ -27,6 +27,14 @@ dependencies = [
     "aidev-bkplugin>=2.2.0",
 ]
 
+[dependency-groups]
+dev = [
+    "pytest>=7.4.4,<9",
+    "pytest-asyncio>=0.23.3,<1",
+    "pytest-django>=4.7.0,<5",
+    "pytest-dotenv>=0.5.2,<1",
+]
+
 [project.scripts]
 "aidev_wxbot.manage" = "aidev_wxbot.manage:main"
 
@@ -66,8 +74,10 @@ section-order = [
 relative-imports-order = "closest-to-furthest"
 
 [tool.pytest.ini_options]
+DJANGO_SETTINGS_MODULE = "aidev_wxbot.settings"
 env_override_existing_values = 1
 env_files = [".env"]
 asyncio_default_fixture_loop_scope = "session"
 addopts = "-vvv --maxfail=2 -s"
 asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/src/plugins/aidev_wxbot/tests/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/conftest.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+"""Test-only stubs for dependencies provided by the BK plugin runtime."""
+
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
+
+def inject_user_token(func):
+    return func
+
+
+framework_module = ModuleType("bk_plugin_framework")
+kit_module = ModuleType("bk_plugin_framework.kit")
+decorators_module = ModuleType("bk_plugin_framework.kit.decorators")
+decorators_module.inject_user_token = inject_user_token
+kit_module.decorators = decorators_module
+framework_module.kit = kit_module
+
+models_module = ModuleType("aidev_bkplugin.models")
+models_module.Checkpoint = MagicMock()
+models_module.Write = MagicMock()
+
+sys.modules.setdefault("bk_plugin_framework", framework_module)
+sys.modules.setdefault("bk_plugin_framework.kit", kit_module)
+sys.modules.setdefault("bk_plugin_framework.kit.decorators", decorators_module)
+sys.modules.setdefault("aidev_bkplugin.models", models_module)

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_context.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_context.py
@@ -5,8 +5,8 @@ import pytest
 
 try:
     import django  # noqa: F401
-    from aidev_wxbot.wxaibot.context import CHUNK_FLUSH_THRESHOLD, LlmChunkMsg, stream_msg
     from aidev_wxbot.wxaibot.constants import QUEUE_EXPIRES_MS
+    from aidev_wxbot.wxaibot.context import CHUNK_FLUSH_THRESHOLD, LlmChunkMsg, stream_msg
     from django.conf import settings
 
     _wxbot_available = True
@@ -162,7 +162,8 @@ class TestLlmChunkMsg:
                 self._get_message_error = get_message_error
 
             def get_queue_info(self, queue_name):
-                return {"message_count": len(self.messages)}
+                message_count = 1 if self._get_message_error else len(self.messages)
+                return {"message_count": message_count}
 
             def get_message(self, queue_name, auto_ack=True):
                 if self._get_message_error:

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_strategies.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_strategies.py
@@ -54,20 +54,20 @@ def _sse(data: dict) -> str:
 
 class TestResolveStrategy:
     @pytest.mark.parametrize("agent_type, expected", [("chat", ChatAgentStrategy), ("flow", FlowAgentStrategy)])
-    @patch("aidev_wxbot.wxaibot.strategies.get_agent_config_info")
+    @patch("aidev_wxbot.wxaibot.strategies.AgentConfigFetcher.get_info")
     def test_dispatches_correct_strategy(self, mock_config, agent_type, expected):
         """正常分发：chat → ChatAgentStrategy，flow → FlowAgentStrategy"""
         mock_config.return_value = {"agent_type": agent_type}
         assert isinstance(resolve_strategy("user"), expected)
 
     @pytest.mark.parametrize("config", [{}, {"agent_type": ""}, {"agent_type": "unknown"}])
-    @patch("aidev_wxbot.wxaibot.strategies.get_agent_config_info")
+    @patch("aidev_wxbot.wxaibot.strategies.AgentConfigFetcher.get_info")
     def test_fallback_to_chat(self, mock_config, config):
         """缺失/空/未知 agent_type 均降级为 Chat"""
         mock_config.return_value = config
         assert isinstance(resolve_strategy("user"), ChatAgentStrategy)
 
-    @patch("aidev_wxbot.wxaibot.strategies.get_agent_config_info", side_effect=Exception("API down"))
+    @patch("aidev_wxbot.wxaibot.strategies.AgentConfigFetcher.get_info", side_effect=Exception("API down"))
     def test_api_exception_fallback(self, _):
         """API 异常降级为 Chat"""
         assert isinstance(resolve_strategy("user"), ChatAgentStrategy)
@@ -79,14 +79,25 @@ class TestResolveStrategy:
 
 
 class TestFlowAgentStrategyExecute:
+    @patch("aidev_wxbot.wxaibot.formatters.AgentHelper.build_session_detail_url", return_value="")
+    @patch("aidev_wxbot.wxaibot.strategies.AgentHelper.get_client")
+    @patch("aidev_wxbot.wxaibot.strategies.WxFlowAgentClient")
+    @patch("aidev_wxbot.wxaibot.strategies.SessionManager")
     @patch("aidev_wxbot.wxaibot.strategies.AgentInstanceFactory")
     @patch("aidev_wxbot.wxaibot.strategies.AGUISessionWriter")
-    @patch("aidev_wxbot.wxaibot.strategies.save_session_content")
-    @patch("aidev_wxbot.wxaibot.strategies.get_or_create_session_by_thread_id")
-    @patch("aidev_wxbot.wxaibot.strategies.resolve_channel_admin_rtx", return_value="admin_rtx")
-    def test_full_execute_pipeline(self, mock_rtx, mock_session, mock_save, mock_writer, mock_factory, mock_rabbitmq):
+    def test_full_execute_pipeline(
+        self,
+        mock_writer,
+        mock_factory,
+        mock_session_cls,
+        mock_flow_client,
+        mock_get_client,
+        mock_build_detail_url,
+        mock_rabbitmq,
+    ):
         """主流程：RTX解析 → session创建 → 用户输入保存 → agent构建执行 → SSE消费写入RabbitMQ"""
-        mock_session.return_value = "sc_abc"
+        session_manager = mock_session_cls.return_value
+        session_manager.get_or_create_by_thread_id.return_value = "sc_abc"
 
         # 模拟 agent 返回完整 SSE 流
         mock_inst = MagicMock()
@@ -98,21 +109,25 @@ class TestFlowAgentStrategyExecute:
                     {
                         "type": "CUSTOM",
                         "name": "flow_agent_result",
-            "value": [{
-                "task_state": "RUNNING",
-                "nodes": {"n1": {"name": "步骤1", "state": "RUNNING", "elapsed_time": 5}},
-                "statistics": {"total": 1, "state_counts": {"RUNNING": 1}},
-            }],
+                        "value": [
+                            {
+                                "task_state": "RUNNING",
+                                "nodes": {"n1": {"name": "步骤1", "state": "RUNNING", "elapsed_time": 5}},
+                                "statistics": {"total": 1, "state_counts": {"RUNNING": 1}},
+                            }
+                        ],
                     }
                 ),
                 _sse(
                     {
                         "type": "CUSTOM",
                         "name": "flow_agent_end",
-            "value": [{
-                "task_id": "999",
-                "task_outputs": [{"key": "out", "value": "done"}],
-            }],
+                        "value": [
+                            {
+                                "task_id": "999",
+                                "task_outputs": [{"key": "out", "value": "done"}],
+                            }
+                        ],
                     }
                 ),
                 _sse({"type": "RUN_FINISHED", "run_id": "r1", "thread_id": "t1"}),
@@ -130,18 +145,25 @@ class TestFlowAgentStrategyExecute:
         )
 
         # 验证完整调用链
-        mock_rtx.assert_called_once_with("wxid_123")  # RTX 解析被调用
-        mock_session.assert_called_once_with("admin_rtx", "t1")  # 使用 RTX 创建 session
-        mock_save.assert_called_once_with("sc_abc", "user", "运行流程", "admin_rtx")  # 用户输入保存
+        mock_session_cls.assert_called_once_with(username="wxid_123")
+        session_manager.get_or_create_by_thread_id.assert_called_once_with("t1")
+        session_manager.save_content.assert_called_once()
+        save_kwargs = session_manager.save_content.call_args.kwargs
+        assert save_kwargs["session_code"] == "sc_abc"
+        assert save_kwargs["role"] == "user"
+        assert save_kwargs["content"] == "运行流程"
         mock_factory.build_agent.assert_called_once()  # agent 通过工厂构建
 
         # 验证传给工厂的关键参数（agent_type=FLOW、session_code、flow_start_params 透传）
         factory_kwargs = mock_factory.build_agent.call_args[1]
         assert factory_kwargs["session_code"] == "sc_abc"
-        assert factory_kwargs["flow_start_params"] == {"session_code": "sc_abc"}
+        assert factory_kwargs["flow_start_params"]["session_code"] == "sc_abc"
+        assert factory_kwargs["flow_resource_manager"] is mock_flow_client.return_value
+        mock_get_client.assert_called_once_with()
+        mock_build_detail_url.assert_called_once_with("sc_abc")
 
-        # 验证 RabbitMQ 写入：start(1) + result(1) + end(1) = 至少 3 次
-        assert mock_rabbitmq.publish_message.call_count >= 3
+        # start 仅缓存 task_id；result 和 end 各写入一次。
+        assert mock_rabbitmq.publish_message.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -150,7 +172,7 @@ class TestFlowAgentStrategyExecute:
 
 
 class TestChatAgentStrategyExecute:
-    @patch("aidev_wxbot.wxaibot.strategies.run_chat_completion_with_thread_id")
+    @patch("aidev_wxbot.wxaibot.strategies.AgentExecutor.run_chat_completion_with_thread_id")
     @patch("aidev_wxbot.wxaibot.strategies.build_execute_kwargs")
     def test_stream_mode_writes_to_rabbitmq(self, mock_build, mock_run, mock_rabbitmq):
         """Chat 流式模式：调用 chat completion → 内容写入 RabbitMQ"""
@@ -195,36 +217,42 @@ class TestConsumeFlowStream:
             {
                 "type": "CUSTOM",
                 "name": "flow_agent_result",
-                "value": [{
-                    "task_state": "RUNNING",
-                    "nodes": {"n1": {"name": "A", "state": "FINISHED", "elapsed_time": 10}},
-                    "statistics": {"total": 1, "state_counts": {"FINISHED": 1}},
-                }],
+                "value": [
+                    {
+                        "task_state": "RUNNING",
+                        "nodes": {"n1": {"name": "A", "state": "FINISHED", "elapsed_time": 10}},
+                        "statistics": {"total": 1, "state_counts": {"FINISHED": 1}},
+                    }
+                ],
             },
             {
                 "type": "CUSTOM",
                 "name": "flow_agent_result",
-                "value": [{
-                    "task_state": "RUNNING",
-                    "nodes": {},
-                    "statistics": {},
-                }],
+                "value": [
+                    {
+                        "task_state": "RUNNING",
+                        "nodes": {},
+                        "statistics": {},
+                    }
+                ],
             },
             {
                 "type": "CUSTOM",
                 "name": "flow_agent_end",
-                "value": [{
-                    "task_id": "123",
-                    "task_outputs": [{"key": "out", "value": "ok"}],
-                }],
+                "value": [
+                    {
+                        "task_id": "123",
+                        "task_outputs": [{"key": "out", "value": "ok"}],
+                    }
+                ],
             },
             {"type": "RUN_FINISHED", "run_id": "r1", "thread_id": "t1"},
         ]
 
         consume_flow_stream(iter([_sse(e) for e in events]), "s_1_1000", 1000.0, mock_rabbitmq)
 
-        # 至少 4 次写入：start + result×2 + end
-        assert mock_rabbitmq.publish_message.call_count >= 4
+        # start 仅缓存 task_id；result×2 和 end 共写入三次。
+        assert mock_rabbitmq.publish_message.call_count == 3
 
         # 检查最后一次写入的消息是 is_finish=True 且 content 包含结果
         last_call_data = mock_rabbitmq.publish_message.call_args_list[-1][0][2]
@@ -261,8 +289,8 @@ class TestConsumeFlowStream:
 
         consume_flow_stream(gen(), "s_1_1000", 1000.0, mock_rabbitmq)
 
-        # 非法行被跳过，后续 start + end 仍然写入
-        assert mock_rabbitmq.publish_message.call_count >= 2
+        # 非法行被跳过；start 仅缓存 task_id，end 写入一次。
+        assert mock_rabbitmq.publish_message.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +304,7 @@ class TestHandleFlowCustomEvent:
     def test_start_saves_task_id(self, mock_rabbitmq):
         """flow_agent_start: 缓存 task_id，不写 think_content，content 为空"""
         chunk = LlmChunkMsg(stream_id="s_1_1000")
-    handle_flow_custom_event("flow_agent_start", {"value": [{"task_id": "42"}]}, chunk, mock_rabbitmq)
+        handle_flow_custom_event("flow_agent_start", {"value": [{"task_id": "42"}]}, chunk, mock_rabbitmq)
 
         assert chunk._flow_task_id == "42"
         assert chunk._flow_nodes_initialized is False
@@ -290,15 +318,17 @@ class TestHandleFlowCustomEvent:
         handle_flow_custom_event(
             "flow_agent_result",
             {
-                "value": [{
-                    "task_state": "RUNNING",
-                    "nodes": {
-                        "n1": {"name": "数据清洗", "state": "FINISHED", "elapsed_time": 90},
-                        "n2": {"name": "模型训练", "state": "RUNNING", "elapsed_time": 30},
-                        "n3": {"name": "汇总", "state": "PENDING", "elapsed_time": 0},
-                    },
-                    "statistics": {"total": 3, "state_counts": {"FINISHED": 1, "RUNNING": 1, "PENDING": 1}},
-                }]
+                "value": [
+                    {
+                        "task_state": "RUNNING",
+                        "nodes": {
+                            "n1": {"name": "数据清洗", "state": "FINISHED", "elapsed_time": 90},
+                            "n2": {"name": "模型训练", "state": "RUNNING", "elapsed_time": 30},
+                            "n3": {"name": "汇总", "state": "PENDING", "elapsed_time": 0},
+                        },
+                        "statistics": {"total": 3, "state_counts": {"FINISHED": 1, "RUNNING": 1, "PENDING": 1}},
+                    }
+                ]
             },
             chunk,
             mock_rabbitmq,
@@ -335,10 +365,12 @@ class TestHandleFlowCustomEvent:
         handle_flow_custom_event(
             "flow_agent_end",
             {
-                "value": [{
-                    "task_id": "1",
-                    "task_outputs": [{"key": "result", "value": "done"}],
-                }]
+                "value": [
+                    {
+                        "task_id": "1",
+                        "task_outputs": [{"key": "result", "value": "done"}],
+                    }
+                ]
             },
             chunk,
             mock_rabbitmq,
@@ -359,11 +391,13 @@ class TestHandleFlowCustomEvent:
         handle_flow_custom_event(
             "flow_agent_end",
             {
-                "value": [{
-                    "task_id": "2",
-                    "error": True,
-                    "state": "FAILED",
-                }]
+                "value": [
+                    {
+                        "task_id": "2",
+                        "error": True,
+                        "state": "FAILED",
+                    }
+                ]
             },
             chunk,
             mock_rabbitmq,
@@ -389,7 +423,9 @@ class TestResolveChannelAdminRtx:
     @patch("aidev_wxbot.wxaibot.auth.BkAiDevApi")
     def test_returns_contact_from_config(self, mock_api_cls):
         """正常路径：从渠道配置获取管理员 RTX"""
-        mock_api_cls.return_value.retrieve_agent_channel_configs.return_value = [{"config": {"contact": "channel_admin_rtx"}}]
+        mock_api_cls.return_value.retrieve_agent_channel_configs.return_value = [
+            {"config": {"contact": "channel_admin_rtx"}}
+        ]
         assert resolve_channel_admin_rtx("A000000A") == "channel_admin_rtx"
 
     @pytest.mark.parametrize(

--- a/src/plugins/aidev_wxbot/uv.lock
+++ b/src/plugins/aidev_wxbot/uv.lock
@@ -83,6 +83,14 @@ dependencies = [
     { name = "stackprinter" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-django" },
+    { name = "pytest-dotenv" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "aidev-bkplugin", specifier = ">=2.2.0" },
@@ -93,6 +101,14 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "stackprinter", specifier = ">=0.2.12" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=7.4.4,<9" },
+    { name = "pytest-asyncio", specifier = ">=0.23.3,<1" },
+    { name = "pytest-django", specifier = ">=4.7.0,<5" },
+    { name = "pytest-dotenv", specifier = ">=0.5.2,<1" },
 ]
 
 [[package]]
@@ -574,6 +590,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1146,6 +1171,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "protobuf"
 version = "7.34.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1326,6 +1360,59 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2e/0b/e1066a2ba154a1fd6ade41b35d38482fc399feb90fe4768ce8d6d3eb368c/Pyro4-4.82.tar.gz", hash = "sha256:511f5b0804e92dd77dc33adf9c947787e3f9e9c5a96b12162f0557a7c4ce21fb", size = 516110, upload-time = "2021-12-25T01:45:34.312Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/e3/8c4e0d24b46fbf02e6b2dc2da5d18f0c73cfd343a1fb01ae64c788c20e56/Pyro4-4.82-py2.py3-none-any.whl", hash = "sha256:bbf5d7413e616d3e1978a05d7caca62eec59692d2dab75dd22a4426ef9b8a691", size = 89999, upload-time = "2021-12-25T01:45:31.066Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+]
+
+[[package]]
+name = "pytest-django"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ae/5ed1ab2d12090bd794392d798c14d092f0470f6446eaa6d2af4183f4aa2b/pytest_django-4.13.0.tar.gz", hash = "sha256:2316e3f63e3bc799deb4212830e39b2ef1dcc3b2d8688060f1d0217db6a56ebe", size = 94200, upload-time = "2026-08-05T21:36:23.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/88/52db7a840fdbd74934f8df11b7450c9919ac00f61c02e88827f3d58180f7/pytest_django-4.13.0-py3-none-any.whl", hash = "sha256:09374c12d947ca0f99e33726bcb720a6d0124f67058e1130586372bd109493e3", size = 27066, upload-time = "2026-08-05T21:36:21.763Z" },
+]
+
+[[package]]
+name = "pytest-dotenv"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/b0/cafee9c627c1bae228eb07c9977f679b3a7cb111b488307ab9594ba9e4da/pytest-dotenv-0.5.2.tar.gz", hash = "sha256:2dc6c3ac6d8764c71c6d2804e902d0ff810fa19692e95fe138aefc9b1aa73732", size = 3782, upload-time = "2020-06-16T12:38:03.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/da/9da67c67b3d0963160e3d2cbc7c38b6fae342670cc8e6d5936644b2cf944/pytest_dotenv-0.5.2-py3-none-any.whl", hash = "sha256:40a2cece120a213898afaa5407673f6bd924b1fa7eafce6bda0e8abffe2f710f", size = 3993, upload-time = "2020-06-16T12:38:01.139Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

- 为 agent 与 wxbot 插件补齐统一、可复用的测试入口，并提升 CI 测试执行效率。

## 原因

- wxbot 插件缺少 `make test`，现有测试依赖和部分 mock 契约也未与当前实现保持一致。
- agent 的 CI 测试没有默认启用并行调度，且开发依赖未包含 pytest-xdist。

## 改动内容

- 为 aidev_wxbot 新增 `make test`，补齐 pytest 配置、开发依赖和测试运行所需的隔离 stub，并更新过期测试契约。
- 为 agent 的 `ci-test` 默认增加 `-n 4 --dist worksteal`，保留 `args` 显式覆盖能力，并补充 pytest-xdist 依赖。

## 收益

- wxbot 插件可以使用标准 Makefile 命令执行完整测试。
- agent CI 默认使用 4 个 worker 的 worksteal 调度，缩短测试反馈时间。

## 测试验证

- `cd src/plugins/aidev_wxbot && make test`：31 passed。
- `cd src/agent && make ci-test args='-n 4 --dist worksteal'`：1856 passed、48 skipped、3 xfailed，覆盖率 68%。
- 完整 pre-commit：通过。
