### PR TITLE
fix: cancel RUN_ERROR 幂等去重；snapshot 还原 reasoning 与 error 状态 --story=134137778

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/agent.py
@@ -113,6 +113,15 @@ class LangGraphAgent:
         # 取消检测回调，返回 True 表示应该取消
         self._cancel_checker = cancel_checker
 
+    def _mark_cancel_run_error_emitted(self) -> bool:
+        """标记本轮 cancel RUN_ERROR 已下发；若已下发则返回 False（调用方应跳过重复 emit）。"""
+        if not self.active_run:
+            return True
+        if self.active_run.get("cancel_run_error_emitted"):
+            return False
+        self.active_run["cancel_run_error_emitted"] = True
+        return True
+
     def _dispatch_event(self, event: ProcessedEvents) -> str:
         if getattr(event, "raw_event", None):
             event.raw_event = make_json_safe(event.raw_event)
@@ -157,6 +166,8 @@ class LangGraphAgent:
             "has_function_streaming": False,
             "has_text_output": False,  # 是否有 AI 文本输出（根据流式是否有TEXT_MESSAGE_START）
             "started_at": datetime.now(timezone.utc),  # 供子类做本轮增量识别（如 artifacts_generated）
+            # 取消占位 RUN_ERROR 是否已下发（防止 stream error + cancel 双发同一 message）
+            "cancel_run_error_emitted": False,
         }
         self.active_run = INITIAL_ACTIVE_RUN
 
@@ -217,10 +228,13 @@ class LangGraphAgent:
                 break
 
             if event["event"] == "error":
+                error_message = event["data"]["message"]
+                if error_message == RunId.CANCELLED_MESSAGE and not self._mark_cancel_run_error_emitted():
+                    break
                 yield self._dispatch_event(
                     RunErrorEvent(
                         type=EventType.RUN_ERROR,
-                        message=event["data"]["message"],
+                        message=error_message,
                         raw_event=event,
                     )
                 )
@@ -273,12 +287,13 @@ class LangGraphAgent:
                 has_text_output,
             )
             if not has_text_output:
-                yield self._dispatch_event(
-                    RunErrorEvent(
-                        type=EventType.RUN_ERROR,
-                        message=RunId.CANCELLED_MESSAGE,
+                if self._mark_cancel_run_error_emitted():
+                    yield self._dispatch_event(
+                        RunErrorEvent(
+                            type=EventType.RUN_ERROR,
+                            message=RunId.CANCELLED_MESSAGE,
+                        )
                     )
-                )
             else:
                 yield self._dispatch_event(
                     RunFinishedEvent(

--- a/src/agent/aidev_agent/core/ag_ui/types.py
+++ b/src/agent/aidev_agent/core/ag_ui/types.py
@@ -350,6 +350,17 @@ class InfoMessage(ChatMessage):
         return self.id
 
 
+class ReasoningLangChainMessage(ChatMessage):
+    """思考过程消息（role=reasoning）的 LangChain 消息。
+
+    用于 DB 历史中的 reasoning 行进入 MESSAGES_SNAPSHOT；在 LLM 入口被过滤，
+    不会送入 graph 输入。
+    """
+
+    role: Literal["reasoning"] = "reasoning"  # pyright: ignore[reportIncompatibleVariableOverride]
+    content: list[str] = Field(default_factory=list)
+
+
 class Interrupt(ConfiguredBaseModel):
     """中断信息，用于 RunFinishedInterruptOutcome"""
 

--- a/src/agent/aidev_agent/core/ag_ui/utils.py
+++ b/src/agent/aidev_agent/core/ag_ui/utils.py
@@ -33,11 +33,13 @@ from langchain_core.messages import (
 
 from .events import ExtendToolCallResultEvent, ExtendToolCallStartEvent
 from .event_builders import TOOL_CALLING_PLACEHOLDER
+from aidev_agent.utils.event import RunId
 from .types import (
     ActivityMessage,
     InfoMessage,
     InterruptMessage,
     LangGraphReasoning,
+    ReasoningLangChainMessage,
     ReasoningMessage,
     SchemaKeys,
     State,
@@ -202,6 +204,18 @@ def convert_langchain_multimodal_to_agui(
     return agui_content
 
 
+def parse_reasoning_content_value(content: Any) -> list[str]:
+    """将 reasoning content 归一为 list[str]。
+
+    JSON 字符串解析由平台 session_context / 读库接口完成；此处只做类型归一。
+    """
+    if isinstance(content, list):
+        return [str(each) for each in content]
+    if content is None:
+        return []
+    return [str(content)]
+
+
 def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]:
     agui_messages: list[AGUIMessage] = []
     for message in messages:
@@ -258,6 +272,11 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
             # 仅在存在产物时才写 property，避免污染无产物的历史 assistant 消息。
             artifacts = message.additional_kwargs.get("artifacts")
             message_property = {"artifacts": artifacts} if artifacts else None
+            content_status = (message.additional_kwargs or {}).get("status") or ""
+            if content == RunId.CANCELLED_MESSAGE or content_status in {"fail", "error"}:
+                assistant_status = "error"
+            else:
+                assistant_status = "complete"
             agui_messages.append(
                 AGUIAssistantMessage(
                     id=str(message.id),
@@ -266,6 +285,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     tool_calls=tool_calls,
                     name=message.name,
                     property=message_property,
+                    status=assistant_status,
                 )
             )
         elif isinstance(message, SystemMessage):
@@ -313,6 +333,14 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                 AGUIInfoMessage(
                     id=str(message.id),
                     content=message.content,
+                )
+            )
+        elif isinstance(message, ReasoningLangChainMessage):
+            agui_messages.append(
+                ReasoningMessage(
+                    id=str(message.id),
+                    content=parse_reasoning_content_value(message.content),
+                    duration=message.additional_kwargs.get("duration"),
                 )
             )
         else:

--- a/src/agent/aidev_agent/core/nodes/model/basic_middleware.py
+++ b/src/agent/aidev_agent/core/nodes/model/basic_middleware.py
@@ -29,7 +29,7 @@ from langchain_core.messages import AIMessage, BaseMessage, HumanMessage, System
 from langchain_core.tools import BaseTool
 from langchain_openai.chat_models.base import _convert_dict_to_message, _convert_message_to_dict
 
-from aidev_agent.core.ag_ui.types import ActivityMessage, InfoMessage
+from aidev_agent.core.ag_ui.types import ActivityMessage, InfoMessage, ReasoningLangChainMessage
 from aidev_agent.enums import ContextType
 from aidev_agent.packages.langchain_core.models.utils import is_deepseek_r1_series_models
 from aidev_agent.packages.langchain_core.tools.render import render_text_description_and_args
@@ -221,7 +221,11 @@ class BaseVariablesMiddleware:
                 auto_vars[var] = ctx.state[var]
 
         messages: List[BaseMessage] = ctx.state.get("messages") or []
-        messages = [each for each in messages if not isinstance(each, (ActivityMessage, InfoMessage))]
+        messages = [
+            each
+            for each in messages
+            if not isinstance(each, (ActivityMessage, InfoMessage, ReasoningLangChainMessage))
+        ]
         cache = ctx.assembly_cache
 
         # 尝试使用缓存的 last_human_idx

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -35,15 +35,16 @@ from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
     InterruptMessage,
+    ReasoningLangChainMessage,
     SchemaKeys,
     SessionPersistenceEventNames,
 )
 from aidev_agent.core.ag_ui.utils import (
-    agui_messages_to_langchain,
     get_schema_keys,
     get_stream_payload_input,
     langchain_messages_to_agui,
     parse_multimodal_content,
+    parse_reasoning_content_value,
 )
 from aidev_agent.core.tools.a2a_tools.types import AgentBackendType, AgentSpec
 from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
@@ -159,7 +160,7 @@ class ChatCompletionAgent(BaseModel):
     IMAGE_FILE_PATTERN: ClassVar[re.Pattern] = re.compile(r"^!\[.*\]\((http[^)]+/([^/]+?))\)")
     TOOL_EXECUTION_INTERVAL: ClassVar[int] = 10
     UPLOAD_IMAGE_PROMPT_PREFIX: ClassVar[Any] = "我上传了个图片文件,文件名为{file_name}。"
-    SKIP_PROMPT_ROLE: ClassVar[list[str]] = ["guide", "reasoning"]
+    SKIP_PROMPT_ROLE: ClassVar[list[str]] = ["guide"]
 
     class Config:
         arbitrary_types_allowed = True
@@ -505,11 +506,9 @@ class ChatCompletionAgent(BaseModel):
         return self._chat_history_to_langchain_messages(self._convert_contents(self.chat_history))
 
     @staticmethod
-    def _filter_cancelled_for_llm(messages: list[BaseMessage]) -> list[BaseMessage]:
-        """LLM 入口过滤「用户已取消」占位，不影响 MESSAGES_SNAPSHOT。"""
-        return [
-            each for each in messages if not (isinstance(each, AIMessage) and each.content == RunId.CANCELLED_MESSAGE)
-        ]
+    def _filter_messages_for_llm(messages: list[BaseMessage]) -> list[BaseMessage]:
+        """LLM 入口过滤 reasoning，不影响 MESSAGES_SNAPSHOT。"""
+        return [each for each in messages if not isinstance(each, ReasoningLangChainMessage)]
 
     @property
     def model_name(self) -> str:
@@ -721,14 +720,14 @@ class ChatCompletionAgent(BaseModel):
         resume_input = forwarded_props.get("command", {}).get("resume", None)
         thread_id = thread_id
 
-        # 1. ag-ui → langchain 转换 + state 合并
+        # 1. LLM 入口过滤 reasoning + state 合并（messages 已是 langchain）
         if resume_input:
             state = agent_state.values.copy() if agent_state.values else state_input
             langchain_messages: list[BaseMessage] = []
         else:
             # 不再依赖 checkpoint 中的 messages，直接使用后端数据库传来的完整历史
             state_input["messages"] = []
-            langchain_messages = self._filter_cancelled_for_llm(agui_messages_to_langchain(messages))
+            langchain_messages = self._filter_messages_for_llm(messages)
             state = self._merge_state(state_input, langchain_messages)
 
         # 2. regenerate 检测 + checkpoint 时间旅行
@@ -868,7 +867,7 @@ class ChatCompletionAgent(BaseModel):
         """
         try:
             input_state: dict[str, Any] = {
-                "messages": self._filter_cancelled_for_llm(messages),
+                "messages": self._filter_messages_for_llm(messages),
                 "execute_kwargs": execute_kwargs,
                 **state,
             }
@@ -902,7 +901,7 @@ class ChatCompletionAgent(BaseModel):
         state: dict[str, Any],
         messages: list[BaseMessage],
     ) -> Generator[Any, None, None]:
-        _input: dict[str, Any] = {"messages": self._filter_cancelled_for_llm(messages), **state}
+        _input: dict[str, Any] = {"messages": self._filter_messages_for_llm(messages), **state}
         agent_type = self.model_context_options.llm_code_agent_type if self.model_context_options else None
         adapter = AgentStreamAdapter(agent_type=agent_type)
         return adapter.stream_standard_event(
@@ -978,7 +977,7 @@ class ChatCompletionAgent(BaseModel):
             state,
             forwarded_props,
             self.thread_id,
-            agui_messages,
+            messages,
             agent_state,
             schema_keys,
         )
@@ -1225,6 +1224,11 @@ class ChatCompletionAgent(BaseModel):
         messages: list[BaseMessage] = []
         for each in chat_history:
             bp = each.builtin_property or {}
+            turn_kwargs = {}
+            if bp.get("turn_id"):
+                turn_kwargs["turn_id"] = bp["turn_id"]
+            if bp.get("status"):
+                turn_kwargs["status"] = bp["status"]
             match each.role:
                 case PromptRole.USER.value:
                     multimodal = parse_multimodal_content(each.content)
@@ -1240,16 +1244,20 @@ class ChatCompletionAgent(BaseModel):
                             else:
                                 new_content.append(each_content)
                         each.content = new_content
-                        messages.append(HumanMessage(id=each.id, content=each.content))
+                        messages.append(
+                            HumanMessage(id=each.id, content=each.content, additional_kwargs=turn_kwargs)
+                        )
                     else:
-                        messages.append(HumanMessage(id=each.id, content=str(each.content)))
+                        messages.append(
+                            HumanMessage(id=each.id, content=str(each.content), additional_kwargs=turn_kwargs)
+                        )
                 case PromptRole.ASSISTANT.value | PromptRole.AI.value:
                     tool_calls = _extract_tool_calls(bp)
                     # 首帧 MESSAGES_SNAPSHOT（历史还原）：artifacts 经 builtin_property 透传，
                     # 放入 AIMessage.additional_kwargs（LangChain 标准扩展位），供
                     # langchain_messages_to_agui 还原到 AGUIAssistantMessage.artifacts。
                     # 无 artifacts 时不写 additional_kwargs，避免污染其它 AIMessage。
-                    additional_kwargs = {}
+                    additional_kwargs = dict(turn_kwargs)
                     artifacts = bp.get("artifacts")
                     if artifacts:
                         additional_kwargs["artifacts"] = artifacts
@@ -1265,7 +1273,23 @@ class ChatCompletionAgent(BaseModel):
                     messages.append(SystemMessage(id=each.id, content=each.content))
                 case PromptRole.TOOL.value:
                     content = each.content if isinstance(each.content, str) else str(each.content)
-                    messages.append(ToolMessage(id=each.id, content=content, tool_call_id=bp.get("tool_call_id", "")))
+                    messages.append(
+                        ToolMessage(
+                            id=each.id,
+                            content=content,
+                            tool_call_id=bp.get("tool_call_id", ""),
+                            additional_kwargs=turn_kwargs,
+                        )
+                    )
+                case PromptRole.REASONING.value:
+                    duration = bp.get("duration", 0)
+                    messages.append(
+                        ReasoningLangChainMessage(
+                            id=each.id,
+                            content=parse_reasoning_content_value(each.content),
+                            additional_kwargs={"duration": duration, **turn_kwargs},
+                        )
+                    )
                 case PromptRole.INTERRUPT.value:
                     # 中断/审批卡片：content 落库为 JSON 字符串（形如
                     # ``{"outcome": {"type": "interrupt"/"success", "interrupts": [...]}}``），

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -65,7 +65,7 @@ class BaseSessionWriter(ABC):
     取消/暂停回写机制：
     - 当用户在非 assistant 阶段（thinking/tool/activity）暂停时，handle_run_finished()
       会转为 RUN_ERROR 语义，回写已有内容并补一条 role=assistant, content="用户已取消",
-      status="fail" 的消息
+      status="error" 的消息
     - 当用户在 assistant 阶段暂停时，已有的 assistant 消息以 status="complete" 正常回写
 
     使用方式：
@@ -482,7 +482,7 @@ class BaseSessionWriter(ABC):
         取消/暂停场景处理：
         - 取消 + 有 assistant 输出：以 status="complete" 正常回写，发 RUN_FINISHED
         - 取消 + 无 assistant 输出（仅有 thinking/tool/知识库/MCP 等）：
-          回写已有内容 + 补一条 role=assistant, content="用户已取消", status="fail" 的消息，
+          回写已有内容 + 补一条 role=assistant, content="用户已取消", status="error" 的消息，
           并转为 RUN_ERROR 语义（确保前端正确展示暂停状态）
 
         Args:
@@ -506,7 +506,7 @@ class BaseSessionWriter(ABC):
             any(mid not in self._written_message_ids for mid in self._streaming_messages) or self._model_end_written
         )
 
-        # 取消 + 无 AI 输出：回写已有内容 + 补写"用户已取消" + status=fail
+        # 取消 + 无 AI 输出：回写已有内容 + 补写"用户已取消" + status=error
         if self._is_cancelled and not has_assistant_output:
             self._write_cancelled_messages(thinking_content)
             return
@@ -561,13 +561,13 @@ class BaseSessionWriter(ABC):
                 reasoning_content=thinking_content,
             )
 
-            # 取消场景：补写"用户已取消" + status=fail
+            # 取消场景：补写"用户已取消" + status=error
             if self._is_cancelled:
                 self._write_assistant_message(
                     message_id=fallback_message_id,
                     content=self.PAUSED_CONTENT_MESSAGE,
                     tool_calls=[],
-                    status="fail",
+                    status="error",
                 )
             else:
                 self._write_assistant_message(
@@ -715,7 +715,7 @@ class BaseSessionWriter(ABC):
         当用户在非 assistant 阶段（thinking/tool/知识库/MCP）取消时：
         1. 回写已有的 thinking/reasoning 内容
         2. 回写未写入的流式 assistant 消息（如有部分内容）
-        3. 补写一条 role=assistant, content="用户已取消", status="fail" 的消息
+        3. 补写一条 role=assistant, content="用户已取消", status="error" 的消息
 
         此方法由 handle_run_finished（取消+无AI输出）和 handle_run_error（取消场景）
         共同调用，避免逻辑重复。
@@ -786,7 +786,7 @@ class BaseSessionWriter(ABC):
                 message_id=paused_message_id,
                 content=self.PAUSED_CONTENT_MESSAGE,
                 tool_calls=[],
-                status="fail",
+                status="error",
             )
             if self._write_error_count != errors_before:
                 logger.warning(
@@ -952,7 +952,7 @@ class BaseSessionWriter(ABC):
 
         对于取消/暂停场景（message 为 RunId.CANCELLED_MESSAGE），
         会先回写已有的非 assistant 内容（thinking/tool/知识库/MCP 等），
-        再补写 content="用户已取消", status="fail" 的 assistant 消息。
+        再补写 content="用户已取消", status="error" 的 assistant 消息。
         对于真正的运行错误，直接写入错误消息。
 
         Args:
@@ -1327,7 +1327,7 @@ class BaseSessionWriter(ABC):
             message_id: assistant 消息 ID
             content: 消息内容
             tool_calls: 工具调用列表
-            status: 消息状态，默认 "complete"；取消/暂停场景使用 "fail"
+            status: 消息状态，默认 "complete"；取消/暂停场景使用 "error"
         """
         assistant_property = {
             "message_id": message_id,

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_cancelled.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""MESSAGES_SNAPSHOT 与 LLM 入口对用户已取消消息的分流。"""
+"""MESSAGES_SNAPSHOT 对 fail/error 消息的还原。"""
 
 import json
 
@@ -13,10 +13,10 @@ from aidev_agent.services.agent.chat import ChatCompletionAgent
 from aidev_agent.utils.event import RunId
 
 
-def _cancelled_history() -> list[ChatPrompt]:
+def _failed_history(status: str = "error", content: str = RunId.CANCELLED_MESSAGE):
     return [
         ChatPrompt(id="1", role="user", content="分析图片"),
-        ChatPrompt(id="2", role="assistant", content=RunId.CANCELLED_MESSAGE),
+        ChatPrompt(id="2", role="assistant", content=content, builtin_property={"status": status}),
     ]
 
 
@@ -26,21 +26,39 @@ def _build_messages_snapshot(agent: ChatCompletionAgent):
 
 
 def test_messages_snapshot_entry_includes_user_cancelled():
-    agent = ChatCompletionAgent(chat_history=_cancelled_history())
+    agent = ChatCompletionAgent(chat_history=_failed_history())
     snapshot = _build_messages_snapshot(agent)
     assert [each.role for each in snapshot] == ["user", "assistant"]
     assert snapshot[-1].content == RunId.CANCELLED_MESSAGE
+    assert snapshot[-1].status == "error"
 
 
-def test_llm_entry_excludes_user_cancelled():
-    agent = ChatCompletionAgent(chat_history=_cancelled_history())
-    llm_messages = agent._filter_cancelled_for_llm(agent.convert_history_to_messages())
-    assert len(llm_messages) == 1
-    assert llm_messages[0].content == "分析图片"
+def test_messages_snapshot_entry_includes_fail_status():
+    agent = ChatCompletionAgent(chat_history=_failed_history(status="fail", content="模型调用失败"))
+    snapshot = _build_messages_snapshot(agent)
+    assert [each.role for each in snapshot] == ["user", "assistant"]
+    assert snapshot[-1].content == "模型调用失败"
+    assert snapshot[-1].status == "error"
+
+
+def test_llm_entry_keeps_cancelled_and_orphan_user_messages():
+    """取消轮与连续 user 均保留入模，不再整轮剔除。"""
+    cancelled_history = _failed_history() + [ChatPrompt(id="3", role="user", content="换个问题")]
+    agent = ChatCompletionAgent(chat_history=cancelled_history)
+    llm_messages = agent._filter_messages_for_llm(agent.convert_history_to_messages())
+    assert [each.content for each in llm_messages] == ["分析图片", RunId.CANCELLED_MESSAGE, "换个问题"]
+
+    orphan_history = [
+        ChatPrompt(id="1", role="user", content="孤立提问"),
+        ChatPrompt(id="2", role="user", content="新问题"),
+    ]
+    agent = ChatCompletionAgent(chat_history=orphan_history)
+    llm_messages = agent._filter_messages_for_llm(agent.convert_history_to_messages())
+    assert [each.content for each in llm_messages] == ["孤立提问", "新问题"]
 
 
 def test_messages_snapshot_sse_includes_user_cancelled():
-    agent = ChatCompletionAgent(chat_history=_cancelled_history())
+    agent = ChatCompletionAgent(chat_history=_failed_history())
     encoded = EventEncoder().encode(
         MessageSnapshotEventExtend(
             type=EventType.MESSAGES_SNAPSHOT,
@@ -50,3 +68,4 @@ def test_messages_snapshot_sse_includes_user_cancelled():
     payload = json.loads(encoded.removeprefix("data: ").strip())
     assert payload["messages"][-1]["role"] == "assistant"
     assert payload["messages"][-1]["content"] == RunId.CANCELLED_MESSAGE
+    assert payload["messages"][-1]["status"] == "error"

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_reasoning.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_reasoning.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+"""MESSAGES_SNAPSHOT 应还原 reasoning，LLM 入口应排除。"""
+
+import json
+
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+
+from aidev_agent.core.ag_ui.types import MessageSnapshotEventExtend, ReasoningLangChainMessage
+from aidev_agent.core.ag_ui.utils import langchain_messages_to_agui, parse_reasoning_content_value
+from aidev_agent.enums import PromptRole
+from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+
+def _reasoning_history() -> list[ChatPrompt]:
+    # 平台 session_context 已解析 JSON；SDK 侧只接收 list / 纯文本
+    return [
+        ChatPrompt(id="u1", role="user", content="查天气"),
+        ChatPrompt(
+            id="rsn_lc1",
+            role=PromptRole.REASONING.value,
+            content=["先分析用户意图", "再选择工具"],
+            builtin_property={"message_id": "rsn_lc1", "duration": 2.5},
+        ),
+        ChatPrompt(id="a1", role="assistant", content="北京今天晴"),
+    ]
+
+
+def _build_messages_snapshot(agent: ChatCompletionAgent):
+    return langchain_messages_to_agui(agent.convert_history_to_messages())
+
+
+def test_parse_reasoning_content_normalizes_types():
+    assert parse_reasoning_content_value(["步骤一", "步骤二"]) == ["步骤一", "步骤二"]
+    assert parse_reasoning_content_value("纯文本思考") == ["纯文本思考"]
+    assert parse_reasoning_content_value(None) == []
+
+
+def test_messages_snapshot_includes_reasoning_with_duration():
+    agent = ChatCompletionAgent(chat_history=_reasoning_history())
+    snapshot = _build_messages_snapshot(agent)
+    assert [each.role for each in snapshot] == ["user", "reasoning", "assistant"]
+    reasoning = snapshot[1]
+    assert reasoning.content == ["先分析用户意图", "再选择工具"]
+    assert reasoning.duration == 2.5
+
+
+def test_llm_entry_excludes_reasoning():
+    agent = ChatCompletionAgent(chat_history=_reasoning_history())
+    llm_messages = agent._filter_messages_for_llm(agent.convert_history_to_messages())
+    assert not any(isinstance(each, ReasoningLangChainMessage) for each in llm_messages)
+    assert [each.content for each in llm_messages] == ["查天气", "北京今天晴"]
+
+
+def test_messages_snapshot_sse_reasoning_payload():
+    agent = ChatCompletionAgent(chat_history=_reasoning_history())
+    encoded = EventEncoder().encode(
+        MessageSnapshotEventExtend(
+            type=EventType.MESSAGES_SNAPSHOT,
+            messages=_build_messages_snapshot(agent),
+        )
+    )
+    payload = json.loads(encoded.removeprefix("data: ").strip())
+    reasoning = payload["messages"][1]
+    assert reasoning["role"] == "reasoning"
+    assert reasoning["content"] == ["先分析用户意图", "再选择工具"]
+    assert reasoning["duration"] == 2.5

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1529,7 +1529,7 @@ class TestSessionWriterCancelUnit:
     """
 
     def test_cancel_error_with_thinking_writes_reasoning_and_paused(self):
-        """取消 + thinking 内容 → 回写 reasoning + 补写"用户已取消" + status=fail"""
+        """取消 + thinking 内容 → 回写 reasoning + 补写"用户已取消" + status=error"""
         writer = _ConcreteWriter()
         writer._thinking_content = "正在深度思考中..."
         writer.handle_run_error(RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE))
@@ -1538,19 +1538,19 @@ class TestSessionWriterCancelUnit:
         assert any(c.get("role") == PromptRole.REASONING.value for c in writer.created_contents)
         assert any(
             c.get("role") == PromptRole.ASSISTANT.value
-            and c.get("status") == "fail"
+            and c.get("status") == "error"
             and c.get("content") == "用户已取消"
             for c in writer.created_contents
         )
 
     def test_cancel_error_no_content_writes_only_paused(self):
-        """取消 + 完全无内容 → 仅补写"用户已取消" + status=fail"""
+        """取消 + 完全无内容 → 仅补写"用户已取消" + status=error"""
         writer = _ConcreteWriter()
         writer.handle_run_error(RunErrorEvent(type=EventType.RUN_ERROR, message=RunId.CANCELLED_MESSAGE))
 
         assert len(writer.created_contents) == 1
         assert writer.created_contents[0]["content"] == "用户已取消"
-        assert writer.created_contents[0]["status"] == "fail"
+        assert writer.created_contents[0]["status"] == "error"
 
     def test_cancel_run_finished_no_output_writes_paused(self):
         """RUN_FINISHED(cancelled) + 无 AI 输出 → 补写"用户已取消"（Flow Agent 任务已启动场景）"""
@@ -1560,7 +1560,7 @@ class TestSessionWriterCancelUnit:
         )
 
         assert writer.is_cancelled is True
-        assert any(c.get("content") == "用户已取消" and c.get("status") == "fail" for c in writer.created_contents)
+        assert any(c.get("content") == "用户已取消" and c.get("status") == "error" for c in writer.created_contents)
 
     def test_cancel_error_then_run_finished_writes_paused_once(self):
         """RUN_ERROR 与 RUN_FINISHED 连续到达时，不重复补写取消消息。"""
@@ -1573,7 +1573,7 @@ class TestSessionWriterCancelUnit:
         paused = [
             content
             for content in writer.created_contents
-            if content.get("content") == "用户已取消" and content.get("status") == "fail"
+            if content.get("content") == "用户已取消" and content.get("status") == "error"
         ]
         assert len(paused) == 1
 
@@ -1612,7 +1612,7 @@ class TestSessionWriterCancelUnit:
         paused = [
             content
             for content in writer.created_contents
-            if content.get("content") == "用户已取消" and content.get("status") == "fail"
+            if content.get("content") == "用户已取消" and content.get("status") == "error"
         ]
         assert len(paused) == 1
 
@@ -1624,7 +1624,7 @@ class TestSessionWriterCancelUnit:
             RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t1", run_id=RunId.CANCELLED)
         )
 
-        assert not any(c.get("content") == "用户已取消" and c.get("status") == "fail" for c in writer.created_contents)
+        assert not any(c.get("content") == "用户已取消" and c.get("status") == "error" for c in writer.created_contents)
 
     def test_real_error_writes_error_with_builtin_flag(self):
         """真正运行错误 → 回写错误消息 + builtin_property.error=True"""
@@ -1650,6 +1650,20 @@ class TestSessionWriterCancelUnit:
     def test_constants_consistency(self):
         """PAUSED_CONTENT_MESSAGE 和 RunId.CANCELLED_MESSAGE 应一致为"用户已取消" """
         assert BaseSessionWriter.PAUSED_CONTENT_MESSAGE == RunId.CANCELLED_MESSAGE == "用户已取消"
+
+
+class TestCancelRunErrorDedupe:
+    """取消 RUN_ERROR SSE 幂等：同一 run 只应下发一条 message=用户已取消 的 RUN_ERROR。"""
+
+    def test_mark_cancel_run_error_emitted_is_idempotent(self):
+        from aidev_agent.core.ag_ui.agent import LangGraphAgent
+
+        agent = LangGraphAgent.__new__(LangGraphAgent)
+        agent.active_run = {"cancel_run_error_emitted": False}
+
+        assert agent._mark_cancel_run_error_emitted() is True
+        assert agent.active_run["cancel_run_error_emitted"] is True
+        assert agent._mark_cancel_run_error_emitted() is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景
取消会话时可能重复下发 `RUN_ERROR`；`MESSAGES_SNAPSHOT` 还原时 reasoning 片段与取消后的 `error` 状态未正确落盘，导致前端展示与平台侧占位状态不一致。

## 改动
### 改动一：取消收口幂等
- `cancel` 路径对 `RUN_ERROR` 做幂等去重，避免重复写入「用户已取消」类终态事件

### 改动二：snapshot 还原
- snapshot 还原时补齐 `reasoning` 内容；LLM 入口仅过滤 `role=reasoning`
- 取消 / fail 场景下 assistant 消息状态按 `error` 还原，与平台侧占位展示对齐

### 改动三：测试
- 调整 `test_messages_snapshot_reasoning`、`test_messages_snapshot_cancelled` 与 `test_chat` 覆盖
- 不再在 SDK 侧剔除「取消轮 / 孤立 user」入模；补充保留入模的回归用例

## 测试
- [x] `test_messages_snapshot_cancelled` / `test_messages_snapshot_reasoning`
- [ ] CI 全量验证

## 兼容性
- 取消终态事件语义不变；仅减少重复下发，并修正 snapshot 还原字段
- fail/error 历史消息会进入 LLM 上下文（不再由 SDK 整轮剔除）

## 关联
tapd: #134137778
配套平台 PR：https://github.com/TencentBlueKing/bk-aidev/pull/1862

Made with [Cursor](https://cursor.com)
