### PR TITLE
feat: 【chat-x】ToolCallRender 补充成功/失败状态图标 --story=136921932

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -187,7 +187,15 @@
   import CustomTabContent from './custom-tab-content.vue';
   import { MOCK_USER_QUESTION_PENDING_MESSAGES } from './interrupt';
   import { streamContent } from './markdown';
-  import { MOCK_INFO_MESSAGES, MOCK_MESSAGES, MOCK_MODELS, MOCK_PROMPTS, MOCK_RESOURCES, mockArtifactClick } from './mock';
+  import {
+    MOCK_INFO_MESSAGES,
+    MOCK_MESSAGES,
+    MOCK_MODELS,
+    MOCK_PROMPTS,
+    MOCK_RESOURCES,
+    MOCK_TOOLCALL_STATUS_MESSAGES,
+    mockArtifactClick,
+  } from './mock';
   import { uploadFileToSession } from './upload-file';
 
   import type { CustomTab, IAiSlashMenuItem, Shortcut, TagSchema } from '../src/types';
@@ -207,9 +215,10 @@
   const handleModelChange = (model: IModelOption) => {
     console.log('model change:', model);
   };
-  // Info 分隔提示 + 含 toolCalls 的会话 mock + 待回答 UserQuestion
+  // Info 分隔提示 + ToolCall 各状态 + 含 toolCalls 的会话 mock + 待回答 UserQuestion
   const messages = deepRef<Message[]>([
     ...MOCK_INFO_MESSAGES,
+    ...MOCK_TOOLCALL_STATUS_MESSAGES,
     ...(MOCK_MESSAGES as Message[]),
     ...MOCK_USER_QUESTION_PENDING_MESSAGES,
   ]);

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -495,6 +495,122 @@ export const MOCK_INFO_MESSAGES = [
   },
 ] as Message[];
 
+/**
+ * ToolCallRender 状态 mock：一条 assistant 内多个 toolCall，覆盖
+ * Pending / Streaming（Loading）与 Success / Complete / Completed（成功）以及 Error（失败）
+ */
+export const MOCK_TOOLCALL_STATUS_MESSAGES = [
+  {
+    id: 'mock-toolcall-status-user',
+    role: MessageRole.User,
+    content: '帮我演示一下工具调用的各种状态',
+    name: 'user',
+    status: MessageStatus.Complete,
+    messageId: 'mock-toolcall-status-user',
+  },
+  {
+    id: 'mock-toolcall-status-assistant',
+    role: MessageRole.Assistant,
+    content: '以下为 ToolCallRender 各状态示例：',
+    name: 'react_agent',
+    status: MessageStatus.Complete,
+    messageId: 'mock-toolcall-status-assistant',
+    toolCalls: [
+      // Pending：无 toolMessage → Loading「调用中」
+      {
+        id: 'mock-tc-pending',
+        type: 'function',
+        function: {
+          name: 'query_service_status',
+          description: '查询服务运行状态（Pending）',
+          arguments: '{"service": "chat-x"}',
+        },
+      },
+      // Streaming：Loading「调用中」
+      {
+        id: 'mock-tc-streaming',
+        type: 'function',
+        function: {
+          name: 'stream_logs',
+          description: '流式拉取日志（Streaming）',
+          arguments: '{"lines": 100}',
+        },
+        toolMessage: {
+          toolCallId: 'mock-tc-streaming',
+          status: MessageStatus.Streaming,
+          content: '',
+          duration: 0,
+        },
+      },
+      // Success
+      {
+        id: 'mock-tc-success',
+        type: 'function',
+        function: {
+          name: 'get_cluster_info',
+          description: '获取集群信息（Success）',
+          arguments: '{"cluster_id": "bk-prod"}',
+        },
+        toolMessage: {
+          toolCallId: 'mock-tc-success',
+          status: MessageStatus.Success,
+          content: '{"cluster": "bk-prod", "nodes": 12}',
+          duration: 1234,
+        },
+      },
+      // Complete
+      {
+        id: 'mock-tc-complete',
+        type: 'function',
+        function: {
+          name: 'list_pods',
+          description: '列出 Pod（Complete）',
+          arguments: '{"namespace": "default"}',
+        },
+        toolMessage: {
+          toolCallId: 'mock-tc-complete',
+          status: MessageStatus.Complete,
+          content: '{"pods": ["api-0", "api-1"]}',
+          duration: 856,
+        },
+      },
+      // Completed
+      {
+        id: 'mock-tc-completed',
+        type: 'function',
+        function: {
+          name: 'check_itsm_ticket',
+          description: '检查 ITSM 工单（Completed）',
+          arguments: '{"ticket_num": "1234"}',
+        },
+        toolMessage: {
+          toolCallId: 'mock-tc-completed',
+          status: MessageStatus.Completed,
+          content: '{"id": "1234", "status": "open"}',
+          duration: 2100,
+        },
+      },
+      // Error：失败图标
+      {
+        id: 'mock-tc-error',
+        type: 'function',
+        function: {
+          name: 'deploy_service',
+          description: '部署服务（Error）',
+          arguments: '{"service": "chat-x", "env": "prod"}',
+        },
+        toolMessage: {
+          toolCallId: 'mock-tc-error',
+          status: MessageStatus.Error,
+          error: '部署失败：权限不足',
+          content: '',
+          duration: 430,
+        },
+      },
+    ],
+  },
+] as Message[];
+
 // @ 资源列表
 export const MOCK_RESOURCES = [
   {

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/toolcall-render.md
@@ -28,7 +28,9 @@
 │   ├── "调用工具：" / "调用 MCP："（有 mcpName 时）
 │   ├── .toolcall-header-title（工具名，overflow-tips 溢出截断）
 │   └── .toolcall-status-title
-│         ├── Loading（仅 pending / streaming 时显示）
+│         ├── Loading（pending / streaming）
+│         ├── BkFlowSuccessIcon（success / complete / completed）
+│         ├── BkFlowFailedIcon（error）
 │         ├── 状态文案（调用中 / 调用成功 / 调用失败）
 │         └── .toolcall-duration（耗时，如 "(1.2s)"）
 │
@@ -73,16 +75,16 @@
 
 ## 调用状态
 
-`status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和 Loading 动画：
+`status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和状态图标：
 
-| `status`                | 状态文案 | 背景色            | 边框色    | Loading |
-| ----------------------- | -------- | ----------------- | --------- | ------- |
-| `pending` / `streaming` | 调用中   | `#fafbfd`         | `#dcdee5` | ✓       |
-| `complete` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | -       |
-| `error`                 | 调用失败 | `#fff0f0`         | `#f8b4b4` | -       |
-| 其他 / `undefined`      | 调用中   | —（无匹配 class） | —         | -       |
+| `status`                             | 状态文案 | 背景色            | 边框色    | 状态图标            |
+| ------------------------------------ | -------- | ----------------- | --------- | ------------------- |
+| `pending` / `streaming`              | 调用中   | `#fafbfd`         | `#dcdee5` | `Loading`           |
+| `complete` / `completed` / `success` | 调用成功 | `#ebfaf0`         | `#a1e3ba` | `BkFlowSuccessIcon` |
+| `error`                              | 调用失败 | `#fff0f0`         | `#f8b4b4` | `BkFlowFailedIcon`  |
+| 其他 / `undefined`                   | 调用中   | —（无匹配 class） | —         | —                   |
 
-> **说明**：`statusTitle` 的 `switch` 语句中 `default` 与 `case Pending` 共享同一返回值，`streaming` 和未知 status 均命中 `default` 分支，显示"调用中"。Loading 动画由 `v-if="status === 'pending' || status === 'streaming'"` 单独控制。
+> **说明**：`statusTitle` 将 `Completed`（`completed`）与 `Complete` / `Success` 一并视为成功；主题 `$toolcallStatusMap` 同步提供 `completed` 色值。`default` 与 `case Pending` 共享「调用中」文案，`streaming` 与未知 status 命中 `default`。状态图标互斥：`pending` / `streaming` 显示 `Loading`；`success` / `complete` / `completed` 显示 `BkFlowSuccessIcon`；`error` 显示 `BkFlowFailedIcon`。
 
 **三种状态对比**
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/assistant-message.vue
@@ -72,6 +72,7 @@
   .ai-assistant-message {
     display: flex;
     flex-direction: column;
+    gap: 12px;
     align-items: flex-start;
     width: 100%;
     font-size: var(--ai-font-size, 12px);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
@@ -70,6 +70,22 @@ vi.mock('../../../icons/content', () => ({
   }),
 }));
 
+// Mock 流程状态图标（成功 / 失败）
+vi.mock('../../../icons', () => ({
+  BkFlowSuccessIcon: defineComponent({
+    name: 'BkFlowSuccessIcon',
+    setup() {
+      return () => h('span', { class: 'mock-bkflow-success' });
+    },
+  }),
+  BkFlowFailedIcon: defineComponent({
+    name: 'BkFlowFailedIcon',
+    setup() {
+      return () => h('span', { class: 'mock-bkflow-failed' });
+    },
+  }),
+}));
+
 // Mock ToolMessage
 vi.mock('../../chat-message/tool-message/tool-message.vue', () => ({
   default: defineComponent({
@@ -189,7 +205,7 @@ describe('ToolcallRender', () => {
       expect(wrapper.find('.toolcall-status-title').text()).toContain('调用中');
     });
 
-    it('Pending 状态应该显示 Loading', () => {
+    it('Pending 状态应该显示 Loading，且不显示成功/失败图标', () => {
       wrapper = mount(ToolcallRender, {
         props: {
           toolCall: mockToolCall,
@@ -198,9 +214,11 @@ describe('ToolcallRender', () => {
       });
 
       expect(wrapper.find('.mock-loading').exists()).toBe(true);
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(false);
     });
 
-    it('Streaming 状态应该显示 Loading', () => {
+    it('Streaming 状态应该显示 Loading，且不显示成功/失败图标', () => {
       wrapper = mount(ToolcallRender, {
         props: {
           toolCall: mockToolCall,
@@ -209,6 +227,8 @@ describe('ToolcallRender', () => {
       });
 
       expect(wrapper.find('.mock-loading').exists()).toBe(true);
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(false);
     });
 
     it('Complete 状态应该显示调用成功', () => {
@@ -245,7 +265,7 @@ describe('ToolcallRender', () => {
       expect(wrapper.find('.toolcall-status-title').text()).toContain('调用成功');
     });
 
-    it('Success 状态不应该显示 Loading', () => {
+    it('Success 状态应该显示成功图标，且不显示 Loading / 失败图标', () => {
       wrapper = mount(ToolcallRender, {
         props: {
           toolCall: mockToolCall,
@@ -253,10 +273,12 @@ describe('ToolcallRender', () => {
         },
       });
 
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(true);
       expect(wrapper.find('.mock-loading').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(false);
     });
 
-    it('Complete 状态不应该显示 Loading', () => {
+    it('Complete 状态应该显示成功图标，且不显示 Loading / 失败图标', () => {
       wrapper = mount(ToolcallRender, {
         props: {
           toolCall: mockToolCall,
@@ -264,10 +286,12 @@ describe('ToolcallRender', () => {
         },
       });
 
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(true);
       expect(wrapper.find('.mock-loading').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(false);
     });
 
-    it('Completed 状态不应该显示 Loading', () => {
+    it('Completed 状态应该显示成功图标，且不显示 Loading / 失败图标', () => {
       wrapper = mount(ToolcallRender, {
         props: {
           toolCall: mockToolCall,
@@ -275,7 +299,9 @@ describe('ToolcallRender', () => {
         },
       });
 
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(true);
       expect(wrapper.find('.mock-loading').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(false);
     });
 
     it('Error 状态应该显示调用失败', () => {
@@ -287,6 +313,19 @@ describe('ToolcallRender', () => {
       });
 
       expect(wrapper.find('.toolcall-status-title').text()).toContain('调用失败');
+    });
+
+    it('Error 状态应该显示失败图标，且不显示 Loading / 成功图标', () => {
+      wrapper = mount(ToolcallRender, {
+        props: {
+          toolCall: mockToolCall,
+          status: MessageStatus.Error,
+        },
+      });
+
+      expect(wrapper.find('.mock-bkflow-failed').exists()).toBe(true);
+      expect(wrapper.find('.mock-loading').exists()).toBe(false);
+      expect(wrapper.find('.mock-bkflow-success').exists()).toBe(false);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
@@ -20,6 +20,13 @@
           size="mini"
           theme="primary"
         />
+        <BkFlowSuccessIcon
+          v-else-if="
+            [MessageStatus.Success, MessageStatus.Complete, MessageStatus.Completed].includes(status as MessageStatus)
+          "
+        />
+        <BkFlowFailedIcon v-else-if="status === MessageStatus.Error" />
+
         <HighlightKeyword :text="statusTitle" />
         <span
           v-if="durationDisplay"
@@ -56,6 +63,7 @@
   import { MessageStatus } from '../../../ag-ui/types/constants';
   import { useCommonTippyInject, useKeywordMatch } from '../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../directives';
+  import { BkFlowFailedIcon, BkFlowSuccessIcon } from '../../../icons';
   import { ArrowRightIcon } from '../../../icons/content';
   import { t } from '../../../lang/lang';
   import { formatDuration } from '../../../utils/utils';
@@ -155,6 +163,9 @@
       .ai-common-icon {
         width: 14px;
         height: 14px;
+      }
+
+      .ai-arrow-right-icon {
         margin-right: 6px;
         cursor: pointer;
         transform: rotate(90deg);

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
@@ -127,7 +127,9 @@ sinceVersion: 1.0.0
 │   ├── "调用工具：" / "调用 MCP："（有 mcpName 时）
 │   ├── .toolcall-header-title（工具名，overflow-tips 溢出截断）
 │   └── .toolcall-status-title
-│         ├── Loading（仅 pending / streaming 时显示）
+│         ├── Loading（pending / streaming）
+│         ├── BkFlowSuccessIcon（success / complete / completed）
+│         ├── BkFlowFailedIcon（error）
 │         ├── 状态文案（调用中 / 调用成功 / 调用失败）
 │         └── .toolcall-duration（耗时，如 "(1.2s)"）
 │
@@ -176,16 +178,16 @@ sinceVersion: 1.0.0
 
 ## 调用状态
 
-`status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和 Loading 动画：
+`status` prop 同时控制头部的 CSS class（`toolcall-status-{status}`）、背景/边框颜色、状态文案和状态图标：
 
-| `status`                              | 状态文案 | 背景色            | 边框色    | Loading |
-| ------------------------------------- | -------- | ----------------- | --------- | ------- |
-| `pending` / `streaming`               | 调用中   | `#fafbfd`         | `#dcdee5` | ✓       |
-| `complete` / `completed` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | -       |
-| `error`                               | 调用失败 | `#fff0f0`         | `#f8b4b4` | -       |
-| 其他 / `undefined`                    | 调用中   | —（无匹配 class） | —         | -       |
+| `status`                              | 状态文案 | 背景色            | 边框色    | 状态图标            |
+| ------------------------------------- | -------- | ----------------- | --------- | ------------------- |
+| `pending` / `streaming`               | 调用中   | `#fafbfd`         | `#dcdee5` | `Loading`           |
+| `complete` / `completed` / `success`  | 调用成功 | `#ebfaf0`         | `#a1e3ba` | `BkFlowSuccessIcon` |
+| `error`                               | 调用失败 | `#fff0f0`         | `#f8b4b4` | `BkFlowFailedIcon`  |
+| 其他 / `undefined`                    | 调用中   | —（无匹配 class） | —         | —                   |
 
-> **说明**：`statusTitle` 将 `Completed`（`completed`）与 `Complete` / `Success` 一并视为成功；主题 `$toolcallStatusMap` 同步提供 `completed` 色值。`default` 与 `case Pending` 共享「调用中」文案，`streaming` 与未知 status 命中 `default`。Loading 由 `v-if="status === 'pending' || status === 'streaming'"` 控制。
+> **说明**：`statusTitle` 将 `Completed`（`completed`）与 `Complete` / `Success` 一并视为成功；主题 `$toolcallStatusMap` 同步提供 `completed` 色值。`default` 与 `case Pending` 共享「调用中」文案，`streaming` 与未知 status 命中 `default`。状态图标互斥：`pending` / `streaming` 显示 `Loading`；`success` / `complete` / `completed` 显示 `BkFlowSuccessIcon`；`error` 显示 `BkFlowFailedIcon`。
 
 **三种状态对比**
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】ToolCallRender 补充成功/失败状态图标与 Completed 态
ID: 1070093903136921932

## 改动
- toolcall-render.vue: 成功态（success/complete/completed）展示 BkFlowSuccessIcon，失败态展示 BkFlowFailedIcon；箭头样式与通用图标分离
- assistant-message.vue: 助手消息列增加 gap: 12px
- toolcall-render.spec.ts: 补齐各状态图标互斥断言
- playground: 新增 MOCK_TOOLCALL_STATUS_MESSAGES 并接入演示会话
- skill/wikis: 同步状态图标与 completed 说明

## 影响面
- 影响 ToolCallRender 状态展示与助手消息间距；不改变 toolCall 状态推导逻辑

## 测试
- [ ] pending/streaming 仅显示 Loading，无成功/失败图标
- [ ] success/complete/completed 显示成功图标与「调用成功」
- [ ] error 显示失败图标与「调用失败」
- [ ] playground 可见各状态 mock
- [ ] toolcall-render 相关单测通过（未运行）

Made with [Cursor](https://cursor.com)