### PR TITLE
fix: 【chat-x】工具调用状态按 toolMessage 维度推导 --story=136907526

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/assistant-message.md
@@ -89,15 +89,15 @@ const doubled = computed(() => count.value * 2);
 
 ## 消息状态
 
-`status` 影响两处渲染：**内容区**和**工具调用状态标题**。
+`status` 直接影响 **内容区**（`ContentRender`）。`ToolCallRender` 的状态**按工具维度推导**（见下方「工具调用状态推导」），不直接等于本组件的 `status`。
 
-| `status`    | 内容区效果                          | ToolCallRender 标题 |
-| ----------- | ----------------------------------- | ------------------- |
-| `pending`   | 正常渲染（通常 content 为空）       | Loading + "调用中"  |
-| `streaming` | Markdown 自动补全未闭合语法         | Loading + "调用中"  |
-| `complete`  | 正常渲染完整 Markdown               | "调用成功" + 耗时   |
-| `error`     | 红色错误图标 + content 作为错误提示 | "调用失败"          |
-| `stop`      | 正常渲染（内容停留在中止时的状态）  | "调用成功"          |
+| `status`    | 内容区效果                          |
+| ----------- | ----------------------------------- |
+| `pending`   | 正常渲染（通常 content 为空）       |
+| `streaming` | Markdown 自动补全未闭合语法         |
+| `complete`  | 正常渲染完整 Markdown               |
+| `error`     | 红色错误图标 + content 作为错误提示 |
+| `stop`      | 正常渲染（内容停留在中止时的状态）  |
 
 ### Pending
 
@@ -117,7 +117,7 @@ const doubled = computed(() => count.value * 2);
 
 ## 工具调用
 
-当 AI 回复中包含工具调用时，传入 `toolCalls` 数组，每项自动渲染为 `ToolCallRender`，位于内容区下方。`status` 会同步传递给每个 `ToolCallRender` 以反映调用状态。
+当 AI 回复中包含工具调用时，传入 `toolCalls` 数组，每项自动渲染为 `ToolCallRender`，位于内容区下方。传给每个 `ToolCallRender` 的 `status` 按下方优先级从 `toolCall.toolMessage` 推导，而非直接同步本组件的 `status`。
 
 ### 单个工具调用
 
@@ -262,13 +262,17 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 
 **渲染效果**
 
-### 工具调用状态随消息状态变化
+### 工具调用状态推导
 
-`ToolCallRender` 的状态标题直接来自 `AssistantMessage` 的 `status` prop：
+传给每个 `ToolCallRender` 的 `status` 按以下优先级计算：
 
-**调用中**（`status = "streaming"`）：
+1. 无 `toolMessage` → `MessageStatus.Pending`（调用中）
+2. `toolMessage.error` 为真 → `MessageStatus.Error`（调用失败）
+3. 否则 → `toolMessage.status ??` 本组件 `status`
 
-**调用成功**（`status = "complete"` + `toolMessage`）：
+**调用中**（有 `toolCalls`、尚无 `toolMessage`；即便助手 `status` 已是 `complete` 也显示调用中）：
+
+**调用成功**（`toolMessage.status = "complete"`）：
 
 ## 自定义内容渲染
 
@@ -364,7 +368,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 | 属性名    | 类型                    | 说明                                                           |
 | --------- | ----------------------- | -------------------------------------------------------------- |
 | content   | `string`                | AI 回复的文本内容，支持 Markdown，`undefined` 时渲染为空字符串 |
-| status    | `MessageStatus`         | 消息状态，影响 Markdown 渲染模式和 ToolCallRender 的状态标题   |
+| status    | `MessageStatus`         | 影响 ContentRender；ToolCallRender 在无 toolMessage.status 时回退使用此值 |
 | toolCalls | `ToolCall[]`            | 工具调用列表，每项渲染一个 `ToolCallRender`                    |
 | id        | `number \| string`      | 消息 ID                                                        |
 | messageId | `number \| string`      | 消息唯一标识                                                   |

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
@@ -241,7 +241,13 @@ const assistantMessage = {
     v-for="toolCall in assistantMessage.toolCalls"
     :key="toolCall.id"
     :tool-call="toolCall"
-    :status="toolCall.toolMessage?.status ?? MessageStatus.Pending"
+    :status="
+      !toolCall.toolMessage
+        ? MessageStatus.Pending
+        : toolCall.toolMessage.error
+          ? MessageStatus.Error
+          : (toolCall.toolMessage.status ?? assistantMessage.status)
+    "
   />
 </template>
 ```

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
@@ -66,15 +66,18 @@ role=user  role=tool     其他 role
 `role: 'tool'` 消息不会独立渲染，而是通过 `toolCallId` 注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段：
 
 ```typescript
-const toolMessage = messages.find(
+const assistantToolMessage = messages.find(
   m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === message.toolCallId),
-);
-if (toolMessage) {
-  const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+) as AssistantMessage | undefined;
+if (assistantToolMessage) {
+  const toolCall = assistantToolMessage.toolCalls?.find(t => t.id === message.toolCallId);
   if (toolCall) {
     toolCall.toolMessage = message;
   }
-  // 同步 assistant 状态（错误等）
+  // error 时强制 assistant 为 Error；否则保留原 status，空值兜底 Complete
+  assistantToolMessage.status = message.error
+    ? MessageStatus.Error
+    : assistantToolMessage.status || MessageStatus.Complete;
 }
 ```
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.spec.ts
@@ -60,6 +60,7 @@ vi.mock('../../tool-call/toolcall-render/toolcall-render.vue', () => ({
         h('div', {
           class: 'mock-toolcall-render',
           'data-tool-id': props.toolCall?.id,
+          'data-status': props.status,
         });
     },
   }),
@@ -148,6 +149,92 @@ describe('AssistantMessage', () => {
       });
 
       expect(wrapper.findAll('.mock-toolcall-render').length).toBe(2);
+    });
+
+    it('无 toolMessage 时应向 ToolCallRender 传递 Pending，即使助手 status 为 Complete', () => {
+      const toolCalls = [
+        { id: 'tool-1', type: MessageContentType.Function, function: { name: 'search', arguments: '{}' } },
+      ];
+
+      wrapper = mount(AssistantMessage, {
+        props: {
+          content: '内容',
+          status: MessageStatus.Complete,
+          toolCalls,
+        },
+      });
+
+      expect(wrapper.find('.mock-toolcall-render').attributes('data-status')).toBe(MessageStatus.Pending);
+    });
+
+    it('toolMessage.error 为真时应向 ToolCallRender 传递 Error', () => {
+      const toolCalls = [
+        {
+          id: 'tool-1',
+          type: MessageContentType.Function,
+          function: { name: 'search', arguments: '{}' },
+          toolMessage: {
+            error: 'rate limit',
+            status: MessageStatus.Complete,
+          },
+        },
+      ];
+
+      wrapper = mount(AssistantMessage, {
+        props: {
+          content: '内容',
+          status: MessageStatus.Complete,
+          toolCalls,
+        },
+      });
+
+      expect(wrapper.find('.mock-toolcall-render').attributes('data-status')).toBe(MessageStatus.Error);
+    });
+
+    it('有 toolMessage.status 时应优先使用该 status', () => {
+      const toolCalls = [
+        {
+          id: 'tool-1',
+          type: MessageContentType.Function,
+          function: { name: 'search', arguments: '{}' },
+          toolMessage: {
+            status: MessageStatus.Success,
+          },
+        },
+      ];
+
+      wrapper = mount(AssistantMessage, {
+        props: {
+          content: '内容',
+          status: MessageStatus.Streaming,
+          toolCalls,
+        },
+      });
+
+      expect(wrapper.find('.mock-toolcall-render').attributes('data-status')).toBe(MessageStatus.Success);
+    });
+
+    it('有 toolMessage 但无 status/error 时应回退到助手 status', () => {
+      const toolCalls = [
+        {
+          id: 'tool-1',
+          type: MessageContentType.Function,
+          function: { name: 'search', arguments: '{}' },
+          toolMessage: {
+            content: 'ok',
+          },
+        },
+      ];
+
+      wrapper = mount(AssistantMessage, {
+        props: {
+          content: '内容',
+          status: MessageStatus.Streaming,
+          toolCalls,
+        },
+      });
+
+      expect(wrapper.find('.mock-toolcall-render').attributes('data-status')).toBe(MessageStatus.Streaming);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
@@ -24,7 +24,13 @@
         :key="toolCall.id"
       >
         <ToolCallRender
-          :status="toolCall.toolMessage?.status ?? status"
+          :status="
+            !toolCall.toolMessage
+              ? MessageStatus.Pending
+              : toolCall.toolMessage.error
+                ? MessageStatus.Error
+                : (toolCall.toolMessage.status ?? status)
+          "
           :tool-call="toolCall"
         />
       </template>
@@ -39,7 +45,7 @@
 <script setup lang="ts">
   import { computed } from 'vue';
 
-  import { MessageContentType } from '../../../ag-ui/types/constants';
+  import { MessageContentType, MessageStatus } from '../../../ag-ui/types/constants';
   import ContentRender from '../../chat-content/content-render/content-render.vue';
   import ToolCallRender from '../../tool-call/toolcall-render/toolcall-render.vue';
   import MessageArtifacts from './message-artifacts/message-artifacts.vue';

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -247,6 +247,48 @@ describe('useMessageGroup', () => {
 
       expect(messageGroups.value.length).toBe(1);
       expect(messageGroups.value[0]?.type).toBe(MessageRole.Assistant);
+      const assistant = messageGroups.value[0]?.messages[0] as AssistantMessage;
+      expect(assistant.toolCalls?.[0]?.toolMessage?.id).toBe('2');
+      expect(assistant.status).toBe(MessageStatus.Complete);
+    });
+
+    it('Tool 消息 error 为真时应将关联的 AssistantMessage status 设为 Error', async () => {
+      const toolCallId = 'tc-err';
+      const toolMessage = createToolMessage('2', toolCallId);
+      toolMessage.error = 'tool failed';
+      const messages: Message[] = [
+        createAssistantMessage('1', 'calling tool', {
+          status: MessageStatus.Streaming,
+          toolCalls: [
+            { id: toolCallId, type: MessageContentType.Function, function: { name: 'search', arguments: '{}' } },
+          ],
+        }),
+        toolMessage,
+      ];
+      const { messageGroups } = setupMessageGroup(messages);
+      await nextTick();
+
+      const assistant = messageGroups.value[0]?.messages[0] as AssistantMessage;
+      expect(assistant.toolCalls?.[0]?.toolMessage?.error).toBe('tool failed');
+      expect(assistant.status).toBe(MessageStatus.Error);
+    });
+
+    it('Tool 成功且 Assistant status 为空时应兜底为 Complete', async () => {
+      const toolCallId = 'tc-empty-status';
+      const messages: Message[] = [
+        createAssistantMessage('1', 'calling tool', {
+          status: '' as MessageStatus,
+          toolCalls: [
+            { id: toolCallId, type: MessageContentType.Function, function: { name: 'search', arguments: '{}' } },
+          ],
+        }),
+        createToolMessage('2', toolCallId),
+      ];
+      const { messageGroups } = setupMessageGroup(messages);
+      await nextTick();
+
+      const assistant = messageGroups.value[0]?.messages[0] as AssistantMessage;
+      expect(assistant.status).toBe(MessageStatus.Complete);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -39,10 +39,10 @@ import {
 import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
 import { t } from '../lang/lang';
 import { generateUUID } from '../utils';
-import { type SessionArtifact } from './use-artifact-preview';
 
 import type { BkFlowMessageContent } from '../ag-ui/types/contents';
 import type { InterruptMessage, UserQuestionInterrupt } from '../ag-ui/types/interrupt';
+import type { SessionArtifact } from './use-artifact-preview';
 
 export type MessageGroup = {
   checked: boolean;
@@ -177,16 +177,19 @@ export const useMessageGroup = (options: {
         });
         continue;
       }
+
       if (message.role === MessageRole.Tool) {
-        const toolMessage = options.messages.value.find(
+        const assistantToolMessage = options.messages.value.find(
           m => m.role === MessageRole.Assistant && m.toolCalls?.some(t => t.id === message.toolCallId),
         ) as AssistantMessage | undefined;
-        if (toolMessage) {
-          const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+        if (assistantToolMessage) {
+          const toolCall = assistantToolMessage.toolCalls?.find(t => t.id === message.toolCallId);
           if (toolCall) {
             toolCall.toolMessage = message;
           }
-          toolMessage.status = message.error ? MessageStatus.Error : toolMessage.status || MessageStatus.Complete;
+          assistantToolMessage.status = message.error
+            ? MessageStatus.Error
+            : assistantToolMessage.status || MessageStatus.Complete;
           continue;
         }
       }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
@@ -364,7 +364,13 @@ const assistantMessage = {
     v-for="toolCall in assistantMessage.toolCalls"
     :key="toolCall.id"
     :tool-call="toolCall"
-    :status="toolCall.toolMessage?.status ?? MessageStatus.Pending"
+    :status="
+      !toolCall.toolMessage
+        ? MessageStatus.Pending
+        : toolCall.toolMessage.error
+          ? MessageStatus.Error
+          : (toolCall.toolMessage.status ?? assistantMessage.status)
+    "
   />
 </template>
 ```

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/assistant-message.md
@@ -242,15 +242,15 @@ const doubled = computed(() => count.value * 2);
 
 ## 消息状态
 
-`status` 影响两处渲染：**内容区**和**工具调用状态标题**。
+`status` 直接影响 **内容区**（`ContentRender`）。`ToolCallRender` 的状态**按工具维度推导**（见下方「工具调用状态推导」），不直接等于本组件的 `status`。
 
-| `status`    | 内容区效果                          | ToolCallRender 标题 |
-| ----------- | ----------------------------------- | ------------------- |
-| `pending`   | 正常渲染（通常 content 为空）       | Loading + "调用中"  |
-| `streaming` | Markdown 自动补全未闭合语法         | Loading + "调用中"  |
-| `complete`  | 正常渲染完整 Markdown               | "调用成功" + 耗时   |
-| `error`     | 红色错误图标 + content 作为错误提示 | "调用失败"          |
-| `stop`      | 正常渲染（内容停留在中止时的状态）  | "调用成功"          |
+| `status`    | 内容区效果                          |
+| ----------- | ----------------------------------- |
+| `pending`   | 正常渲染（通常 content 为空）       |
+| `streaming` | Markdown 自动补全未闭合语法         |
+| `complete`  | 正常渲染完整 Markdown               |
+| `error`     | 红色错误图标 + content 作为错误提示 |
+| `stop`      | 正常渲染（内容停留在中止时的状态）  |
 
 ### Pending
 
@@ -307,7 +307,7 @@ const doubled = computed(() => count.value * 2);
 
 ## 工具调用
 
-当 AI 回复中包含工具调用时，传入 `toolCalls` 数组，每项自动渲染为 `ToolCallRender`，位于内容区下方。`status` 会同步传递给每个 `ToolCallRender` 以反映调用状态。
+当 AI 回复中包含工具调用时，传入 `toolCalls` 数组，每项自动渲染为 `ToolCallRender`，位于内容区下方。传给每个 `ToolCallRender` 的 `status` 按下方优先级从 `toolCall.toolMessage` 推导，而非直接同步本组件的 `status`。
 
 ### 单个工具调用
 
@@ -495,25 +495,29 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
   />
 </div>
 
-### 工具调用状态随消息状态变化
+### 工具调用状态推导
 
-`ToolCallRender` 的状态标题直接来自 `AssistantMessage` 的 `status` prop：
+传给每个 `ToolCallRender` 的 `status` 按以下优先级计算：
 
-**调用中**（`status = "streaming"`）：
+1. 无 `toolMessage` → `MessageStatus.Pending`（调用中）
+2. `toolMessage.error` 为真 → `MessageStatus.Error`（调用失败）
+3. 否则 → `toolMessage.status ??` 本组件 `status`
+
+**调用中**（有 `toolCalls`、尚无 `toolMessage`；即便助手 `status` 已是 `complete` 也显示调用中）：
 
 <div class="demo">
-  <p style="margin: 0 0 4px; font-size: 12px; color: #979ba5;">status = "streaming" + toolCalls</p>
+  <p style="margin: 0 0 4px; font-size: 12px; color: #979ba5;">无 toolMessage → Pending</p>
   <AssistantMessageComp
     content="正在调用工具获取信息..."
-    status="streaming"
+    status="complete"
     :tool-calls="singleToolCall"
   />
 </div>
 
-**调用成功**（`status = "complete"` + `toolMessage`）：
+**调用成功**（`toolMessage.status = "complete"`）：
 
 <div class="demo">
-  <p style="margin: 0 0 4px; font-size: 12px; color: #979ba5;">status = "complete" + toolMessage</p>
+  <p style="margin: 0 0 4px; font-size: 12px; color: #979ba5;">toolMessage.status = "complete"</p>
   <AssistantMessageComp
     content="已查询到天气信息。"
     status="complete"
@@ -681,7 +685,7 @@ AI 可在一次回复中发起多个工具调用，组件依次渲染：
 | 属性名    | 类型                    | 说明                                                                                      |
 | --------- | ----------------------- | ----------------------------------------------------------------------------------------- |
 | content   | `string`                | AI 回复文本，支持 Markdown；空值时不渲染内容区                                            |
-| status    | `MessageStatus`         | 影响 ContentRender / ToolCallRender 状态表现                                              |
+| status    | `MessageStatus`         | 影响 ContentRender；ToolCallRender 在无 toolMessage.status 时回退使用此值                 |
 | toolCalls | `ToolCall[]`            | 工具调用列表，每项渲染一个 `ToolCallRender`                                               |
 | id        | `number \| string`      | 消息 ID；无 `uid` 时回退为 `messageUid`                                                   |
 | messageId | `number \| string`      | 消息唯一标识                                                                              |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -79,15 +79,18 @@ role=user  role=tool     其他 role
 `role: 'tool'` 消息不会独立渲染，而是通过 `toolCallId` 注入到对应 AssistantMessage 的 `toolCall.toolMessage` 字段：
 
 ```typescript
-const toolMessage = messages.find(
+const assistantToolMessage = messages.find(
   m => m.role === 'assistant' && m.toolCalls?.some(t => t.id === message.toolCallId),
-);
-if (toolMessage) {
-  const toolCall = toolMessage.toolCalls?.find(t => t.id === message.toolCallId);
+) as AssistantMessage | undefined;
+if (assistantToolMessage) {
+  const toolCall = assistantToolMessage.toolCalls?.find(t => t.id === message.toolCallId);
   if (toolCall) {
     toolCall.toolMessage = message;
   }
-  // 同步 assistant 状态（错误等）
+  // error 时强制 assistant 为 Error；否则保留原 status，空值兜底 Complete
+  assistantToolMessage.status = message.error
+    ? MessageStatus.Error
+    : assistantToolMessage.status || MessageStatus.Complete;
 }
 ```
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】工具调用状态按 toolMessage 维度推导
ID: 1070093903136907526

## 改动
- assistant-message.vue: ToolCallRender status 按 toolMessage 推导（无结果 Pending / error→Error / 否则 status 回退）
- use-message-group.ts: Tool 关联变量重命名 assistantToolMessage，error 时同步 assistant Error
- wikis + skills: 同步工具状态推导与 Tool 注入说明
- *.spec.ts: 补强 status 推导与 Tool 关联断言

## 影响面
- 工具调用头部状态展示逻辑；不影响消息分组结构与业务发送流程

## 测试
- [ ] assistant-message：无 toolMessage → Pending
- [ ] assistant-message：toolMessage.error → Error
- [ ] assistant-message：优先 toolMessage.status / 回退助手 status
- [ ] use-message-group：注入 toolMessage；error → assistant Error；空 status 兜底 Complete
- [ ] （单测本次未运行）


Made with [Cursor](https://cursor.com)