### PR TITLE
fix: 新增 GeneratorStreamingHelper.is_registered 供 stop 等待流注册 --bug=161864770

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -168,6 +168,24 @@ class GeneratorStreamingHelper:
         return False
 
     @classmethod
+    def is_registered(cls, thread_id: str, message_handler: BaseMessageQueueHandler | None = None) -> bool:
+        """判断流式侧是否已注册，此时调用 cancel 可投递到活跃流。
+
+        - 进程内：``stream()`` 开头已写入 ``_cancel_events``
+        - 跨进程：存在活跃消费者（``stream()`` 在注册 cancel 后 ``acquire_consumer``）
+        """
+        with cls._cancel_lock:
+            if thread_id in cls._cancel_events:
+                return True
+        if message_handler is None:
+            message_handler = message_handler_factory.get()
+        try:
+            return bool(message_handler.has_active_consumer(thread_id))
+        except Exception:
+            logger.exception("Error checking stream registration for thread_id=%s", thread_id)
+            return False
+
+    @classmethod
     def cancel(cls, thread_id: str, message_handler: BaseMessageQueueHandler | None = None) -> bool:
         """取消指定 thread_id 的流式生产（支持多进程）
 


### PR DESCRIPTION
## 背景

关联 `tapd: #161864770`。工作台在 `chat_completion` 首包前点击「停止生成」时，stop 可能在流尚未注册时投递 cancel，导致 SSE 无终态而 UI 残留「请求中…」。平台 stop 需先确认流已可 cancel 再调用 `GeneratorStreamingHelper.cancel`。

本 PR 范围：SDK 侧新增 `is_registered` API，供平台 `stop_content` 轮询等待流注册。

## 改动

### GeneratorStreamingHelper

- 新增类方法 `is_registered(thread_id)`：
  - 进程内：`_cancel_events` 已写入（`stream()` 开头注册）
  - 跨进程：`message_handler.has_active_consumer(thread_id)` 为 true
- 供工作台 / 插件 stop 在 cancel 前等待流就绪，减少「cancel 打空」窗口

## 测试

- `src/agent/tests/services/test_rabbitmq_handler.py`（本地执行，17 skipped，无失败）

## 关联

- tapd: #161864770
- 平台侧配套改动见 `bk-aidev` 工作台 `stop_content`（依赖本 API，需 `aidev-agent>=2.2.1rc282`）


Made with [Cursor](https://cursor.com)