### PR TITLE
refactor: 【chat-x】文件产物预览取消 URL TTL 缓存，每次重新取链

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.spec.ts
@@ -235,9 +235,7 @@ describe('ArtifactPreviewHost', () => {
     await flushPromises();
 
     expect(resolveArtifactUrls).toHaveBeenCalledTimes(2);
-    expect(resolveArtifactUrls).toHaveBeenLastCalledWith(expect.objectContaining({ outputId: 'output-1' }), {
-      force: true,
-    });
+    expect(resolveArtifactUrls).toHaveBeenLastCalledWith(expect.objectContaining({ outputId: 'output-1' }));
     expect(wrapper.find('.ai-artifact-url-iframe-preview').attributes('src')).toBe('https://example.com/retry.pdf');
   });
 });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -15,7 +15,7 @@
         size="small"
         text
         theme="primary"
-        @click="() => load({ force: true })"
+        @click="() => load()"
       >
         {{ t('重试') }}
       </Button>
@@ -66,10 +66,7 @@
   const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
     canResolve: () => !!artifactPreview?.canResolveArtifactUrl.value,
     getFile: () => props.file,
-    // 无 options 时不传第二参，避免 mock 断言收到 (file, undefined)
-    resolveUrls: (file, options) =>
-      (options ? artifactPreview?.resolveArtifactUrls(file, options) : artifactPreview?.resolveArtifactUrls(file)) ??
-      Promise.resolve({}),
+    resolveUrls: file => artifactPreview?.resolveArtifactUrls(file) ?? Promise.resolve({}),
   });
 
   // 以 outputId 为唯一键；同文件类型变更时也需重新加载预览策略

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.spec.ts
@@ -7,7 +7,6 @@ import { AIFileType } from '../../../../../ag-ui/types/file';
 import { useArtifactPreviewLoader } from './use-artifact-preview-loader';
 
 import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
-import type { ResolveArtifactUrlsOptions } from '../../../../../composables/use-artifact-preview';
 
 const createFile = (type: AIFileType, name = `a.${type}`): AIFileInfo => ({
   name,
@@ -36,7 +35,7 @@ describe('use-artifact-preview-loader', () => {
   const mountLoader = (opts: {
     canResolve?: boolean;
     file: AIFileInfo | undefined;
-    resolveUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
+    resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
   }) => {
     let api: ReturnType<typeof useArtifactPreviewLoader> | undefined;
     const fileRef = shallowRef(opts.file);
@@ -215,20 +214,6 @@ describe('use-artifact-preview-loader', () => {
     expect(resolveUrls).toHaveBeenCalledTimes(1);
     expect(resolveUrls).toHaveBeenCalledWith(file);
     expect(resolveUrls.mock.calls[0]).toHaveLength(1);
-    wrapper.unmount();
-  });
-
-  it('load({ force: true }) 应向 resolveUrls 传 force', async () => {
-    const resolveUrls = vi.fn().mockResolvedValue({ preview_url: 'https://example.com/a.pdf' });
-    const { api, wrapper } = mountLoader({
-      file: createFile(AIFileType.Pdf),
-      resolveUrls,
-    });
-
-    await api.load({ force: true });
-
-    expect(resolveUrls).toHaveBeenCalledWith(expect.objectContaining({ type: AIFileType.Pdf }), { force: true });
-    expect(api.status.value).toBe('ready');
     wrapper.unmount();
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
@@ -28,7 +28,6 @@ import { onBeforeUnmount, shallowRef } from 'vue';
 import { getArtifactPreviewStrategy } from './preview-strategy';
 
 import type { AIFileInfo, ArtifactUrlResult } from '../../../../../ag-ui/types/file';
-import type { ResolveArtifactUrlsOptions } from '../../../../../composables/use-artifact-preview';
 import type { ArtifactPreviewRendererKind } from './preview-strategy';
 
 export type ArtifactPreviewPayload = {
@@ -40,12 +39,10 @@ export type ArtifactPreviewPayload = {
 
 export type ArtifactPreviewStatus = 'empty' | 'error' | 'idle' | 'loading' | 'ready';
 
-export type ArtifactPreviewLoadOptions = ResolveArtifactUrlsOptions;
-
 export const useArtifactPreviewLoader = (options: {
   canResolve: () => boolean;
   getFile: () => AIFileInfo | undefined;
-  resolveUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
+  resolveUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
 }) => {
   const status = shallowRef<ArtifactPreviewStatus>('idle');
   const content = shallowRef('');
@@ -60,7 +57,7 @@ export const useArtifactPreviewLoader = (options: {
     previewUrl.value = '';
   };
 
-  const load = async (loadOptions?: ArtifactPreviewLoadOptions) => {
+  const load = async () => {
     const seq = ++loadSeq;
     abortController?.abort();
     abortController = undefined;
@@ -79,10 +76,8 @@ export const useArtifactPreviewLoader = (options: {
     renderer.value = strategy.renderer;
 
     try {
-      // 重试传 force，绕过 TTL 缓存重新取链
-      const urls = loadOptions?.force
-        ? await options.resolveUrls(file, { force: true })
-        : await options.resolveUrls(file);
+      // 每次 load 都重新取链（无 URL 缓存）
+      const urls = await options.resolveUrls(file);
       if (seq !== loadSeq) {
         return;
       }

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.spec.ts
@@ -27,14 +27,10 @@
 import { defineComponent, h } from 'vue';
 
 import { mount } from '@vue/test-utils';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { AIFileType } from '../ag-ui/types/file';
-import {
-  ARTIFACT_URL_CACHE_TTL_MS,
-  useArtifactPreviewConsumer,
-  useArtifactPreviewProvider,
-} from './use-artifact-preview';
+import { useArtifactPreviewConsumer, useArtifactPreviewProvider } from './use-artifact-preview';
 
 import type { AIFileInfo, OnArtifactClick } from '../ag-ui/types/file';
 
@@ -48,14 +44,6 @@ const createFile = (overrides: Partial<AIFileInfo> = {}): AIFileInfo => ({
 
 describe('use-artifact-preview', () => {
   describe('Provider / Consumer', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
     const setup = (
       options: {
         getOnArtifactClick?: () => OnArtifactClick | undefined;
@@ -109,26 +97,7 @@ describe('use-artifact-preview', () => {
       expect(consumerCtx?.canResolveArtifactUrl.value).toBe(false);
     });
 
-    it('resolveArtifactUrls 在 TTL 内应复用缓存', async () => {
-      const onArtifactClick = vi.fn().mockResolvedValue({
-        download_url: 'https://example.com/d',
-        preview_url: 'https://example.com/p',
-      });
-      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
-      const file = createFile({ outputId: 'cache-1' });
-
-      const first = await consumerCtx!.resolveArtifactUrls(file);
-      const second = await consumerCtx!.resolveArtifactUrls(file);
-
-      expect(first).toEqual({
-        download_url: 'https://example.com/d',
-        preview_url: 'https://example.com/p',
-      });
-      expect(second).toEqual(first);
-      expect(onArtifactClick).toHaveBeenCalledTimes(1);
-    });
-
-    it('resolveArtifactUrls 过期后应重新取链', async () => {
+    it('resolveArtifactUrls 每次调用都应重新取链', async () => {
       const onArtifactClick = vi
         .fn()
         .mockResolvedValueOnce({
@@ -140,10 +109,9 @@ describe('use-artifact-preview', () => {
           preview_url: 'https://example.com/p2',
         });
       const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
-      const file = createFile({ outputId: 'cache-ttl' });
+      const file = createFile({ outputId: 'no-cache' });
 
       const first = await consumerCtx!.resolveArtifactUrls(file);
-      vi.advanceTimersByTime(ARTIFACT_URL_CACHE_TTL_MS + 1);
       const second = await consumerCtx!.resolveArtifactUrls(file);
 
       expect(first).toEqual({
@@ -154,21 +122,6 @@ describe('use-artifact-preview', () => {
         download_url: 'https://example.com/d2',
         preview_url: 'https://example.com/p2',
       });
-      expect(onArtifactClick).toHaveBeenCalledTimes(2);
-    });
-
-    it('resolveArtifactUrls 传 force 时应绕过缓存重新取链', async () => {
-      const onArtifactClick = vi
-        .fn()
-        .mockResolvedValueOnce({ download_url: 'https://example.com/d1' })
-        .mockResolvedValueOnce({ download_url: 'https://example.com/d2' });
-      const { consumerCtx } = setup({ getOnArtifactClick: () => onArtifactClick });
-      const file = createFile({ outputId: 'cache-force' });
-
-      await consumerCtx!.resolveArtifactUrls(file);
-      const forced = await consumerCtx!.resolveArtifactUrls(file, { force: true });
-
-      expect(forced).toEqual({ download_url: 'https://example.com/d2' });
       expect(onArtifactClick).toHaveBeenCalledTimes(2);
     });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-artifact-preview.ts
@@ -34,18 +34,9 @@ export const ARTIFACT_PREVIEW_TOKEN = Symbol('ARTIFACT_PREVIEW_TOKEN');
 /** 文件产物侧栏 Tab 的保留唯一标识（固定 Tab，不可关闭） */
 export const FILE_ARTIFACT_TAB_NAME = 'file-artifact';
 
-/** 临时链接缓存有效期（短于后端 token 常见 10 分钟时效） */
-export const ARTIFACT_URL_CACHE_TTL_MS = 8 * 60 * 1000;
-
 export type OpenArtifactPreviewPayload = {
   /** 被点击的文件 */
   file: AIFileInfo;
-};
-
-/** resolveArtifactUrls 可选参数 */
-export type ResolveArtifactUrlsOptions = {
-  /** 为 true 时跳过 TTL 缓存，强制重新取链（如预览重试） */
-  force?: boolean;
 };
 
 /**
@@ -61,15 +52,10 @@ type ArtifactPreviewContext = {
   canResolveArtifactUrl: ComputedRef<boolean>;
   /** 由文件卡片触发：命中文件并弹出/切换到文件产物侧栏 */
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
-  /** 解析 download_url / preview_url：TTL 内复用缓存；force 时强制刷新；并发去重 */
-  resolveArtifactUrls: (file: AIFileInfo, options?: ResolveArtifactUrlsOptions) => Promise<ArtifactUrlResult>;
+  /** 解析 download_url / preview_url：每次重新取链；同文件并发去重 */
+  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
   /** 直接设置命中文件 outputId（侧栏列表内切换用） */
   setActiveArtifactId: (id: string) => void;
-};
-
-type ArtifactUrlCacheEntry = {
-  expiresAt: number;
-  urls: ArtifactUrlResult;
 };
 
 /** 通过临时 <a> 触发浏览器下载 */
@@ -86,7 +72,7 @@ export const triggerArtifactDownload = (url: string, fileName: string) => {
 
 /**
  * 文件产物预览 Provider（在 ChatContainer 内使用）。
- * 维护「命中文件」状态，并封装 onArtifactClick 取链（TTL 缓存 + 并发去重）；
+ * 维护「命中文件」状态，并封装 onArtifactClick 取链（每次重新获取 + 并发去重）；
  * 打开侧栏 Tab 的副作用由外部 onOpen 注入。
  */
 export const useArtifactPreviewProvider = (options: {
@@ -96,8 +82,6 @@ export const useArtifactPreviewProvider = (options: {
   onOpen: (outputId: string) => void;
 }) => {
   const activeArtifactId = shallowRef('');
-  // 成功结果按 outputId 缓存，带过期时间
-  const urlCache = new Map<string, ArtifactUrlCacheEntry>();
   // 进行中的请求，避免同文件并发重复打接口
   const inflight = new Map<string, Promise<ArtifactUrlResult>>();
 
@@ -113,20 +97,8 @@ export const useArtifactPreviewProvider = (options: {
     options.onOpen(id);
   };
 
-  const resolveArtifactUrls = async (
-    file: AIFileInfo,
-    resolveOptions?: ResolveArtifactUrlsOptions,
-  ): Promise<ArtifactUrlResult> => {
+  const resolveArtifactUrls = async (file: AIFileInfo): Promise<ArtifactUrlResult> => {
     const key = file.outputId;
-
-    if (resolveOptions?.force) {
-      urlCache.delete(key);
-    } else {
-      const cached = urlCache.get(key);
-      if (cached && cached.expiresAt > Date.now()) {
-        return cached.urls;
-      }
-    }
 
     const pending = inflight.get(key);
     if (pending) {
@@ -140,13 +112,8 @@ export const useArtifactPreviewProvider = (options: {
 
     const request = onArtifactClick(file)
       .then(result => {
-        const urls = result ?? {};
-        urlCache.set(key, {
-          expiresAt: Date.now() + ARTIFACT_URL_CACHE_TTL_MS,
-          urls,
-        });
         inflight.delete(key);
-        return urls;
+        return result ?? {};
       })
       .catch(error => {
         inflight.delete(key);

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
@@ -629,7 +629,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 | `html` / `markdown` / `md` / `txt` / `json` | `download_url` | 正文直渲染（srcdoc / MarkdownContent / `<pre>`） |
 | `pdf` / `jpg` 等 | `preview_url` | iframe（一般为后台转好的 PDF） |
 
-`md` 与 `markdown` 等价（见 `AIFileType.Md` / `AIFileType.Markdown`）。预览重载、`force` 重试与取链约定见 [FileArtifactPanel 预览机制](/components/message/file-artifact-panel#预览机制)。
+`md` 与 `markdown` 等价（见 `AIFileType.Md` / `AIFileType.Markdown`）。预览重载、重试与取链约定见 [FileArtifactPanel 预览机制](/components/message/file-artifact-panel#预览机制)。
 
 ```vue
 <template>

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/file-artifact-panel.md
@@ -7,8 +7,8 @@ description: 汇总当前会话全部文件产物，支持搜索、选中与分�
 aiSummary: >
   汇总当前会话所有 AssistantMessage 的 artifacts（按 outputId 去重），支持关键词搜索、列表选中与下载；
   预览区委托 ArtifactPreviewHost：按类型走 text_from_download（html / markdown / md / txt / json）
-  或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 异步获取（TTL 缓存，重试 force）；
-  预览重载键为 outputId:type；常规 resolveArtifactUrls 只传 file。
+  或 preview_url_iframe（其余类型）；download_url / preview_url 经 onArtifactClick 每次异步获取（无 URL 缓存，并发去重）；
+  预览重载键为 outputId:type；重试再次调用 load() 重新取链。
   源码位置：src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue。
 relatedComponents:
   - slug: assistant-message
@@ -63,7 +63,7 @@ sinceVersion: 0.0.20
 - **会话级聚合**：拍平当前会话所有 `AssistantMessage.property.artifacts`，以 `outputId` 去重后统一在一个列表内展示
 - **唯一命中**：以 `outputId` 作为会话内唯一键（同 `outputId` 视为同一文件）；文件名可能重复，不可作唯一键
 - **关键词搜索**：按文件名实时过滤列表
-- **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 获取 `download_url` / `preview_url`（TTL 8 分钟缓存；预览重试会 `force` 刷新）
+- **异步取链**：`AIFileInfo` 本身不含 `url` / `previewUrl`，通过 `ChatContainer` 的 `onArtifactClick` 按 `outputId` 获取 `download_url` / `preview_url`（每次重新取链，无 URL 缓存；同文件并发去重）
 - **职责拆分**：
   - **面板本身**：列表、搜索、预览头（文件名 / 图标 / 下载）
   - **`ArtifactPreviewHost`**：按策略加载正文或预览 URL，分派到对应 renderer；展示 loading / empty / error（含重试）
@@ -248,8 +248,8 @@ sessionArtifacts 有产物时
 ### 重载与取链约定
 
 - **重载键**：`ArtifactPreviewHost` 以 `` `${outputId}:${type}` `` 监听文件变化；`outputId` 或 `type` 任一变化会重新 `load()`，仅改文件名等其它字段不会
-- **常规取链**：`resolveArtifactUrls(file)`，只传文件，不传第二参
-- **重试 / 强刷**：错误态点击重试走 `load({ force: true })` → `resolveArtifactUrls(file, { force: true })`，绕过 TTL 缓存重新取链
+- **取链**：`resolveArtifactUrls(file)` 每次重新调用 `onArtifactClick`；同文件进行中的请求会复用（并发去重）
+- **重试**：错误态点击重试再次走 `load()`，重新取链并加载
 - **竞态**：切换文件时 `useArtifactPreviewLoader` 用 `loadSeq` + `AbortController` 中断上一次 `fetch`，避免过期结果覆盖最新内容
 
 下载图标仍由面板用 bkui `Loading` spin 单独表达。

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -568,8 +568,8 @@ ai-chat-container（:data-ai-size="size"）
 - **主动打开**：点击 AI 回复中的文件卡片（[ArtifactFileCard](/components/message/assistant-message)）时，容器通过 `useArtifactPreviewProvider` 以 `outputId` 命中该文件，再 `addCustomTab` 展开侧栏并选中「文件产物」
 - **排序 / 关闭**：`order: -1` 排在「执行情况」之前，`closable: false` 不可关闭
 - **显隐解耦**：该 Tab 存在时，侧栏展示不再受「`executionGroups` 为空」约束（即使当前会话没有执行类消息，也能独立展示文件产物侧栏）；会话切换或无文件产物时自动移除并重置命中态
-- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取。文本类（`html` / `markdown` / `md` / `txt` / `json`）拉 `download_url` 正文直渲染（`md` 与 `markdown` 等价）；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）。预览重载键为 `outputId:type`；失败重试会 `force` 绕过 URL 缓存
-- **状态管理**：命中、切换与 URL 缓存由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）；正文加载与分类型渲染由 Host 内部完成；常规取链只传 `file`，勿传 `undefined` 作为第二参
+- **内容**：由 [FileArtifactPanel](/components/message/file-artifact-panel) 渲染列表与下载头，预览委托内部 `ArtifactPreviewHost`；`download_url` / `preview_url` 通过 `onArtifactClick` 异步获取（每次重新取链，无 URL 缓存）。文本类（`html` / `markdown` / `md` / `txt` / `json`）拉 `download_url` 正文直渲染（`md` 与 `markdown` 等价）；其余类型用 `preview_url` iframe（一般为后台转好的 PDF）。预览重载键为 `outputId:type`；失败重试再次 `load()` 重新取链
+- **状态管理**：命中与切换由 [useArtifactPreview](/composables/use-artifact-preview) 提供（Provider 在容器内、Consumer 在文件卡片 / 面板内）；正文加载与分类型渲染由 Host 内部完成；取链只传 `file`，同文件并发去重
 - **未传 `onArtifactClick`**：下载按钮隐藏，预览区展示无数据
 
 详见 [FileArtifactPanel 文件产物预览](/components/message/file-artifact-panel) 与 [useArtifactPreview 文件产物预览](/composables/use-artifact-preview)。
@@ -1149,7 +1149,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | size                      | `'normal' \| 'small'`                                                                    | `'small'` | 字号主题：`small` 12px / `normal` 14px；根节点设置 `data-ai-size` 并注入 `useGlobalConfig`                                           |
 | welcomeTitle              | `string`                                                                                 | —         | 欢迎页标题；未传时默认展示「你好，我是小鲸」                                                                                         |
 | onCustomTabChange         | `(tab: CustomTab) => Promise<any>`                                                       | —         | 自定义 Tab 切换回调，返回值作为 Tab 组件 props                                                                                       |
-| onArtifactClick           | `(file: AIFileInfo) => Promise<{ download_url?: string; preview_url?: string }>`          | —         | 异步获取下载 / 预览链接（按 `outputId` 缓存）。文本类预览依赖 `download_url`，iframe 类依赖 `preview_url`；未传则隐藏下载、预览无数据 |
+| onArtifactClick           | `(file: AIFileInfo) => Promise<{ download_url?: string; preview_url?: string }>`          | —         | 异步获取下载 / 预览链接（每次调用重新获取，无缓存；同文件并发去重）。文本类预览依赖 `download_url`，iframe 类依赖 `preview_url`；未传则隐藏下载、预览无数据 |
 
 > 其余 Props（如 `messages`、`messageStatus`、`onSendMessage`、`shortcuts` 等）继承自 [ChatInput](/components/input/chat-input) 与 [MessageContainer](/components/setup/message-container)。
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-artifact-preview.md
@@ -7,7 +7,7 @@ description: >-
   Provider 在 ChatContainer 中创建，Consumer 在深层文件卡片中注入使用。
 aiSummary: >
   useArtifactPreviewProvider 维护 activeArtifactId（值为 outputId），openPreview 命中文件并触发 onOpen 打开侧栏 Tab；
-  并通过 getOnArtifactClick 封装 resolveArtifactUrls（TTL 8 分钟缓存；常规只传 file，force 可强制刷新，并发去重）；
+  并通过 getOnArtifactClick 封装 resolveArtifactUrls（每次重新取链，并发去重）；
   useArtifactPreviewConsumer 在后代注入同一套 API。SessionArtifact 即 AIFileInfo，会话内以 outputId 为唯一键。
   正文加载与分类型渲染不在本 composable，由 FileArtifactPanel 内 ArtifactPreviewHost 完成（重载键 outputId:type）。
   FILE_ARTIFACT_TAB_NAME 标识固定「文件产物」Tab。
@@ -29,7 +29,7 @@ Provider/Consumer 模式的文件产物预览状态管理。Provider 在 `ChatCo
 
 **职责边界**：
 
-- **本 composable**：维护「命中文件」与「URL 解析」（TTL 缓存 + 并发去重；常规 `resolveArtifactUrls(file)`，重试可 `force` 刷新）；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
+- **本 composable**：维护「命中文件」与「URL 解析」（每次重新取链 + 并发去重）；打开侧栏 Tab（`addCustomTab`）由容器通过 `onOpen` 注入
 - **不在本 composable**：聚合会话文件列表、渲染预览面板、按类型 fetch 正文 / iframe 展示 —— 分别由 `useMessageGroup.sessionArtifacts`、`FileArtifactPanel`、内部 `ArtifactPreviewHost` + `useArtifactPreviewLoader` 承担（预览重载键为 `outputId:type`）
 
 ## 函数签名
@@ -46,7 +46,7 @@ function useArtifactPreviewProvider(options: {
   activeArtifactId: ShallowRef<string>;
   canResolveArtifactUrl: ComputedRef<boolean>;
   openPreview: (payload: OpenArtifactPreviewPayload) => void;
-  resolveArtifactUrls: (file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>;
+  resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
   setActiveArtifactId: (id: string) => void;
 };
 ```
@@ -60,7 +60,7 @@ function useArtifactPreviewConsumer():
       activeArtifactId: Ref<string>;
       canResolveArtifactUrl: ComputedRef<boolean>;
       openPreview: (payload: OpenArtifactPreviewPayload) => void;
-      resolveArtifactUrls: (file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>;
+      resolveArtifactUrls: (file: AIFileInfo) => Promise<ArtifactUrlResult>;
       setActiveArtifactId: (id: string) => void;
     };
 ```
@@ -176,7 +176,7 @@ const onArtifactClick = async (file: AIFileInfo) => {
 | activeArtifactId    | `ShallowRef<string>`                      | 当前命中的文件 `outputId`                                            |
 | canResolveArtifactUrl | `ComputedRef<boolean>`                  | 是否具备异步取链能力（有 `onArtifactClick` 时为 true，下载按钮据此显隐） |
 | openPreview         | `(payload: OpenArtifactPreviewPayload) => void` | 由文件卡片触发：以 `file.outputId` 更新命中态、调用 `onOpen`   |
-| resolveArtifactUrls | `(file: AIFileInfo, options?: { force?: boolean }) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 取链；成功结果按 `outputId` 缓存 8 分钟；**常规调用只传 `file`**，仅预览重试 / 强刷传 `{ force: true }`（不要传 `undefined` 作为第二参）；并发去重 |
+| resolveArtifactUrls | `(file: AIFileInfo) => Promise<ArtifactUrlResult>` | 调用 `onArtifactClick` 取链；每次重新获取，不缓存；同文件并发去重 |
 | setActiveArtifactId | `(id: string) => void`                    | 直接设置命中文件 `outputId`；侧栏列表内切换选中时使用                |
 
 ## 类型定义


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件产物预览取消 URL TTL 缓存，每次重新取链
ID: 1070093903136901151

## 改动
- use-artifact-preview: 移除 URL TTL 缓存与 force 参数，每次 resolve 重新取链，保留并发去重
- artifact-preview-loader / host: load/重试不再传 force
- 单测与 wikis: 同步无缓存 / 无 force 语义

## 影响面
- 文件产物预览取链会更频繁调用 onArtifactClick；同文件并发仍去重
- resolveArtifactUrls 第二参 force 已移除（破坏性 API 简化）

## 测试
- [ ] 同一文件连续两次 resolve 均重新取链
- [ ] 预览错误态重试再次 load 可重新取链
- [ ] 同文件并发 resolve 仍只打一次进行中请求
- [ ] 相关单测通过（本交付未运行，待 PR 勾选）

Made with [Cursor](https://cursor.com)