### PR TITLE
fix: 修复 ask user question 恢复与 checkpoint 兼容写入 --story=1070093903136621156

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
@@ -202,9 +202,9 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         让前端能立即据此把原中断卡片更新为最终状态（关闭弹窗）。
         支持 approval 和 ask_user_question 两种中断类型，统一构造 RunFinishedEvent。
 
-        注意：ask_user_question 路径的 RunFinishedEvent 走 _dispatch_event（DB writer
-        通过 handle_run_finished 消费事件写 DB），approval 路径的 RunFinishedEvent
-        保持直发（DB 已在审批回调时落库）。
+        该 RunFinishedEvent 仅用于更新前端的旧中断卡片，所属 run_id 是 interruptId，
+        不是当前恢复请求的 run_id。中断终态已由入口层落库，因此这里只直发 SSE，
+        不能走 _dispatch_event 提前结束当前 session。
 
         ask_user_question 路径额外推送 MESSAGES_SNAPSHOT：前端 handleRunFinishedEvent
         只标记 loading 完成，不更新消息列表中的 interrupt 卡片内容。前端依赖
@@ -214,7 +214,6 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
         resume_event = self._build_resume_finished_event(input)
         if resume_event is not None:
             try:
-                self._dispatch_event(resume_event)
                 yield event_encoder.encode(resume_event)
             except Exception:
                 logger.exception("[Resume] Failed to emit resume event")
@@ -306,6 +305,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             run_id=interrupt_id,
             outcome=outcome_dict,
             result=result_dict,
+            resume_replay=True,
         )
 
     def _build_resume_approval_finished_event(self, input: RunAgentInput) -> RunFinishedEvent:
@@ -337,6 +337,7 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             run_id=interrupt_id,
             outcome=outcome_dict,
             result=result_dict,
+            resume_replay=True,
         )
 
     def build_terminal_replay_stream(

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -347,14 +347,18 @@ class GeneratorStreamingHelper:
 
     @staticmethod
     def _is_run_finished_event_chunk(chunk: Any) -> bool:
-        """判断 chunk 是否为 AG-UI RUN_FINISHED 事件。"""
+        """判断 chunk 是否为当前 run 的 AG-UI RUN_FINISHED 事件。"""
         if not isinstance(chunk, str) or not chunk.startswith("data:"):
             return False
         try:
             payload = json.loads(chunk.removeprefix("data:").strip())
         except (TypeError, json.JSONDecodeError):
             return False
-        return isinstance(payload, dict) and payload.get("type") == EventType.RUN_FINISHED.value
+        return (
+            isinstance(payload, dict)
+            and payload.get("type") == EventType.RUN_FINISHED.value
+            and not payload.get("resume_replay", False)
+        )
 
     def _is_cancelled(self, cancel_event: threading.Event) -> bool:
         """检查是否被取消（同时检查进程内事件和跨进程信号）

--- a/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_db_persistence.py
@@ -58,6 +58,7 @@ class _RecordingSessionWriter(BaseSessionWriter):
         self.created: list[dict] = []
         self.updated: list[dict] = []
         self._next_id = 1
+        self.streaming_finished_count = 0
         # 模拟 DB 中存储的记录（content_id -> {role, status, content, builtin_property}）
         self._db_records: dict[int, dict] = {}
 
@@ -90,7 +91,7 @@ class _RecordingSessionWriter(BaseSessionWriter):
         pass
 
     def set_streaming_finished(self):
-        pass
+        self.streaming_finished_count += 1
 
 
 def _extract_ask_user_question_interrupts(graph, config) -> list[dict]:
@@ -403,6 +404,5 @@ async def test_resume_preserves_prior_messages_and_writes_final_reply():
         if isinstance(u.get("payload", {}).get("content"), dict)
         and u["payload"]["content"].get("outcome", {}).get("type") == "success"
     ]
-    assert not interrupt_updates, (
-        f" 后 SSE 层不应再 UPDATE interrupt 记录为 resolved，updates={len(writer.updated)}"
-    )
+    assert not interrupt_updates, f" 后 SSE 层不应再 UPDATE interrupt 记录为 resolved，updates={len(writer.updated)}"
+    assert writer.streaming_finished_count == 0, "旧 interrupt 的回放事件不应结束当前恢复 run"

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -7,7 +7,8 @@ import time
 
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
-from ag_ui.core import EventType
+from ag_ui.core import EventType, RunFinishedEvent
+from ag_ui.encoder import EventEncoder
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
     CANCELLED_CHUNK,
@@ -300,6 +301,37 @@ class TestReplayFromStartStreamingHelper:
         )
 
         assert result == [finished]
+
+    def test_resume_card_run_finished_does_not_stop_current_run(self):
+        handler = ReplayFromStartHandler()
+        helper = GeneratorStreamingHelper(handler, thread_id="thread-1")
+        resume_card_finished = EventEncoder().encode(
+            RunFinishedEvent(
+                type=EventType.RUN_FINISHED,
+                thread_id="thread-1",
+                run_id="interrupt-1",
+                resume_replay=True,
+            )
+        )
+        current_run_finished = emit_run_finished_event(thread_id="thread-1", run_id="run-1")
+        lifecycle = []
+
+        def resumed_generator():
+            yield resume_card_finished
+            yield "current_run_chunk"
+            yield current_run_finished
+            raise AssertionError("producer read after current RUN_FINISHED")
+
+        result = list(
+            helper.stream(
+                resumed_generator(),
+                expected_run_id="run-1",
+                on_complete=lambda: lifecycle.append("complete"),
+            )
+        )
+
+        assert result == [resume_card_finished, "current_run_chunk", current_run_finished]
+        assert lifecycle == ["complete"]
 
     def test_run_finished_finalizes_session_then_closes_generator_before_eod(self, monkeypatch):
         handler = ReplayFromStartHandler()

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
@@ -50,7 +50,7 @@ def bulk_upsert(model, objs, update_fields, unique_fields):
     """
     通用 bulk upsert 函数：
     - MySQL: 使用 ON DUPLICATE KEY UPDATE
-    - 其他数据库: 使用默认的 bulk_create
+    - 其他数据库: 缺少唯一约束时按逻辑键更新最新记录
     """
 
     if not objs:
@@ -59,37 +59,37 @@ def bulk_upsert(model, objs, update_fields, unique_fields):
     # 自动选择数据库
     db = router.db_for_write(model)
     connection = connections[db]
-    vendor = connection.vendor  # e.g. 'mysql', 'postgresql', 'sqlite'
+    vendor = connection.vendor
 
     # MySQL: 使用原生 SQL 实现 ON DUPLICATE KEY UPDATE
     if vendor == "mysql":
         table = model._meta.db_table
         fields = [f.name for f in model._meta.local_fields]
-        # 构造字段和值
         insert_fields = [f for f in fields if f in update_fields or f in unique_fields]
         placeholders = ", ".join(["%s"] * len(insert_fields))
         columns = ", ".join(f"`{f}`" for f in insert_fields)
-        # ON DUPLICATE KEY UPDATE 子句
         update_clause = ", ".join(f"`{f}` = VALUES(`{f}`)" for f in update_fields)
         sql = f"""
         INSERT INTO `{table}` ({columns})
         VALUES ({placeholders})
         ON DUPLICATE KEY UPDATE {update_clause};
         """
-        params = []
-        for obj in objs:
-            row = [getattr(obj, f) for f in insert_fields]
-            params.append(row)
+        params = [[getattr(obj, field) for field in insert_fields] for obj in objs]
         with connection.cursor() as cursor, transaction.atomic(using=db):
             cursor.executemany(sql, params)
         return
 
-    model.objects.bulk_create(
-        objs,
-        update_conflicts=True,
-        update_fields=update_fields,
-        unique_fields=unique_fields,
-    )
+    manager = model.objects.using(db)
+    ordering = ("-created_at", "-pk") if any(f.name == "created_at" for f in model._meta.get_fields()) else ("-pk",)
+    with transaction.atomic(using=db):
+        for obj in objs:
+            lookup = {field: getattr(obj, field) for field in unique_fields}
+            defaults = {field: getattr(obj, field) for field in update_fields}
+            latest = manager.select_for_update().filter(**lookup).order_by(*ordering).first()
+            if latest is None:
+                manager.create(**lookup, **defaults)
+                continue
+            manager.filter(pk=latest.pk).update(**defaults)
 
 
 class BKDjangoSaver(BaseCheckpointSaver[str]):

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
@@ -3,8 +3,23 @@
 import threading
 
 import pytest
-from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver
-from django.db import OperationalError
+from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver, bulk_upsert
+from django.db import OperationalError, connection, models
+
+
+class WriteForTest(models.Model):
+    thread_id = models.CharField(max_length=255)
+    checkpoint_ns = models.CharField(max_length=255, default="")
+    checkpoint_id = models.CharField(max_length=255)
+    task_id = models.CharField(max_length=255)
+    idx = models.IntegerField()
+    channel = models.TextField()
+    type = models.TextField(null=True, blank=True)
+    value = models.BinaryField()
+    created_at = models.DateTimeField(auto_now_add=True, null=True)
+
+    class Meta:
+        app_label = "tests"
 
 
 @pytest.fixture
@@ -59,6 +74,7 @@ def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args)
 def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpoint_args):
     error = OperationalError(1213, "deadlock")
     saver.checkpoint_model.objects.update_or_create.side_effect = error
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
     sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
 
     with pytest.raises(OperationalError) as exc_info:
@@ -67,3 +83,84 @@ def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpo
     assert exc_info.value is error
     assert saver.checkpoint_model.objects.update_or_create.call_count == 3
     assert [call.args[0] for call in sleep.call_args_list] == [0.05, 0.1]
+
+
+@pytest.fixture
+def write_obj():
+    return WriteForTest(
+        thread_id="thread-id",
+        checkpoint_ns="",
+        checkpoint_id="checkpoint-id",
+        task_id="task-id",
+        idx=0,
+        channel="channel",
+        type="json",
+        value=b"1",
+    )
+
+
+@pytest.fixture
+def write_model(transactional_db, django_db_blocker):
+    with django_db_blocker.unblock(), connection.schema_editor() as editor:
+        editor.create_model(WriteForTest)
+    yield WriteForTest
+    with django_db_blocker.unblock(), connection.schema_editor() as editor:
+        editor.delete_model(WriteForTest)
+
+
+def test_bulk_upsert_non_mysql_without_unique_constraint_creates_record(write_model, write_obj):
+    fields = ["thread_id", "checkpoint_ns", "checkpoint_id", "task_id", "idx"]
+
+    bulk_upsert(write_model, [write_obj], ["channel", "type", "value"], fields)
+
+    saved = write_model.objects.get()
+    assert (saved.channel, saved.type, saved.value) == ("channel", "json", b"1")
+
+
+@pytest.mark.parametrize("vendor", ["sqlite", "postgresql"])
+def test_bulk_upsert_non_mysql_updates_latest_duplicate_record(mocker, write_model, write_obj, vendor):
+    connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.connections")
+    connections.__getitem__.return_value.vendor = vendor
+    lookup = {
+        "thread_id": write_obj.thread_id,
+        "checkpoint_ns": write_obj.checkpoint_ns,
+        "checkpoint_id": write_obj.checkpoint_id,
+        "task_id": write_obj.task_id,
+        "idx": write_obj.idx,
+    }
+    older = write_model.objects.create(**lookup, channel="older", type="json", value=b"older")
+    latest = write_model.objects.create(**lookup, channel="latest", type="json", value=b"latest")
+    write_obj.channel = "updated"
+    write_obj.value = b"updated"
+
+    bulk_upsert(
+        write_model,
+        [write_obj],
+        ["channel", "type", "value"],
+        ["thread_id", "checkpoint_ns", "checkpoint_id", "task_id", "idx"],
+    )
+
+    older.refresh_from_db()
+    latest.refresh_from_db()
+    assert (older.channel, older.value) == ("older", b"older")
+    assert (latest.channel, latest.value) == ("updated", b"updated")
+
+
+def test_bulk_upsert_preserves_mysql_native_upsert(mocker, write_obj):
+    connection = mocker.MagicMock(vendor="mysql")
+    cursor = connection.cursor.return_value.__enter__.return_value
+    connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.connections")
+    connections.__getitem__.return_value = connection
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.router.db_for_write", return_value="default")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.transaction.atomic")
+
+    bulk_upsert(
+        WriteForTest,
+        [write_obj],
+        ["channel", "type", "value"],
+        ["thread_id", "checkpoint_ns", "checkpoint_id", "task_id", "idx"],
+    )
+
+    sql, params = cursor.executemany.call_args.args
+    assert "ON DUPLICATE KEY UPDATE" in sql
+    assert params == [["thread-id", "", "checkpoint-id", "task-id", 0, "channel", "json", b"1"]]


### PR DESCRIPTION
## 问题

- Ask User Question 提交答案后，用于关闭旧交互卡片的 `RUN_FINISHED` 被误判为当前恢复任务的结束事件，导致生成器提前停止，后续工具结果和最终回复无法输出。
- checkpoint writes 的批量 upsert 依赖数据库唯一约束；在未配置对应唯一约束的数据库中会直接失败。

## 修复

- 为旧交互卡片的结束事件增加 `resume_replay` 标记，仅直发 SSE，不触发当前会话终态写入。
- 消息流只把当前任务的普通 `RUN_FINISHED` 作为生产结束信号，继续消费恢复任务的后续事件。
- 保留 MySQL 原生 `ON DUPLICATE KEY UPDATE`；其他数据库缺少唯一约束时按逻辑键选取最新记录更新，无记录时创建。

## 验证

- 消息处理与流式结束回归：60 passed
- Ask User Question / Resume 回归：30 passed, 1 skipped
- checkpoint saver 回归：8 passed，覆盖 SQLite、PostgreSQL 兼容路径及 MySQL 原生 upsert
- 浏览器端完成提问、选择答案、工具结果、最终回复和 EOD 全链路验证
- 本次 6 个文件的 pre-commit hooks 全部通过

## 风险说明

非 MySQL 数据库的 checkpoint writes 没有数据库唯一约束时，多进程并发首次写入仍可能产生重复记录；后续写入只更新按时间排序的最新记录。本次按已确认的最小兼容方案处理，不新增数据库索引或迁移，MySQL 路径不变。
