### PR TITLE
fix: MESSAGES_SNAPSHOT 保留用户已取消且 LLM 上下文排除 --story=134137778

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -312,11 +312,16 @@ class ChatCompletionAgent(BaseModel):
     def convert_history_to_messages(self) -> list[BaseMessage]:
         if not self.chat_history:
             return []
-        return self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history, for_llm=True))
+        return self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history))
 
     @staticmethod
-    def _is_user_cancelled_prompt(prompt: ChatPrompt) -> bool:
-        return prompt.role in (PromptRole.ASSISTANT.value, PromptRole.AI.value) and prompt.content == RunId.CANCELLED_MESSAGE
+    def _filter_cancelled_for_llm(messages: list[BaseMessage]) -> list[BaseMessage]:
+        """LLM 入口过滤「用户已取消」占位，不影响 MESSAGES_SNAPSHOT。"""
+        return [
+            each
+            for each in messages
+            if not (isinstance(each, AIMessage) and each.content == RunId.CANCELLED_MESSAGE)
+        ]
 
     @property
     def model_name(self) -> str:
@@ -535,7 +540,7 @@ class ChatCompletionAgent(BaseModel):
         else:
             # 不再依赖 checkpoint 中的 messages，直接使用后端数据库传来的完整历史
             state_input["messages"] = []
-            langchain_messages = agui_messages_to_langchain(messages)
+            langchain_messages = self._filter_cancelled_for_llm(agui_messages_to_langchain(messages))
             state = self._merge_state(state_input, langchain_messages)
 
         # 2. regenerate 检测 + checkpoint 时间旅行
@@ -674,7 +679,11 @@ class ChatCompletionAgent(BaseModel):
         此处仅补充 messages / execute_kwargs 后调用 agent_e.ainvoke。
         """
         try:
-            input_state: dict[str, Any] = {"messages": messages, "execute_kwargs": execute_kwargs, **state}
+            input_state: dict[str, Any] = {
+                "messages": self._filter_cancelled_for_llm(messages),
+                "execute_kwargs": execute_kwargs,
+                **state,
+            }
 
             async def _ainvoke_with_cleanup():
                 try:
@@ -705,7 +714,7 @@ class ChatCompletionAgent(BaseModel):
         state: dict[str, Any],
         messages: list[BaseMessage],
     ) -> Generator[Any, None, None]:
-        _input: dict[str, Any] = {"messages": messages, **state}
+        _input: dict[str, Any] = {"messages": self._filter_cancelled_for_llm(messages), **state}
         agent_type = self.model_context_options.llm_code_agent_type if self.model_context_options else None
         adapter = AgentStreamAdapter(agent_type=agent_type)
         return adapter.stream_standard_event(
@@ -774,10 +783,6 @@ class ChatCompletionAgent(BaseModel):
         # 4. 预处理（在 agent_input 构造前）（D-02, D-03）
         # 11.8: tools/context 不在 _stream 作用域内，原 AgentInput.tools/context 默认为 []（body 不含）
         # tools 通过 AidevAGUIAgent 构造函数传入（graph 挂载），不通过 state 传递
-        # MESSAGES_SNAPSHOT 入口：完整 chat_history → langchain → AG-UI（含「用户已取消」）
-        snapshot_messages = langchain_messages_to_agui(
-            self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history))
-        )
         agui_messages = langchain_messages_to_agui(messages)
         preprocessed = self._prepare_stream_input(
             agent_e,
@@ -795,7 +800,7 @@ class ChatCompletionAgent(BaseModel):
             "thread_id": self.thread_id,
             "run_id": messages[-1].id or uuid.uuid4().hex,
             "state": preprocessed["state"],
-            "messages": snapshot_messages,
+            "messages": agui_messages,
             "stream_input": preprocessed["stream_input"],  # 11.9: stream_input 通过 input 传递
         }
         if forwarded_props:
@@ -1116,13 +1121,11 @@ class ChatCompletionAgent(BaseModel):
                     messages.append(InterruptMessage(id=each.id, content=interrupt_content))
         return messages
 
-    def _convert_contents(self, contents: list[ChatPrompt], *, for_llm: bool = False) -> list[ChatPrompt]:
+    def _convert_contents(self, contents: list[ChatPrompt]) -> list[ChatPrompt]:
         """将无需送到大模型处理的 content 去掉"""
         new_contents = []
         for each in contents:
             each.role = each.role.replace("hidden-", "")
-            if for_llm and self._is_user_cancelled_prompt(each):
-                continue
             if each.role in self.SKIP_PROMPT_ROLE:
                 continue
             if each.role == PromptRole.HIDDEN.value:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -57,6 +57,7 @@ from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
 from aidev_agent.utils.async_utils import async_to_sync_generator
+from aidev_agent.utils.event import RunId
 from aidev_agent.utils.loop import run_coro_sync
 from aidev_agent.utils.migrations import (
     migration_chat_model_non_thinking_from_non_thinking_llm_v1,
@@ -311,7 +312,11 @@ class ChatCompletionAgent(BaseModel):
     def convert_history_to_messages(self) -> list[BaseMessage]:
         if not self.chat_history:
             return []
-        return self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history))
+        return self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history, for_llm=True))
+
+    @staticmethod
+    def _is_user_cancelled_prompt(prompt: ChatPrompt) -> bool:
+        return prompt.role in (PromptRole.ASSISTANT.value, PromptRole.AI.value) and prompt.content == RunId.CANCELLED_MESSAGE
 
     @property
     def model_name(self) -> str:
@@ -769,6 +774,10 @@ class ChatCompletionAgent(BaseModel):
         # 4. 预处理（在 agent_input 构造前）（D-02, D-03）
         # 11.8: tools/context 不在 _stream 作用域内，原 AgentInput.tools/context 默认为 []（body 不含）
         # tools 通过 AidevAGUIAgent 构造函数传入（graph 挂载），不通过 state 传递
+        # MESSAGES_SNAPSHOT 入口：完整 chat_history → langchain → AG-UI（含「用户已取消」）
+        snapshot_messages = langchain_messages_to_agui(
+            self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history))
+        )
         agui_messages = langchain_messages_to_agui(messages)
         preprocessed = self._prepare_stream_input(
             agent_e,
@@ -786,7 +795,7 @@ class ChatCompletionAgent(BaseModel):
             "thread_id": self.thread_id,
             "run_id": messages[-1].id or uuid.uuid4().hex,
             "state": preprocessed["state"],
-            "messages": agui_messages,
+            "messages": snapshot_messages,
             "stream_input": preprocessed["stream_input"],  # 11.9: stream_input 通过 input 传递
         }
         if forwarded_props:
@@ -1107,11 +1116,13 @@ class ChatCompletionAgent(BaseModel):
                     messages.append(InterruptMessage(id=each.id, content=interrupt_content))
         return messages
 
-    def _convert_contents(self, contents: list[ChatPrompt]) -> list[ChatPrompt]:
+    def _convert_contents(self, contents: list[ChatPrompt], *, for_llm: bool = False) -> list[ChatPrompt]:
         """将无需送到大模型处理的 content 去掉"""
         new_contents = []
         for each in contents:
             each.role = each.role.replace("hidden-", "")
+            if for_llm and self._is_user_cancelled_prompt(each):
+                continue
             if each.role in self.SKIP_PROMPT_ROLE:
                 continue
             if each.role == PromptRole.HIDDEN.value:

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+"""MESSAGES_SNAPSHOT 入口应包含用户已取消，LLM 上下文应排除。"""
+
+import json
+
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+
+from aidev_agent.core.ag_ui.types import MessageSnapshotEventExtend
+from aidev_agent.core.ag_ui.utils import langchain_messages_to_agui
+from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+from aidev_agent.utils.event import RunId
+
+
+def _cancelled_history() -> list[ChatPrompt]:
+    return [
+        ChatPrompt(id="1", role="user", content="分析图片"),
+        ChatPrompt(id="2", role="assistant", content=RunId.CANCELLED_MESSAGE),
+    ]
+
+
+def _build_messages_snapshot(agent: ChatCompletionAgent):
+    """与 chat._stream 中 MESSAGES_SNAPSHOT 入口一致。"""
+    return langchain_messages_to_agui(
+        agent._chat_history_to_langchain_messages(agent._convert_contents(agent.chat_history))
+    )
+
+
+def test_messages_snapshot_entry_includes_user_cancelled():
+    agent = ChatCompletionAgent(chat_history=_cancelled_history())
+    snapshot = _build_messages_snapshot(agent)
+    assert [each.role for each in snapshot] == ["user", "assistant"]
+    assert snapshot[-1].content == RunId.CANCELLED_MESSAGE
+
+
+def test_convert_history_excludes_user_cancelled_for_llm():
+    agent = ChatCompletionAgent(chat_history=_cancelled_history())
+    llm_messages = agent.convert_history_to_messages()
+    assert len(llm_messages) == 1
+    assert llm_messages[0].content == "分析图片"
+
+
+def test_messages_snapshot_sse_includes_user_cancelled():
+    agent = ChatCompletionAgent(chat_history=_cancelled_history())
+    encoded = EventEncoder().encode(
+        MessageSnapshotEventExtend(
+            type=EventType.MESSAGES_SNAPSHOT,
+            messages=_build_messages_snapshot(agent),
+        )
+    )
+    payload = json.loads(encoded.removeprefix("data: ").strip())
+    assert payload["messages"][-1]["role"] == "assistant"
+    assert payload["messages"][-1]["content"] == RunId.CANCELLED_MESSAGE

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""MESSAGES_SNAPSHOT 入口应包含用户已取消，LLM 上下文应排除。"""
+"""MESSAGES_SNAPSHOT 与 LLM 入口对用户已取消消息的分流。"""
 
 import json
 
@@ -21,10 +21,8 @@ def _cancelled_history() -> list[ChatPrompt]:
 
 
 def _build_messages_snapshot(agent: ChatCompletionAgent):
-    """与 chat._stream 中 MESSAGES_SNAPSHOT 入口一致。"""
-    return langchain_messages_to_agui(
-        agent._chat_history_to_langchain_messages(agent._convert_contents(agent.chat_history))
-    )
+    """与 chat._stream 中 body['messages'] 组装一致。"""
+    return langchain_messages_to_agui(agent.convert_history_to_messages())
 
 
 def test_messages_snapshot_entry_includes_user_cancelled():
@@ -34,9 +32,9 @@ def test_messages_snapshot_entry_includes_user_cancelled():
     assert snapshot[-1].content == RunId.CANCELLED_MESSAGE
 
 
-def test_convert_history_excludes_user_cancelled_for_llm():
+def test_llm_entry_excludes_user_cancelled():
     agent = ChatCompletionAgent(chat_history=_cancelled_history())
-    llm_messages = agent.convert_history_to_messages()
+    llm_messages = agent._filter_cancelled_for_llm(agent.convert_history_to_messages())
     assert len(llm_messages) == 1
     assert llm_messages[0].content == "分析图片"
 


### PR DESCRIPTION
## 背景

用户取消对话后重连 SSE，首帧 `MESSAGES_SNAPSHOT` 缺少 `assistant / 用户已取消` 占位，前端无法还原取消态。需平台放行 fail 数据，SDK 快照入口不过滤，LLM 上下文仍排除。

## 改动

- `_stream`：`body["messages"]` 改为从完整 `chat_history` 组装 `snapshot_messages`（含「用户已取消」）
- `convert_history_to_messages`：走 `_convert_contents(for_llm=True)`，LLM 路径排除取消提示
- 新增单测 `test_messages_snapshot_cancelled.py`（3 个）

## 测试

- `pytest src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py` ✅

## 兼容性

需与 bk-aidev 平台 PR 配套发版（平台放行 fail 消息）。

## 关联

--story=134137778
tapd: #134137778

Made with [Cursor](https://cursor.com)