### PR TITLE
fix: 区分 SSE 新执行与接管请求 --story=1070093903136621156

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-helper/src/agent/use-agent.ts
+++ b/src/frontend/ai-blueking/packages/chat-helper/src/agent/use-agent.ts
@@ -48,6 +48,7 @@ import { SessionStatus } from '../session/type';
 const MAX_RECONNECT_ATTEMPTS = 5;
 const RECONNECT_BASE_DELAY_MS = 1000;
 const RECONNECT_MAX_DELAY_MS = 8000;
+type StreamMode = 'start' | 'attach';
 
 const getReconnectDelayMs = (attempt: number): number =>
   Math.min(RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1), RECONNECT_MAX_DELAY_MS);
@@ -257,6 +258,7 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
       config: ctx?.config,
       lastMessageId: lastMessageId !== undefined ? String(lastMessageId) : undefined,
       isReconnect: true,
+      streamMode: 'attach',
     });
     return 'reconnected';
   };
@@ -269,6 +271,7 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
     input,
     lastMessageId,
     isReconnect = false,
+    streamMode = 'start',
   }: {
     sessionCode: string;
     url?: string;
@@ -278,6 +281,8 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
     lastMessageId?: string;
     /** 内部静默重连，不重置重连计数 */
     isReconnect?: boolean;
+    /** start 可启动新一轮执行；attach 仅接管/回放已有流 */
+    streamMode?: StreamMode;
   }) => {
     if (!isReconnect) {
       resetStreamReconnectState();
@@ -399,6 +404,7 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
           input,
           execute_kwargs: {
             stream: true,
+            stream_mode: streamMode,
             persist_input: !!input,
             last_message_id: lastMessageId,
             resume,
@@ -453,7 +459,7 @@ export const useAgent = (mediator: IMediatorModule, protocol: ISSEProtocol) => {
   const resumeStreamingChat = (sessionCode: string, url?: string, config?: IRequestConfig) => {
     if (mediator.session?.current.value?.status === SessionStatus.Running) {
       const lastMessageId = mediator.message?.list.value.at(-1)?.id;
-      streamRequest({ sessionCode, url, config, lastMessageId });
+      streamRequest({ sessionCode, url, config, lastMessageId, streamMode: 'attach' });
     }
   };
 


### PR DESCRIPTION
## 背景

页面刷新或 SSE 连接中断后，前端只能看到会话仍为 `running`，无法判断当前处于慢 token、工具执行还是连接已断。原实现重建 `chat_completion` 请求时与新执行使用同一语义；当后端已无活跃 producer 且状态尚未收敛时，可能重新启动一次 Agent 执行。

## 调整

- 新消息、重发、审批续流继续发送 `stream_mode=start`。
- 页面重新打开运行中会话、可恢复 SSE 错误静默重连发送 `stream_mode=attach`。
- `attach` 只用于接管/回放已有流，后端协议由 #773 提供。

## 兼容与发布顺序

- 建议先发布 #773，再发布本 PR。
- 后端缺省模式为 `start`，因此前端未发布前的现有请求行为不变。
- 本 PR 提前发布到旧后端时，未知字段会被旧模型忽略，仍按原逻辑执行，不具备防重复启动能力。

## 验证

- `vue-tsc --noEmit` 通过。
- 新消息路径保持默认 `start`；页面恢复和静默重连显式为 `attach`。
- 完整 bundle 构建在本机因 `@swc/core` 原生 bindings 缺失未完成，与 TypeScript 改动无关。

--story=1070093903136621156
