### PR TITLE
feat: 新增智能体指标与 BKM 异步上报 --story=1070093903136959970

### DIFF
--- a/dev/otel/Makefile
+++ b/dev/otel/Makefile
@@ -1,0 +1,61 @@
+SHELL := /bin/bash
+
+OTEL_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST))))
+ROOT_DIR := $(abspath $(OTEL_DIR)/../..)
+PLUGIN_DIR := $(ROOT_DIR)/src/plugins/aidev_bkplugin
+PYTHON ?= $(PLUGIN_DIR)/.venv/bin/python
+PODMAN ?= podman
+COMPOSE := $(PODMAN) compose -f $(OTEL_DIR)/docker-compose.yml
+
+N ?= 3
+MODELS ?= mock-log-analysis-a,mock-log-analysis-b,mock-log-analysis-c
+HANDLER ?= all
+ITERATIONS ?= 400
+INTERVAL ?= 1.5
+SEED ?= 20260809
+
+MOCK_COMMAND = env PYTHONPATH="$(ROOT_DIR)/src/agent:$(PLUGIN_DIR):$(ROOT_DIR)" \
+	"$(PYTHON)" "$(OTEL_DIR)/mock_agent_metrics.py" \
+	-n "$(N)" --models "$(MODELS)" --handler "$(HANDLER)" \
+	--iterations "$(ITERATIONS)" --interval "$(INTERVAL)" --seed "$(SEED)"
+
+.PHONY: help start stop up down status logs mock test metrics
+
+help:
+	@echo "Local OpenTelemetry observability"
+	@echo "  make start       Start Podman services and run mock in foreground"
+	@echo "  make stop        Stop Podman services"
+	@echo "  make status      Show Podman container status"
+	@echo "  make logs        Follow Podman service logs"
+	@echo "  make mock        Run mock in the foreground"
+	@echo "  make test        Run exporter and local observability tests"
+	@echo "  make metrics     Print the Collector Prometheus endpoint"
+	@echo ""
+	@echo "Parameters: N=3 MODELS=a,b,c HANDLER=all ITERATIONS=400 INTERVAL=1.5 SEED=20260809"
+
+start: up mock
+
+stop: down
+
+up:
+	$(COMPOSE) up -d
+
+down:
+	$(COMPOSE) down
+
+status:
+	$(COMPOSE) ps
+
+logs:
+	$(COMPOSE) logs -f
+
+mock:
+	$(MOCK_COMMAND)
+
+test:
+	cd "$(PLUGIN_DIR)" && env PYTHONPATH="$(ROOT_DIR)/src/agent:$(PLUGIN_DIR):$(ROOT_DIR)" \
+		"$(PYTHON)" -m pytest --ds=tests.settings -c "$(PLUGIN_DIR)/pyproject.toml" \
+		"$(PLUGIN_DIR)/tests/services/test_otel_metrics.py" "$(OTEL_DIR)/tests"
+
+metrics:
+	curl -fsS http://localhost:8889/metrics

--- a/dev/otel/README.md
+++ b/dev/otel/README.md
@@ -24,6 +24,8 @@ make status
 
 Collector 接收端口为 `4317`（gRPC）和 `4318`（HTTP），Prometheus 为
 <http://localhost:9090>，Grafana 为 <http://localhost:3000/d/aidev-agent-metrics>。
+本地镜像固定为 Grafana `10.4.19`，仪表盘使用该版本生成的 schema 39，保持与线上
+Grafana 10.x 的兼容性；后续编辑和导出也应继续使用 10.x 环境。
 
 ## 发送 mock 指标
 

--- a/dev/otel/README.md
+++ b/dev/otel/README.md
@@ -170,8 +170,8 @@ make test
   "otel_token": "",
   "metrics": {
     "enabled": true,
-    "export_interval_millis": 1000,
-    "export_timeout_millis": 5000,
+    "export_interval_millis": 10000,
+    "export_timeout_millis": 30000,
     "export_via_celery": true,
     "agent_data_id": 1001,
     "agent_access_token": "<由平台下发>",
@@ -207,6 +207,8 @@ OTel Counter 转成 BKM 的 `*_total`；Histogram 转成累计 `*_bucket`（`le`
 `*_sum` 和 `*_count`，因此现有速率与 P95 查询语义保持不变。这里不依赖 Celery Beat：
 各产生指标的进程负责按 `export_interval_millis` 截取自己的累计快照，Celery Worker 只负责
 可靠隔离实际网络请求，避免 Worker 无法读取其他进程内存中的 OTel 聚合器。
+生产默认周期为 10 秒；显式下发 `export_interval_millis` 时仍以配置值为准。本地 mock 为了缩短
+仪表盘验证等待时间，继续使用 1 秒周期。
 
 本地生成项目的 `.env` 可只配置以下三项；未显式配置 `metrics.enabled` 时，三项齐全会自动启用
 BKM 指标。平台下发的 `otel_info.metrics.agent_*` 优先级高于环境变量：

--- a/dev/otel/README.md
+++ b/dev/otel/README.md
@@ -1,0 +1,241 @@
+# AIDev Agent 本地指标验证
+
+该环境验证完整路径：Agent 指标 API 埋点 → bkplugin OTLP/HTTP 直连（仅本地）→
+OpenTelemetry Collector → Prometheus → Grafana 预置仪表盘。生产环境默认由源进程的
+OpenTelemetry Reader 定期生成累计快照，经 `plugin_schedule` 队列交给 Celery Worker，
+再按 BKM 自定义指标协议推送到 `${PROXY_IP}:10205/v2/push/`。
+
+## 启动
+
+在仓库根目录执行，一条命令会使用 Podman 启动 Collector、Prometheus、Grafana，
+并在当前终端运行默认 mock：
+
+```bash
+cd dev/otel
+make start
+```
+
+默认 mock 持续约 10 分钟；执行期间可直接观察终端输出，`Ctrl+C` 只停止 mock。
+在另一个终端查看 Podman 服务状态：
+
+```bash
+make status
+```
+
+Collector 接收端口为 `4317`（gRPC）和 `4318`（HTTP），Prometheus 为
+<http://localhost:9090>，Grafana 为 <http://localhost:3000/d/aidev-agent-metrics>。
+
+## 发送 mock 指标
+
+`make start` 默认同时模拟 4 个 Handler。每个 Handler 有一个持续运行的基础槽位，
+另外两个槽位按随机间隔启停新的 Agent Run，因此活跃 Run 会在 `4～12` 之间变化。
+可以在启动时覆盖参数：
+
+```bash
+make start N=3 MODELS=mock-a,mock-b,mock-c ITERATIONS=400 INTERVAL=1.5
+```
+
+使用 `-n/--concurrency` 指定每个 Handler 的并发上限。例如 `-n 5` 时，每个 Handler
+同时运行 1～5 个 Run，总活跃 Agent 数在 `4～20` 之间变化；`-n 1` 时固定为 4：
+
+```bash
+make start N=5
+```
+
+默认启用 `mock-log-analysis-a`、`mock-log-analysis-b`、`mock-log-analysis-c` 三个
+mock 模型，实际 Run 会按模型列表轮询分配。启动时可指定任意 1～n 个逗号分隔的模型名：
+
+```bash
+make start N=3 MODELS=mock-a,mock-b,mock-c
+```
+
+也可以使用 `AIDEV_MOCK_MODELS=mock-a,mock-b`；模型名仅作为本地指标的低基数过滤维度。
+
+每个 Run 会真实执行 `30～120s`，耗时随机分配给 6 次 LLM、4 次 Tool、Agent processing
+和 finalizing 阶段；LLM TTFT 不超过对应的 LLM 调用耗时。Mock 不再每 1.5 秒瞬时上报
+一个伪造的长耗时完成样本，因此 Agent 并发、进入/完成速率和耗时满足真实生命周期关系。
+同一 `--seed` 会得到可重复的耗时与模型分配序列。
+
+如果只需要前台运行 mock，不重启 Podman 服务：
+
+```bash
+make mock N=3 ITERATIONS=40 INTERVAL=1.5
+```
+
+原有的 `AIDEV_MOCK_CONCURRENCY`、`AIDEV_MOCK_ITERATIONS`、
+`AIDEV_MOCK_INTERVAL_SECONDS` 环境变量仍可使用，命令参数优先。可以通过 `--seed`
+让耗时和运行槽位行为可重复验证。
+
+mock 使用“日志查询与聚合总结”场景，模拟 6 次 LLM 调用和 4 次工具调用。
+`activate_skill` 来自实际验证链路；其余日志工具统一使用
+`inspect_log_fields`、`search_logs`、`aggregate_logs` 脱敏别名。业务 ID、索引集 ID、
+时间、节点、日志正文和总结均为不可回推的合成数据，不保留原会话的真实内容。
+
+默认同步生成 `inmemory`、`rabbitmq`、`rabbitmq_stream`、`redis` 四组指标。
+如只需验证单个 Message Handler，可显式指定：
+
+```bash
+make start HANDLER=redis N=3
+```
+
+可选值为 `all`、`inmemory`、`rabbitmq`、`rabbitmq_stream`、`redis`；
+`AIDEV_MOCK_MESSAGE_HANDLER` 环境变量也继续兼容。mock 会按模型与工具输出的
+编码大小生成合并前 SSE 逻辑事件数、合并后物理写入数和物理消息 Payload 大小；
+模型/工具正文不会进入指标标签或 OTLP resource。
+
+等待 2～5 秒后可以观察活跃 Run 和阶段；首批完成耗时、迭代、SSE 和 Broker 指标需要等待
+至少 30 秒。也可以直接在 Prometheus 查询：
+
+```promql
+{__name__=~"gen_ai_invoke_agent_duration.*"}
+```
+
+“活跃 Agent Run”统计正在执行的 Run，不代表已持久化但空闲的历史 session。
+当前阶段按 `processing`、`llm`、`tool`、`finalizing`、`mixed` 互斥统计；具体 Run 身份
+需要查看 Trace 或日志。平均 Agent 迭代次数把一次 LLM 推理定义为一次迭代；范围内没有
+已完成 Run 时显示 `No data`，不显示伪造的 0。
+
+仪表盘提供以下多选过滤器，`All` 使用正则 `.*`：
+
+- `Agent Code`、`Agent Version`：作用于全部面板；
+- `Request Model`：作用于全部 LLM 面板；`Response Model` 只有调用结束后可用，因此只作用于
+  LLM 已结束调用耗时和完成速率；
+- `Tool Name`：作用于 Tool 活跃数和耗时面板；
+- `Message Handler`：作用于 SSE 与消息发布面板，值为实际生效的 handler。
+
+“活跃 Agent Run”展示当前仍在执行的 Run 总数，并应与各 Agent 阶段并发之和一致；
+“活跃智能体数量”展示至少有一个 Run 正在执行的 Agent Code 去重数，同一 Agent Code 的多个并发 Run
+只计为 1。两者都不是累计会话次数。“Agent 阶段并发”展示当前值与时间走势；耗时类折线图统一展示 P95，
+其中“Agent 阶段耗时 P95”只统计已经结束的阶段，
+因为运行中的阶段尚未产生 Histogram 样本。阶段累计时间占比来自阶段切换时的直接计时，互斥阶段
+在同一窗口内合计约 100%，不再用子调用累计值除以已完成 Run 数估算耗时分配。
+Agent 首 Token 趋势按 Agent Code 展示流式 Run 从开始到首个 Token 的 P95，非流式 Run 不产生样本；
+顶部同名卡片是所选 Agent 的聚合摘要。LLM 展示按模型
+拆分的并发、完成速率和已结束调用耗时；Tool 展示按工具名称拆分的并发和已结束调用耗时。
+“SSE 输出与物理消息”以与发布速率面板一致的折线和表格图例展示每个查询窗口的
+SSE 逻辑事件数量、物理消息数量及 SSE/物理消息压缩比，并按 Handler 名称升序，
+不再按 SSE 事件类型拆分；“Broker 发布侧”展示合并前逻辑事件速率、
+合并后物理消息速率、所选时段按 Agent Code 去重的 Handler 分布、应用序列化 Payload IO、消息大小和
+Handler 写入耗时，并按 Handler 名称升序展示。
+Payload IO 不等于 RabbitMQ/Redis 的网络、磁盘 IO；队列积压、消费 lag 和真实 IO 仍需
+对应 Broker 的原生 exporter。
+
+指标身份维度包含 `agent.info.code`、`agent.info.name` 和
+`agent.info.sdk_version`；不包含固定值 `agent.info.type`。Agent 版本由 bkplugin
+从平台下发并解码后的 `agent_info.agent_sdk_version` 获取，缺失时使用 `unknown`。
+bkplugin 同时设置标准 Resource 属性 `service.instance.id`，用于区分同一服务的不同进程；
+仪表盘按 Agent 聚合该属性，因此多进程活跃数能够正确求和，但不把实例 ID 暴露为业务过滤器。
+
+## 查看原始指标数据
+
+Collector 的 `debug` exporter 会把每批 OTLP `MetricData`（resource、scope、data
+point 和聚合值）输出到容器日志：
+
+```bash
+podman compose logs -f otel-collector
+```
+
+Prometheus exporter 的原始 exposition 文本可通过以下命令查看：
+
+```bash
+curl http://localhost:8889/metrics
+curl 'http://localhost:9090/api/v1/query?query=aidev_agent_active'
+curl 'http://localhost:9090/api/v1/query?query=aidev_agent_phase_active'
+curl 'http://localhost:9090/api/v1/query?query=gen_ai_client_operation_active'
+curl 'http://localhost:9090/api/v1/query?query=gen_ai_execute_tool_active'
+curl 'http://localhost:9090/api/v1/query?query=aidev_message_publish_count_total'
+```
+
+本地 Collector 已开启 `resource_to_telemetry_conversion`，因此 OTLP resource
+属性 `agent.info.sdk_version` 会在 Prometheus 中显示为标签
+`agent_info_sdk_version`。
+
+Prometheus 保存的是按 scrape 时间采集的聚合时间序列，不是逐次 Agent 事件；如果要
+定位单次执行，请结合对应 Trace，而不是尝试从 Counter 或 Histogram 反推事件明细。
+
+本地观测配置和 mock 测试均位于 `dev/otel`。执行以下命令同时验证 bkplugin exporter
+和本地观测场景：
+
+```bash
+make test
+```
+
+## 使用真实 bkplugin 请求
+
+平台下发的 `agent_info.otel_info` 解码后可使用：
+
+```json
+{
+  "otel_url": "http://localhost:4318",
+  "otel_token": "",
+  "metrics": {
+    "enabled": true,
+    "export_interval_millis": 1000,
+    "export_timeout_millis": 5000,
+    "export_via_celery": true,
+    "agent_data_id": 1001,
+    "agent_access_token": "<由平台下发>",
+    "agent_push_url": "http://proxy.example:10205/v2/push/",
+    "agent_target": "127.0.0.1"
+  }
+}
+```
+
+`otel_url/otel_token` 继续用于 Trace；指标使用 Agent 命名空间下的
+`agent_data_id/agent_access_token/agent_push_url` 独立配置，不能复用 Trace token。
+`agent_push_url` 未配置时会根据 Worker 的 `PROXY_IP` 自动生成
+`http://${PROXY_IP}:10205/v2/push/`；`agent_target` 未配置时使用指标源进程所在主机名。
+`data_id`、`access_token` 与完整 URL 不进入 Celery 消息，Broker 中只有不可逆端点指纹和
+不含凭据的指标数据。Worker 按以下协议补齐凭据并推送：
+
+```json
+{
+  "data_id": 1001,
+  "access_token": "***",
+  "data": [
+    {
+      "metrics": {"aidev_agent_active": 3},
+      "target": "127.0.0.1",
+      "dimension": {"agent_info_code": "ai-demo"},
+      "timestamp": 1786300118338
+    }
+  ]
+}
+```
+
+OTel Counter 转成 BKM 的 `*_total`；Histogram 转成累计 `*_bucket`（`le` 维度）、
+`*_sum` 和 `*_count`，因此现有速率与 P95 查询语义保持不变。这里不依赖 Celery Beat：
+各产生指标的进程负责按 `export_interval_millis` 截取自己的累计快照，Celery Worker 只负责
+可靠隔离实际网络请求，避免 Worker 无法读取其他进程内存中的 OTel 聚合器。
+
+本地生成项目的 `.env` 可只配置以下三项；未显式配置 `metrics.enabled` 时，三项齐全会自动启用
+BKM 指标。平台下发的 `otel_info.metrics.agent_*` 优先级高于环境变量：
+
+```bash
+BKAI_AGENT_METRICS_HOST=proxy.example
+BKAI_AGENT_METRICS_DATA_ID=1001
+BKAI_AGENT_METRICS_TOKEN=<本地密钥>
+BKAI_AGENT_METRICS_TARGET=127.0.0.1
+```
+
+如果 bkplugin 也运行在 Docker 中，将地址改为
+`http://host.docker.internal:4318`，或改为同一 Compose 网络内的
+`http://otel-collector:4318`。
+
+本地 Collector 场景必须关闭 Celery/BKM 转发，由 mock 自动设置
+`export_via_celery=false`；真实 bkplugin 如需直连本地 Collector，也可临时使用相同配置。
+
+环境变量仍可覆盖本地配置：
+
+```bash
+export BKAI_AGENT_OTEL_ENABLED=true
+export BKAI_AGENT_ENABLE_METRICS=true
+export BKAI_AGENT_OTEL_EXPORTER_TYPE=http
+export BKAI_AGENT_OTEL_ENDPOINTS='[{"url":"http://localhost:4318","token":"","exporter_type":"http"}]'
+```
+
+完成后停止全部 Podman 服务：
+
+```bash
+make stop
+```

--- a/dev/otel/docker-compose.yml
+++ b/dev/otel/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.132.0
+    command: ["--config=/etc/otelcol-contrib/config.yaml"]
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otelcol-contrib/config.yaml:ro
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "8889:8889"
+
+  prometheus:
+    image: prom/prometheus:v3.5.0
+    command: ["--config.file=/etc/prometheus/prometheus.yml"]
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+    depends_on:
+      - otel-collector
+
+  grafana:
+    image: grafana/grafana:12.1.1
+    environment:
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: Admin
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus

--- a/dev/otel/docker-compose.yml
+++ b/dev/otel/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       - otel-collector
 
   grafana:
-    image: grafana/grafana:12.1.1
+    image: grafana/grafana:10.4.19
     environment:
       GF_AUTH_ANONYMOUS_ENABLED: "true"
       GF_AUTH_ANONYMOUS_ORG_ROLE: Admin

--- a/dev/otel/grafana/dashboards/aidev-agent-metrics.json
+++ b/dev/otel/grafana/dashboards/aidev-agent-metrics.json
@@ -1,0 +1,355 @@
+{
+  "annotations": {"list": []},
+  "description": "Agent 运行态、耗时、LLM、工具以及应用侧 SSE/Broker 写入压力。真实 Broker 积压和磁盘/网络 IO 需要接入 RabbitMQ/Redis 原生 exporter。",
+  "editable": false,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "id": 100, "panels": [], "title": "运行态与关键指标", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：当前仍在执行的 Agent Run 总数，不是累计会话次数；应与各 Agent 阶段并发之和一致。计算：对筛选范围内 aidev_agent_active Gauge 求和；当前无序列时显式回退为 0，避免 Stat 沿用上一个非空值。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 4, "y": 1},
+      "id": 1,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "sum(aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) or vector(0)", "legendFormat": "活跃 Run", "range": true, "refId": "A"}],
+      "title": "活跃 Agent Run", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：至少有一个 Run 正在执行的智能体数量，同一 Agent Code 的多个并发 Run 只计为 1。计算：先按 agent.info.code 汇总 aidev_agent_active，保留大于 0 的分组后计数；无活跃项时返回 0。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 0, "y": 1},
+      "id": 30,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "count(sum by (agent_info_code) (aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) > 0) or vector(0)", "legendFormat": "活跃 Agent Code", "range": true, "refId": "A"}],
+      "title": "活跃智能体数量", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：当前正在执行的 LLM Operation 数量。计算：对筛选范围内 gen_ai_client_operation_active Gauge 求和；按请求模型过滤，不使用调用结束后才确定的响应模型。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 3, "x": 8, "y": 1},
+      "id": 2,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "sum(gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}) or vector(0)", "legendFormat": "活跃 LLM", "range": true, "refId": "A"}],
+      "title": "活跃 LLM Operation", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：当前正在执行的工具 Operation 数量。计算：对筛选范围内 gen_ai_execute_tool_active Gauge 求和，可按工具名称过滤。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 3, "x": 11, "y": 1},
+      "id": 3,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "sum(gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}) or vector(0)", "legendFormat": "活跃 Tool", "range": true, "refId": "A"}],
+      "title": "活跃 Tool Operation", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：已结束 Agent Run 的墙钟运行耗时 P95。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 3, "x": 14, "y": 1},
+      "id": 4,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}],
+      "title": "Agent 运行耗时 P95", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：Agent Run 开始到收到首个流式 LLM Token 的耗时 P95；非流式调用不产生样本。计算：对 gen_ai_invoke_agent_time_to_first_token_seconds Histogram bucket 的窗口速率按 le 汇总，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 3, "x": 17, "y": 1},
+      "id": 5,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}],
+      "title": "Agent 首 Token P95", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：所选时段内每个已完成 Agent Run 的平均迭代次数，一次 LLM 推理调用计为一次迭代。计算：inference_calls_total 的 increase 总和除以 Agent duration count 的 increase 总和，分母最小取 1。",
+      "fieldConfig": {"defaults": {"decimals": 2, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 5, "w": 4, "x": 20, "y": 1},
+      "id": 6,
+      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
+      "targets": [{"editorMode": "code", "expr": "sum(increase(gen_ai_invoke_agent_inference_calls_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / clamp_min(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 1)", "legendFormat": "迭代/Run", "range": true, "refId": "A"}],
+      "title": "平均 Agent 迭代次数", "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：当前 Agent Run 在 processing、llm、tool、mixed、finalizing 阶段的并发数及趋势；每个 Run 同时只归属一个阶段，并行 LLM 与 Tool 归入 mixed。计算：按 aidev_agent_phase 对 aidev_agent_phase_active Gauge 求和。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "id": 7,
+      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (aidev_agent_phase) (aidev_agent_phase_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"})", "legendFormat": "{{aidev_agent_phase}}", "range": true, "refId": "A"}],
+      "title": "Agent 阶段并发（当前与趋势）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：各 Agent 阶段已结束片段的互斥墙钟耗时 P95；正在运行的阶段尚未形成 Histogram 样本。计算：按 le 和 aidev_agent_phase 汇总阶段 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "id": 11,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_agent_phase) (rate(aidev_agent_phase_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_agent_phase}} P95", "range": true, "refId": "A"}
+      ],
+      "title": "Agent 阶段耗时 P95（已结束阶段）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：Agent Run 每秒进入数与完成数，用于判断流入、流出是否平衡。计算：分别对 gen_ai_invoke_agent_started_total 和 gen_ai_invoke_agent_duration_seconds_count 计算 rate 后求和。",
+      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 14},
+      "id": 9,
+      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "sum(rate(gen_ai_invoke_agent_started_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))", "legendFormat": "进入速率", "range": true, "refId": "A"},
+        {"editorMode": "code", "expr": "sum(rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))", "legendFormat": "完成速率", "range": true, "refId": "B"}
+      ],
+      "title": "Agent 进入与完成速率", "type": "timeseries"
+    },
+
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 22}, "id": 101, "panels": [], "title": "Agent 耗时", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：已结束 Agent Run 墙钟运行耗时 P95 的时间走势。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "id": 10,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}
+      ],
+      "title": "Agent 墙钟耗时 P95", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按 Agent Code 拆分的 Agent Run 首 Token 耗时 P95，即 Run 开始到收到首个流式 LLM Token 的时间；非流式调用不产生样本。计算：按 le 和 agent.info.code 汇总 gen_ai_invoke_agent_time_to_first_token_seconds bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "id": 32,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, agent_info_code) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "{{agent_info_code}} P95", "range": true, "refId": "A"}
+      ],
+      "title": "Agent 首 Token P95（流式调用，按 Agent Code）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：所选时段内 processing、llm、tool、mixed、finalizing 各阶段累计耗时占比，互斥阶段合计约 100%。计算：各阶段 duration sum 的 increase 除以所有阶段 increase 总和。",
+      "fieldConfig": {"defaults": {"min": 0, "max": 1, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 31},
+      "id": 12,
+      "options": {"displayLabels": ["name", "percent"], "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"]}, "pieType": "donut", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (aidev_agent_phase) (increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / ignoring(aidev_agent_phase) group_left clamp_min(sum(increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 0.000001)", "instant": true, "legendFormat": "{{aidev_agent_phase}}", "range": false, "refId": "A"}],
+      "title": "Agent 阶段累计时间占比（所选时段）", "type": "piechart"
+    },
+
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 39}, "id": 102, "panels": [], "title": "LLM", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按请求模型拆分的已结束 LLM 调用耗时 P95。计算：按 le 和 gen_ai.request.model 汇总 LLM duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)；响应模型过滤只作用于已结束调用。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 40},
+      "id": 13,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_request_model}} P95", "range": true, "refId": "A"}
+      ],
+      "title": "LLM 耗时 P95（已结束调用，按请求模型）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按请求模型拆分的 LLM 首 Token/首 Chunk 耗时 P95，仅统计产生流式回调的调用。计算：按 le 和 gen_ai.request.model 汇总 time_to_first_chunk bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 40},
+      "id": 14,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_time_to_first_chunk_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_request_model}} P95", "range": true, "refId": "A"}
+      ],
+      "title": "LLM 首 Token P95（流式调用，按请求模型）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按请求模型拆分的当前 LLM 并发数及趋势；响应模型只有调用结束后才能确定，因此不用于活跃调用过滤。计算：按 gen_ai.request.model 对 gen_ai_client_operation_active Gauge 求和。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 48},
+      "id": 16,
+      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_request_model) (gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"})", "legendFormat": "{{gen_ai_request_model}}", "range": true, "refId": "A"}],
+      "title": "LLM 并发（当前与趋势，按请求模型）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按请求模型拆分的 LLM 每秒完成调用数。计算：对 gen_ai_client_operation_duration_seconds_count 计算 rate，再按 gen_ai.request.model 求和；可按请求模型和已确定的响应模型过滤。",
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 48},
+      "id": 15,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval]))", "legendFormat": "{{gen_ai_request_model}}", "range": true, "refId": "A"}],
+      "title": "LLM 完成速率（按请求模型）", "type": "timeseries"
+    },
+
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 56}, "id": 103, "panels": [], "title": "Tool", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按工具名称拆分的当前工具调用并发数及趋势。计算：按 gen_ai.tool.name 对 gen_ai_execute_tool_active Gauge 求和。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 57},
+      "id": 29,
+      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_tool_name) (gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"})", "legendFormat": "{{gen_ai_tool_name}}", "range": true, "refId": "A"}],
+      "title": "工具并发（当前与趋势，按工具名称）", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按工具名称拆分的已结束工具调用耗时 P95。计算：按 le 和 gen_ai.tool.name 汇总工具 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 65},
+      "id": 18,
+      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_tool_name) (rate(gen_ai_execute_tool_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_tool_name}} P95", "range": true, "refId": "A"}
+      ],
+      "title": "工具耗时 P95（已结束调用，按工具名称）", "type": "timeseries"
+    },
+
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 73}, "id": 104, "panels": [], "title": "SSE 输出与物理消息", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：每个查询窗口内的 SSE 逻辑事件数量与实际提交给 Handler 的物理消息数量，均按 Handler 展示且不按 SSE 事件类型拆分。计算：分别对 aidev_sse_event_count total 和 aidev_message_publish_count total 使用 increase([$__rate_interval]) 后按 Handler 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 74},
+      "id": 25,
+      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "targets": [
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "A"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "B"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "C"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "D"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "E"}
+      ],
+      "title": "SSE 事件与物理消息数量", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：每个查询窗口内每条物理消息平均承载的 SSE 事件数，数值越大表示事件合并程度越高。计算：按 Handler 汇总 SSE 事件 increase，除以物理消息 increase；分母最小取 0.000001 以避免除零，查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {"defaults": {"decimals": 2, "unit": "short"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 74},
+      "id": 31,
+      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "targets": [
+        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "A"},
+        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "B"},
+        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "C"},
+        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "D"},
+        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "E"}
+      ],
+      "title": "SSE/物理消息压缩比", "type": "timeseries"
+    },
+
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 82}, "id": 106, "panels": [], "title": "Broker 发布侧", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：逻辑事件表示合并前进入 flush 的事件速率，物理消息表示合并后实际提交给 Handler/Broker 的写入速率。计算：分别对 publish_event_count sum 和 publish_count total 计算 rate，再按 Handler 和 messaging.system 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {"defaults": {"unit": "eps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 83},
+      "id": 20,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "targets": [
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "A"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "B"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "C"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "D"},
+        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "E"}
+      ],
+      "title": "逻辑事件与物理消息速率", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：所选时段内各 Handler 上实际发布过物理消息的 Agent Code 去重分布；同一个 Agent 在同一 Handler 上无论发布多少消息只计 1，在多个 Handler 上发布则分别计入对应 Handler。计算：先按 Handler 和 agent.info.code 汇总 aidev_message_publish_count increase 并过滤零值，再按 Handler 计数并除以全部 Handler-Agent 去重组合数；按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {"defaults": {"decimals": 1, "min": 0, "max": 1, "unit": "percentunit"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 83},
+      "id": 21,
+      "options": {"displayMode": "gradient", "minVizHeight": 10, "minVizWidth": 0, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "targets": [
+        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "A"},
+        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "B"},
+        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "C"},
+        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "D"},
+        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "E"}
+      ],
+      "title": "Handler 分布（所选时段）", "type": "bargauge"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：应用序列化后提交给 Handler 的 Payload 吞吐量（bytes/s），不等同于 Broker 实际网络或磁盘 IO。计算：对 publish_size Histogram sum 计算 rate，再按 Handler 求和。",
+      "fieldConfig": {"defaults": {"unit": "Bps"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 91},
+      "id": 22,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_sum\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval]))", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "A"}],
+      "title": "应用写入 Payload IO", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按 Handler 拆分的单条物理消息 Payload 大小 P95。计算：按 le 和 Handler 汇总 publish_size bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 91},
+      "id": 23,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_message_handler_type}} P95", "range": true, "refId": "A"}],
+      "title": "物理消息大小 P95", "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按 Handler 拆分的单次应用侧消息写入耗时 P95，不包含 Broker 消费耗时。计算：按 le 和 Handler 汇总 publish_duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 91},
+      "id": 24,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_duration.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_message_handler_type}} P95", "range": true, "refId": "A"}],
+      "title": "Handler 写入耗时 P95", "type": "timeseries"
+    },
+    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 99}, "id": 105, "panels": [], "title": "错误", "type": "row"},
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "含义：按 Agent、LLM、Tool 和 Handler 指标来源以及 error.type 拆分的每秒错误完成数，仅覆盖带非空 error_type 标签的已结束操作。计算：分别对四类 duration count 错误序列计算 rate，再按 error_type 求和；拆分查询可避免 rate 移除指标名后不同来源发生标签冲突。",
+      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
+      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 100},
+      "id": 28,
+      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "targets": [
+        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Agent · {{error_type}}", "range": true, "refId": "A"},
+        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "LLM · {{error_type}}", "range": true, "refId": "B"},
+        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Tool · {{error_type}}", "range": true, "refId": "C"},
+        {"editorMode": "code", "expr": "sum by (error_type) (rate(aidev_message_publish_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Handler · {{error_type}}", "range": true, "refId": "D"}
+      ],
+      "title": "错误速率（指标来源与 error.type）", "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 41,
+  "tags": ["aidev", "agent", "opentelemetry"],
+  "templating": {
+    "list": [
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)", "includeAll": true, "label": "Agent Code", "multi": true, "name": "agent_code", "options": [], "query": {"query": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)", "refId": "Variable-AgentCode"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)", "includeAll": true, "label": "Agent Version", "multi": true, "name": "agent_version", "options": [], "query": {"query": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)", "refId": "Variable-AgentVersion"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)", "includeAll": true, "label": "Request Model", "multi": true, "name": "request_model", "options": [], "query": {"query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)", "refId": "Variable-RequestModel"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)", "includeAll": true, "label": "Response Model", "multi": true, "name": "response_model", "options": [], "query": {"query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)", "refId": "Variable-ResponseModel"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)", "includeAll": true, "label": "Tool Name", "multi": true, "name": "tool_name", "options": [], "query": {"query": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)", "refId": "Variable-ToolName"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
+      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)", "includeAll": true, "label": "Message Handler", "multi": true, "name": "handler_type", "options": [], "query": {"query": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)", "refId": "Variable-HandlerType"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"}
+    ]
+  },
+  "time": {"from": "now-15m", "to": "now"},
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AIDev Agent Metrics",
+  "uid": "aidev-agent-metrics",
+  "version": 2
+}

--- a/dev/otel/grafana/dashboards/aidev-agent-metrics.json
+++ b/dev/otel/grafana/dashboards/aidev-agent-metrics.json
@@ -1,355 +1,2271 @@
 {
-  "annotations": {"list": []},
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
   "description": "Agent 运行态、耗时、LLM、工具以及应用侧 SSE/Broker 写入压力。真实 Broker 积压和磁盘/网络 IO 需要接入 RabbitMQ/Redis 原生 exporter。",
   "editable": false,
+  "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
   "links": [],
   "panels": [
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0}, "id": 100, "panels": [], "title": "运行态与关键指标", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "含义：当前仍在执行的 Agent Run 总数，不是累计会话次数；应与各 Agent 阶段并发之和一致。计算：对筛选范围内 aidev_agent_active Gauge 求和；当前无序列时显式回退为 0，避免 Stat 沿用上一个非空值。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 4, "x": 4, "y": 1},
-      "id": 1,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "sum(aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) or vector(0)", "legendFormat": "活跃 Run", "range": true, "refId": "A"}],
-      "title": "活跃 Agent Run", "type": "stat"
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "运行态与关键指标",
+      "type": "row"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：至少有一个 Run 正在执行的智能体数量，同一 Agent Code 的多个并发 Run 只计为 1。计算：先按 agent.info.code 汇总 aidev_agent_active，保留大于 0 的分组后计数；无活跃项时返回 0。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 4, "x": 0, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
       "id": 30,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "count(sum by (agent_info_code) (aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) > 0) or vector(0)", "legendFormat": "活跃 Agent Code", "range": true, "refId": "A"}],
-      "title": "活跃智能体数量", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count(sum by (agent_info_code) (aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) > 0) or vector(0)",
+          "legendFormat": "活跃 Agent Code",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "活跃智能体数量",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：当前仍在执行的 Agent Run 总数，不是累计会话次数；应与各 Agent 阶段并发之和一致。计算：对筛选范围内 aidev_agent_active Gauge 求和；当前无序列时显式回退为 0，避免 Stat 沿用上一个非空值。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) or vector(0)",
+          "legendFormat": "活跃 Run",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "活跃 Agent Run",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：当前正在执行的 LLM Operation 数量。计算：对筛选范围内 gen_ai_client_operation_active Gauge 求和；按请求模型过滤，不使用调用结束后才确定的响应模型。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 3, "x": 8, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 8,
+        "y": 1
+      },
       "id": 2,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "sum(gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}) or vector(0)", "legendFormat": "活跃 LLM", "range": true, "refId": "A"}],
-      "title": "活跃 LLM Operation", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}) or vector(0)",
+          "legendFormat": "活跃 LLM",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "活跃 LLM Operation",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：当前正在执行的工具 Operation 数量。计算：对筛选范围内 gen_ai_execute_tool_active Gauge 求和，可按工具名称过滤。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 3, "x": 11, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 11,
+        "y": 1
+      },
       "id": 3,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "sum(gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}) or vector(0)", "legendFormat": "活跃 Tool", "range": true, "refId": "A"}],
-      "title": "活跃 Tool Operation", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}) or vector(0)",
+          "legendFormat": "活跃 Tool",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "活跃 Tool Operation",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：已结束 Agent Run 的墙钟运行耗时 P95。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 3, "x": 14, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 14,
+        "y": 1
+      },
       "id": 4,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}],
-      "title": "Agent 运行耗时 P95", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent 运行耗时 P95",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：Agent Run 开始到收到首个流式 LLM Token 的耗时 P95；非流式调用不产生样本。计算：对 gen_ai_invoke_agent_time_to_first_token_seconds Histogram bucket 的窗口速率按 le 汇总，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 3, "x": 17, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 17,
+        "y": 1
+      },
       "id": 5,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}],
-      "title": "Agent 首 Token P95", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent 首 Token P95",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：所选时段内每个已完成 Agent Run 的平均迭代次数，一次 LLM 推理调用计为一次迭代。计算：inference_calls_total 的 increase 总和除以 Agent duration count 的 increase 总和，分母最小取 1。",
-      "fieldConfig": {"defaults": {"decimals": 2, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 5, "w": 4, "x": 20, "y": 1},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
       "id": 6,
-      "options": {"colorMode": "value", "graphMode": "area", "justifyMode": "auto", "orientation": "auto", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "textMode": "auto", "wideLayout": true},
-      "targets": [{"editorMode": "code", "expr": "sum(increase(gen_ai_invoke_agent_inference_calls_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / clamp_min(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 1)", "legendFormat": "迭代/Run", "range": true, "refId": "A"}],
-      "title": "平均 Agent 迭代次数", "type": "stat"
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(increase(gen_ai_invoke_agent_inference_calls_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / clamp_min(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 1)",
+          "legendFormat": "迭代/Run",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "平均 Agent 迭代次数",
+      "type": "stat"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：当前 Agent Run 在 processing、llm、tool、mixed、finalizing 阶段的并发数及趋势；每个 Run 同时只归属一个阶段，并行 LLM 与 Tool 归入 mixed。计算：按 aidev_agent_phase 对 aidev_agent_phase_active Gauge 求和。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
       "id": 7,
-      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (aidev_agent_phase) (aidev_agent_phase_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"})", "legendFormat": "{{aidev_agent_phase}}", "range": true, "refId": "A"}],
-      "title": "Agent 阶段并发（当前与趋势）", "type": "timeseries"
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_agent_phase) (aidev_agent_phase_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"})",
+          "legendFormat": "{{aidev_agent_phase}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent 阶段并发（当前与趋势）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：各 Agent 阶段已结束片段的互斥墙钟耗时 P95；正在运行的阶段尚未形成 Histogram 样本。计算：按 le 和 aidev_agent_phase 汇总阶段 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
       "id": 11,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_agent_phase) (rate(aidev_agent_phase_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_agent_phase}} P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, aidev_agent_phase) (rate(aidev_agent_phase_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{aidev_agent_phase}} P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "Agent 阶段耗时 P95（已结束阶段）", "type": "timeseries"
+      "title": "Agent 阶段耗时 P95（已结束阶段）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：Agent Run 每秒进入数与完成数，用于判断流入、流出是否平衡。计算：分别对 gen_ai_invoke_agent_started_total 和 gen_ai_invoke_agent_duration_seconds_count 计算 rate 后求和。",
-      "fieldConfig": {"defaults": {"unit": "reqps"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 14},
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
       "id": 9,
-      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "sum(rate(gen_ai_invoke_agent_started_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))", "legendFormat": "进入速率", "range": true, "refId": "A"},
-        {"editorMode": "code", "expr": "sum(rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))", "legendFormat": "完成速率", "range": true, "refId": "B"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gen_ai_invoke_agent_started_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))",
+          "legendFormat": "进入速率",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))",
+          "legendFormat": "完成速率",
+          "range": true,
+          "refId": "B"
+        }
       ],
-      "title": "Agent 进入与完成速率", "type": "timeseries"
+      "title": "Agent 进入与完成速率",
+      "type": "timeseries"
     },
-
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 22}, "id": 101, "panels": [], "title": "Agent 耗时", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 101,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Agent 耗时",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：已结束 Agent Run 墙钟运行耗时 P95 的时间走势。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 23},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
       "id": 10,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "Agent 墙钟耗时 P95", "type": "timeseries"
+      "title": "Agent 墙钟耗时 P95",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按 Agent Code 拆分的 Agent Run 首 Token 耗时 P95，即 Run 开始到收到首个流式 LLM Token 的时间；非流式调用不产生样本。计算：按 le 和 agent.info.code 汇总 gen_ai_invoke_agent_time_to_first_token_seconds bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 23},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
       "id": 32,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, agent_info_code) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))", "legendFormat": "{{agent_info_code}} P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, agent_info_code) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{agent_info_code}} P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "Agent 首 Token P95（流式调用，按 Agent Code）", "type": "timeseries"
+      "title": "Agent 首 Token P95（流式调用，按 Agent Code）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：所选时段内 processing、llm、tool、mixed、finalizing 各阶段累计耗时占比，互斥阶段合计约 100%。计算：各阶段 duration sum 的 increase 除以所有阶段 increase 总和。",
-      "fieldConfig": {"defaults": {"min": 0, "max": 1, "unit": "percentunit"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 31},
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
       "id": 12,
-      "options": {"displayLabels": ["name", "percent"], "legend": {"displayMode": "table", "placement": "right", "showLegend": true, "values": ["value", "percent"]}, "pieType": "donut", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "tooltip": {"hideZeros": false, "mode": "single", "sort": "none"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (aidev_agent_phase) (increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / ignoring(aidev_agent_phase) group_left clamp_min(sum(increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 0.000001)", "instant": true, "legendFormat": "{{aidev_agent_phase}}", "range": false, "refId": "A"}],
-      "title": "Agent 阶段累计时间占比（所选时段）", "type": "piechart"
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_agent_phase) (increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / ignoring(aidev_agent_phase) group_left clamp_min(sum(increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 0.000001)",
+          "instant": true,
+          "legendFormat": "{{aidev_agent_phase}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Agent 阶段累计时间占比（所选时段）",
+      "type": "piechart"
     },
-
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 39}, "id": 102, "panels": [], "title": "LLM", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 102,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "LLM",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按请求模型拆分的已结束 LLM 调用耗时 P95。计算：按 le 和 gen_ai.request.model 汇总 LLM duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)；响应模型过滤只作用于已结束调用。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 40},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
       "id": 13,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_request_model}} P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_request_model}} P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "LLM 耗时 P95（已结束调用，按请求模型）", "type": "timeseries"
+      "title": "LLM 耗时 P95（已结束调用，按请求模型）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按请求模型拆分的 LLM 首 Token/首 Chunk 耗时 P95，仅统计产生流式回调的调用。计算：按 le 和 gen_ai.request.model 汇总 time_to_first_chunk bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 40},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
       "id": 14,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_time_to_first_chunk_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_request_model}} P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_time_to_first_chunk_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_request_model}} P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "LLM 首 Token P95（流式调用，按请求模型）", "type": "timeseries"
+      "title": "LLM 首 Token P95（流式调用，按请求模型）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按请求模型拆分的当前 LLM 并发数及趋势；响应模型只有调用结束后才能确定，因此不用于活跃调用过滤。计算：按 gen_ai.request.model 对 gen_ai_client_operation_active Gauge 求和。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 48},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
       "id": 16,
-      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_request_model) (gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"})", "legendFormat": "{{gen_ai_request_model}}", "range": true, "refId": "A"}],
-      "title": "LLM 并发（当前与趋势，按请求模型）", "type": "timeseries"
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (gen_ai_request_model) (gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"})",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM 并发（当前与趋势，按请求模型）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按请求模型拆分的 LLM 每秒完成调用数。计算：对 gen_ai_client_operation_duration_seconds_count 计算 rate，再按 gen_ai.request.model 求和；可按请求模型和已确定的响应模型过滤。",
-      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 48},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
       "id": 15,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval]))", "legendFormat": "{{gen_ai_request_model}}", "range": true, "refId": "A"}],
-      "title": "LLM 完成速率（按请求模型）", "type": "timeseries"
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{gen_ai_request_model}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "LLM 完成速率（按请求模型）",
+      "type": "timeseries"
     },
-
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 56}, "id": 103, "panels": [], "title": "Tool", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 103,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Tool",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按工具名称拆分的当前工具调用并发数及趋势。计算：按 gen_ai.tool.name 对 gen_ai_execute_tool_active Gauge 求和。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 57},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
       "id": 29,
-      "options": {"legend": {"calcs": ["max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (gen_ai_tool_name) (gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"})", "legendFormat": "{{gen_ai_tool_name}}", "range": true, "refId": "A"}],
-      "title": "工具并发（当前与趋势，按工具名称）", "type": "timeseries"
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (gen_ai_tool_name) (gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"})",
+          "legendFormat": "{{gen_ai_tool_name}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "工具并发（当前与趋势，按工具名称）",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按工具名称拆分的已结束工具调用耗时 P95。计算：按 le 和 gen_ai.tool.name 汇总工具 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 65},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
       "id": 18,
-      "options": {"legend": {"calcs": ["mean", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, gen_ai_tool_name) (rate(gen_ai_execute_tool_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}[$__rate_interval])))", "legendFormat": "{{gen_ai_tool_name}} P95", "range": true, "refId": "A"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, gen_ai_tool_name) (rate(gen_ai_execute_tool_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{gen_ai_tool_name}} P95",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "工具耗时 P95（已结束调用，按工具名称）", "type": "timeseries"
+      "title": "工具耗时 P95（已结束调用，按工具名称）",
+      "type": "timeseries"
     },
-
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 73}, "id": 104, "panels": [], "title": "SSE 输出与物理消息", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 104,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "SSE 输出与物理消息",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：每个查询窗口内的 SSE 逻辑事件数量与实际提交给 Handler 的物理消息数量，均按 Handler 展示且不按 SSE 事件类型拆分。计算：分别对 aidev_sse_event_count total 和 aidev_message_publish_count total 使用 increase([$__rate_interval]) 后按 Handler 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
-      "fieldConfig": {"defaults": {"decimals": 0, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 74},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
       "id": 25,
-      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "A"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "B"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "C"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "D"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "E"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "E"
+        }
       ],
-      "title": "SSE 事件与物理消息数量", "type": "timeseries"
+      "title": "SSE 事件与物理消息数量",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：每个查询窗口内每条物理消息平均承载的 SSE 事件数，数值越大表示事件合并程度越高。计算：按 Handler 汇总 SSE 事件 increase，除以物理消息 increase；分母最小取 0.000001 以避免除零，查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
-      "fieldConfig": {"defaults": {"decimals": 2, "unit": "short"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 74},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
       "id": 31,
-      "options": {"legend": {"calcs": ["mean", "max", "lastNotNull"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "A"},
-        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "B"},
-        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "C"},
-        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "D"},
-        {"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "E"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), 0.000001)",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "E"
+        }
       ],
-      "title": "SSE/物理消息压缩比", "type": "timeseries"
+      "title": "SSE/物理消息压缩比",
+      "type": "timeseries"
     },
-
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 82}, "id": 106, "panels": [], "title": "Broker 发布侧", "type": "row"},
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 106,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "Broker 发布侧",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：逻辑事件表示合并前进入 flush 的事件速率，物理消息表示合并后实际提交给 Handler/Broker 的写入速率。计算：分别对 publish_event_count sum 和 publish_count total 计算 rate，再按 Handler 和 messaging.system 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
-      "fieldConfig": {"defaults": {"unit": "eps"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 83},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "eps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
       "id": 20,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true, "sortBy": "Name", "sortDesc": false}, "tooltip": {"mode": "multi", "sort": "none"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "A"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "B"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "C"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "D"},
-        {"editorMode": "code", "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")", "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}", "range": true, "refId": "E"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "legendFormat": "{{aidev_message_handler_type}} {{aidev_message_kind}}",
+          "range": true,
+          "refId": "E"
+        }
       ],
-      "title": "逻辑事件与物理消息速率", "type": "timeseries"
+      "title": "逻辑事件与物理消息速率",
+      "type": "timeseries"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：所选时段内各 Handler 上实际发布过物理消息的 Agent Code 去重分布；同一个 Agent 在同一 Handler 上无论发布多少消息只计 1，在多个 Handler 上发布则分别计入对应 Handler。计算：先按 Handler 和 agent.info.code 汇总 aidev_message_publish_count increase 并过滤零值，再按 Handler 计数并除以全部 Handler-Agent 去重组合数；按 Handler 名称升序，未知 Handler 追加在末尾。",
-      "fieldConfig": {"defaults": {"decimals": 1, "min": 0, "max": 1, "unit": "percentunit"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 83},
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
       "id": 21,
-      "options": {"displayMode": "gradient", "minVizHeight": 10, "minVizWidth": 0, "namePlacement": "auto", "orientation": "horizontal", "reduceOptions": {"calcs": ["lastNotNull"], "fields": "", "values": false}, "showUnfilled": true, "sizing": "auto", "valueMode": "color"},
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
       "targets": [
-        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "A"},
-        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "B"},
-        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "C"},
-        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "D"},
-        {"editorMode": "code", "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))", "instant": true, "legendFormat": "{{aidev_message_handler_type}}", "range": false, "refId": "E"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))",
+          "instant": true,
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": false,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))",
+          "instant": true,
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))",
+          "instant": true,
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": false,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))",
+          "instant": true,
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": false,
+          "refId": "D"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__range])) > 0), 0.000001))",
+          "instant": true,
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": false,
+          "refId": "E"
+        }
       ],
-      "title": "Handler 分布（所选时段）", "type": "bargauge"
+      "title": "Handler 分布（所选时段）",
+      "type": "bargauge"
     },
     {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：应用序列化后提交给 Handler 的 Payload 吞吐量（bytes/s），不等同于 Broker 实际网络或磁盘 IO。计算：对 publish_size Histogram sum 计算 rate，再按 Handler 求和。",
-      "fieldConfig": {"defaults": {"unit": "Bps"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 8, "x": 0, "y": 91},
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 91
+      },
       "id": 22,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "sum by (aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_sum\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval]))", "legendFormat": "{{aidev_message_handler_type}}", "range": true, "refId": "A"}],
-      "title": "应用写入 Payload IO", "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "含义：按 Handler 拆分的单条物理消息 Payload 大小 P95。计算：按 le 和 Handler 汇总 publish_size bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "bytes"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 8, "x": 8, "y": 91},
-      "id": 23,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_message_handler_type}} P95", "range": true, "refId": "A"}],
-      "title": "物理消息大小 P95", "type": "timeseries"
-    },
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "含义：按 Handler 拆分的单次应用侧消息写入耗时 P95，不包含 Broker 消费耗时。计算：按 le 和 Handler 汇总 publish_duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
-      "fieldConfig": {"defaults": {"unit": "s"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 8, "x": 16, "y": 91},
-      "id": 24,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
-      "targets": [{"editorMode": "code", "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_duration.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))", "legendFormat": "{{aidev_message_handler_type}} P95", "range": true, "refId": "A"}],
-      "title": "Handler 写入耗时 P95", "type": "timeseries"
-    },
-    {"collapsed": false, "gridPos": {"h": 1, "w": 24, "x": 0, "y": 99}, "id": 105, "panels": [], "title": "错误", "type": "row"},
-    {
-      "datasource": {"type": "prometheus", "uid": "prometheus"},
-      "description": "含义：按 Agent、LLM、Tool 和 Handler 指标来源以及 error.type 拆分的每秒错误完成数，仅覆盖带非空 error_type 标签的已结束操作。计算：分别对四类 duration count 错误序列计算 rate，再按 error_type 求和；拆分查询可避免 rate 移除指标名后不同来源发生标签冲突。",
-      "fieldConfig": {"defaults": {"unit": "ops"}, "overrides": []},
-      "gridPos": {"h": 8, "w": 24, "x": 0, "y": 100},
-      "id": 28,
-      "options": {"legend": {"calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true}, "tooltip": {"mode": "multi", "sort": "desc"}},
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
       "targets": [
-        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Agent · {{error_type}}", "range": true, "refId": "A"},
-        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "LLM · {{error_type}}", "range": true, "refId": "B"},
-        {"editorMode": "code", "expr": "sum by (error_type) (rate(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Tool · {{error_type}}", "range": true, "refId": "C"},
-        {"editorMode": "code", "expr": "sum by (error_type) (rate(aidev_message_publish_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\",error_type!=\"\"}[$__rate_interval]))", "legendFormat": "Handler · {{error_type}}", "range": true, "refId": "D"}
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_sum\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{aidev_message_handler_type}}",
+          "range": true,
+          "refId": "A"
+        }
       ],
-      "title": "错误速率（指标来源与 error.type）", "type": "timeseries"
+      "title": "应用写入 Payload IO",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：按 Handler 拆分的单条物理消息 Payload 大小 P95。计算：按 le 和 Handler 汇总 publish_size bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 91
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{aidev_message_handler_type}} P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "物理消息大小 P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：按 Handler 拆分的单次应用侧消息写入耗时 P95，不包含 Broker 消费耗时。计算：按 le 和 Handler 汇总 publish_duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 91
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_duration.*_bucket\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\"}[$__rate_interval])))",
+          "legendFormat": "{{aidev_message_handler_type}} P95",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Handler 写入耗时 P95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 105,
+      "panels": [],
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "refId": "A"
+        }
+      ],
+      "title": "错误",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：按 Agent、LLM、Tool 和 Handler 指标来源以及 error.type 拆分的每秒错误完成数，仅覆盖带非空 error_type 标签的已结束操作。计算：分别对四类 duration count 错误序列计算 rate，再按 error_type 求和；拆分查询可避免 rate 移除指标名后不同来源发生标签冲突。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 100
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (error_type) (rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",error_type!=\"\"}[$__rate_interval]))",
+          "legendFormat": "Agent · {{error_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (error_type) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\",error_type!=\"\"}[$__rate_interval]))",
+          "legendFormat": "LLM · {{error_type}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (error_type) (rate(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\",error_type!=\"\"}[$__rate_interval]))",
+          "legendFormat": "Tool · {{error_type}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (error_type) (rate(aidev_message_publish_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\",error_type!=\"\"}[$__rate_interval]))",
+          "legendFormat": "Handler · {{error_type}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "错误速率（指标来源与 error.type）",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 41,
-  "tags": ["aidev", "agent", "opentelemetry"],
+  "schemaVersion": 39,
+  "tags": [
+    "aidev",
+    "agent",
+    "opentelemetry"
+  ],
   "templating": {
     "list": [
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)", "includeAll": true, "label": "Agent Code", "multi": true, "name": "agent_code", "options": [], "query": {"query": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)", "refId": "Variable-AgentCode"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)", "includeAll": true, "label": "Agent Version", "multi": true, "name": "agent_version", "options": [], "query": {"query": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)", "refId": "Variable-AgentVersion"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)", "includeAll": true, "label": "Request Model", "multi": true, "name": "request_model", "options": [], "query": {"query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)", "refId": "Variable-RequestModel"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)", "includeAll": true, "label": "Response Model", "multi": true, "name": "response_model", "options": [], "query": {"query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)", "refId": "Variable-ResponseModel"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)", "includeAll": true, "label": "Tool Name", "multi": true, "name": "tool_name", "options": [], "query": {"query": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)", "refId": "Variable-ToolName"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"},
-      {"allValue": ".*", "current": {"selected": true, "text": "All", "value": "$__all"}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "definition": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)", "includeAll": true, "label": "Message Handler", "multi": true, "name": "handler_type", "options": [], "query": {"query": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)", "refId": "Variable-HandlerType"}, "refresh": 1, "regex": "", "sort": 1, "type": "query"}
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent Code",
+        "multi": true,
+        "name": "agent_code",
+        "options": [],
+        "query": {
+          "query": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)",
+          "refId": "Variable-AgentCode"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent Version",
+        "multi": true,
+        "name": "agent_version",
+        "options": [],
+        "query": {
+          "query": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\"}, agent_info_sdk_version)",
+          "refId": "Variable-AgentVersion"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Request Model",
+        "multi": true,
+        "name": "request_model",
+        "options": [],
+        "query": {
+          "query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_request_model)",
+          "refId": "Variable-RequestModel"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Response Model",
+        "multi": true,
+        "name": "response_model",
+        "options": [],
+        "query": {
+          "query": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}, gen_ai_response_model)",
+          "refId": "Variable-ResponseModel"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tool Name",
+        "multi": true,
+        "name": "tool_name",
+        "options": [],
+        "query": {
+          "query": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, gen_ai_tool_name)",
+          "refId": "Variable-ToolName"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Message Handler",
+        "multi": true,
+        "name": "handler_type",
+        "options": [],
+        "query": {
+          "query": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}, aidev_message_handler_type)",
+          "refId": "Variable-HandlerType"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
     ]
   },
-  "time": {"from": "now-15m", "to": "now"},
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
   "timepicker": {},
   "timezone": "browser",
   "title": "AIDev Agent Metrics",
   "uid": "aidev-agent-metrics",
-  "version": 2
+  "version": 2,
+  "weekStart": ""
 }

--- a/dev/otel/grafana/provisioning/dashboards/aidev-agent.yaml
+++ b/dev/otel/grafana/provisioning/dashboards/aidev-agent.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: AIDev Agent
+    orgId: 1
+    folder: AIDev
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards

--- a/dev/otel/grafana/provisioning/datasources/prometheus.yaml
+++ b/dev/otel/grafana/provisioning/datasources/prometheus.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/dev/otel/mock_agent_metrics.py
+++ b/dev/otel/mock_agent_metrics.py
@@ -1,0 +1,699 @@
+"""Emit a sanitized log-query scenario through the real bkplugin exporter."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+
+from aidev_agent.packages.opentelemetry.metrics import AgentMetrics, configure_metric_identity
+from aidev_agent.packages.opentelemetry.utils import ExporterType
+from aidev_bkplugin.services.otel_metrics import BkPluginMetricService, MetricExportSettings
+
+HANDLER_SYSTEMS = {
+    "inmemory": "in_memory",
+    "rabbitmq": "rabbitmq",
+    "rabbitmq_stream": "rabbitmq",
+    "redis": "redis",
+}
+DEFAULT_MODELS = (
+    "mock-log-analysis-a",
+    "mock-log-analysis-b",
+    "mock-log-analysis-c",
+)
+MOCK_ERROR_CASES = ("success", "agent", "llm", "tool", "handler")
+SANITIZED_PROMPT = "查一下业务 <BK_BIZ_ID> 的索引集 <INDEX_SET_ID> 近 1 天前 10 条日志，按合适维度输出总结"
+SANITIZED_LOGS = (
+    {
+        "timestamp": "2026-01-01T00:01:00Z",
+        "level": "INFO",
+        "service": "api",
+        "node": "node-a",
+        "message": "request completed",
+    },
+    {
+        "timestamp": "2026-01-01T00:02:00Z",
+        "level": "WARN",
+        "service": "worker",
+        "node": "node-b",
+        "message": "retry scheduled",
+    },
+    {
+        "timestamp": "2026-01-01T00:03:00Z",
+        "level": "ERROR",
+        "service": "api",
+        "node": "node-a",
+        "message": "upstream timeout",
+    },
+    {
+        "timestamp": "2026-01-01T00:04:00Z",
+        "level": "INFO",
+        "service": "scheduler",
+        "node": "node-c",
+        "message": "job dispatched",
+    },
+    {
+        "timestamp": "2026-01-01T00:05:00Z",
+        "level": "WARN",
+        "service": "api",
+        "node": "node-b",
+        "message": "response latency elevated",
+    },
+    {
+        "timestamp": "2026-01-01T00:06:00Z",
+        "level": "INFO",
+        "service": "worker",
+        "node": "node-b",
+        "message": "task completed",
+    },
+    {
+        "timestamp": "2026-01-01T00:07:00Z",
+        "level": "ERROR",
+        "service": "scheduler",
+        "node": "node-c",
+        "message": "dependency unavailable",
+    },
+    {
+        "timestamp": "2026-01-01T00:08:00Z",
+        "level": "INFO",
+        "service": "api",
+        "node": "node-a",
+        "message": "health check passed",
+    },
+    {
+        "timestamp": "2026-01-01T00:09:00Z",
+        "level": "WARN",
+        "service": "worker",
+        "node": "node-c",
+        "message": "queue depth elevated",
+    },
+    {
+        "timestamp": "2026-01-01T00:10:00Z",
+        "level": "INFO",
+        "service": "scheduler",
+        "node": "node-a",
+        "message": "job completed",
+    },
+)
+
+
+@dataclass(frozen=True)
+class ModelStep:
+    output: str
+    duration: float
+    time_to_first_chunk: float
+    usage: dict[str, int]
+
+
+@dataclass(frozen=True)
+class ToolStep:
+    name: str
+    arguments: dict[str, Any]
+    output: Any
+    duration: float
+
+
+@dataclass(frozen=True)
+class MockSseEvent:
+    event_type: str
+    size: int
+
+
+@dataclass(frozen=True)
+class ScenarioTimings:
+    agent_duration: float
+    llm_durations: tuple[float, ...]
+    llm_first_chunk_durations: tuple[float, ...]
+    tool_durations: tuple[float, ...]
+    processing_duration: float
+
+
+@dataclass(frozen=True)
+class ScenarioStage:
+    phase: str
+    duration: float
+    operation_index: int | None = None
+
+
+class MockAgentExecutionError(RuntimeError):
+    """Agent run failure used only by the local observability scenario."""
+
+
+class MockLlmTimeoutError(TimeoutError):
+    """LLM timeout used only by the local observability scenario."""
+
+
+class MockToolInvocationError(RuntimeError):
+    """Tool invocation failure used only by the local observability scenario."""
+
+
+class MockHandlerPublishError(ConnectionError):
+    """Handler publish failure used only by the local observability scenario."""
+
+
+def _usage(input_tokens: int, output_tokens: int, cache_creation: int = 0, cache_read: int = 0) -> dict[str, int]:
+    return {
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": input_tokens + output_tokens + cache_creation + cache_read,
+    }
+
+
+MODEL_STEPS = (
+    ModelStep(
+        "我会先激活日志分析能力，再根据时间范围和数量限制执行查询。", 4.0, 0.8, _usage(220, 52, cache_creation=64)
+    ),
+    ModelStep(
+        "日志分析能力已就绪，先确认可用字段，避免使用不存在的聚合维度。", 4.5, 0.9, _usage(110, 45, cache_read=64)
+    ),
+    ModelStep(
+        "字段中包含时间、级别、服务和节点，现在查询最近一天的 10 条样本。", 3.8, 0.7, _usage(160, 58, cache_read=64)
+    ),
+    ModelStep(
+        "已取得 10 条脱敏日志，继续按 level 和 service 聚合，检查异常集中度。",
+        5.2,
+        1.0,
+        _usage(180, 62, cache_read=128),
+    ),
+    ModelStep(
+        "聚合结果显示 ERROR 2 条、WARN 3 条、INFO 5 条；api 服务的日志数最多。",
+        4.8,
+        0.9,
+        _usage(450, 85, cache_read=256),
+    ),
+    ModelStep(
+        "总结：10 条样本中 ERROR 2 条、WARN 3 条、INFO 5 条。异常主要集中在 api 超时和 scheduler 依赖不可用；"
+        "worker 出现重试与队列深度升高。建议优先核对上游依赖可用性，并按 service、level 和 node 继续扩大时间窗口观察。",
+        7.0,
+        1.2,
+        _usage(620, 210, cache_read=256),
+    ),
+)
+
+TOOL_STEPS = (
+    ToolStep(
+        "activate_skill",
+        {"skill_name": "log-analysis"},
+        {"status": "activated", "capabilities": ["search_logs", "aggregate_logs"]},
+        0.2,
+    ),
+    ToolStep(
+        "inspect_log_fields",
+        {"index_set_id": "<INDEX_SET_ID>"},
+        {"fields": ["timestamp", "level", "service", "node", "message"]},
+        0.3,
+    ),
+    ToolStep(
+        "search_logs",
+        {"bk_biz_id": "<BK_BIZ_ID>", "index_set_id": "<INDEX_SET_ID>", "time_range": "24h", "size": 10},
+        {"total": 10, "records": SANITIZED_LOGS},
+        12.0,
+    ),
+    ToolStep(
+        "aggregate_logs",
+        {"dimensions": ["level", "service"]},
+        {"level": {"ERROR": 2, "WARN": 3, "INFO": 5}, "service": {"api": 4, "worker": 3, "scheduler": 3}},
+        0.8,
+    ),
+)
+
+
+def _serialized_size(event_type: str, payload: Any) -> int:
+    return len(json.dumps({"type": event_type, "payload": payload}, ensure_ascii=False, separators=(",", ":")).encode())
+
+
+def _append_text_events(events: list[MockSseEvent], prefix: str, text: str, chunk_size: int = 12) -> None:
+    events.append(MockSseEvent(f"{prefix}_START", _serialized_size(f"{prefix}_START", {})))
+    for offset in range(0, len(text), chunk_size):
+        chunk = text[offset : offset + chunk_size]
+        events.append(MockSseEvent(f"{prefix}_CONTENT", _serialized_size(f"{prefix}_CONTENT", {"delta": chunk})))
+    events.append(MockSseEvent(f"{prefix}_END", _serialized_size(f"{prefix}_END", {})))
+
+
+def build_sanitized_sse_events() -> list[MockSseEvent]:
+    """Build a realistic AG-UI event mix without retaining source conversation data."""
+    events = [MockSseEvent("RUN_STARTED", _serialized_size("RUN_STARTED", {}))]
+    for index, model_step in enumerate(MODEL_STEPS):
+        prefix = "TEXT_MESSAGE" if index == len(MODEL_STEPS) - 1 else "THINKING_TEXT_MESSAGE"
+        _append_text_events(events, prefix, model_step.output)
+        if index < len(TOOL_STEPS):
+            tool = TOOL_STEPS[index]
+            for event_type, payload in (
+                ("TOOL_CALL_START", {"tool": tool.name}),
+                ("TOOL_CALL_ARGS", tool.arguments),
+                ("TOOL_CALL_END", {"tool": tool.name}),
+                ("TOOL_CALL_RESULT", tool.output),
+            ):
+                events.append(MockSseEvent(event_type, _serialized_size(event_type, payload)))
+    events.append(MockSseEvent("RUN_FINISHED", _serialized_size("RUN_FINISHED", {"status": "completed"})))
+    return events
+
+
+def coalesce_content_events(events: list[MockSseEvent]) -> list[int]:
+    """Approximate the handler's consecutive text-content coalescing."""
+    physical_sizes: list[int] = []
+    buffered_size = 0
+    for event in events:
+        if event.event_type in {"TEXT_MESSAGE_CONTENT", "THINKING_TEXT_MESSAGE_CONTENT"}:
+            buffered_size += event.size
+            continue
+        if buffered_size:
+            physical_sizes.append(buffered_size)
+            buffered_size = 0
+        physical_sizes.append(event.size)
+    if buffered_size:
+        physical_sizes.append(buffered_size)
+    return physical_sizes
+
+
+def selected_handlers(handler_type: str) -> tuple[str, ...]:
+    if handler_type == "all":
+        return tuple(HANDLER_SYSTEMS)
+    if handler_type not in HANDLER_SYSTEMS:
+        raise ValueError(f"Unsupported message handler: {handler_type}")
+    return (handler_type,)
+
+
+def selected_models(value: str) -> tuple[str, ...]:
+    models = tuple(dict.fromkeys(model.strip() for model in value.split(",") if model.strip()))
+    if not models:
+        raise ValueError("At least one mock model is required")
+    return models
+
+
+def sample_handler_runs(
+    handlers: tuple[str, ...],
+    max_concurrency: int,
+    rng: random.Random,
+) -> dict[str, int]:
+    return {handler_type: rng.randint(1, max_concurrency) for handler_type in handlers}
+
+
+def assigned_models(models: tuple[str, ...], run_count: int) -> tuple[str, ...]:
+    return tuple(models[index % len(models)] for index in range(run_count))
+
+
+def mock_error_case(handler_index: int, slot_index: int, run_index: int) -> str:
+    """Select reproducible success and error cases across handlers, slots and runs."""
+    return MOCK_ERROR_CASES[(handler_index * 3 + slot_index + run_index) % len(MOCK_ERROR_CASES)]
+
+
+def _scaled_durations(base_durations: tuple[float, ...], total: float, rng: random.Random) -> tuple[float, ...]:
+    weights = tuple(base_duration * rng.uniform(0.5, 1.5) for base_duration in base_durations)
+    weight_sum = sum(weights)
+    return tuple(total * weight / weight_sum for weight in weights)
+
+
+def build_scenario_timings(rng: random.Random) -> ScenarioTimings:
+    agent_duration = rng.uniform(30.0, 120.0)
+    llm_total = agent_duration * rng.uniform(0.5, 0.7)
+    tool_total = agent_duration * rng.uniform(0.08, 0.18)
+    llm_durations = _scaled_durations(tuple(step.duration for step in MODEL_STEPS), llm_total, rng)
+    tool_durations = _scaled_durations(tuple(step.duration for step in TOOL_STEPS), tool_total, rng)
+    first_chunk_durations = tuple(
+        min(duration * 0.8, step.time_to_first_chunk * rng.uniform(0.5, 1.5))
+        for step, duration in zip(MODEL_STEPS, llm_durations, strict=True)
+    )
+    return ScenarioTimings(
+        agent_duration=agent_duration,
+        llm_durations=llm_durations,
+        llm_first_chunk_durations=first_chunk_durations,
+        tool_durations=tool_durations,
+        processing_duration=agent_duration - llm_total - tool_total,
+    )
+
+
+def build_scenario_stages(timings: ScenarioTimings) -> tuple[ScenarioStage, ...]:
+    """Build an exclusive wall-clock phase sequence for one realistic Agent Run."""
+    operation_order = (
+        ("llm", 0),
+        ("tool", 0),
+        ("llm", 1),
+        ("tool", 1),
+        ("llm", 2),
+        ("tool", 2),
+        ("llm", 3),
+        ("tool", 3),
+        ("llm", 4),
+        ("llm", 5),
+    )
+    finalizing_duration = timings.processing_duration * 0.1
+    processing_slice = (timings.processing_duration - finalizing_duration) / len(operation_order)
+    stages: list[ScenarioStage] = []
+    for phase, operation_index in operation_order:
+        stages.append(ScenarioStage("processing", processing_slice))
+        duration = timings.llm_durations[operation_index] if phase == "llm" else timings.tool_durations[operation_index]
+        stages.append(ScenarioStage(phase, duration, operation_index))
+    stages.append(ScenarioStage("finalizing", finalizing_duration))
+    return tuple(stages)
+
+
+def _llm_attributes(agent_attrs: dict[str, str], model_name: str) -> dict[str, str]:
+    return {
+        **agent_attrs,
+        "gen_ai.request.model": model_name,
+        "gen_ai.response.model": f"{model_name}-routed",
+    }
+
+
+def _record_scenario_output(
+    recorder: AgentMetrics,
+    handler_type: str,
+    rng: random.Random,
+    error: BaseException | None = None,
+) -> None:
+    messaging_system = HANDLER_SYSTEMS[handler_type]
+    message_attrs = {"aidev.message.handler.type": handler_type, "messaging.system": messaging_system}
+    events = build_sanitized_sse_events()
+    for _event in events:
+        recorder.record_sse_event(message_attrs)
+    physical_sizes = coalesce_content_events(events)
+    recorder.record_message_publish(
+        handler_type=handler_type,
+        messaging_system=messaging_system,
+        event_count=len(events),
+        message_sizes=physical_sizes,
+        duration=rng.uniform(0.008, 0.03) + len(physical_sizes) * 0.0002,
+        error=error,
+    )
+
+
+def _record_initial_error_samples(
+    recorder: AgentMetrics,
+    agent_attrs: dict[str, str],
+    handlers: tuple[str, ...],
+    models: tuple[str, ...],
+) -> None:
+    """Make every error source visible before the first 30-120s Agent run completes."""
+    recorder.record_agent(0.05, 0, agent_attrs, error=MockAgentExecutionError("mock Agent execution failed"))
+    recorder.record_llm(
+        0.04,
+        _llm_attributes(agent_attrs, models[0]),
+        error=MockLlmTimeoutError("mock LLM request timed out"),
+    )
+    recorder.record_tool(
+        0.03,
+        {
+            **agent_attrs,
+            "gen_ai.tool.name": TOOL_STEPS[0].name,
+            "gen_ai.tool.type": "function",
+        },
+        error=MockToolInvocationError("mock tool invocation failed"),
+    )
+    for handler_type in handlers:
+        recorder.record_message_publish(
+            handler_type=handler_type,
+            messaging_system=HANDLER_SYSTEMS[handler_type],
+            event_count=0,
+            message_sizes=[],
+            duration=0.02,
+            error=MockHandlerPublishError("mock Handler publish failed"),
+        )
+
+
+def _run_scenario(
+    recorder: AgentMetrics,
+    agent_attrs: dict[str, str],
+    handler_type: str,
+    model_name: str,
+    rng: random.Random,
+    stop_event: threading.Event,
+    error_case: str = "success",
+) -> None:
+    """Run one scenario in real wall-clock time so concurrency, rate and latency stay coherent."""
+    timings = build_scenario_timings(rng)
+    stages = build_scenario_stages(timings)
+    llm_attrs = _llm_attributes(agent_attrs, model_name)
+    agent_started_at = time.monotonic()
+    current_phase: str | None = None
+    phase_started_at: float | None = None
+    active_llm_attrs: dict[str, str] | None = None
+    active_tool_attrs: dict[str, str] | None = None
+    first_agent_token_seen = False
+    completed = False
+
+    def transition_phase(phase: str) -> None:
+        nonlocal current_phase, phase_started_at
+        if current_phase == phase:
+            return
+        transitioned_at = time.monotonic()
+        if current_phase is not None and phase_started_at is not None:
+            recorder.record_agent_phase_duration(transitioned_at - phase_started_at, current_phase, agent_attrs)
+            recorder.record_agent_phase_active(-1, current_phase, agent_attrs)
+        current_phase = phase
+        phase_started_at = transitioned_at
+        recorder.record_agent_phase_active(1, phase, agent_attrs)
+
+    def finish_phase() -> None:
+        nonlocal current_phase, phase_started_at
+        if current_phase is None:
+            return
+        finished_at = time.monotonic()
+        if phase_started_at is not None:
+            recorder.record_agent_phase_duration(finished_at - phase_started_at, current_phase, agent_attrs)
+        recorder.record_agent_phase_active(-1, current_phase, agent_attrs)
+        current_phase = None
+        phase_started_at = None
+
+    recorder.record_agent_started(agent_attrs)
+    recorder.record_active_agent(1, agent_attrs)
+    try:
+        for stage in stages:
+            transition_phase(stage.phase)
+            stage_started_at = time.monotonic()
+            if stage.phase in {"processing", "finalizing"}:
+                if stop_event.wait(stage.duration):
+                    return
+                continue
+
+            if stage.phase == "llm":
+                active_llm_attrs = llm_attrs
+                recorder.record_active_llm(1, active_llm_attrs)
+                first_chunk_duration = timings.llm_first_chunk_durations[stage.operation_index or 0]
+                if stop_event.wait(first_chunk_duration):
+                    return
+                recorder.record_first_llm_chunk(time.monotonic() - stage_started_at, llm_attrs)
+                if not first_agent_token_seen:
+                    first_agent_token_seen = True
+                    recorder.record_agent_first_token(time.monotonic() - agent_started_at, agent_attrs)
+                if stop_event.wait(max(0, stage.duration - first_chunk_duration)):
+                    return
+                llm_duration = time.monotonic() - stage_started_at
+                llm_error = (
+                    MockLlmTimeoutError("mock LLM request timed out")
+                    if error_case == "llm" and stage.operation_index == 0
+                    else None
+                )
+                recorder.record_llm(llm_duration, llm_attrs, error=llm_error)
+                recorder.record_active_llm(-1, active_llm_attrs)
+                active_llm_attrs = None
+                continue
+
+            step = TOOL_STEPS[stage.operation_index or 0]
+            active_tool_attrs = {
+                **agent_attrs,
+                "gen_ai.tool.name": step.name,
+                "gen_ai.tool.type": "function",
+            }
+            recorder.record_active_tool(1, active_tool_attrs)
+            if stop_event.wait(stage.duration):
+                return
+            tool_duration = time.monotonic() - stage_started_at
+            tool_error = (
+                MockToolInvocationError("mock tool invocation failed")
+                if error_case == "tool" and stage.operation_index == 0
+                else None
+            )
+            recorder.record_tool(tool_duration, active_tool_attrs, error=tool_error)
+            recorder.record_active_tool(-1, active_tool_attrs)
+            active_tool_attrs = None
+        completed = True
+    finally:
+        if active_llm_attrs is not None:
+            recorder.record_active_llm(-1, active_llm_attrs)
+        if active_tool_attrs is not None:
+            recorder.record_active_tool(-1, active_tool_attrs)
+        finish_phase()
+        if completed:
+            agent_duration = time.monotonic() - agent_started_at
+            recorder.record_agent(
+                agent_duration,
+                len(MODEL_STEPS),
+                agent_attrs,
+                error=(MockAgentExecutionError("mock Agent execution failed") if error_case == "agent" else None),
+            )
+            _record_scenario_output(
+                recorder,
+                handler_type,
+                rng,
+                error=(MockHandlerPublishError("mock Handler publish failed") if error_case == "handler" else None),
+            )
+        recorder.record_active_agent(-1, agent_attrs)
+
+
+def _worker_loop(
+    *,
+    recorder: AgentMetrics,
+    agent_attrs: dict[str, str],
+    handler_type: str,
+    handler_index: int,
+    slot_index: int,
+    concurrency: int,
+    models: tuple[str, ...],
+    seed: int,
+    interval: float,
+    stop_event: threading.Event,
+) -> None:
+    rng = random.Random(seed + handler_index * 1000 + slot_index * 100)
+    run_index = 0
+    while not stop_event.is_set():
+        if slot_index > 0 and stop_event.wait(rng.uniform(interval, max(interval * 8, 4.0))):
+            return
+        model_index = handler_index * concurrency + slot_index + run_index
+        _run_scenario(
+            recorder,
+            agent_attrs,
+            handler_type,
+            models[model_index % len(models)],
+            rng,
+            stop_event,
+            error_case=mock_error_case(handler_index, slot_index, run_index),
+        )
+        run_index += 1
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Emit concurrent mock metrics for all Agent message handlers.")
+    parser.add_argument(
+        "-n",
+        "--concurrency",
+        type=int,
+        default=int(os.getenv("AIDEV_MOCK_CONCURRENCY", "3")),
+        help="Maximum concurrent Agent runs per handler (default: 3; minimum is always 1).",
+    )
+    parser.add_argument(
+        "--handler",
+        choices=("all", *HANDLER_SYSTEMS),
+        default=os.getenv("AIDEV_MOCK_MESSAGE_HANDLER", "all"),
+        help="Message handler to simulate (default: all).",
+    )
+    parser.add_argument(
+        "--models",
+        type=selected_models,
+        default=selected_models(os.getenv("AIDEV_MOCK_MODELS", ",".join(DEFAULT_MODELS))),
+        metavar="MODEL_A,MODEL_B,...",
+        help="Comma-separated mock model names (default: three models).",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=int(os.getenv("AIDEV_MOCK_RANDOM_SEED", "20260809")),
+        help="Seed used to vary active runs reproducibly.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=int(os.getenv("AIDEV_MOCK_ITERATIONS", "10")),
+        help="Number of metric batches (default: 10).",
+    )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=float(os.getenv("AIDEV_MOCK_INTERVAL_SECONDS", "1.5")),
+        help="Seconds between metric batches (default: 1.5).",
+    )
+    args = parser.parse_args()
+    if args.concurrency < 1:
+        parser.error("--concurrency must be at least 1")
+    if args.iterations < 1:
+        parser.error("--iterations must be at least 1")
+    if args.interval < 0.1:
+        parser.error("--interval must be at least 0.1")
+    return args
+
+
+def main() -> None:
+    args = _parse_args()
+    endpoint = os.getenv("AIDEV_LOCAL_OTLP_ENDPOINT", "http://localhost:4318")
+    handlers = selected_handlers(args.handler)
+    service = BkPluginMetricService(
+        service_name="aidev-agent-local",
+        endpoints=[{"url": endpoint, "token": "", "exporter_type": ExporterType.HTTP}],
+        agent_info={
+            "agent_code": "ai-agent-local-demo",
+            "agent_name": "本地指标验证智能体",
+            "agent_sdk_version": "2.2.3",
+        },
+        settings=MetricExportSettings(
+            enabled=True,
+            export_interval_millis=1000,
+            export_timeout_millis=5000,
+            export_via_celery=False,
+        ),
+    )
+    service.start()
+
+    configure_metric_identity("ai-agent-local-demo", "本地指标验证智能体", "2.2.3")
+    recorder = AgentMetrics()
+    agent_attrs = recorder.agent_attributes("ai-agent-local-demo", "本地指标验证智能体", "2.2.3")
+    _record_initial_error_samples(recorder, agent_attrs, handlers, args.models)
+    print(f"Sanitized scenario: {SANITIZED_PROMPT}")
+    print("Mock tools: " + ", ".join(step.name for step in TOOL_STEPS))
+    print(
+        f"Mock handlers: {', '.join(handlers)}; active runs per handler: 1-{args.concurrency}; "
+        f"total active range: {len(handlers)}-{len(handlers) * args.concurrency}"
+    )
+    print("Mock models: " + ", ".join(args.models))
+    print("Mock outcomes: " + ", ".join(MOCK_ERROR_CASES) + "; error.type is the mock exception class name")
+    print(
+        f"Real wall-clock lifecycle: {args.iterations} ticks x {args.interval:.1f}s; "
+        "each completed Agent Run lasts 30-120s"
+    )
+    stop_event = threading.Event()
+    try:
+        with ThreadPoolExecutor(max_workers=len(handlers) * args.concurrency) as executor:
+            futures = [
+                executor.submit(
+                    _worker_loop,
+                    recorder=recorder,
+                    agent_attrs=agent_attrs,
+                    handler_type=handler_type,
+                    handler_index=handler_index,
+                    slot_index=slot_index,
+                    concurrency=args.concurrency,
+                    models=args.models,
+                    seed=args.seed,
+                    interval=args.interval,
+                    stop_event=stop_event,
+                )
+                for handler_index, handler_type in enumerate(handlers)
+                for slot_index in range(args.concurrency)
+            ]
+            try:
+                for _ in range(args.iterations):
+                    if stop_event.wait(args.interval):
+                        break
+            except KeyboardInterrupt:
+                pass
+            finally:
+                stop_event.set()
+            for future in futures:
+                future.result()
+    finally:
+        stop_event.set()
+        if service.provider is not None:
+            service.provider.force_flush(timeout_millis=5000)
+        service.stop()
+    print("Mock metrics exported. Open http://localhost:3000/d/aidev-agent-metrics")
+
+
+if __name__ == "__main__":
+    main()

--- a/dev/otel/otel-collector-config.yaml
+++ b/dev/otel/otel-collector-config.yaml
@@ -1,0 +1,26 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch: {}
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheus:
+    endpoint: 0.0.0.0:8889
+    enable_open_metrics: true
+    resource_to_telemetry_conversion:
+      enabled: true
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, debug]

--- a/dev/otel/prometheus.yml
+++ b/dev/otel/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 2s
+  evaluation_interval: 2s
+
+scrape_configs:
+  - job_name: aidev-agent-otel
+    static_configs:
+      - targets: ["otel-collector:8889"]

--- a/dev/otel/tests/test_local_observability.py
+++ b/dev/otel/tests/test_local_observability.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import json
+import random
+from pathlib import Path
+
+import pytest
+
+from dev.otel.mock_agent_metrics import (
+    DEFAULT_MODELS,
+    HANDLER_SYSTEMS,
+    MOCK_ERROR_CASES,
+    SANITIZED_LOGS,
+    SANITIZED_PROMPT,
+    TOOL_STEPS,
+    assigned_models,
+    build_sanitized_sse_events,
+    build_scenario_stages,
+    build_scenario_timings,
+    coalesce_content_events,
+    mock_error_case,
+    sample_handler_runs,
+    selected_handlers,
+    selected_models,
+)
+
+OTEL_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_local_dashboard_covers_required_filters_and_metric_groups():
+    dashboard = json.loads((OTEL_ROOT / "grafana/dashboards/aidev-agent-metrics.json").read_text())
+    variables = {item["name"] for item in dashboard["templating"]["list"]}
+    panels_by_id = {panel["id"]: panel for panel in dashboard["panels"]}
+    panel_queries = "\n".join(target["expr"] for panel in dashboard["panels"] for target in panel.get("targets", []))
+
+    for panel in dashboard["panels"]:
+        if panel.get("type") == "row":
+            continue
+        assert panel.get("description", "").startswith("含义：")
+        assert "计算：" in panel["description"]
+
+    assert variables == {
+        "agent_code",
+        "agent_version",
+        "request_model",
+        "response_model",
+        "tool_name",
+        "handler_type",
+    }
+    for metric in (
+        "aidev_agent_phase_active",
+        "aidev_agent_phase_duration",
+        "gen_ai_invoke_agent_time_to_first_token",
+        "gen_ai_client_operation_active",
+        "gen_ai_execute_tool_active",
+        "aidev_sse_event_count",
+        "aidev_message_publish_count",
+        "aidev_message_publish_size",
+    ):
+        assert metric in panel_queries
+
+    assert 8 not in panels_by_id
+    assert panels_by_id[1]["title"] == "活跃 Agent Run"
+    assert "sum(aidev_agent_active" in panels_by_id[1]["targets"][0]["expr"]
+    assert "or vector(0)" in panels_by_id[1]["targets"][0]["expr"]
+    assert panels_by_id[30]["title"] == "活跃智能体数量"
+    assert "or vector(0)" in panels_by_id[2]["targets"][0]["expr"]
+    assert "or vector(0)" in panels_by_id[3]["targets"][0]["expr"]
+    assert panels_by_id[30]["gridPos"]["x"] == 0
+    assert panels_by_id[1]["gridPos"]["x"] == 4
+    assert "sum by (agent_info_code)" in panels_by_id[30]["targets"][0]["expr"]
+    assert "or vector(0)" in panels_by_id[30]["targets"][0]["expr"]
+    assert panels_by_id[7]["type"] == "timeseries"
+    assert panels_by_id[7]["title"] == "Agent 阶段并发（当前与趋势）"
+    assert panels_by_id[11]["title"] == "Agent 阶段耗时 P95（已结束阶段）"
+    assert len(panels_by_id[11]["targets"]) == 1
+    assert panels_by_id[10]["title"] == "Agent 墙钟耗时 P95"
+    assert len(panels_by_id[10]["targets"]) == 1
+    assert panels_by_id[32]["title"] == "Agent 首 Token P95（流式调用，按 Agent Code）"
+    assert panels_by_id[32]["type"] == "timeseries"
+    assert "sum by (le, agent_info_code)" in panels_by_id[32]["targets"][0]["expr"]
+    assert "gen_ai_invoke_agent_time_to_first_token_seconds_bucket" in panels_by_id[32]["targets"][0]["expr"]
+    assert panels_by_id[32]["gridPos"] == {"h": 8, "w": 12, "x": 12, "y": 23}
+    assert panels_by_id[12]["gridPos"] == {"h": 8, "w": 24, "x": 0, "y": 31}
+    assert panels_by_id[16]["title"].startswith("LLM 并发")
+    for panel_id in (2, 14, 16):
+        assert all("gen_ai_response_model" not in target["expr"] for target in panels_by_id[panel_id]["targets"])
+    for panel_id in (13, 15):
+        assert any("gen_ai_response_model" in target["expr"] for target in panels_by_id[panel_id]["targets"])
+    assert panels_by_id[29]["title"].startswith("工具并发")
+    assert panels_by_id[29]["gridPos"]["w"] == 24
+    assert 19 not in panels_by_id
+    assert 17 not in panels_by_id
+    assert len(panels_by_id[18]["targets"]) == 1
+    for panel in dashboard["panels"]:
+        if panel.get("type") != "timeseries":
+            continue
+        for target in panel.get("targets", []):
+            if "histogram_quantile" not in target["expr"]:
+                continue
+            assert "P95" in panel["title"]
+            assert "histogram_quantile(0.95" in target["expr"]
+            assert "P95" in target["legendFormat"]
+    assert panels_by_id[20]["options"]["legend"]["sortBy"] == "Name"
+    assert panels_by_id[20]["options"]["tooltip"]["sort"] == "none"
+    assert all("aidev_message_publish_event_count.*_total" in target["expr"] for target in panels_by_id[20]["targets"])
+    assert all(
+        "aidev_message_publish_event_count.*_sum" not in target["expr"] for target in panels_by_id[20]["targets"]
+    )
+    assert [target["refId"] for target in panels_by_id[20]["targets"]] == ["A", "B", "C", "D", "E"]
+    assert panels_by_id[21]["title"] == "Handler 分布（所选时段）"
+    assert panels_by_id[21]["type"] == "bargauge"
+    assert panels_by_id[21]["fieldConfig"]["defaults"]["unit"] == "percentunit"
+    assert [target["refId"] for target in panels_by_id[21]["targets"]] == ["A", "B", "C", "D", "E"]
+    assert all(target["instant"] is True for target in panels_by_id[21]["targets"])
+    assert all("aidev_message_publish_count" in target["expr"] for target in panels_by_id[21]["targets"])
+    assert all(
+        "sum by (aidev_message_handler_type, agent_info_code)" in target["expr"]
+        for target in panels_by_id[21]["targets"]
+    )
+    assert all("count by (aidev_message_handler_type)" in target["expr"] for target in panels_by_id[21]["targets"])
+    assert all("aidev_message_publish_event_count" not in target["expr"] for target in panels_by_id[21]["targets"])
+    assert panels_by_id[104]["title"] == "SSE 输出与物理消息"
+    assert panels_by_id[106]["title"] == "Broker 发布侧"
+    assert 27 not in panels_by_id
+    assert panels_by_id[105]["gridPos"]["y"] == 99
+    assert panels_by_id[28]["gridPos"]["y"] == 100
+    assert [target["legendFormat"] for target in panels_by_id[28]["targets"]] == [
+        "Agent · {{error_type}}",
+        "LLM · {{error_type}}",
+        "Tool · {{error_type}}",
+        "Handler · {{error_type}}",
+    ]
+    assert all('error_type!=""' in target["expr"] for target in panels_by_id[28]["targets"])
+    assert 26 not in panels_by_id
+    assert panels_by_id[25]["title"] == "SSE 事件与物理消息数量"
+    assert panels_by_id[25]["gridPos"]["y"] == panels_by_id[31]["gridPos"]["y"] == 74
+    assert [target["refId"] for target in panels_by_id[25]["targets"]] == ["A", "B", "C", "D", "E"]
+    assert panels_by_id[25]["type"] == "timeseries"
+    assert all(target["range"] is True for target in panels_by_id[25]["targets"])
+    assert all("aidev_sse_event_type" not in target["expr"] for target in panels_by_id[25]["targets"])
+    assert [
+        next(
+            handler
+            for handler in ("inmemory", "rabbitmq", "rabbitmq_stream", "redis")
+            if f'="{handler}"' in target["expr"]
+        )
+        for target in panels_by_id[25]["targets"][:4]
+    ] == ["inmemory", "rabbitmq", "rabbitmq_stream", "redis"]
+    assert panels_by_id[25]["options"]["legend"]["sortBy"] == "Name"
+    assert panels_by_id[25]["options"]["legend"]["sortDesc"] is False
+    assert panels_by_id[31]["title"] == "SSE/物理消息压缩比"
+    assert panels_by_id[31]["type"] == "timeseries"
+    assert [target["refId"] for target in panels_by_id[31]["targets"]] == ["A", "B", "C", "D", "E"]
+    assert all(target["range"] is True for target in panels_by_id[31]["targets"])
+    assert panels_by_id[31]["options"]["legend"]["sortBy"] == "Name"
+    assert "aidev_sse_event_count" in panels_by_id[31]["targets"][0]["expr"]
+    assert "aidev_message_publish_count" in panels_by_id[31]["targets"][0]["expr"]
+    assert panels_by_id[20]["gridPos"]["y"] == panels_by_id[21]["gridPos"]["y"] == 83
+    panel_order = [panel["id"] for panel in dashboard["panels"]]
+    assert panel_order.index(104) < panel_order.index(25) < panel_order.index(106) < panel_order.index(20)
+
+
+def test_log_query_mock_is_sanitized_and_models_broker_coalescing():
+    assert SANITIZED_PROMPT.count("<BK_BIZ_ID>") == 1
+    assert SANITIZED_PROMPT.count("<INDEX_SET_ID>") == 1
+    assert len(SANITIZED_LOGS) == 10
+    assert [step.name for step in TOOL_STEPS] == [
+        "activate_skill",
+        "inspect_log_fields",
+        "search_logs",
+        "aggregate_logs",
+    ]
+
+    events = build_sanitized_sse_events()
+    physical_sizes = coalesce_content_events(events)
+
+    assert any(event.event_type == "TOOL_CALL_RESULT" for event in events)
+    assert len(physical_sizes) < len(events)
+    assert sum(physical_sizes) == sum(event.size for event in events)
+
+
+@pytest.mark.parametrize(
+    ("handler_type", "expected"),
+    [
+        ("all", tuple(HANDLER_SYSTEMS)),
+        ("redis", ("redis",)),
+    ],
+)
+def test_log_query_mock_selects_handlers(handler_type, expected):
+    assert selected_handlers(handler_type) == expected
+
+
+def test_log_query_mock_varies_active_runs_between_one_and_maximum_per_handler():
+    handlers = selected_handlers("all")
+    rng = random.Random(20260809)
+    samples = [sample_handler_runs(handlers, 3, rng) for _ in range(20)]
+
+    assert all(set(sample) == set(handlers) for sample in samples)
+    assert all(1 <= count <= 3 for sample in samples for count in sample.values())
+    assert all(4 <= sum(sample.values()) <= 12 for sample in samples)
+    assert len({sum(sample.values()) for sample in samples}) > 1
+
+
+def test_log_query_mock_distributes_active_runs_across_three_default_models():
+    assignments = assigned_models(DEFAULT_MODELS, 12)
+
+    assert len(assignments) == 12
+    assert {model: assignments.count(model) for model in DEFAULT_MODELS} == {
+        "mock-log-analysis-a": 4,
+        "mock-log-analysis-b": 4,
+        "mock-log-analysis-c": 4,
+    }
+
+
+def test_log_query_mock_accepts_custom_models_and_removes_duplicates():
+    assert selected_models("mock-a, mock-b,mock-a") == ("mock-a", "mock-b")
+
+
+def test_log_query_mock_cycles_success_and_distinct_error_sources():
+    cases = {
+        mock_error_case(handler_index, slot_index, run_index)
+        for handler_index in range(4)
+        for slot_index in range(3)
+        for run_index in range(5)
+    }
+
+    assert cases == set(MOCK_ERROR_CASES)
+    assert MOCK_ERROR_CASES == ("success", "agent", "llm", "tool", "handler")
+
+
+def test_log_query_mock_randomizes_stage_durations_within_agent_total():
+    rng = random.Random(20260810)
+    samples = [build_scenario_timings(rng) for _ in range(50)]
+
+    assert all(30 <= sample.agent_duration <= 120 for sample in samples)
+    assert all(len(sample.llm_durations) == 6 and len(sample.tool_durations) == 4 for sample in samples)
+    assert all(
+        sum(sample.llm_durations) + sum(sample.tool_durations) + sample.processing_duration
+        == pytest.approx(sample.agent_duration)
+        for sample in samples
+    )
+    assert all(
+        0 < first_chunk_duration <= llm_duration
+        for sample in samples
+        for first_chunk_duration, llm_duration in zip(
+            sample.llm_first_chunk_durations,
+            sample.llm_durations,
+            strict=True,
+        )
+    )
+    assert len({round(sample.agent_duration, 3) for sample in samples}) == len(samples)
+
+
+def test_log_query_mock_builds_exclusive_real_time_agent_phases():
+    timings = build_scenario_timings(random.Random(20260810))
+    stages = build_scenario_stages(timings)
+
+    assert sum(stage.duration for stage in stages) == pytest.approx(timings.agent_duration)
+    assert stages[-1].phase == "finalizing"
+    assert {stage.phase for stage in stages} == {"processing", "llm", "tool", "finalizing"}

--- a/dev/otel/tests/test_local_observability.py
+++ b/dev/otel/tests/test_local_observability.py
@@ -29,9 +29,17 @@ OTEL_ROOT = Path(__file__).resolve().parents[1]
 
 def test_local_dashboard_covers_required_filters_and_metric_groups():
     dashboard = json.loads((OTEL_ROOT / "grafana/dashboards/aidev-agent-metrics.json").read_text())
+    compose = (OTEL_ROOT / "docker-compose.yml").read_text()
     variables = {item["name"] for item in dashboard["templating"]["list"]}
     panels_by_id = {panel["id"]: panel for panel in dashboard["panels"]}
-    panel_queries = "\n".join(target["expr"] for panel in dashboard["panels"] for target in panel.get("targets", []))
+    panel_queries = "\n".join(
+        target["expr"] for panel in dashboard["panels"] for target in panel.get("targets", []) if target.get("expr")
+    )
+
+    assert "grafana/grafana:10.4.19" in compose
+    assert dashboard["schemaVersion"] == 39
+    assert dashboard["graphTooltip"] == 1
+    assert len(dashboard["panels"]) == 34
 
     for panel in dashboard["panels"]:
         if panel.get("type") == "row":

--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -39,6 +39,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 from aidev_agent.pydantic_models import ExecuteKwargs
 
+from .metrics import AgentMetrics, extract_token_usage, get_agent_metrics
 from .span_utils import (
     SpanHolder,
     set_chat_request,
@@ -236,17 +237,20 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         *,
         enabled: bool = True,
         enable_traces: bool = True,
+        enable_metrics: bool = False,
         debug: bool = False,
         max_attribute_length: int = 4096,
         agent_id: Optional[str] = None,
         agent_code: Optional[str] = None,
         agent_name: Optional[str] = None,
+        agent_sdk_version: Optional[str] = None,
         session_code: Optional[str] = None,
         caller_executor: Optional[str] = None,
         injector: Optional["BkAidevAgentInjector"] = None,
         start_inputs: Any = None,
         start_execute_kwargs: Optional[ExecuteKwargs] = None,
         start_agent_info: Optional[Dict[str, Any]] = None,
+        metric_recorder: Optional[AgentMetrics] = None,
     ):
         """
         初始化 Trace 收集器
@@ -256,11 +260,13 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             parent_trace_context: 父级 Trace Context (用于跨服务传播)
             enabled: 是否启用追踪，默认 True
             enable_traces: 是否启用 traces，默认 True
+            enable_metrics: 是否启用 metrics，默认 False
             debug: 是否为调试状态
             max_attribute_length: 属性值最大长度，默认 4096
             agent_id: agent.info.id
             agent_code: agent.info.code
             agent_name: agent.info.name
+            agent_sdk_version: agent.info.sdk_version
             session_code: agent.session.session_code
             caller_executor: agent.session.caller_executor
             injector: 可选的 BkAidevAgentInjector 实例。本 handler 会在顶层 chain
@@ -281,6 +287,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         # 配置项
         self.enabled = enabled
         self.enable_traces = enable_traces
+        self.enable_metrics = enable_metrics
         self.debug = debug
         self.max_attribute_length = max_attribute_length
 
@@ -313,6 +320,22 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         # 工具调用计数器
         self.tool_call_counter = 0
         self.rag_call_counter = 0
+        self.inference_call_counter = 0
+
+        # Metric state uses monotonic clocks and contains no session/user data.
+        self._metrics = metric_recorder or (get_agent_metrics() if enable_metrics else None)
+        self._metric_agent_attributes = AgentMetrics.agent_attributes(agent_code, agent_name, agent_sdk_version)
+        self._agent_started_at: float | None = None
+        self._llm_started_at: Dict[UUID, float] = {}
+        self._llm_active_attributes: Dict[UUID, Dict[str, str]] = {}
+        self._llm_first_chunk_seen: set[UUID] = set()
+        self._tool_started_at: Dict[UUID, float] = {}
+        self._tool_metric_attributes: Dict[UUID, Dict[str, str]] = {}
+        self._active_llm_operation_count = 0
+        self._active_tool_operation_count = 0
+        self._agent_phase: str | None = None
+        self._agent_phase_started_at: float | None = None
+        self._agent_first_token_seen = False
 
         # Token 用量累加计数器（一个 handler 生命周期 = 一轮 Agent 执行，与 root span 对齐）
         self._total_input_tokens = 0
@@ -346,12 +369,98 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         - 顶层 chain 异常结束（``on_chain_error``）
         - 顶层 chain 因流式上游关闭而抛 GeneratorExit（视为正常结束）
         """
-        if self._injector is None or self._injector_ended:
+        if self._injector_ended:
             return
+        self._transition_agent_phase("finalizing")
+        self._finish_active_metric_operations()
         try:
-            self._injector.on_bk_agent_end(error=error)
+            if self._injector is not None:
+                self._injector.on_bk_agent_end(error=error)
         finally:
-            self._injector_ended = True
+            try:
+                if self._metrics is not None and self._agent_started_at is not None:
+                    started_at = self._agent_started_at
+                    self._agent_started_at = None
+                    try:
+                        self._metrics.record_agent(
+                            duration=time.monotonic() - started_at,
+                            inference_calls=self.inference_call_counter,
+                            attributes=self._metric_agent_attributes,
+                            error=error,
+                        )
+                    finally:
+                        try:
+                            self._finish_agent_phase()
+                        finally:
+                            self._metrics.record_active_agent(-1, self._metric_agent_attributes)
+            finally:
+                self._injector_ended = True
+
+    def _operation_phase(self) -> str:
+        if self._active_llm_operation_count and self._active_tool_operation_count:
+            return "mixed"
+        if self._active_tool_operation_count:
+            return "tool"
+        if self._active_llm_operation_count:
+            return "llm"
+        return "processing"
+
+    def _transition_agent_phase(self, phase: str, *, now: float | None = None) -> None:
+        if self._metrics is None or self._agent_started_at is None or self._agent_phase == phase:
+            return
+        transitioned_at = now if now is not None else time.monotonic()
+        previous_phase = self._agent_phase
+        previous_started_at = self._agent_phase_started_at
+        self._agent_phase = phase
+        self._agent_phase_started_at = transitioned_at
+        if previous_phase is not None and previous_started_at is not None:
+            self._metrics.record_agent_phase_duration(
+                max(0, transitioned_at - previous_started_at),
+                previous_phase,
+                self._metric_agent_attributes,
+            )
+            self._metrics.record_agent_phase_active(-1, previous_phase, self._metric_agent_attributes)
+        self._metrics.record_agent_phase_active(1, phase, self._metric_agent_attributes)
+
+    def _finish_agent_phase(self) -> None:
+        if self._metrics is None or self._agent_phase is None:
+            return
+        finished_at = time.monotonic()
+        phase = self._agent_phase
+        phase_started_at = self._agent_phase_started_at
+        self._agent_phase = None
+        self._agent_phase_started_at = None
+        if phase_started_at is not None:
+            self._metrics.record_agent_phase_duration(
+                max(0, finished_at - phase_started_at),
+                phase,
+                self._metric_agent_attributes,
+            )
+        self._metrics.record_agent_phase_active(-1, phase, self._metric_agent_attributes)
+
+    def _finish_active_metric_operations(self) -> None:
+        """Balance active operation gauges when a child callback never reaches its terminal hook."""
+        if self._metrics is None:
+            return
+        for attributes in self._llm_active_attributes.values():
+            self._metrics.record_active_llm(-1, attributes)
+        for attributes in self._tool_metric_attributes.values():
+            self._metrics.record_active_tool(-1, attributes)
+        self._llm_active_attributes.clear()
+        self._tool_metric_attributes.clear()
+        self._llm_started_at.clear()
+        self._tool_started_at.clear()
+        self._llm_first_chunk_seen.clear()
+        self._active_llm_operation_count = 0
+        self._active_tool_operation_count = 0
+
+    def _llm_metric_attributes(self, run_id: UUID, response_model: str | None = None) -> Dict[str, str]:
+        attrs = dict(self._metric_agent_attributes)
+        holder = self.spans.get(run_id)
+        request_model = getattr(holder, "request_model", None) if holder is not None else None
+        attrs["gen_ai.request.model"] = str(request_model or "unknown")
+        attrs["gen_ai.response.model"] = str(response_model or request_model or "unknown")
+        return attrs
 
     def _detach_root_attach_token(self) -> None:
         """detach 顶层 chain start 时为对外可见的 active context attach 的 root span token。
@@ -644,13 +753,19 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
 
         # 顶层 chain 首次触发：先在执行线程上启动 injector 得到 root span。
         # 之后 _create_span 才能通过 self._injector.root_span 把 chain span 挂在 root 下。
-        if is_top_level and self._injector is not None and not self._injector_started:
+        if is_top_level and not self._injector_started:
+            if self._metrics is not None:
+                self._agent_started_at = time.monotonic()
+                self._metrics.record_agent_started(self._metric_agent_attributes)
+                self._metrics.record_active_agent(1, self._metric_agent_attributes)
+                self._transition_agent_phase("processing", now=self._agent_started_at)
             try:
-                self._injector.on_bk_agent_start(
-                    inputs=self._start_inputs,
-                    execute_kwargs=self._start_execute_kwargs,
-                    agent_info=self._start_agent_info,
-                )
+                if self._injector is not None:
+                    self._injector.on_bk_agent_start(
+                        inputs=self._start_inputs,
+                        execute_kwargs=self._start_execute_kwargs,
+                        agent_info=self._start_agent_info,
+                    )
             except Exception:  # noqa: BLE001
                 logger.debug("Failed to call injector.on_bk_agent_start", exc_info=True)
             finally:
@@ -788,7 +903,22 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             metadata=metadata,
             serialized=serialized,
         )
-        set_chat_request(span, serialized, messages, kwargs, self.spans[run_id])
+        set_chat_request(
+            span,
+            serialized,
+            messages,
+            kwargs,
+            self.spans[run_id],
+            max_attribute_length=self.max_attribute_length,
+        )
+        if self._metrics is not None:
+            self.inference_call_counter += 1
+            self._llm_started_at[run_id] = time.monotonic()
+            active_attributes = self._llm_metric_attributes(run_id)
+            self._llm_active_attributes[run_id] = active_attributes
+            self._metrics.record_active_llm(1, active_attributes)
+            self._active_llm_operation_count += 1
+            self._transition_agent_phase(self._operation_phase())
 
     @dont_throw
     async def on_llm_start(
@@ -812,7 +942,47 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             name="llm.generate",
             serialized=serialized,
         )
-        set_llm_request(span, serialized, prompts, kwargs, self.spans[run_id])
+        set_llm_request(
+            span,
+            serialized,
+            prompts,
+            kwargs,
+            self.spans[run_id],
+            max_attribute_length=self.max_attribute_length,
+        )
+        if self._metrics is not None:
+            self.inference_call_counter += 1
+            self._llm_started_at[run_id] = time.monotonic()
+            active_attributes = self._llm_metric_attributes(run_id)
+            self._llm_active_attributes[run_id] = active_attributes
+            self._metrics.record_active_llm(1, active_attributes)
+            self._active_llm_operation_count += 1
+            self._transition_agent_phase(self._operation_phase())
+
+    @dont_throw
+    async def on_llm_new_token(
+        self,
+        token: str,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        """Record TTFT once; token contents are intentionally not metric labels."""
+        if self._metrics is None or run_id in self._llm_first_chunk_seen:
+            return
+        started_at = self._llm_started_at.get(run_id)
+        if started_at is None:
+            return
+        self._llm_first_chunk_seen.add(run_id)
+        first_token_at = time.monotonic()
+        self._metrics.record_first_llm_chunk(first_token_at - started_at, self._llm_metric_attributes(run_id))
+        if not self._agent_first_token_seen and self._agent_started_at is not None:
+            self._agent_first_token_seen = True
+            self._metrics.record_agent_first_token(
+                first_token_at - self._agent_started_at,
+                self._metric_agent_attributes,
+            )
 
     @dont_throw
     async def on_llm_end(
@@ -828,6 +998,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             return
 
         span = self._get_span(run_id)
+        model_name = None
         if response.llm_output is not None:
             model_name = response.llm_output.get("model_name") or response.llm_output.get("model_id")
             if model_name is not None:
@@ -853,7 +1024,33 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             self._total_total_tokens += usage["total_tokens"]
 
         # 提取响应内容
-        set_chat_response(span, response)
+        set_chat_response(span, response, max_attribute_length=self.max_attribute_length)
+        usage = extract_token_usage(response)
+        if usage:
+            _set_span_attribute(
+                span,
+                "gen_ai.usage.cache_creation.input_tokens",
+                usage["cache_creation_input_tokens"],
+            )
+            _set_span_attribute(span, "gen_ai.usage.cache_read.input_tokens", usage["cache_read_input_tokens"])
+            _set_span_attribute(span, "gen_ai.usage.input_tokens", usage["input_tokens"])
+            _set_span_attribute(span, "gen_ai.usage.output_tokens", usage["output_tokens"])
+            _set_span_attribute(span, "gen_ai.usage.total_tokens", usage["total_tokens"])
+        started_at = self._llm_started_at.pop(run_id, None)
+        if self._metrics is not None and started_at is not None:
+            duration = time.monotonic() - started_at
+            try:
+                self._metrics.record_llm(
+                    duration=duration,
+                    attributes=self._llm_metric_attributes(run_id, model_name),
+                )
+            finally:
+                active_attributes = self._llm_active_attributes.pop(run_id, None)
+                if active_attributes is not None:
+                    self._metrics.record_active_llm(-1, active_attributes)
+                    self._active_llm_operation_count = max(0, self._active_llm_operation_count - 1)
+                    self._transition_agent_phase(self._operation_phase())
+        self._llm_first_chunk_seen.discard(run_id)
         # 设置状态为成功
         span.set_status(Status(StatusCode.OK))
         self._end_span(span, run_id)
@@ -877,6 +1074,22 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """LLM 调用出错 - 标记 LLM Span 为错误"""
+        started_at = self._llm_started_at.pop(run_id, None)
+        if self._metrics is not None and started_at is not None:
+            duration = time.monotonic() - started_at
+            try:
+                self._metrics.record_llm(
+                    duration=duration,
+                    attributes=self._llm_metric_attributes(run_id),
+                    error=error,
+                )
+            finally:
+                active_attributes = self._llm_active_attributes.pop(run_id, None)
+                if active_attributes is not None:
+                    self._metrics.record_active_llm(-1, active_attributes)
+                    self._active_llm_operation_count = max(0, self._active_llm_operation_count - 1)
+                    self._transition_agent_phase(self._operation_phase())
+        self._llm_first_chunk_seen.discard(run_id)
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 
     @dont_throw
@@ -908,6 +1121,17 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             kind=SpanKind.INTERNAL,
             attributes=attributes,
         )
+        if self._metrics is not None:
+            self._tool_started_at[run_id] = time.monotonic()
+            metric_attributes = {
+                **self._metric_agent_attributes,
+                "gen_ai.tool.name": tool_name,
+                "gen_ai.tool.type": "function",
+            }
+            self._tool_metric_attributes[run_id] = metric_attributes
+            self._metrics.record_active_tool(1, metric_attributes)
+            self._active_tool_operation_count += 1
+            self._transition_agent_phase(self._operation_phase())
 
     @dont_throw
     async def on_tool_end(
@@ -924,6 +1148,17 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         span = self._get_span(run_id)
         _set_span_attribute(span, "tool.output", output)
         _set_span_attribute(span, "tool.execution_status", "success")
+        started_at = self._tool_started_at.pop(run_id, None)
+        metric_attributes = self._tool_metric_attributes.pop(run_id, None)
+        if self._metrics is not None and metric_attributes is not None:
+            try:
+                if started_at is not None:
+                    duration = time.monotonic() - started_at
+                    self._metrics.record_tool(duration, metric_attributes)
+            finally:
+                self._metrics.record_active_tool(-1, metric_attributes)
+                self._active_tool_operation_count = max(0, self._active_tool_operation_count - 1)
+                self._transition_agent_phase(self._operation_phase())
         span.set_status(Status(StatusCode.OK))
         self._end_span(span, run_id)
 
@@ -937,11 +1172,22 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         **kwargs: Any,
     ) -> None:
         """工具调用出错 - 标记 Tool Span 为错误"""
-        if not self.enabled or not self.enable_traces:
+        if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
             return
         span = self._get_span(run_id)
         _set_span_attribute(span, "tool.execution_status", "failed")
         _set_span_attribute(span, "tool.error_message", traceback.format_exc())
+        started_at = self._tool_started_at.pop(run_id, None)
+        metric_attributes = self._tool_metric_attributes.pop(run_id, None)
+        if self._metrics is not None and metric_attributes is not None:
+            try:
+                if started_at is not None:
+                    duration = time.monotonic() - started_at
+                    self._metrics.record_tool(duration, metric_attributes, error=error)
+            finally:
+                self._metrics.record_active_tool(-1, metric_attributes)
+                self._active_tool_operation_count = max(0, self._active_tool_operation_count - 1)
+                self._transition_agent_phase(self._operation_phase())
         # 使用统一的错误处理
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 

--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -39,7 +39,8 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 from aidev_agent.pydantic_models import ExecuteKwargs
 
-from .metrics import AgentMetrics, extract_token_usage, get_agent_metrics
+from .metrics import AgentMetrics, get_agent_metrics
+from .metrics import extract_token_usage as extract_metric_token_usage
 from .span_utils import (
     SpanHolder,
     set_chat_request,
@@ -1025,17 +1026,18 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
 
         # 提取响应内容
         set_chat_response(span, response, max_attribute_length=self.max_attribute_length)
-        usage = extract_token_usage(response)
-        if usage:
+        metric_usage = extract_metric_token_usage(response)
+        if metric_usage:
             _set_span_attribute(
                 span,
                 "gen_ai.usage.cache_creation.input_tokens",
-                usage["cache_creation_input_tokens"],
+                metric_usage["cache_creation_input_tokens"],
             )
-            _set_span_attribute(span, "gen_ai.usage.cache_read.input_tokens", usage["cache_read_input_tokens"])
-            _set_span_attribute(span, "gen_ai.usage.input_tokens", usage["input_tokens"])
-            _set_span_attribute(span, "gen_ai.usage.output_tokens", usage["output_tokens"])
-            _set_span_attribute(span, "gen_ai.usage.total_tokens", usage["total_tokens"])
+            _set_span_attribute(
+                span,
+                "gen_ai.usage.cache_read.input_tokens",
+                metric_usage["cache_read_input_tokens"],
+            )
         started_at = self._llm_started_at.pop(run_id, None)
         if self._metrics is not None and started_at is not None:
             duration = time.monotonic() - started_at

--- a/src/agent/aidev_agent/packages/opentelemetry/config.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/config.py
@@ -39,6 +39,8 @@ class OTelConfig:
         self.enable_metrics: bool = get_env_bool("BKAI_AGENT_ENABLE_METRICS", False)
         # bkplugin may install a BKM-specific MeterProvider while the Agent SDK keeps metric instrumentation enabled.
         self.metric_provider_managed_externally: bool = False
+        self.metric_export_interval_millis: int = max(1000, int(os.getenv("OTEL_METRIC_EXPORT_INTERVAL", "60000")))
+        self.metric_export_timeout_millis: int = max(1000, int(os.getenv("OTEL_METRIC_EXPORT_TIMEOUT", "30000")))
         self.enable_logs: bool = get_env_bool("BKAI_AGENT_ENABLE_LOGS", False)
 
         # ===== 性能优化配置 =====

--- a/src/agent/aidev_agent/packages/opentelemetry/config.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/config.py
@@ -37,6 +37,8 @@ class OTelConfig:
         # ===== 功能开关 =====
         self.enable_traces: bool = get_env_bool("BKAI_AGENT_ENABLE_TRACES", True)
         self.enable_metrics: bool = get_env_bool("BKAI_AGENT_ENABLE_METRICS", False)
+        # bkplugin may install a BKM-specific MeterProvider while the Agent SDK keeps metric instrumentation enabled.
+        self.metric_provider_managed_externally: bool = False
         self.enable_logs: bool = get_env_bool("BKAI_AGENT_ENABLE_LOGS", False)
 
         # ===== 性能优化配置 =====

--- a/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
@@ -29,6 +29,7 @@ from aidev_agent.pydantic_models import ExecuteKwargs
 
 from .callback_handler import BkAidevAgentCallbackHandler, BkAidevAgentInjector
 from .config import OTelConfig
+from .metrics import configure_metrics
 from .otel_service import BkAgentOTelService
 from .utils import dont_throw
 
@@ -70,6 +71,7 @@ class BkAidevAgentInstrumentor(BaseInstrumentor):
         if config is None:
             raise TypeError("BkAidevAgentInstrumentor requires a non-None OTelConfig")
         self._otel_service_config = config
+        configure_metrics(config.enabled and config.enable_metrics)
         self._otel_service: Optional[BkAgentOTelService] = None
 
     def start_otel_service(self):
@@ -308,11 +310,13 @@ class ChatCompletionAgentGetAgentWrapper:
             parent_trace_context=execute_kwargs.caller_trace_context,
             enabled=self.config.enabled,
             enable_traces=self.config.enable_traces,
+            enable_metrics=self.config.enable_metrics,
             debug=self.config.debug,
             max_attribute_length=self.config.max_attribute_length,
             agent_id=agent_info.get("agent_id"),
             agent_code=agent_info.get("agent_code"),
             agent_name=agent_info.get("agent_name"),
+            agent_sdk_version=agent_info.get("agent_sdk_version"),
             session_code=execute_kwargs.session_code,
             caller_executor=execute_kwargs.caller_executor,
             injector=injector,

--- a/src/agent/aidev_agent/packages/opentelemetry/metrics.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/metrics.py
@@ -14,6 +14,8 @@ from langchain_core.outputs import LLMResult
 from opentelemetry import metrics
 
 METER_NAME = "aidev_agent"
+DURATION_HISTOGRAM_BOUNDARIES = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300)
+MESSAGE_SIZE_HISTOGRAM_BOUNDARIES = (64, 256, 1024, 4096, 16384, 65536, 262144, 1048576)
 
 
 def _as_int(value: Any) -> int:

--- a/src/agent/aidev_agent/packages/opentelemetry/metrics.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/metrics.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+"""Agent metric instruments.
+
+This module deliberately depends on the OpenTelemetry API only.  The SDK,
+readers and exporters are owned by the runtime integration (bkplugin), so the
+agent framework is responsible for instrumentation but not transport.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from langchain_core.outputs import LLMResult
+from opentelemetry import metrics
+
+METER_NAME = "aidev_agent"
+
+
+def _as_int(value: Any) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _coerce_usage_dict(usage: Any) -> dict[str, Any] | None:
+    for method_name in ("to_dict_recursive", "model_dump", "dict"):
+        if hasattr(usage, method_name):
+            usage = getattr(usage, method_name)()
+            break
+    return usage if isinstance(usage, dict) else None
+
+
+def extract_token_usage(response: LLMResult) -> dict[str, int] | None:
+    """Extract provider token details without putting them in metric labels.
+
+    ``input_tokens`` is normalized to non-cache input.  Cache creation/read are
+    retained separately for trace attributes, while the metric input value is
+    the sum of all three input categories.
+    """
+
+    llm_output = response.llm_output or {}
+    raw_usage: Any = next((llm_output[key] for key in ("token_usage", "usage") if llm_output.get(key)), None)
+    if raw_usage is None:
+        for generation_group in reversed(response.generations or []):
+            for generation in reversed(generation_group):
+                message = getattr(generation, "message", None)
+                raw_usage = getattr(message, "usage_metadata", None)
+                if raw_usage is not None:
+                    break
+            if raw_usage is not None:
+                break
+
+    usage = _coerce_usage_dict(raw_usage)
+    if usage is None:
+        return None
+
+    input_details = usage.get("input_token_details") or usage.get("prompt_tokens_details") or {}
+    if not isinstance(input_details, dict):
+        input_details = {}
+
+    cache_creation = _as_int(
+        usage.get("cache_creation_input_tokens")
+        or input_details.get("cache_creation")
+        or input_details.get("cache_creation_input_tokens")
+    )
+    cache_read = _as_int(
+        usage.get("cache_read_input_tokens") or input_details.get("cache_read") or input_details.get("cached_tokens")
+    )
+
+    # Anthropic-style input_tokens is already non-cache input. OpenAI-style
+    # prompt_tokens includes cached tokens, so subtract the explicit cache
+    # detail before reporting the non-cache component.
+    has_provider_cache_fields = any(key in usage for key in ("cache_creation_input_tokens", "cache_read_input_tokens"))
+    if usage.get("input_tokens") is not None:
+        input_tokens = _as_int(usage.get("input_tokens"))
+        # LangChain UsageMetadata expresses input_tokens as the inclusive total
+        # and puts cache detail in input_token_details. Provider-native
+        # Anthropic usage instead exposes cache_* beside non-cache input_tokens.
+        if input_details and not has_provider_cache_fields:
+            input_tokens = max(0, input_tokens - cache_creation - cache_read)
+    else:
+        input_tokens = max(0, _as_int(usage.get("prompt_tokens")) - cache_creation - cache_read)
+
+    output_tokens = _as_int(usage.get("output_tokens") or usage.get("completion_tokens"))
+    total_tokens = _as_int(usage.get("total_tokens")) or (input_tokens + cache_creation + cache_read + output_tokens)
+    return {
+        "cache_creation_input_tokens": cache_creation,
+        "cache_read_input_tokens": cache_read,
+        "input_tokens": input_tokens,
+        "output_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+class AgentMetrics:
+    """Low-cardinality OpenTelemetry metrics emitted by the agent SDK."""
+
+    def __init__(self, meter=None):
+        meter = meter or metrics.get_meter(METER_NAME)
+        self.agent_duration = meter.create_histogram(
+            "gen_ai.invoke_agent.duration", unit="s", description="Agent invocation duration"
+        )
+        self.agent_started = meter.create_counter(
+            "gen_ai.invoke_agent.started", unit="{call}", description="Agent invocations started"
+        )
+        self.agent_time_to_first_token = meter.create_histogram(
+            "gen_ai.invoke_agent.time_to_first_token",
+            unit="s",
+            description="Agent invocation time to the first streamed LLM token",
+        )
+        self.agent_inference_calls = meter.create_counter(
+            "gen_ai.invoke_agent.inference_calls", unit="{call}", description="LLM calls per agent invocation"
+        )
+        self.active_agents = meter.create_up_down_counter(
+            "aidev.agent.active",
+            unit="{run}",
+            description="Agent runs currently executing",
+        )
+        self.active_agent_phases = meter.create_up_down_counter(
+            "aidev.agent.phase.active",
+            unit="{run}",
+            description="Agent runs currently in an exclusive runtime phase",
+        )
+        self.agent_phase_duration = meter.create_histogram(
+            "aidev.agent.phase.duration",
+            unit="s",
+            description="Measured wall-clock duration of an Agent runtime phase",
+        )
+        self.llm_duration = meter.create_histogram(
+            "gen_ai.client.operation.duration", unit="s", description="LLM operation duration"
+        )
+        self.active_llm_operations = meter.create_up_down_counter(
+            "gen_ai.client.operation.active",
+            unit="{operation}",
+            description="LLM operations currently executing",
+        )
+        self.llm_time_to_first_chunk = meter.create_histogram(
+            "gen_ai.client.operation.time_to_first_chunk", unit="s", description="LLM time to first stream chunk"
+        )
+        self.tool_duration = meter.create_histogram(
+            "gen_ai.execute_tool.duration", unit="s", description="Tool execution duration"
+        )
+        self.active_tool_operations = meter.create_up_down_counter(
+            "gen_ai.execute_tool.active",
+            unit="{operation}",
+            description="Tool operations currently executing",
+        )
+        self.sse_event_count = meter.create_counter(
+            "aidev.sse.event.count", unit="{event}", description="Produced SSE event count"
+        )
+        self.message_publish_count = meter.create_counter(
+            "aidev.message.publish.count", unit="{message}", description="Messages submitted to the configured handler"
+        )
+        self.message_publish_event_count = meter.create_counter(
+            "aidev.message.publish.event_count",
+            unit="{event}",
+            description="Logical events submitted to the configured handler",
+        )
+        self.message_publish_size = meter.create_histogram(
+            "aidev.message.publish.size", unit="By", description="Serialized handler message size"
+        )
+        self.message_publish_duration = meter.create_histogram(
+            "aidev.message.publish.duration", unit="s", description="Handler publish batch duration"
+        )
+
+    @staticmethod
+    def agent_attributes(
+        agent_code: str | None,
+        agent_name: str | None,
+        agent_sdk_version: str | None = None,
+    ) -> dict[str, str]:
+        return {
+            "agent.info.code": agent_code or "unknown",
+            "agent.info.name": agent_name or "unknown",
+            "agent.info.sdk_version": agent_sdk_version or "unknown",
+        }
+
+    def record_agent(
+        self,
+        duration: float,
+        inference_calls: int,
+        attributes: dict[str, str],
+        error: BaseException | None = None,
+    ) -> None:
+        attrs = dict(attributes)
+        if error is not None:
+            attrs["error.type"] = type(error).__name__
+        self.agent_duration.record(duration, attrs)
+        self.agent_inference_calls.add(inference_calls, attributes)
+
+    def record_active_agent(self, delta: int, attributes: dict[str, str]) -> None:
+        """Adjust the number of Agent runs that are currently executing."""
+        self.active_agents.add(delta, attributes)
+
+    def record_agent_started(self, attributes: dict[str, str]) -> None:
+        self.agent_started.add(1, attributes)
+
+    def record_agent_first_token(self, duration: float, attributes: dict[str, str]) -> None:
+        self.agent_time_to_first_token.record(duration, attributes)
+
+    def record_agent_phase_active(self, delta: int, phase: str, attributes: dict[str, str]) -> None:
+        self.active_agent_phases.add(delta, {**attributes, "aidev.agent.phase": phase})
+
+    def record_agent_phase_duration(self, duration: float, phase: str, attributes: dict[str, str]) -> None:
+        self.agent_phase_duration.record(duration, {**attributes, "aidev.agent.phase": phase})
+
+    def record_active_llm(self, delta: int, attributes: dict[str, str]) -> None:
+        """Adjust the number of LLM operations currently executing."""
+        self.active_llm_operations.add(delta, attributes)
+
+    def record_active_tool(self, delta: int, attributes: dict[str, str]) -> None:
+        """Adjust the number of tool operations currently executing."""
+        self.active_tool_operations.add(delta, attributes)
+
+    def record_llm(
+        self,
+        duration: float,
+        attributes: dict[str, str],
+        error: BaseException | None = None,
+    ) -> None:
+        attrs = dict(attributes)
+        if error is not None:
+            attrs["error.type"] = type(error).__name__
+        self.llm_duration.record(duration, attrs)
+
+    def record_first_llm_chunk(self, duration: float, attributes: dict[str, str]) -> None:
+        self.llm_time_to_first_chunk.record(duration, attributes)
+
+    def record_tool(
+        self,
+        duration: float,
+        attributes: dict[str, str],
+        error: BaseException | None = None,
+    ) -> None:
+        attrs = dict(attributes)
+        if error is not None:
+            attrs["error.type"] = type(error).__name__
+        self.tool_duration.record(duration, attrs)
+
+    def record_sse_event(self, message_attributes: dict[str, str] | None = None) -> None:
+        self.sse_event_count.add(1, {**_metric_identity, **(message_attributes or {})})
+
+    def record_message_publish(
+        self,
+        *,
+        handler_type: str,
+        messaging_system: str,
+        event_count: int,
+        message_sizes: list[int],
+        duration: float,
+        error: BaseException | None = None,
+    ) -> None:
+        """Record one handler flush without using queue or session identifiers as labels."""
+        attributes = {
+            **_metric_identity,
+            "aidev.message.handler.type": handler_type,
+            "messaging.system": messaging_system,
+        }
+        duration_attributes = dict(attributes)
+        if error is not None:
+            duration_attributes["error.type"] = type(error).__name__
+        else:
+            if message_sizes:
+                self.message_publish_count.add(len(message_sizes), attributes)
+                for size in message_sizes:
+                    self.message_publish_size.record(size, attributes)
+            self.message_publish_event_count.add(event_count, attributes)
+        self.message_publish_duration.record(duration, duration_attributes)
+
+
+_agent_metrics: AgentMetrics | None = None
+_metrics_enabled = False
+_metric_identity: dict[str, str] = {}
+
+
+def get_agent_metrics() -> AgentMetrics:
+    global _agent_metrics
+    if _agent_metrics is None:
+        _agent_metrics = AgentMetrics()
+    return _agent_metrics
+
+
+def configure_metrics(enabled: bool) -> None:
+    """Set the process-level instrumentation gate from the runtime config."""
+    global _metrics_enabled
+    _metrics_enabled = enabled
+
+
+def configure_metric_identity(
+    agent_code: str | None,
+    agent_name: str | None,
+    agent_sdk_version: str | None = None,
+) -> None:
+    """Configure the low-cardinality identity used by process-level SSE hooks."""
+    global _metric_identity
+    _metric_identity = AgentMetrics.agent_attributes(agent_code, agent_name, agent_sdk_version)
+
+
+def get_enabled_agent_metrics() -> AgentMetrics | None:
+    return get_agent_metrics() if _metrics_enabled else None

--- a/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
@@ -46,6 +46,7 @@ except ImportError:
 
 
 from .config import OTelConfig
+from .metrics import DURATION_HISTOGRAM_BOUNDARIES, MESSAGE_SIZE_HISTOGRAM_BOUNDARIES
 from .utils import ExporterType
 
 logger = logging.getLogger(__name__)
@@ -196,7 +197,11 @@ class BkAgentOTelService:
                 exporter = self._create_metric_exporter(endpoint_config)
 
                 # 创建 PeriodicExportingMetricReader
-                reader = PeriodicExportingMetricReader(exporter)
+                reader = PeriodicExportingMetricReader(
+                    exporter,
+                    export_interval_millis=self.config.metric_export_interval_millis,
+                    export_timeout_millis=self.config.metric_export_timeout_millis,
+                )
                 readers.append(reader)
 
                 logger.info(
@@ -209,16 +214,20 @@ class BkAgentOTelService:
                 # 某个端点失败不影响其他端点,继续处理
 
         # 配置 Histogram 视图
-        histogram_view = View(
-            instrument_type=Histogram,
-            instrument_unit="s",
-            aggregation=ExplicitBucketHistogramAggregation(
-                boundaries=[0.01, 0.05, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0]
+        histogram_views = [
+            View(
+                instrument_type=Histogram,
+                instrument_unit="s",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=DURATION_HISTOGRAM_BOUNDARIES),
             ),
-        )
+            View(
+                instrument_name="aidev.message.publish.size",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=MESSAGE_SIZE_HISTOGRAM_BOUNDARIES),
+            ),
+        ]
 
         # 创建 MeterProvider
-        self.meter_provider = MeterProvider(resource=resource, metric_readers=readers, views=[histogram_view])
+        self.meter_provider = MeterProvider(resource=resource, metric_readers=readers, views=histogram_views)
         metrics.set_meter_provider(self.meter_provider)
 
     def _create_metric_exporter(self, endpoint_config: dict):

--- a/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
@@ -81,7 +81,7 @@ class BkAgentOTelService:
         # 设置 Traces
         if self.config.enable_traces:
             self._setup_traces(resource)
-        if self.config.enable_metrics:
+        if self.config.enable_metrics and not self.config.metric_provider_managed_externally:
             self._setup_metrics(resource)
         if self.config.enable_logs:
             self._setup_logs(resource)

--- a/src/agent/aidev_agent/packages/opentelemetry/span_utils.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/span_utils.py
@@ -51,9 +51,8 @@ def _set_content_attributes(
 
 
 def set_request_params(span, kwargs, span_holder: SpanHolder):
-    if not span.is_recording():
-        return
-    # 设置请求的名称模型
+    # Metrics still need the request model when tracing is disabled and the
+    # callback receives a non-recording span.
     for model_tag in ("model", "model_id", "model_name"):
         if (model := kwargs.get(model_tag)) is not None or (
             model := (kwargs.get("invocation_params") or {}).get(model_tag)
@@ -62,6 +61,9 @@ def set_request_params(span, kwargs, span_holder: SpanHolder):
             break
     else:
         model = "unknown"
+    if not span.is_recording():
+        return
+    # 设置请求的名称模型
     _set_span_attribute(span, "gen_ai.request.model", model)
     _set_span_attribute(span, "gen_ai.response.model", model)
     # 设置请求的相关参数

--- a/src/agent/aidev_agent/packages/opentelemetry/span_utils.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/span_utils.py
@@ -34,6 +34,22 @@ class SpanHolder:
     start_time: float = field(default_factory=time.time)
 
 
+def _set_content_attributes(
+    span: Span,
+    *,
+    content_key: str,
+    original_length_key: str,
+    truncated_key: str,
+    value: str,
+    max_attribute_length: int,
+) -> None:
+    original_length = len(value)
+    truncated = original_length > max_attribute_length
+    _set_span_attribute(span, content_key, value[:max_attribute_length] if truncated else value)
+    _set_span_attribute(span, original_length_key, original_length)
+    _set_span_attribute(span, truncated_key, truncated)
+
+
 def set_request_params(span, kwargs, span_holder: SpanHolder):
     if not span.is_recording():
         return
@@ -82,10 +98,19 @@ def set_llm_request(
     prompts: list[str],
     kwargs: Any,
     span_holder: SpanHolder,
+    max_attribute_length: int = 10000,
 ) -> None:
     set_request_params(span, kwargs, span_holder)
     for i, msg in enumerate(prompts):
         _set_span_attribute(span, "llm.input" if i == 0 else f"llm.input{i}", json.dumps(msg))
+    _set_content_attributes(
+        span,
+        content_key="gen_ai.input.messages",
+        original_length_key="llm.input_original_length",
+        truncated_key="llm.input_truncated",
+        value=json.dumps(prompts, cls=CallbackFilteredJSONEncoder),
+        max_attribute_length=max_attribute_length,
+    )
 
 
 def set_chat_request(
@@ -94,6 +119,7 @@ def set_chat_request(
     messages: list[list[BaseMessage]],
     kwargs: Any,
     span_holder: SpanHolder,
+    max_attribute_length: int = 10000,
 ) -> None:
     # 本部分由于做训练数据收集
     # 收集模型基本的配置：名称/核心参数/工具
@@ -101,6 +127,14 @@ def set_chat_request(
     # 收集 prompt
     for i, message in enumerate(messages):
         _set_span_attribute(span, "llm.input" if i == 0 else f"llm.output{i}", json.dumps(messages_to_dict(message)))
+    _set_content_attributes(
+        span,
+        content_key="gen_ai.input.messages",
+        original_length_key="llm.input_original_length",
+        truncated_key="llm.input_truncated",
+        value=json.dumps([messages_to_dict(group) for group in messages], cls=CallbackFilteredJSONEncoder),
+        max_attribute_length=max_attribute_length,
+    )
 
 
 def generation_to_dict(generation: Union[Generation, ChatGeneration, GenerationChunk, ChatGenerationChunk]):
@@ -152,10 +186,21 @@ def generation_to_dict(generation: Union[Generation, ChatGeneration, GenerationC
     return ret
 
 
-def set_chat_response(span: Span, response: LLMResult) -> None:
+def set_chat_response(span: Span, response: LLMResult, max_attribute_length: int = 10000) -> None:
+    output_groups = [
+        [generation_to_dict(generation) for generation in generations] for generations in response.generations
+    ]
     for i, generations in enumerate(response.generations):
         _set_span_attribute(
             span,
             "llm.output" if i == 0 else f"llm.output{i}",
             json.dumps([generation_to_dict(generation) for generation in generations]),
         )
+    _set_content_attributes(
+        span,
+        content_key="gen_ai.output.messages",
+        original_length_key="llm.output_original_length",
+        truncated_key="llm.output_truncated",
+        value=json.dumps(output_groups, cls=CallbackFilteredJSONEncoder),
+        max_attribute_length=max_attribute_length,
+    )

--- a/src/agent/aidev_agent/services/messages_handler/in_memory.py
+++ b/src/agent/aidev_agent/services/messages_handler/in_memory.py
@@ -1,3 +1,4 @@
+import pickle
 import queue
 import threading
 import time
@@ -6,6 +7,7 @@ from typing import Any, ClassVar, Optional
 
 from .base import BaseMessageQueueHandler
 from .single_process_mixin import SingleProcessMixin
+from .telemetry import record_message_publish_metrics
 
 logger = getLogger(__name__)
 
@@ -94,8 +96,20 @@ class InMemoryQueueMessageHandler(SingleProcessMixin, BaseMessageQueueHandler):
             thread_id: 线程ID
             message: 要添加的消息
         """
+        started_at = time.monotonic()
         main_queue, _, _ = self._get_or_create_queues(thread_id)
         main_queue.put(message)
+        try:
+            message_sizes = [len(pickle.dumps(message))]
+        except Exception:  # noqa: BLE001
+            message_sizes = []
+        record_message_publish_metrics(
+            handler_type="inmemory",
+            messaging_system="in_memory",
+            event_count=1,
+            message_sizes=message_sizes,
+            started_at=started_at,
+        )
         logger.debug(f"Put message to queue for thread_id={thread_id}")
 
     def flush(self, thread_id: str) -> None:

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -18,6 +18,7 @@ from environs import Env
 from .base import BaseMessageQueueHandler, ConsumerPreemptedError, QueueTTLConfig
 from .constants import EOD_CHUNK, QueueNamePrefixes
 from .replay_buffer_mixin import ReplayBufferMixin
+from .telemetry import record_message_publish_metrics
 
 logger = getLogger(__name__)
 
@@ -1603,6 +1604,22 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
         except Exception as e:
             logger.error(f"Error flushing messages on daemon exit: {e}")
 
+    @staticmethod
+    def _record_publish_metrics(
+        event_count: int,
+        message_sizes: list[int],
+        started_at: float,
+        error: BaseException | None = None,
+    ) -> None:
+        record_message_publish_metrics(
+            handler_type="rabbitmq",
+            messaging_system="rabbitmq",
+            event_count=event_count,
+            message_sizes=message_sizes,
+            started_at=started_at,
+            error=error,
+        )
+
     def _flush_messages(self) -> None:
         """批量推送缓冲区中的所有消息到 RabbitMQ
 
@@ -1620,6 +1637,9 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
         any_flushed = False
         for thread_id in thread_ids_to_flush:
             flush_peek_lock = self._get_flush_peek_lock(thread_id)
+            messages: list[Any] = []
+            message_sizes: list[int] = []
+            publish_started_at: float | None = None
             try:
                 with flush_peek_lock:
                     # 在 flush_peek_lock 内取出该 thread_id 的 buffer
@@ -1628,6 +1648,7 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
                     if not messages:
                         continue
                     messages_to_publish = self._coalesce_sse_messages(messages)
+                    publish_started_at = time.monotonic()
 
                     # 在同一个 flush_peek_lock 内 publish 到 RabbitMQ
                     with self._with_channel() as channel:
@@ -1640,6 +1661,8 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                            message_sizes.append(len(body))
+                    self._record_publish_metrics(len(messages), message_sizes, publish_started_at)
                     logger.debug(
                         "Flushed %d logical messages as %d RabbitMQ messages to queue %s",
                         len(messages),
@@ -1656,6 +1679,8 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
                     self._notify_eod_committed(thread_id, messages)
                     any_flushed = True
             except Exception as e:
+                if publish_started_at is not None:
+                    self._record_publish_metrics(len(messages), message_sizes, publish_started_at, error=e)
                 logger.error(f"Error flushing messages for thread_id={thread_id}: {e}")
                 # 推送失败，将消息放回缓冲区（放到前面保持顺序）
                 with self._buffer_lock:
@@ -1712,6 +1737,8 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
 
                 logger.debug("[Streaming] rabbitmq flush thread_id=%s, count=%d", thread_id, len(messages_to_flush))
                 messages_to_publish = self._coalesce_sse_messages(messages_to_flush)
+                publish_started_at = time.monotonic()
+                message_sizes: list[int] = []
 
                 try:
                     with self._with_channel() as channel:
@@ -1725,6 +1752,8 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
                                 body=body,
                                 properties=pika.BasicProperties(delivery_mode=2),
                             )
+                            message_sizes.append(len(body))
+                    self._record_publish_metrics(len(messages_to_flush), message_sizes, publish_started_at)
                     if EOD_CHUNK in messages_to_flush:
                         logger.info(
                             "[EOD] flush thread_id=%s logical=%d published=%d",
@@ -1735,6 +1764,7 @@ class RabbitMQMessageHandler(_RabbitMQConsumerMixin, ReplayBufferMixin, BaseMess
                     self._notify_eod_committed(thread_id, messages_to_flush)
                     self._notify_replay_waiters()
                 except Exception as e:
+                    self._record_publish_metrics(len(messages_to_flush), message_sizes, publish_started_at, error=e)
                     logger.error(f"Error flushing messages for {thread_id}: {e}")
                     # 推送失败，放回缓冲区
                     with self._buffer_lock:

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
@@ -12,6 +12,7 @@ import os
 import pickle
 import queue
 import threading
+import time
 from dataclasses import dataclass, field
 from logging import getLogger
 from typing import Any, ClassVar, Optional
@@ -21,6 +22,7 @@ from rstream import Consumer, ConsumerOffsetSpecification, OffsetType, Producer
 
 from .constants import EOD_CHUNK, HEARTBEAT_TIMEOUT, EnvVarNames
 from .rabbitmq import RabbitMQMessageHandler
+from .telemetry import record_message_publish_metrics
 
 logger = getLogger(__name__)
 env = Env()
@@ -364,13 +366,33 @@ class RabbitMQStreamMessageHandler(RabbitMQMessageHandler):
     def _get_stream_name(self, thread_id: str) -> str:
         return f"{self.STREAM_PREFIX}{thread_id}"
 
-    def _publish_stream_messages(self, thread_id: str, messages: list[Any]) -> None:
+    def _publish_stream_messages(self, thread_id: str, messages: list[Any], *, event_count: int) -> None:
         stream_name = self._get_stream_name(thread_id)
-        publishing_ids = self._stream_runtime.publish(
-            stream=stream_name,
-            payloads=[pickle.dumps(message) for message in messages],
-            publisher_name=stream_name,
-            max_age_seconds=max(1, self.QUEUE_TTL_MS // 1000),
+        payloads = [pickle.dumps(message) for message in messages]
+        publish_started_at = time.monotonic()
+        try:
+            publishing_ids = self._stream_runtime.publish(
+                stream=stream_name,
+                payloads=payloads,
+                publisher_name=stream_name,
+                max_age_seconds=max(1, self.QUEUE_TTL_MS // 1000),
+            )
+        except Exception as error:
+            record_message_publish_metrics(
+                handler_type="rabbitmq_stream",
+                messaging_system="rabbitmq",
+                event_count=event_count,
+                message_sizes=[len(payload) for payload in payloads],
+                started_at=publish_started_at,
+                error=error,
+            )
+            raise
+        record_message_publish_metrics(
+            handler_type="rabbitmq_stream",
+            messaging_system="rabbitmq",
+            event_count=event_count,
+            message_sizes=[len(payload) for payload in payloads],
+            started_at=publish_started_at,
         )
         if publishing_ids:
             with self._stream_count_lock:
@@ -381,7 +403,7 @@ class RabbitMQStreamMessageHandler(RabbitMQMessageHandler):
 
     def _flush_one_stream(self, thread_id: str, messages: list[Any], background: bool) -> None:
         messages_to_publish = self._coalesce_sse_messages(messages)
-        self._publish_stream_messages(thread_id, messages_to_publish)
+        self._publish_stream_messages(thread_id, messages_to_publish, event_count=len(messages))
         if EOD_CHUNK in messages:
             logger.info(
                 "[EOD] RabbitMQ Stream flush thread_id=%s logical=%d published=%d background=%s",

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
@@ -360,7 +360,7 @@ class RabbitMQStreamMessageHandler(RabbitMQMessageHandler):
             "vhost": env.str("RABBITMQ_VHOST", "/"),
             "heartbeat": env.int("RABBITMQ_STREAM_HEARTBEAT", 60),
             "max_retries": env.int("RABBITMQ_STREAM_MAX_RETRIES", 20),
-            "load_balancer_mode": env.bool("RABBITMQ_STREAM_LB_MODE", True)
+            "load_balancer_mode": env.bool("RABBITMQ_STREAM_LB_MODE", True),
         }
 
     def _get_stream_name(self, thread_id: str) -> str:

--- a/src/agent/aidev_agent/services/messages_handler/redis.py
+++ b/src/agent/aidev_agent/services/messages_handler/redis.py
@@ -18,6 +18,7 @@ from redis.exceptions import RedisError
 from .base import BaseMessageQueueHandler
 from .constants import EOD_CHUNK, EnvVarNames, QueueTTLConfig
 from .replay_buffer_mixin import ReplayBufferMixin
+from .telemetry import record_message_publish_metrics
 
 logger = logging.getLogger(__name__)
 env = Env()
@@ -369,18 +370,37 @@ class RedisMessageHandler(ReplayBufferMixin, BaseMessageQueueHandler):
 
             published_messages = self._coalesce_sse_messages(messages)
             stream_key = self._stream_key(thread_id)
+            message_sizes: list[int] = []
+            publish_started_at = time.monotonic()
             try:
                 pipeline = self._client.pipeline(transaction=True)
                 for message in published_messages:
                     payload = json.dumps(message, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+                    message_sizes.append(len(payload))
                     pipeline.xadd(stream_key, {b"data": payload})
                 pipeline.expire(stream_key, self._queue_ttl_seconds)
                 pipeline.execute()
-            except Exception:
+            except Exception as error:
+                record_message_publish_metrics(
+                    handler_type="redis",
+                    messaging_system="redis",
+                    event_count=len(messages),
+                    message_sizes=message_sizes,
+                    started_at=publish_started_at,
+                    error=error,
+                )
                 with self._buffer_lock:
                     self._message_buffer[thread_id] = messages + self._message_buffer.get(thread_id, [])
                 logger.exception("Failed to flush Redis messages for thread_id=%s", thread_id)
                 raise
+
+            record_message_publish_metrics(
+                handler_type="redis",
+                messaging_system="redis",
+                event_count=len(messages),
+                message_sizes=message_sizes,
+                started_at=publish_started_at,
+            )
 
             if EOD_CHUNK in messages:
                 logger.info(

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -12,6 +12,11 @@ from ag_ui.encoder import EventEncoder
 from aidev_agent.core.ag_ui.types import RunFinishedSuccessOutcome, serialize_run_finished_outcome
 from aidev_agent.utils.event import RunId, emit_run_finished_event, stamp_round_end_event
 
+try:
+    from aidev_agent.packages.opentelemetry.metrics import get_enabled_agent_metrics
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    get_enabled_agent_metrics = None
+
 from .base import (
     BaseMessageQueueHandler,
     ConsumerPreemptedError,
@@ -36,6 +41,25 @@ _SSE_HEARTBEAT_EVENT = EventEncoder().encode(
 # 断点续传时需要过滤的事件类型
 # flow_agent_start 事件在续聊时不应该重复发送，避免前端重新渲染
 _RESUME_FILTER_EVENT_TYPES: frozenset[str] = frozenset({"flow_agent_start"})
+
+
+def _get_message_handler_metric_attributes(handler: BaseMessageQueueHandler) -> dict[str, str]:
+    """Return the actual handler implementation without queue/session identifiers."""
+    class_name = type(handler).__name__.lower()
+    if "rabbitmqstream" in class_name or "rabbitmq_stream" in class_name:
+        handler_type, messaging_system = "rabbitmq_stream", "rabbitmq"
+    elif "rabbitmq" in class_name:
+        handler_type, messaging_system = "rabbitmq", "rabbitmq"
+    elif "redis" in class_name:
+        handler_type, messaging_system = "redis", "redis"
+    elif "inmemory" in class_name or "in_memory" in class_name:
+        handler_type, messaging_system = "inmemory", "in_memory"
+    else:
+        handler_type, messaging_system = "unknown", "unknown"
+    return {
+        "aidev.message.handler.type": handler_type,
+        "messaging.system": messaging_system,
+    }
 
 
 class GeneratorStreamingHelper:
@@ -1201,6 +1225,8 @@ class GeneratorStreamingHelper:
         无法中断的工具调用会先执行到下一次 yield，再由生产者统一结束。
         """
         _producer_start = time.monotonic()
+        metric_recorder = get_enabled_agent_metrics() if get_enabled_agent_metrics is not None else None
+        metric_message_attributes = _get_message_handler_metric_attributes(self.message_handler)
         logger.info(f"[PRODUCER] start thread_id={self.thread_id} thread={threading.current_thread().name}")
         heartbeat_stop_event = threading.Event()
         heartbeat_thread: threading.Thread | None = None
@@ -1215,6 +1241,14 @@ class GeneratorStreamingHelper:
         run_finished_seen = False
         cancel_error_emitted = False
         cancel_finished_emitted = False
+
+        def _record_published_sse_event() -> None:
+            if metric_recorder is None:
+                return
+            try:
+                metric_recorder.record_sse_event(metric_message_attributes)
+            except Exception:  # noqa: BLE001
+                logger.debug("Failed to record SSE event metrics", exc_info=True)
 
         def _heartbeat_worker() -> None:
             """独立心跳线程：即使 generator 阻塞也保持心跳。"""
@@ -1265,6 +1299,7 @@ class GeneratorStreamingHelper:
                 if (is_run_finished and cancel_finished_emitted) or (not is_run_finished and cancel_error_emitted):
                     continue
                 self.message_handler.put(self.thread_id, encoded_event)
+                _record_published_sse_event()
                 if event_handler is not None:
                     try:
                         event_handler(event)
@@ -1317,6 +1352,7 @@ class GeneratorStreamingHelper:
                     run_finished_seen = True
 
                 self.message_handler.put(self.thread_id, chunk)
+                _record_published_sse_event()
                 if isinstance(chunk, str) and '"type":"RUN_STARTED"' in chunk:
                     # 初始化帧也由后台 producer 写入。RUN_STARTED 到达后立即提交，
                     # 避免等待批量写入周期，同时保持 MESSAGES_SNAPSHOT 在其之前。
@@ -1347,6 +1383,7 @@ class GeneratorStreamingHelper:
                         if is_run_finished:
                             run_finished_seen = True
                         self.message_handler.put(self.thread_id, event)
+                        _record_published_sse_event()
                         if is_run_finished:
                             _complete_session()
                 except Exception as encode_err:
@@ -1391,6 +1428,7 @@ class GeneratorStreamingHelper:
                             event_handler=event_handler,
                         ),
                     )
+                    _record_published_sse_event()
                     _complete_session()
 
                 # 无论是正常结束还是取消，都推送 EOD_CHUNK 让消费者知道流已结束。

--- a/src/agent/aidev_agent/services/messages_handler/telemetry.py
+++ b/src/agent/aidev_agent/services/messages_handler/telemetry.py
@@ -1,0 +1,41 @@
+"""Optional metric hooks shared by message handler implementations."""
+
+from __future__ import annotations
+
+import logging
+import time
+
+try:
+    from aidev_agent.packages.opentelemetry.metrics import get_enabled_agent_metrics
+except ImportError:  # pragma: no cover - OpenTelemetry is an optional SDK extra
+    get_enabled_agent_metrics = None
+
+logger = logging.getLogger(__name__)
+
+
+def record_message_publish_metrics(
+    *,
+    handler_type: str,
+    messaging_system: str,
+    event_count: int,
+    message_sizes: list[int],
+    started_at: float,
+    error: BaseException | None = None,
+) -> None:
+    """Record one logical handler batch without affecting the publish path."""
+    if get_enabled_agent_metrics is None:
+        return
+    metric_recorder = get_enabled_agent_metrics()
+    if metric_recorder is None:
+        return
+    try:
+        metric_recorder.record_message_publish(
+            handler_type=handler_type,
+            messaging_system=messaging_system,
+            event_count=event_count,
+            message_sizes=message_sizes,
+            duration=time.monotonic() - started_at,
+            error=error,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to record %s publish metrics", handler_type, exc_info=True)

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -21,17 +21,16 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 import pytest
+from aidev_agent.packages.opentelemetry.callback_handler import (
+    BkAidevAgentCallbackHandler,
+    BkAidevAgentInjector,
+)
 from langchain_core.messages import AIMessage, HumanMessage
 from langchain_core.outputs import ChatGeneration, LLMResult
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import NoOpTracerProvider
-
-from aidev_agent.packages.opentelemetry.callback_handler import (
-    BkAidevAgentCallbackHandler,
-    BkAidevAgentInjector,
-)
 
 
 @pytest.fixture

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -124,10 +124,10 @@ class TestBkAidevAgentInjector:
         # 验证 agent.session.* 属性
         assert span.attributes["agent.session.executor"] == "test-executor"
         assert span.attributes["agent.session.session_code"] == "test-session-123"
+        assert span.attributes["agent.session.caller_executor"] == "test-user"
         assert span.attributes["agent.session.caller_bk_app_code"] == "test-app"
         assert span.attributes["agent.session.caller_bk_biz_env"] == "domestic_biz"
         assert span.attributes["agent.session.caller_bk_biz_id"] == 123
-        assert span.attributes["agent.session.caller_executor"] == "test-user"
         assert span.attributes["agent.session.caller_order_type"] == "ai_chat"
         assert "agent.session.input" in span.attributes
         assert "agent.session.start_time" in span.attributes
@@ -176,6 +176,156 @@ class TestBkAidevAgentInjector:
 
 class TestBkAidevAgentCallbackHandler:
     """测试 BkAidevAgentCallbackHandler 类"""
+
+    def test_agent_metrics_follow_top_level_chain_without_injector(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        run_id = uuid4()
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=run_id))
+        asyncio.run(handler.on_chain_end(outputs={}, run_id=run_id))
+
+        recorder.record_active_agent.assert_any_call(1, handler._metric_agent_attributes)
+        recorder.record_active_agent.assert_any_call(-1, handler._metric_agent_attributes)
+        recorder.record_agent.assert_called_once()
+
+    def test_agent_metrics_are_finalized_once_on_top_level_error(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        run_id = uuid4()
+        error = RuntimeError("boom")
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=run_id))
+        asyncio.run(handler.on_chain_error(error, run_id=run_id))
+        handler._finalize_injector(error=error)
+
+        assert recorder.record_active_agent.call_count == 2
+        recorder.record_active_agent.assert_called_with(-1, handler._metric_agent_attributes)
+        recorder.record_agent.assert_called_once()
+
+    def test_active_agent_is_decremented_when_summary_recording_fails(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        recorder.record_agent.side_effect = RuntimeError("metric backend failed")
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        run_id = uuid4()
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=run_id))
+        asyncio.run(handler.on_chain_end(outputs={}, run_id=run_id))
+        handler._finalize_injector()
+
+        assert recorder.record_active_agent.call_count == 2
+        recorder.record_active_agent.assert_called_with(-1, handler._metric_agent_attributes)
+        recorder.record_agent.assert_called_once()
+
+    def test_active_llm_is_decremented_with_the_same_dimensions(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        run_id = uuid4()
+
+        asyncio.run(handler.on_llm_start(serialized={"name": "model-a"}, prompts=["hello"], run_id=run_id))
+        asyncio.run(handler.on_llm_error(RuntimeError("boom"), run_id=run_id))
+
+        assert recorder.record_active_llm.call_count == 2
+        start_call, end_call = recorder.record_active_llm.call_args_list
+        assert start_call.args[0] == 1
+        assert end_call.args[0] == -1
+        assert start_call.args[1] == end_call.args[1]
+
+    def test_agent_phase_and_first_token_metrics_follow_runtime_callbacks(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        chain_run_id = uuid4()
+        llm_run_id = uuid4()
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=chain_run_id))
+        asyncio.run(
+            handler.on_llm_start(
+                serialized={"name": "model-a"},
+                prompts=["hello"],
+                run_id=llm_run_id,
+                parent_run_id=chain_run_id,
+            )
+        )
+        asyncio.run(handler.on_llm_new_token("a", run_id=llm_run_id, parent_run_id=chain_run_id))
+        asyncio.run(handler.on_llm_new_token("b", run_id=llm_run_id, parent_run_id=chain_run_id))
+        asyncio.run(handler.on_llm_error(RuntimeError("boom"), run_id=llm_run_id, parent_run_id=chain_run_id))
+        asyncio.run(handler.on_chain_end(outputs={}, run_id=chain_run_id))
+
+        recorder.record_agent_started.assert_called_once_with(handler._metric_agent_attributes)
+        recorder.record_agent_first_token.assert_called_once()
+        phase_deltas: dict[str, int] = {}
+        for call in recorder.record_agent_phase_active.call_args_list:
+            phase_deltas[call.args[1]] = phase_deltas.get(call.args[1], 0) + call.args[0]
+        assert phase_deltas == {"processing": 0, "llm": 0, "finalizing": 0}
+
+    def test_active_tool_is_decremented_with_the_same_dimensions(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        run_id = uuid4()
+
+        asyncio.run(handler.on_tool_start(serialized={"name": "demo-tool"}, input_str="input", run_id=run_id))
+        asyncio.run(handler.on_tool_error(RuntimeError("boom"), run_id=run_id))
+
+        assert recorder.record_active_tool.call_count == 2
+        start_call, end_call = recorder.record_active_tool.call_args_list
+        assert start_call.args[0] == 1
+        assert end_call.args[0] == -1
+        assert start_call.args[1] == end_call.args[1]
+
+    def test_finalize_balances_unfinished_llm_and_tool_operations(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        chain_run_id = uuid4()
+        llm_run_id = uuid4()
+        tool_run_id = uuid4()
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=chain_run_id))
+        asyncio.run(
+            handler.on_llm_start(
+                serialized={"name": "model-a"},
+                prompts=["hello"],
+                run_id=llm_run_id,
+                parent_run_id=chain_run_id,
+            )
+        )
+        asyncio.run(
+            handler.on_tool_start(
+                serialized={"name": "demo-tool"},
+                input_str="input",
+                run_id=tool_run_id,
+                parent_run_id=chain_run_id,
+            )
+        )
+        asyncio.run(handler.on_chain_error(RuntimeError("cancelled"), run_id=chain_run_id))
+
+        assert [call.args[0] for call in recorder.record_active_llm.call_args_list] == [1, -1]
+        assert [call.args[0] for call in recorder.record_active_tool.call_args_list] == [1, -1]
+        assert handler._active_llm_operation_count == 0
+        assert handler._active_tool_operation_count == 0
+
+    def test_tool_error_metric_is_recorded_when_traces_are_disabled(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(
+            tracer=tracer,
+            enable_traces=False,
+            metric_recorder=recorder,
+        )
+        run_id = uuid4()
+        error = RuntimeError("boom")
+
+        asyncio.run(handler.on_tool_start(serialized={"name": "demo-tool"}, input_str="input", run_id=run_id))
+        asyncio.run(handler.on_tool_error(error, run_id=run_id))
+
+        recorder.record_tool.assert_called_once()
+        assert recorder.record_tool.call_args.kwargs["error"] is error
 
     def test_llm_generate_span_attributes(self, tracer_and_exporter):
         """测试 llm.generate span 包含 llm.input 和 llm.output 属性"""

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -26,6 +26,7 @@ from langchain_core.outputs import ChatGeneration, LLMResult
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import NoOpTracerProvider
 
 from aidev_agent.packages.opentelemetry.callback_handler import (
     BkAidevAgentCallbackHandler,
@@ -326,6 +327,27 @@ class TestBkAidevAgentCallbackHandler:
 
         recorder.record_tool.assert_called_once()
         assert recorder.record_tool.call_args.kwargs["error"] is error
+
+    def test_llm_metric_keeps_request_model_when_traces_are_disabled(self):
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(
+            tracer=NoOpTracerProvider().get_tracer(__name__),
+            enable_traces=False,
+            metric_recorder=recorder,
+        )
+        run_id = uuid4()
+
+        asyncio.run(
+            handler.on_llm_start(
+                serialized={"name": "demo-model"},
+                prompts=["hello"],
+                run_id=run_id,
+                invocation_params={"model": "qwen3"},
+            )
+        )
+
+        attributes = recorder.record_active_llm.call_args_list[0].args[1]
+        assert attributes["gen_ai.request.model"] == "qwen3"
 
     def test_llm_generate_span_attributes(self, tracer_and_exporter):
         """测试 llm.generate span 包含 llm.input 和 llm.output 属性"""

--- a/src/agent/tests/packages/opentelemetry/test_instrumentor.py
+++ b/src/agent/tests/packages/opentelemetry/test_instrumentor.py
@@ -192,6 +192,37 @@ class TestChatCompletionAgentGetAgentWrapper:
         callback_handlers = [cb for cb in cfg["callbacks"] if isinstance(cb, BkAidevAgentCallbackHandler)]
         assert len(callback_handlers) == 1
 
+    def test_wrapper_does_not_use_noncanonical_agent_identity(self, tracer_and_config):
+        tracer, config, _ = tracer_and_config
+        mock_instance = _build_mock_instance({"code": "fallback-code", "name": "fallback-name"})
+        wrapper = ChatCompletionAgentGetAgentWrapper(tracer, config)
+
+        _, cfg = wrapper(
+            wrapped=lambda *_args, **_kwargs: (MagicMock(), {}),
+            instance=mock_instance,
+            args=([HumanMessage(content="hi")],),
+            kwargs={"execute_kwargs": ExecuteKwargs()},
+        )
+
+        handler = cfg["callbacks"][0]
+        assert handler._agent_code is None
+        assert handler._agent_name is None
+
+    def test_wrapper_adds_agent_sdk_version_to_metric_attributes(self, tracer_and_config):
+        tracer, config, _ = tracer_and_config
+        config.enable_metrics = True
+        wrapper = ChatCompletionAgentGetAgentWrapper(tracer, config)
+        instance = _build_mock_instance({"agent_code": "ai-demo", "agent_name": "Demo", "agent_sdk_version": "2.2.3"})
+
+        _, cfg = wrapper(
+            wrapped=lambda *_args, **_kwargs: (MagicMock(), {}),
+            instance=instance,
+            args=([HumanMessage(content="hi")],),
+            kwargs={"execute_kwargs": ExecuteKwargs()},
+        )
+
+        assert cfg["callbacks"][0]._metric_agent_attributes["agent.info.sdk_version"] == "2.2.3"
+
     def test_wrapper_propagates_get_agent_failure_without_orphan_span(self, tracer_and_config):
         """``_get_agent`` 自身失败时直接抛出，不应留下任何孤儿 ``agent.execution`` span。
 

--- a/src/agent/tests/packages/opentelemetry/test_metrics.py
+++ b/src/agent/tests/packages/opentelemetry/test_metrics.py
@@ -1,0 +1,231 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from aidev_agent.packages.opentelemetry.metrics import (
+    AgentMetrics,
+    configure_metric_identity,
+    configure_metrics,
+    extract_token_usage,
+    get_enabled_agent_metrics,
+)
+from langchain_core.outputs import LLMResult
+
+
+@dataclass
+class FakeInstrument:
+    calls: list[tuple[float, dict | None]] = field(default_factory=list)
+
+    def record(self, value, attributes=None):
+        self.calls.append((value, attributes))
+
+    def add(self, value, attributes=None):
+        self.calls.append((value, attributes))
+
+
+class FakeMeter:
+    def __init__(self):
+        self.instruments = {}
+
+    def create_histogram(self, name, **kwargs):
+        return self.instruments.setdefault(name, FakeInstrument())
+
+    def create_counter(self, name, **kwargs):
+        return self.instruments.setdefault(name, FakeInstrument())
+
+    def create_up_down_counter(self, name, **kwargs):
+        return self.instruments.setdefault(name, FakeInstrument())
+
+
+def test_agent_metrics_only_create_instruments_used_by_the_dashboard():
+    meter = FakeMeter()
+
+    AgentMetrics(meter)
+
+    assert set(meter.instruments) == {
+        "aidev.agent.active",
+        "aidev.agent.phase.active",
+        "aidev.agent.phase.duration",
+        "aidev.message.publish.count",
+        "aidev.message.publish.duration",
+        "aidev.message.publish.event_count",
+        "aidev.message.publish.size",
+        "aidev.sse.event.count",
+        "gen_ai.client.operation.active",
+        "gen_ai.client.operation.duration",
+        "gen_ai.client.operation.time_to_first_chunk",
+        "gen_ai.execute_tool.active",
+        "gen_ai.execute_tool.duration",
+        "gen_ai.invoke_agent.duration",
+        "gen_ai.invoke_agent.inference_calls",
+        "gen_ai.invoke_agent.started",
+        "gen_ai.invoke_agent.time_to_first_token",
+    }
+
+
+def test_extract_token_usage_preserves_cache_breakdown_and_normalizes_prompt_tokens():
+    response = LLMResult(
+        generations=[],
+        llm_output={
+            "token_usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 48,
+                "total_tokens": 168,
+                "prompt_tokens_details": {"cached_tokens": 16, "cache_creation": 8},
+            }
+        },
+    )
+
+    assert extract_token_usage(response) == {
+        "cache_creation_input_tokens": 8,
+        "cache_read_input_tokens": 16,
+        "input_tokens": 96,
+        "output_tokens": 48,
+        "total_tokens": 168,
+    }
+
+
+def test_extract_standard_usage_metadata_subtracts_nested_cache_from_input():
+    response = LLMResult(
+        generations=[],
+        llm_output={
+            "usage": {
+                "input_tokens": 120,
+                "output_tokens": 48,
+                "total_tokens": 168,
+                "input_token_details": {"cache_read": 16, "cache_creation": 8},
+            }
+        },
+    )
+
+    usage = extract_token_usage(response)
+    assert usage is not None
+    assert usage["input_tokens"] == 96
+
+
+def test_error_type_is_added_only_to_duration_metric():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attrs = recorder.agent_attributes("ai-demo", "演示智能体")
+
+    recorder.record_agent(1.2, 2, attrs, error=RuntimeError("boom"))
+
+    duration_attrs = meter.instruments["gen_ai.invoke_agent.duration"].calls[0][1]
+    assert duration_attrs["error.type"] == "RuntimeError"
+    assert "error.type" not in meter.instruments["gen_ai.invoke_agent.inference_calls"].calls[0][1]
+    assert "agent.session.session_code" not in duration_attrs
+
+
+def test_active_agent_metric_is_symmetric_and_low_cardinality():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attrs = recorder.agent_attributes("ai-demo", "演示智能体")
+
+    recorder.record_active_agent(1, attrs)
+    recorder.record_active_agent(-1, attrs)
+
+    assert meter.instruments["aidev.agent.active"].calls == [(1, attrs), (-1, attrs)]
+    assert "agent.session.session_code" not in attrs
+    assert "agent.info.type" not in attrs
+
+
+def test_active_llm_metric_is_symmetric():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attrs = {**recorder.agent_attributes("ai-demo", "演示智能体"), "gen_ai.request.model": "model-a"}
+
+    recorder.record_active_llm(1, attrs)
+    recorder.record_active_llm(-1, attrs)
+
+    assert meter.instruments["gen_ai.client.operation.active"].calls == [(1, attrs), (-1, attrs)]
+
+
+def test_agent_lifecycle_metrics_use_only_low_cardinality_phase_attributes():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attrs = recorder.agent_attributes("ai-demo", "演示智能体")
+
+    recorder.record_agent_started(attrs)
+    recorder.record_agent_first_token(0.8, attrs)
+    recorder.record_agent_phase_active(1, "llm", attrs)
+    recorder.record_agent_phase_duration(0.6, "llm", attrs)
+    recorder.record_agent_phase_active(-1, "llm", attrs)
+
+    assert meter.instruments["gen_ai.invoke_agent.started"].calls == [(1, attrs)]
+    assert meter.instruments["gen_ai.invoke_agent.time_to_first_token"].calls == [(0.8, attrs)]
+    phase_calls = meter.instruments["aidev.agent.phase.active"].calls
+    assert [value for value, _ in phase_calls] == [1, -1]
+    assert {call_attrs["aidev.agent.phase"] for _, call_attrs in phase_calls} == {"llm"}
+    assert "agent.session.session_code" not in phase_calls[0][1]
+
+
+def test_active_tool_metric_preserves_tool_name():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attrs = {**recorder.agent_attributes("ai-demo", "演示智能体"), "gen_ai.tool.name": "search_logs"}
+
+    recorder.record_active_tool(1, attrs)
+    recorder.record_active_tool(-1, attrs)
+
+    assert meter.instruments["gen_ai.execute_tool.active"].calls == [(1, attrs), (-1, attrs)]
+
+
+def test_process_metric_gate_disables_sse_instrumentation():
+    configure_metrics(False)
+    assert get_enabled_agent_metrics() is None
+    configure_metrics(True)
+    assert get_enabled_agent_metrics() is not None
+    configure_metrics(False)
+
+
+def test_sse_metrics_include_configured_agent_code_dimension():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    configure_metric_identity("ai-demo", "演示智能体", "2.2.3")
+
+    recorder.record_sse_event()
+
+    event_attrs = meter.instruments["aidev.sse.event.count"].calls[0][1]
+    assert event_attrs["agent.info.code"] == "ai-demo"
+    assert event_attrs["agent.info.sdk_version"] == "2.2.3"
+
+
+def test_message_publish_metrics_include_actual_handler_without_session_labels():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    configure_metric_identity("ai-demo", "演示智能体")
+
+    recorder.record_message_publish(
+        handler_type="rabbitmq",
+        messaging_system="rabbitmq",
+        event_count=6,
+        message_sizes=[128, 256],
+        duration=0.02,
+    )
+
+    count_value, attrs = meter.instruments["aidev.message.publish.count"].calls[0]
+    assert count_value == 2
+    assert attrs["aidev.message.handler.type"] == "rabbitmq"
+    assert attrs["messaging.system"] == "rabbitmq"
+    assert "agent.session.session_code" not in attrs
+    assert meter.instruments["aidev.message.publish.event_count"].calls[0][0] == 6
+    assert [value for value, _ in meter.instruments["aidev.message.publish.size"].calls] == [128, 256]
+
+
+def test_failed_message_publish_is_not_counted_as_successful_broker_writes():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+
+    recorder.record_message_publish(
+        handler_type="redis",
+        messaging_system="redis",
+        event_count=3,
+        message_sizes=[128, 256],
+        duration=0.02,
+        error=TimeoutError(),
+    )
+
+    assert meter.instruments["aidev.message.publish.count"].calls == []
+    assert meter.instruments["aidev.message.publish.event_count"].calls == []
+    assert meter.instruments["aidev.message.publish.size"].calls == []
+    assert meter.instruments["aidev.message.publish.duration"].calls[0][1]["error.type"] == "TimeoutError"

--- a/src/agent/tests/packages/opentelemetry/test_otel_service.py
+++ b/src/agent/tests/packages/opentelemetry/test_otel_service.py
@@ -1,4 +1,10 @@
+from types import SimpleNamespace
+
 from aidev_agent.packages.opentelemetry.config import OTelConfig
+from aidev_agent.packages.opentelemetry.metrics import (
+    DURATION_HISTOGRAM_BOUNDARIES,
+    MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
+)
 from aidev_agent.packages.opentelemetry.otel_service import BkAgentOTelService
 
 
@@ -33,3 +39,22 @@ def test_externally_managed_metric_provider_does_not_duplicate_setup(mocker):
 
     setup_traces.assert_called_once()
     setup_metrics.assert_not_called()
+
+
+def test_direct_metric_provider_uses_configured_reader_and_shared_histogram_views(mocker):
+    config = OTelConfig(otel_endpoints=[{"url": "http://collector", "exporter_type": SimpleNamespace(value="http")}])
+    config.metric_export_interval_millis = 1500
+    config.metric_export_timeout_millis = 7000
+    service = BkAgentOTelService(config)
+    exporter = mocker.Mock()
+    mocker.patch.object(service, "_create_metric_exporter", return_value=exporter)
+    reader = mocker.patch("aidev_agent.packages.opentelemetry.otel_service.PeriodicExportingMetricReader")
+    provider = mocker.patch("aidev_agent.packages.opentelemetry.otel_service.MeterProvider")
+    mocker.patch("aidev_agent.packages.opentelemetry.otel_service.metrics.set_meter_provider")
+
+    service._setup_metrics(mocker.Mock())
+
+    reader.assert_called_once_with(exporter, export_interval_millis=1500, export_timeout_millis=7000)
+    views = provider.call_args.kwargs["views"]
+    assert tuple(views[0]._aggregation._boundaries) == DURATION_HISTOGRAM_BOUNDARIES
+    assert tuple(views[1]._aggregation._boundaries) == MESSAGE_SIZE_HISTOGRAM_BOUNDARIES

--- a/src/agent/tests/packages/opentelemetry/test_otel_service.py
+++ b/src/agent/tests/packages/opentelemetry/test_otel_service.py
@@ -1,0 +1,35 @@
+from aidev_agent.packages.opentelemetry.config import OTelConfig
+from aidev_agent.packages.opentelemetry.otel_service import BkAgentOTelService
+
+
+def test_metric_toggle_does_not_change_trace_service_setup(mocker):
+    config = OTelConfig(otel_endpoints=[])
+    config.enabled = True
+    config.enable_traces = True
+    config.enable_metrics = True
+    config.enable_logs = False
+    service = BkAgentOTelService(config)
+    setup_traces = mocker.patch.object(service, "_setup_traces")
+    setup_metrics = mocker.patch.object(service, "_setup_metrics")
+
+    service.start()
+
+    setup_traces.assert_called_once()
+    setup_metrics.assert_called_once()
+
+
+def test_externally_managed_metric_provider_does_not_duplicate_setup(mocker):
+    config = OTelConfig(otel_endpoints=[])
+    config.enabled = True
+    config.enable_traces = True
+    config.enable_metrics = True
+    config.enable_logs = False
+    config.metric_provider_managed_externally = True
+    service = BkAgentOTelService(config)
+    setup_traces = mocker.patch.object(service, "_setup_traces")
+    setup_metrics = mocker.patch.object(service, "_setup_metrics")
+
+    service.start()
+
+    setup_traces.assert_called_once()
+    setup_metrics.assert_not_called()

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -5,7 +5,9 @@ import json
 import threading
 import time
 from contextvars import ContextVar
+from unittest.mock import MagicMock
 
+import aidev_agent.services.messages_handler.in_memory as in_memory_module
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
 from ag_ui.core import EventType, RunFinishedEvent
@@ -385,6 +387,19 @@ class TestInMemoryQueueMessageHandler:
         messages = handler.get(thread_id, timeout=1.0)
         assert len(messages) == 3
         assert messages == ["message1", "message2", "message3"]
+
+    def test_put_records_actual_handler_metrics(self, handler, monkeypatch):
+        publish_metric = MagicMock()
+        monkeypatch.setattr(in_memory_module, "record_message_publish_metrics", publish_metric)
+
+        handler.put("metric-thread", "message")
+
+        publish_metric.assert_called_once()
+        call = publish_metric.call_args.kwargs
+        assert call["handler_type"] == "inmemory"
+        assert call["messaging_system"] == "in_memory"
+        assert call["event_count"] == 1
+        assert call["message_sizes"][0] > 0
 
     def test_get_timeout(self, handler):
         """测试 get 超时"""
@@ -978,11 +993,13 @@ class TestInMemoryQueueMessageHandler:
         assert notified == []
         handler.release_consumer(helper.thread_id, consumer_id)
 
-    def test_producer_error_emits_terminal_events(self, handler):
+    def test_producer_error_emits_terminal_events(self, handler, monkeypatch):
         """producer 异常应形成完整终止事件对并同步分发。"""
         helper = GeneratorStreamingHelper(handler, thread_id="test_producer_error")
         dispatched = []
         completed = []
+        recorder = MagicMock()
+        monkeypatch.setattr(streaming_helper_module, "get_enabled_agent_metrics", lambda: recorder)
 
         def broken_generator():
             yield "chunk"
@@ -1000,6 +1017,39 @@ class TestInMemoryQueueMessageHandler:
         assert _event_types(result[1:]) == ["RUN_ERROR", "RUN_FINISHED"]
         assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
         assert completed == [True]
+        assert recorder.record_sse_event.call_count == 3
+
+    def test_sse_metrics_count_only_events_enqueued_for_delivery(self, handler, monkeypatch):
+        recorder = MagicMock()
+        monkeypatch.setattr(streaming_helper_module, "get_enabled_agent_metrics", lambda: recorder)
+        helper = GeneratorStreamingHelper(handler, thread_id="test_sse_metric_delivery")
+
+        helper._producer(iter(["chunk"]))
+
+        recorder.record_sse_event.assert_called_once_with(
+            {"aidev.message.handler.type": "inmemory", "messaging.system": "in_memory"}
+        )
+
+    def test_sse_metrics_count_cancel_terminal_events_not_discarded_chunk(self, handler, monkeypatch):
+        recorder = MagicMock()
+        monkeypatch.setattr(streaming_helper_module, "get_enabled_agent_metrics", lambda: recorder)
+        cancel_event = threading.Event()
+        cancel_event.set()
+
+        GeneratorStreamingHelper(handler, thread_id="test_sse_metric_cancel")._producer(
+            iter(["discarded"]), cancel_event=cancel_event
+        )
+
+        assert recorder.record_sse_event.call_count == 2
+
+    def test_sse_metric_failure_does_not_interrupt_stream(self, handler, monkeypatch):
+        recorder = MagicMock()
+        recorder.record_sse_event.side_effect = RuntimeError("metric backend unavailable")
+        monkeypatch.setattr(streaming_helper_module, "get_enabled_agent_metrics", lambda: recorder)
+
+        result = list(GeneratorStreamingHelper(handler, thread_id="test_sse_metric_failure").stream(iter(["chunk"])))
+
+        assert result == ["chunk"]
 
     def test_cancel_terminal_events_retry_after_partial_queue_failure(self, handler, monkeypatch):
         """取消终态第二帧首次入队失败时，只重试缺失帧且完成回调仅执行一次。"""

--- a/src/agent/tests/services/test_rabbitmq_replay.py
+++ b/src/agent/tests/services/test_rabbitmq_replay.py
@@ -3,6 +3,7 @@ import pickle
 import threading
 from unittest.mock import MagicMock
 
+import aidev_agent.services.messages_handler.rabbitmq as rabbitmq_module
 import pytest
 from aidev_agent.services.messages_handler.constants import EOD_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
@@ -130,7 +131,7 @@ def test_coalesce_sse_messages_splits_by_utf8_bytes(monkeypatch):
     assert messages == [first, second]
 
 
-def test_flush_publishes_coalesced_sse_and_eod():
+def test_flush_publishes_coalesced_sse_and_eod(monkeypatch):
     handler = object.__new__(RabbitMQMessageHandler)
     first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
     second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
@@ -142,12 +143,18 @@ def test_flush_publishes_coalesced_sse_and_eod():
     handler._ensure_queue = MagicMock(return_value="replay-queue")
     handler._notify_eod_committed = MagicMock()
     handler._notify_replay_waiters = MagicMock()
+    publish_metric = MagicMock()
+    monkeypatch.setattr(rabbitmq_module, "record_message_publish_metrics", publish_metric)
 
     handler.flush("thread-id")
 
     published = [pickle.loads(call.kwargs["body"]) for call in channel.basic_publish.call_args_list]
     assert published == [first + second, EOD_CHUNK]
     handler._notify_eod_committed.assert_called_once_with("thread-id", [first, second, EOD_CHUNK])
+    metric_call = publish_metric.call_args.kwargs
+    assert metric_call["handler_type"] == "rabbitmq"
+    assert metric_call["event_count"] == 3
+    assert len(metric_call["message_sizes"]) == 2
 
 
 def test_get_messages_since_replays_mixed_physical_messages():

--- a/src/agent/tests/services/test_rabbitmq_stream.py
+++ b/src/agent/tests/services/test_rabbitmq_stream.py
@@ -5,6 +5,7 @@ import threading
 import time
 from unittest.mock import MagicMock
 
+import aidev_agent.services.messages_handler.rabbitmq_stream as rabbitmq_stream_module
 import pytest
 from aidev_agent.services.messages_handler.constants import EOD_CHUNK
 from aidev_agent.services.messages_handler.rabbitmq import RabbitMQMessageHandler
@@ -50,8 +51,10 @@ def test_stream_subscription_times_out_without_message():
         subscription.read(offset=0, timeout=0)
 
 
-def test_flush_publishes_coalesced_messages_with_confirm():
+def test_flush_publishes_coalesced_messages_with_confirm(monkeypatch):
     handler = _make_handler()
+    publish_metric = MagicMock()
+    monkeypatch.setattr(rabbitmq_stream_module, "record_message_publish_metrics", publish_metric)
     first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
     second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
     handler._message_buffer = {"thread-id": [first, second, EOD_CHUNK]}
@@ -64,6 +67,11 @@ def test_flush_publishes_coalesced_messages_with_confirm():
     assert len(published["payloads"]) == 2
     assert handler.get_cached_count("thread-id") == 2
     handler._notify_eod_committed.assert_called_once_with("thread-id", [first, second, EOD_CHUNK])
+    metric_call = publish_metric.call_args.kwargs
+    assert metric_call["handler_type"] == "rabbitmq_stream"
+    assert metric_call["messaging_system"] == "rabbitmq"
+    assert metric_call["event_count"] == 3
+    assert len(metric_call["message_sizes"]) == 2
 
 
 def test_get_messages_since_uses_native_stream_offset_and_expands_sse():

--- a/src/agent/tests/services/test_redis_handler.py
+++ b/src/agent/tests/services/test_redis_handler.py
@@ -1,7 +1,9 @@
 import os
 import threading
 import time
+from unittest.mock import MagicMock
 
+import aidev_agent.services.messages_handler.redis as redis_module
 import pytest
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
 from aidev_agent.services.messages_handler.constants import EOD_CHUNK
@@ -96,6 +98,30 @@ class _SignalClient:
         else:
             self.values[key] = replacement
         return 1
+
+
+def test_flush_records_redis_publish_metrics(monkeypatch):
+    handler = object.__new__(RedisMessageHandler)
+    first = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"a"}\n\n'
+    second = 'data: {"type":"TEXT_MESSAGE_CONTENT","delta":"b"}\n\n'
+    messages = [first, second, EOD_CHUNK]
+    handler._buffer_lock = threading.Lock()
+    handler._message_buffer = {"thread-id": messages}
+    handler._client = _CapabilityClient()
+    handler._queue_ttl_seconds = 3600
+    handler._get_flush_lock = MagicMock(return_value=threading.Lock())
+    handler._stream_key = MagicMock(return_value="stream-key")
+    handler._notify_eod_committed = MagicMock()
+    publish_metric = MagicMock()
+    monkeypatch.setattr(redis_module, "record_message_publish_metrics", publish_metric)
+
+    assert handler._flush_thread("thread-id") is True
+
+    metric_call = publish_metric.call_args.kwargs
+    assert metric_call["handler_type"] == "redis"
+    assert metric_call["messaging_system"] == "redis"
+    assert metric_call["event_count"] == 3
+    assert len(metric_call["message_sizes"]) == 2
 
 
 class TestRedisMessageHandlerCapabilities:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
@@ -104,6 +104,8 @@ def init_bk_aidev_agent_otel() -> None:
             default_enabled=otel_config.enable_metrics,
         )
         otel_config.enable_metrics = metric_settings.enabled
+        otel_config.metric_export_interval_millis = metric_settings.export_interval_millis
+        otel_config.metric_export_timeout_millis = metric_settings.export_timeout_millis
         configure_metric_identity(
             agent_info.get("agent_code") or otel_config.service_name,
             agent_info.get("agent_name"),

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
@@ -6,6 +6,8 @@ from aidev_agent.utils.module_loading import import_string
 from django.apps import AppConfig
 from django.conf import settings
 
+from aidev_bkplugin.services.metric_runtime import set_metric_service
+
 try:
     import bkoauth
 except ImportError:
@@ -16,9 +18,31 @@ except ImportError:
 try:
     from aidev_agent.packages.opentelemetry import BkAidevAgentInstrumentor
     from aidev_agent.packages.opentelemetry.config import OTelConfig
+    from aidev_agent.packages.opentelemetry.utils import (
+        get_otel_endpoint_by_agent_info,
+        get_otel_endpoint_by_env,
+        get_otel_endpoint_by_json_str,
+    )
 except ImportError:
     BkAidevAgentInstrumentor = None
     OTelConfig = None
+    get_otel_endpoint_by_agent_info = None
+    get_otel_endpoint_by_env = None
+    get_otel_endpoint_by_json_str = None
+
+try:
+    from aidev_agent.packages.opentelemetry.metrics import configure_metric_identity
+
+    from aidev_bkplugin.services.otel_metrics import BkPluginMetricService, MetricExportSettings
+except ImportError:
+    configure_metric_identity = None
+    BkPluginMetricService = None
+    MetricExportSettings = None
+
+try:
+    from aidev_bkplugin.tasks import push_bkm_metrics_task
+except ImportError:
+    push_bkm_metrics_task = None
 
 try:
     from opentelemetry.instrumentation.httpx import HTTPXClientInstrumentor
@@ -51,12 +75,6 @@ def init_bk_aidev_agent_otel() -> None:
         )
         return
 
-    from aidev_agent.packages.opentelemetry.utils import (
-        get_otel_endpoint_by_agent_info,
-        get_otel_endpoint_by_env,
-        get_otel_endpoint_by_json_str,
-    )
-
     from aidev_bkplugin.services.agent_config import AgentConfigFetcher
 
     endpoints = []
@@ -75,6 +93,44 @@ def init_bk_aidev_agent_otel() -> None:
     endpoints.extend(get_otel_endpoint_by_env())
 
     otel_config = OTelConfig(otel_endpoints=endpoints)
+    if configure_metric_identity is None or BkPluginMetricService is None or MetricExportSettings is None:
+        logger.info("[aidev_bkplugin] metric OpenTelemetry extras unavailable; metric export skipped")
+        otel_config.enable_metrics = False
+        BkAidevAgentInstrumentor(config=otel_config).instrument()
+        return
+    try:
+        metric_settings = MetricExportSettings.from_agent_info(
+            agent_info,
+            default_enabled=otel_config.enable_metrics,
+        )
+        otel_config.enable_metrics = metric_settings.enabled
+        configure_metric_identity(
+            agent_info.get("agent_code") or otel_config.service_name,
+            agent_info.get("agent_name"),
+            agent_info.get("agent_sdk_version"),
+        )
+        if metric_settings.export_via_celery:
+            metric_service = BkPluginMetricService(
+                service_name=otel_config.service_name,
+                endpoints=endpoints,
+                agent_info=agent_info,
+                settings=metric_settings,
+                enqueue_bkm_metrics=push_bkm_metrics_task.delay if push_bkm_metrics_task is not None else None,
+            )
+            set_metric_service(metric_service)
+            otel_config.enable_metrics = metric_service.start()
+            otel_config.metric_provider_managed_externally = otel_config.enable_metrics
+            if not otel_config.enable_metrics:
+                set_metric_service(None)
+        else:
+            # 直连 OTLP 继续复用 Agent SDK 原有的 MetricProvider / MetricExporter；
+            # bkplugin 只负责根据 agent_info 选择该路径并传入配置。
+            set_metric_service(None)
+            otel_config.metric_provider_managed_externally = False
+    except Exception:  # noqa: BLE001
+        logger.exception("[aidev_bkplugin] metric export initialization failed; continuing without metrics")
+        set_metric_service(None)
+        otel_config.enable_metrics = False
     BkAidevAgentInstrumentor(config=otel_config).instrument()
 
 

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/metric_runtime.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/metric_runtime.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+"""Process-local metric service registry shared by Django and Celery."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+
+class RetryableMetricPushError(RuntimeError):
+    """A transient BKM delivery failure that Celery may safely retry."""
+
+
+class BkmMetricPusher(Protocol):
+    """Minimal worker-side interface required by the BKM Celery task."""
+
+    def push_bkm(self, endpoint_key: str, payload: str) -> None: ...
+
+
+_metric_service: BkmMetricPusher | None = None
+
+
+def get_metric_service() -> BkmMetricPusher | None:
+    """Return the metric service initialized in the current process."""
+    return _metric_service
+
+
+def set_metric_service(metric_service: BkmMetricPusher | None) -> None:
+    """Replace the metric service used by worker tasks in this process."""
+    global _metric_service
+    _metric_service = metric_service

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
@@ -42,6 +42,8 @@ from .metric_runtime import RetryableMetricPushError
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_METRIC_EXPORT_INTERVAL_MILLIS = 10_000
+
 
 def _as_bool(value: Any) -> bool:
     if isinstance(value, str):
@@ -69,7 +71,7 @@ class MetricExportSettings:
     """Metric-specific settings parsed from decoded ``agent_info.otel_info``."""
 
     enabled: bool
-    export_interval_millis: int = 5000
+    export_interval_millis: int = DEFAULT_METRIC_EXPORT_INTERVAL_MILLIS
     export_timeout_millis: int = 30000
     export_via_celery: bool = True
     bkm_data_id: int | None = None
@@ -83,7 +85,7 @@ class MetricExportSettings:
         metrics_info = otel_info.get("metrics") or {}
         interval = metrics_info.get(
             "export_interval_millis",
-            otel_info.get("metric_export_interval_millis", 5000),
+            otel_info.get("metric_export_interval_millis", DEFAULT_METRIC_EXPORT_INTERVAL_MILLIS),
         )
         timeout = metrics_info.get(
             "export_timeout_millis",

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
@@ -14,6 +14,10 @@ from typing import Any, Callable
 from urllib.parse import urlparse, urlunparse
 
 import requests
+from aidev_agent.packages.opentelemetry.metrics import (
+    DURATION_HISTOGRAM_BOUNDARIES,
+    MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
+)
 from aidev_agent.packages.opentelemetry.utils import ExporterType
 from opentelemetry import metrics
 from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GRPCMetricExporter
@@ -401,15 +405,11 @@ class BkPluginMetricService:
             View(
                 instrument_type=Histogram,
                 instrument_unit="s",
-                aggregation=ExplicitBucketHistogramAggregation(
-                    boundaries=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]
-                ),
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=DURATION_HISTOGRAM_BOUNDARIES),
             ),
             View(
                 instrument_name="aidev.message.publish.size",
-                aggregation=ExplicitBucketHistogramAggregation(
-                    boundaries=[64, 256, 1024, 4096, 16384, 65536, 262144, 1048576]
-                ),
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=MESSAGE_SIZE_HISTOGRAM_BOUNDARIES),
             ),
         ]
 

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+"""bkplugin-owned OpenTelemetry metric provider with BKM worker export."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import socket
+from dataclasses import dataclass
+from typing import Any, Callable
+from urllib.parse import urlparse, urlunparse
+
+import requests
+from aidev_agent.packages.opentelemetry.utils import ExporterType
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter as GRPCMetricExporter
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter as HTTPMetricExporter
+from opentelemetry.sdk.metrics import Histogram, MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    Gauge,
+    MetricExporter,
+    MetricExportResult,
+    MetricsData,
+    PeriodicExportingMetricReader,
+    Sum,
+)
+from opentelemetry.sdk.metrics.export import (
+    Histogram as HistogramData,
+)
+from opentelemetry.sdk.metrics.view import ExplicitBucketHistogramAggregation, View
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.semconv.resource import ResourceAttributes
+
+from .metric_runtime import RetryableMetricPushError
+
+logger = logging.getLogger(__name__)
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return bool(value)
+
+
+def _normalize_bkm_push_url(value: Any) -> str:
+    """Expand a proxy host or base URL to the BKM v2 push endpoint."""
+    raw_url = str(value or "").strip()
+    if not raw_url:
+        return ""
+    if "://" not in raw_url:
+        raw_url = f"http://{raw_url}"
+    parsed = urlparse(raw_url)
+    netloc = parsed.netloc
+    if parsed.port is None:
+        netloc = f"{netloc}:10205"
+    path = parsed.path if parsed.path not in ("", "/") else "/v2/push/"
+    return urlunparse((parsed.scheme, netloc, path, "", parsed.query, ""))
+
+
+@dataclass(frozen=True)
+class MetricExportSettings:
+    """Metric-specific settings parsed from decoded ``agent_info.otel_info``."""
+
+    enabled: bool
+    export_interval_millis: int = 5000
+    export_timeout_millis: int = 30000
+    export_via_celery: bool = True
+    bkm_data_id: int | None = None
+    bkm_access_token: str = ""
+    bkm_push_url: str = ""
+    bkm_target: str = ""
+
+    @classmethod
+    def from_agent_info(cls, agent_info: dict[str, Any] | None, *, default_enabled: bool) -> "MetricExportSettings":
+        otel_info = (agent_info or {}).get("otel_info") or {}
+        metrics_info = otel_info.get("metrics") or {}
+        interval = metrics_info.get(
+            "export_interval_millis",
+            otel_info.get("metric_export_interval_millis", 5000),
+        )
+        timeout = metrics_info.get(
+            "export_timeout_millis",
+            otel_info.get("metric_export_timeout_millis", 30000),
+        )
+        export_via_celery = metrics_info.get(
+            "export_via_celery",
+            otel_info.get("metric_export_via_celery"),
+        )
+        data_id = metrics_info.get("agent_data_id", os.getenv("BKAI_AGENT_METRICS_DATA_ID"))
+        access_token = metrics_info.get("agent_access_token", os.getenv("BKAI_AGENT_METRICS_TOKEN", ""))
+        push_url = metrics_info.get("agent_push_url", os.getenv("BKAI_AGENT_METRICS_HOST", ""))
+        if not push_url and os.getenv("PROXY_IP"):
+            push_url = os.environ["PROXY_IP"]
+        push_url = _normalize_bkm_push_url(push_url)
+        target = metrics_info.get("agent_target", os.getenv("BKAI_AGENT_METRICS_TARGET", ""))
+        has_bkm_config = data_id not in (None, "") and bool(access_token and push_url)
+        if export_via_celery is None:
+            export_via_celery = has_bkm_config
+        enabled = metrics_info.get("enabled", otel_info.get("enable_metrics", default_enabled or has_bkm_config))
+        return cls(
+            enabled=_as_bool(enabled),
+            export_interval_millis=max(1000, int(interval)),
+            export_timeout_millis=max(1000, int(timeout)),
+            export_via_celery=_as_bool(export_via_celery),
+            bkm_data_id=int(data_id) if data_id not in (None, "") else None,
+            bkm_access_token=str(access_token or ""),
+            bkm_push_url=str(push_url or ""),
+            bkm_target=str(target or ""),
+        )
+
+
+def _bkm_endpoint_key(settings: MetricExportSettings) -> str:
+    """Return a stable BKM endpoint identity without exposing its access token."""
+    identity = f"{settings.bkm_data_id}\0{settings.bkm_push_url}"
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()
+
+
+def _bkm_name(value: str) -> str:
+    return re.sub(r"[^a-zA-Z0-9_]", "_", value)
+
+
+def _bkm_metric_name(name: str, unit: str) -> str:
+    """Match the Prometheus exporter's stable unit suffixes for BKM metrics."""
+    metric_name = _bkm_name(name)
+    unit_suffix = {"s": "seconds", "By": "bytes"}.get(unit)
+    if unit_suffix and not metric_name.endswith(f"_{unit_suffix}"):
+        return f"{metric_name}_{unit_suffix}"
+    return metric_name
+
+
+def _bkm_dimension_value(value: Any) -> str:
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def _bkm_record(
+    *,
+    metric_name: str,
+    value: int | float,
+    dimensions: dict[str, str],
+    target: str,
+    timestamp: int,
+) -> dict[str, Any]:
+    return {
+        "metrics": {metric_name: value},
+        "target": target,
+        "dimension": dimensions,
+        "timestamp": timestamp,
+    }
+
+
+def _bkm_records(metrics_data: MetricsData, target: str) -> list[dict[str, Any]]:
+    """Convert an OTel cumulative snapshot into BKM custom metric records."""
+    records: list[dict[str, Any]] = []
+    resource_dimension_names = {
+        "service.name",
+        "service.instance.id",
+        "agent.info.code",
+        "agent.info.name",
+        "agent.info.sdk_version",
+    }
+    for resource_metrics in metrics_data.resource_metrics:
+        resource_dimensions = {
+            _bkm_name(key): _bkm_dimension_value(value)
+            for key, value in resource_metrics.resource.attributes.items()
+            if key in resource_dimension_names
+        }
+        for scope_metrics in resource_metrics.scope_metrics:
+            for metric in scope_metrics.metrics:
+                metric_name = _bkm_metric_name(metric.name, metric.unit)
+                for point in metric.data.data_points:
+                    dimensions = dict(resource_dimensions)
+                    dimensions.update(
+                        {_bkm_name(key): _bkm_dimension_value(value) for key, value in (point.attributes or {}).items()}
+                    )
+                    timestamp = point.time_unix_nano // 1_000_000
+                    if isinstance(metric.data, Sum):
+                        sum_name = (
+                            f"{metric_name}_total"
+                            if metric.data.is_monotonic and not metric_name.endswith("_total")
+                            else metric_name
+                        )
+                        records.append(
+                            _bkm_record(
+                                metric_name=sum_name,
+                                value=point.value,
+                                dimensions=dimensions,
+                                target=target,
+                                timestamp=timestamp,
+                            )
+                        )
+                    elif isinstance(metric.data, Gauge):
+                        records.append(
+                            _bkm_record(
+                                metric_name=metric_name,
+                                value=point.value,
+                                dimensions=dimensions,
+                                target=target,
+                                timestamp=timestamp,
+                            )
+                        )
+                    elif isinstance(metric.data, HistogramData):
+                        cumulative_count = 0
+                        for bound, bucket_count in zip(
+                            [*point.explicit_bounds, "+Inf"],
+                            point.bucket_counts,
+                            strict=True,
+                        ):
+                            cumulative_count += bucket_count
+                            bucket_dimensions = {**dimensions, "le": str(bound)}
+                            records.append(
+                                _bkm_record(
+                                    metric_name=f"{metric_name}_bucket",
+                                    value=cumulative_count,
+                                    dimensions=bucket_dimensions,
+                                    target=target,
+                                    timestamp=timestamp,
+                                )
+                            )
+                        records.extend(
+                            [
+                                _bkm_record(
+                                    metric_name=f"{metric_name}_sum",
+                                    value=point.sum,
+                                    dimensions=dimensions,
+                                    target=target,
+                                    timestamp=timestamp,
+                                ),
+                                _bkm_record(
+                                    metric_name=f"{metric_name}_count",
+                                    value=point.count,
+                                    dimensions=dimensions,
+                                    target=target,
+                                    timestamp=timestamp,
+                                ),
+                            ]
+                        )
+    return records
+
+
+class CeleryMetricExporter(MetricExporter):
+    """Convert one periodic OTel snapshot and delegate its BKM push to Celery."""
+
+    def __init__(
+        self,
+        endpoint_key: str,
+        target: str,
+        enqueue: Callable[[str, str], Any],
+    ) -> None:
+        super().__init__()
+        self.endpoint_key = endpoint_key
+        self.target = target
+        self.enqueue = enqueue
+
+    def export(
+        self,
+        metrics_data: MetricsData,
+        timeout_millis: float = 10000,
+        **kwargs: Any,
+    ) -> MetricExportResult:
+        try:
+            records = _bkm_records(metrics_data, self.target)
+            if not records:
+                return MetricExportResult.SUCCESS
+            payload = json.dumps(records, ensure_ascii=False, separators=(",", ":"))
+            self.enqueue(self.endpoint_key, payload)
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "[aidev_bkplugin] failed to enqueue metric snapshot for endpoint %s",
+                self.endpoint_key,
+            )
+            return MetricExportResult.FAILURE
+        return MetricExportResult.SUCCESS
+
+    def force_flush(self, timeout_millis: float = 10000) -> bool:
+        return True
+
+    def shutdown(self, timeout_millis: float = 30000, **kwargs: Any) -> None:
+        return None
+
+
+class BkPluginMetricService:
+    """Own the metric SDK lifecycle; the Agent SDK only calls metric APIs."""
+
+    def __init__(
+        self,
+        *,
+        service_name: str,
+        endpoints: list[dict[str, Any]],
+        agent_info: dict[str, Any] | None,
+        settings: MetricExportSettings,
+        enqueue_bkm_metrics: Callable[[str, str], Any] | None = None,
+    ) -> None:
+        self.service_name = service_name
+        self.endpoints = endpoints
+        self.agent_info = agent_info or {}
+        self.settings = settings
+        self.enqueue_bkm_metrics = enqueue_bkm_metrics
+        self.provider: MeterProvider | None = None
+
+    def start(self) -> bool:
+        if not self.settings.enabled:
+            logger.info("[aidev_bkplugin] metric export disabled")
+            return False
+        readers = []
+        if self.settings.export_via_celery:
+            if self.enqueue_bkm_metrics is None:
+                logger.warning("[aidev_bkplugin] BKM metric export enabled but Celery enqueue is unavailable")
+                return False
+            if not self.settings.bkm_data_id or not self.settings.bkm_access_token or not self.settings.bkm_push_url:
+                logger.warning("[aidev_bkplugin] BKM metric export enabled but push configuration is incomplete")
+                return False
+            readers.append(
+                PeriodicExportingMetricReader(
+                    self._create_celery_exporter(),
+                    export_interval_millis=self.settings.export_interval_millis,
+                    export_timeout_millis=self.settings.export_timeout_millis,
+                )
+            )
+        else:
+            if not self.endpoints:
+                logger.warning("[aidev_bkplugin] direct metric export enabled but no OTLP endpoint configured")
+                return False
+            for endpoint in self.endpoints:
+                readers.append(
+                    PeriodicExportingMetricReader(
+                        self._create_exporter(endpoint),
+                        export_interval_millis=self.settings.export_interval_millis,
+                        export_timeout_millis=self.settings.export_timeout_millis,
+                    )
+                )
+
+        self.provider = MeterProvider(resource=self._create_resource(), metric_readers=readers, views=self._views())
+        metrics.set_meter_provider(self.provider)
+        if metrics.get_meter_provider() is not self.provider:
+            logger.warning(
+                "[aidev_bkplugin] metric export disabled because the global MeterProvider is already configured"
+            )
+            self.provider.shutdown()
+            self.provider = None
+            return False
+        transport = "celery" if self.settings.export_via_celery else "direct"
+        logger.info(
+            "[aidev_bkplugin] metric export started with %d reader(s), transport=%s",
+            len(readers),
+            transport,
+        )
+        return True
+
+    def _create_celery_exporter(self) -> CeleryMetricExporter:
+        if self.enqueue_bkm_metrics is None:
+            raise RuntimeError("Celery metric enqueue is unavailable")
+        target = self.settings.bkm_target or socket.gethostname()
+        return CeleryMetricExporter(_bkm_endpoint_key(self.settings), target, self.enqueue_bkm_metrics)
+
+    def push_bkm(self, endpoint_key: str, payload: str) -> None:
+        if endpoint_key != _bkm_endpoint_key(self.settings):
+            raise ValueError(f"Unknown metric endpoint key: {endpoint_key}")
+        records = json.loads(payload)
+        if not isinstance(records, list):
+            raise ValueError("BKM metric payload must be a list")
+        report_data = {
+            "data_id": self.settings.bkm_data_id,
+            "access_token": self.settings.bkm_access_token,
+            "data": records,
+        }
+        try:
+            response = requests.post(
+                self.settings.bkm_push_url,
+                json=report_data,
+                timeout=max(1.0, self.settings.export_timeout_millis / 1000),
+            )
+        except (requests.ConnectionError, requests.Timeout) as error:
+            raise RetryableMetricPushError("BKM metric push failed due to a transient network error") from error
+        if response.status_code in {408, 425, 429} or response.status_code >= 500:
+            raise RetryableMetricPushError(f"BKM metric push returned retryable HTTP {response.status_code}")
+        response.raise_for_status()
+
+    def _create_resource(self) -> Resource:
+        return Resource.create(
+            {
+                ResourceAttributes.SERVICE_NAME: self.service_name,
+                "service.instance.id": f"{socket.gethostname()}:{os.getpid()}",
+                "agent.info.code": self.agent_info.get("agent_code") or self.service_name,
+                "agent.info.name": self.agent_info.get("agent_name") or "unknown",
+                "agent.info.sdk_version": self.agent_info.get("agent_sdk_version") or "unknown",
+            }
+        )
+
+    def stop(self) -> None:
+        if self.provider is not None:
+            self.provider.shutdown()
+
+    @staticmethod
+    def _views() -> list[View]:
+        return [
+            View(
+                instrument_type=Histogram,
+                instrument_unit="s",
+                aggregation=ExplicitBucketHistogramAggregation(
+                    boundaries=[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]
+                ),
+            ),
+            View(
+                instrument_name="aidev.message.publish.size",
+                aggregation=ExplicitBucketHistogramAggregation(
+                    boundaries=[64, 256, 1024, 4096, 16384, 65536, 262144, 1048576]
+                ),
+            ),
+        ]
+
+    @staticmethod
+    def _create_exporter(endpoint: dict[str, Any]):
+        url = endpoint["url"]
+        headers = {"x-bk-token": endpoint.get("token", "")} if endpoint.get("token") else {}
+        exporter_type = endpoint["exporter_type"]
+        if exporter_type == ExporterType.GRPC:
+            return GRPCMetricExporter(endpoint=url, insecure=True, headers=headers)
+        if exporter_type == ExporterType.HTTP:
+            if not url.endswith("/v1/metrics"):
+                url = f"{url.rstrip('/')}/v1/metrics"
+            return HTTPMetricExporter(endpoint=url, headers=headers)
+        raise ValueError(f"Unsupported OTLP exporter type: {exporter_type}")

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/tasks.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/tasks.py
@@ -6,8 +6,27 @@ from __future__ import annotations
 from aidev_agent.enums import AgentType
 from celery import shared_task
 
+from .services.metric_runtime import RetryableMetricPushError, get_metric_service
+
 # 与模板 app_desc.yml 中 celery worker 的 -Q 保持一致，否则任务会进默认 celery 队列而无人消费
 BKPLUGIN_CELERY_QUEUE = "plugin_schedule"
+
+
+@shared_task(
+    name="aidev_bkplugin.push_bkm_metrics",
+    ignore_result=True,
+    queue=BKPLUGIN_CELERY_QUEUE,
+    autoretry_for=(RetryableMetricPushError,),
+    retry_backoff=True,
+    retry_jitter=True,
+    max_retries=3,
+)
+def push_bkm_metrics_task(endpoint_key: str, payload: str) -> None:
+    """Push one periodic BKM metric snapshot from the Celery worker."""
+    metric_service = get_metric_service()
+    if metric_service is None:
+        raise RuntimeError("Metric service is unavailable in the Celery worker")
+    metric_service.push_bkm(endpoint_key, payload)
 
 
 @shared_task(

--- a/src/plugins/aidev_bkplugin/pyproject.toml
+++ b/src/plugins/aidev_bkplugin/pyproject.toml
@@ -10,6 +10,11 @@ dependencies = [
     "django>=4.2.28,<5.0",
 ]
 
+[project.optional-dependencies]
+opentelemetry = [
+    "aidev-agent[opentelemetry]>=2.2.1post1",
+]
+
 [dependency-groups]
 dev = [
     "pytest>=7.4.4,<9",

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -7,6 +7,10 @@ from types import ModuleType
 
 import pytest
 import requests
+from aidev_agent.packages.opentelemetry.metrics import (
+    DURATION_HISTOGRAM_BOUNDARIES,
+    MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
+)
 
 pytest.importorskip("opentelemetry.sdk.metrics")
 
@@ -246,6 +250,13 @@ def test_metric_resource_does_not_use_noncanonical_agent_identity():
 
     assert attributes["agent.info.code"] == "agent-service"
     assert attributes["agent.info.name"] == "unknown"
+
+
+def test_metric_service_uses_agent_sdk_histogram_boundaries():
+    views = BkPluginMetricService._views()
+
+    assert tuple(views[0]._aggregation._boundaries) == DURATION_HISTOGRAM_BOUNDARIES
+    assert tuple(views[1]._aggregation._boundaries) == MESSAGE_SIZE_HISTOGRAM_BOUNDARIES
 
 
 def test_bkm_records_preserve_counter_and_histogram_semantics():

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -7,13 +7,13 @@ from types import ModuleType
 
 import pytest
 import requests
+
+pytest.importorskip("opentelemetry.sdk.metrics")
+
 from aidev_agent.packages.opentelemetry.metrics import (
     DURATION_HISTOGRAM_BOUNDARIES,
     MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
 )
-
-pytest.importorskip("opentelemetry.sdk.metrics")
-
 from aidev_bkplugin.services.metric_runtime import RetryableMetricPushError
 from aidev_bkplugin.services.otel_metrics import (
     BkPluginMetricService,

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -1,0 +1,411 @@
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+from types import ModuleType
+
+import pytest
+import requests
+
+pytest.importorskip("opentelemetry.sdk.metrics")
+
+from aidev_bkplugin.services.metric_runtime import RetryableMetricPushError
+from aidev_bkplugin.services.otel_metrics import (
+    BkPluginMetricService,
+    CeleryMetricExporter,
+    MetricExportSettings,
+    _bkm_endpoint_key,
+    _bkm_metric_name,
+    _bkm_records,
+    _normalize_bkm_push_url,
+)
+from opentelemetry.sdk.metrics.export import (
+    AggregationTemporality,
+    Histogram,
+    HistogramDataPoint,
+    Metric,
+    MetricExportResult,
+    MetricsData,
+    NumberDataPoint,
+    ResourceMetrics,
+    ScopeMetrics,
+    Sum,
+)
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.util.instrumentation import InstrumentationScope
+
+
+def _import_tasks_with_celery_stub(mocker):
+    """Load task functions without requiring the template-only Celery dependency."""
+    celery = ModuleType("celery")
+
+    def shared_task(**options):
+        def decorate(function):
+            function.shared_task_options = options
+            return function
+
+        return decorate
+
+    celery.shared_task = shared_task
+    mocker.patch.dict(sys.modules, {"celery": celery})
+    sys.modules.pop("aidev_bkplugin.tasks", None)
+    return importlib.import_module("aidev_bkplugin.tasks")
+
+
+def _sample_metrics_data() -> MetricsData:
+    timestamp = 1_786_300_118_338_000_000
+    counter = Metric(
+        name="aidev.sse.event.count",
+        description="SSE events",
+        unit="{event}",
+        data=Sum(
+            data_points=[NumberDataPoint({"handler.type": "redis"}, timestamp - 1, timestamp, 3)],
+            aggregation_temporality=AggregationTemporality.CUMULATIVE,
+            is_monotonic=True,
+        ),
+    )
+    duration = Metric(
+        name="gen_ai.invoke_agent.duration",
+        description="Agent duration",
+        unit="s",
+        data=Histogram(
+            data_points=[
+                HistogramDataPoint(
+                    {"error.type": "TimeoutError"},
+                    timestamp - 1,
+                    timestamp,
+                    count=4,
+                    sum=2.5,
+                    bucket_counts=[1, 2, 1],
+                    explicit_bounds=[0.1, 1.0],
+                    min=0.05,
+                    max=1.2,
+                )
+            ],
+            aggregation_temporality=AggregationTemporality.CUMULATIVE,
+        ),
+    )
+    resource = Resource.create(
+        {
+            "service.name": "ai-demo",
+            "service.instance.id": "host:123",
+            "agent.info.code": "ai-demo",
+            "agent.info.name": "演示智能体",
+            "agent.info.sdk_version": "2.2.3",
+        }
+    )
+    scope_metrics = ScopeMetrics(InstrumentationScope("test"), [counter, duration], "")
+    return MetricsData([ResourceMetrics(resource, [scope_metrics], "")])
+
+
+def _bkm_settings(**overrides) -> MetricExportSettings:
+    values = {
+        "enabled": True,
+        "bkm_data_id": 1001,
+        "bkm_access_token": "secret",
+        "bkm_push_url": "http://proxy:10205/v2/push/",
+        "bkm_target": "127.0.0.1",
+    }
+    values.update(overrides)
+    return MetricExportSettings(**values)
+
+
+def test_metric_settings_parse_nested_otel_info():
+    settings = MetricExportSettings.from_agent_info(
+        {
+            "otel_info": {
+                "metrics": {
+                    "enabled": True,
+                    "export_interval_millis": 1500,
+                    "export_timeout_millis": 7000,
+                    "agent_data_id": "1001",
+                    "agent_access_token": "metric-secret",
+                    "agent_push_url": "http://proxy:10205/v2/push/",
+                    "agent_target": "127.0.0.1",
+                }
+            }
+        },
+        default_enabled=False,
+    )
+
+    assert settings.enabled is True
+    assert settings.export_interval_millis == 1500
+    assert settings.export_timeout_millis == 7000
+    assert settings.export_via_celery is True
+    assert settings.bkm_data_id == 1001
+    assert settings.bkm_access_token == "metric-secret"
+    assert settings.bkm_push_url == "http://proxy:10205/v2/push/"
+    assert settings.bkm_target == "127.0.0.1"
+
+
+def test_metric_settings_use_local_environment_fallback(monkeypatch):
+    monkeypatch.setenv("BKAI_AGENT_METRICS_DATA_ID", "1002")
+    monkeypatch.setenv("BKAI_AGENT_METRICS_TOKEN", "local-secret")
+    monkeypatch.setenv("BKAI_AGENT_METRICS_HOST", "local-proxy")
+    monkeypatch.setenv("BKAI_AGENT_METRICS_TARGET", "local-target")
+
+    settings = MetricExportSettings.from_agent_info({}, default_enabled=False)
+
+    assert settings.enabled is True
+    assert settings.bkm_data_id == 1002
+    assert settings.bkm_access_token == "local-secret"
+    assert settings.bkm_push_url == "http://local-proxy:10205/v2/push/"
+    assert settings.bkm_target == "local-target"
+    assert settings.export_via_celery is True
+
+
+def test_metric_settings_keep_direct_otlp_transport_without_bkm_config(monkeypatch):
+    for name in ("BKAI_AGENT_METRICS_DATA_ID", "BKAI_AGENT_METRICS_TOKEN", "BKAI_AGENT_METRICS_HOST", "PROXY_IP"):
+        monkeypatch.delenv(name, raising=False)
+
+    settings = MetricExportSettings.from_agent_info({}, default_enabled=True)
+
+    assert settings.enabled is True
+    assert settings.export_via_celery is False
+
+
+def test_metric_settings_do_not_reuse_trace_credentials(monkeypatch):
+    monkeypatch.setenv("BKAI_AGENT_OTEL_TOKEN", "trace-secret")
+
+    settings = MetricExportSettings.from_agent_info({}, default_enabled=False)
+
+    assert settings.enabled is False
+    assert settings.bkm_data_id is None
+    assert settings.bkm_access_token == ""
+    assert settings.bkm_push_url == ""
+
+
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("bk-report.example.com", "http://bk-report.example.com:10205/v2/push/"),
+        ("http://proxy:10205", "http://proxy:10205/v2/push/"),
+        ("http://proxy:10205/v2/push/", "http://proxy:10205/v2/push/"),
+    ],
+)
+def test_normalize_bkm_push_url(configured, expected):
+    assert _normalize_bkm_push_url(configured) == expected
+
+
+def test_metric_settings_prefer_agent_info_over_local_environment(monkeypatch):
+    monkeypatch.setenv("BKAI_AGENT_METRICS_DATA_ID", "1002")
+    monkeypatch.setenv("BKAI_AGENT_METRICS_TOKEN", "local-secret")
+    monkeypatch.setenv("BKAI_AGENT_METRICS_HOST", "local-proxy")
+
+    settings = MetricExportSettings.from_agent_info(
+        {
+            "otel_info": {
+                "metrics": {
+                    "agent_data_id": 1003,
+                    "agent_access_token": "platform-secret",
+                    "agent_push_url": "http://platform-proxy:10205/v2/push/",
+                }
+            }
+        },
+        default_enabled=False,
+    )
+
+    assert settings.bkm_data_id == 1003
+    assert settings.bkm_access_token == "platform-secret"
+    assert settings.bkm_push_url == "http://platform-proxy:10205/v2/push/"
+
+
+def test_metric_settings_parse_false_string_safely():
+    settings = MetricExportSettings.from_agent_info(
+        {"otel_info": {"metrics": {"enabled": "false"}}},
+        default_enabled=True,
+    )
+    assert settings.enabled is False
+
+
+def test_metric_resource_uses_agent_sdk_version_without_agent_type():
+    service = BkPluginMetricService(
+        service_name="ai-demo",
+        endpoints=[],
+        agent_info={"agent_code": "ai-demo", "agent_name": "演示智能体", "agent_sdk_version": "2.2.3"},
+        settings=_bkm_settings(),
+    )
+
+    attributes = service._create_resource().attributes
+
+    assert attributes["agent.info.sdk_version"] == "2.2.3"
+    assert attributes["service.instance.id"]
+    assert "agent.info.type" not in attributes
+
+
+def test_metric_resource_does_not_use_noncanonical_agent_identity():
+    service = BkPluginMetricService(
+        service_name="agent-service",
+        endpoints=[],
+        agent_info={"code": "fallback-code", "name": "fallback-name"},
+        settings=_bkm_settings(),
+    )
+
+    attributes = service._create_resource().attributes
+
+    assert attributes["agent.info.code"] == "agent-service"
+    assert attributes["agent.info.name"] == "unknown"
+
+
+def test_bkm_records_preserve_counter_and_histogram_semantics():
+    records = _bkm_records(_sample_metrics_data(), "127.0.0.1")
+    by_metric = {next(iter(record["metrics"])): record for record in records if "le" not in record["dimension"]}
+    buckets = [record for record in records if "le" in record["dimension"]]
+
+    counter = by_metric["aidev_sse_event_count_total"]
+    assert counter["metrics"] == {"aidev_sse_event_count_total": 3}
+    assert counter["dimension"]["handler_type"] == "redis"
+    assert counter["dimension"]["agent_info_code"] == "ai-demo"
+    assert counter["timestamp"] == 1_786_300_118_338
+    assert counter["target"] == "127.0.0.1"
+    assert [record["metrics"]["gen_ai_invoke_agent_duration_seconds_bucket"] for record in buckets] == [1, 3, 4]
+    assert [record["dimension"]["le"] for record in buckets] == ["0.1", "1.0", "+Inf"]
+    assert by_metric["gen_ai_invoke_agent_duration_seconds_sum"]["metrics"] == {
+        "gen_ai_invoke_agent_duration_seconds_sum": 2.5
+    }
+    assert by_metric["gen_ai_invoke_agent_duration_seconds_count"]["metrics"] == {
+        "gen_ai_invoke_agent_duration_seconds_count": 4
+    }
+
+
+@pytest.mark.parametrize(
+    ("name", "unit", "expected"),
+    [
+        ("aidev.message.publish.duration", "s", "aidev_message_publish_duration_seconds"),
+        ("aidev.message.publish.size", "By", "aidev_message_publish_size_bytes"),
+        ("aidev.sse.event.count", "{event}", "aidev_sse_event_count"),
+        ("custom.duration_seconds", "s", "custom_duration_seconds"),
+    ],
+)
+def test_bkm_metric_name_matches_prometheus_unit_suffixes(name, unit, expected):
+    assert _bkm_metric_name(name, unit) == expected
+
+
+def test_celery_exporter_enqueues_bkm_records_without_credentials(mocker):
+    delay = mocker.Mock()
+
+    result = CeleryMetricExporter(
+        endpoint_key="endpoint-fingerprint",
+        target="127.0.0.1",
+        enqueue=delay,
+    ).export(_sample_metrics_data())
+
+    assert result is MetricExportResult.SUCCESS
+    endpoint_key, payload = delay.call_args.args
+    assert endpoint_key == "endpoint-fingerprint"
+    assert "secret" not in payload
+    assert json.loads(payload)[0]["target"] == "127.0.0.1"
+
+
+def test_metric_service_uses_credential_free_bkm_endpoint_key():
+    settings = _bkm_settings()
+    service = BkPluginMetricService(
+        service_name="ai-demo",
+        endpoints=[],
+        agent_info={},
+        settings=settings,
+        enqueue_bkm_metrics=lambda *_args: None,
+    )
+
+    exporter = service._create_celery_exporter()
+
+    assert isinstance(exporter, CeleryMetricExporter)
+    assert exporter.endpoint_key == _bkm_endpoint_key(settings)
+    assert settings.bkm_access_token not in exporter.endpoint_key
+
+
+def test_metric_service_does_not_enable_incomplete_bkm_export():
+    service = BkPluginMetricService(
+        service_name="ai-demo",
+        endpoints=[],
+        agent_info={},
+        settings=MetricExportSettings(enabled=True, bkm_data_id=1001),
+    )
+
+    assert service.start() is False
+    assert service.provider is None
+
+
+def test_metric_service_does_not_enable_when_global_provider_is_already_configured(mocker):
+    existing_provider = mocker.Mock()
+    new_provider = mocker.Mock()
+    mocker.patch("aidev_bkplugin.services.otel_metrics.MeterProvider", return_value=new_provider)
+    mocker.patch("aidev_bkplugin.services.otel_metrics.metrics.get_meter_provider", return_value=existing_provider)
+    set_meter_provider = mocker.patch("aidev_bkplugin.services.otel_metrics.metrics.set_meter_provider")
+    service = BkPluginMetricService(
+        service_name="ai-demo",
+        endpoints=[],
+        agent_info={},
+        settings=_bkm_settings(),
+        enqueue_bkm_metrics=lambda *_args: None,
+    )
+
+    assert service.start() is False
+    set_meter_provider.assert_called_once_with(new_provider)
+    new_provider.shutdown.assert_called_once_with()
+    assert service.provider is None
+
+
+def test_worker_posts_bkm_report_with_process_local_credentials(mocker):
+    post = mocker.patch("aidev_bkplugin.services.otel_metrics.requests.post")
+    post.return_value.status_code = 200
+    settings = _bkm_settings(export_timeout_millis=7000)
+    service = BkPluginMetricService(service_name="ai-demo", endpoints=[], agent_info={}, settings=settings)
+    records = [{"metrics": {"aidev_agent_active": 3}, "target": "127.0.0.1", "dimension": {}, "timestamp": 1}]
+
+    service.push_bkm(_bkm_endpoint_key(settings), json.dumps(records))
+
+    post.assert_called_once_with(
+        "http://proxy:10205/v2/push/",
+        json={"data_id": 1001, "access_token": "secret", "data": records},
+        timeout=7.0,
+    )
+    post.return_value.raise_for_status.assert_called_once_with()
+
+
+@pytest.mark.parametrize("status_code", [408, 425, 429, 500, 503])
+def test_worker_marks_transient_bkm_status_as_retryable(mocker, status_code):
+    post = mocker.patch("aidev_bkplugin.services.otel_metrics.requests.post")
+    post.return_value.status_code = status_code
+    service = BkPluginMetricService(service_name="ai-demo", endpoints=[], agent_info={}, settings=_bkm_settings())
+
+    with pytest.raises(RetryableMetricPushError, match=str(status_code)):
+        service.push_bkm(_bkm_endpoint_key(service.settings), "[]")
+
+
+def test_worker_marks_bkm_network_failure_as_retryable(mocker):
+    mocker.patch("aidev_bkplugin.services.otel_metrics.requests.post", side_effect=requests.Timeout)
+    service = BkPluginMetricService(service_name="ai-demo", endpoints=[], agent_info={}, settings=_bkm_settings())
+
+    with pytest.raises(RetryableMetricPushError, match="transient network error"):
+        service.push_bkm(_bkm_endpoint_key(service.settings), "[]")
+
+
+def test_worker_keeps_non_retryable_bkm_client_error(mocker):
+    post = mocker.patch("aidev_bkplugin.services.otel_metrics.requests.post")
+    post.return_value.status_code = 400
+    post.return_value.raise_for_status.side_effect = requests.HTTPError("bad request")
+    service = BkPluginMetricService(service_name="ai-demo", endpoints=[], agent_info={}, settings=_bkm_settings())
+
+    with pytest.raises(requests.HTTPError, match="bad request"):
+        service.push_bkm(_bkm_endpoint_key(service.settings), "[]")
+
+
+def test_metric_service_rejects_unknown_worker_endpoint():
+    service = BkPluginMetricService(service_name="ai-demo", endpoints=[], agent_info={}, settings=_bkm_settings())
+
+    with pytest.raises(ValueError, match="Unknown metric endpoint key"):
+        service.push_bkm("unknown", "[]")
+
+
+def test_celery_task_exports_through_process_local_metric_service(mocker):
+    tasks = _import_tasks_with_celery_stub(mocker)
+    service = mocker.Mock()
+    mocker.patch.object(tasks, "get_metric_service", return_value=service)
+
+    tasks.push_bkm_metrics_task("endpoint-fingerprint", "payload")
+
+    service.push_bkm.assert_called_once_with("endpoint-fingerprint", "payload")
+    assert tasks.push_bkm_metrics_task.shared_task_options["autoretry_for"] == (RetryableMetricPushError,)
+    assert tasks.push_bkm_metrics_task.shared_task_options["max_retries"] == 3

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -157,6 +157,7 @@ def test_metric_settings_use_local_environment_fallback(monkeypatch):
     assert settings.bkm_push_url == "http://local-proxy:10205/v2/push/"
     assert settings.bkm_target == "local-target"
     assert settings.export_via_celery is True
+    assert settings.export_interval_millis == 10_000
 
 
 def test_metric_settings_keep_direct_otlp_transport_without_bkm_config(monkeypatch):

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -1,0 +1,68 @@
+from types import SimpleNamespace
+
+import aidev_agent.packages as aidev_agent_packages
+from aidev_bkplugin import apps
+
+
+def _mock_otel_inputs(mocker, agent_info, metric_settings):
+    mocker.patch.object(apps, "get_otel_endpoint_by_json_str", return_value=[])
+    mocker.patch.object(apps, "get_otel_endpoint_by_agent_info", return_value=[])
+    mocker.patch.object(apps, "get_otel_endpoint_by_env", return_value=[])
+    mocker.patch(
+        "aidev_bkplugin.services.agent_config.AgentConfigFetcher.get_info",
+        return_value=agent_info,
+    )
+    otel_config = SimpleNamespace(
+        enable_metrics=True,
+        service_name="agent-service",
+        metric_provider_managed_externally=False,
+    )
+    mocker.patch.object(apps, "OTelConfig", return_value=otel_config)
+    mocker.patch.object(apps.MetricExportSettings, "from_agent_info", return_value=metric_settings)
+    instrumentor = mocker.patch.object(apps, "BkAidevAgentInstrumentor").return_value
+    return otel_config, instrumentor
+
+
+def test_init_otel_keeps_direct_metric_export_in_agent_sdk(mocker, monkeypatch):
+    # Some installations expose the optional OTel modules only through their
+    # fully qualified imports, not as an attribute on ``aidev_agent.packages``.
+    monkeypatch.delattr(aidev_agent_packages, "opentelemetry", raising=False)
+    settings = SimpleNamespace(enabled=True, export_via_celery=False)
+    otel_config, instrumentor = _mock_otel_inputs(
+        mocker,
+        {"code": "legacy-code", "name": "legacy-name"},
+        settings,
+    )
+    metric_service = mocker.patch.object(apps, "BkPluginMetricService")
+    set_metric_service = mocker.patch.object(apps, "set_metric_service")
+    configure_identity = mocker.patch.object(apps, "configure_metric_identity")
+
+    apps.init_bk_aidev_agent_otel()
+
+    metric_service.assert_not_called()
+    set_metric_service.assert_called_once_with(None)
+    configure_identity.assert_called_once_with("agent-service", None, None)
+    assert otel_config.enable_metrics is True
+    assert otel_config.metric_provider_managed_externally is False
+    instrumentor.instrument.assert_called_once_with()
+
+
+def test_init_otel_uses_bkplugin_metric_provider_for_celery_export(mocker):
+    settings = SimpleNamespace(enabled=True, export_via_celery=True)
+    otel_config, instrumentor = _mock_otel_inputs(
+        mocker,
+        {"agent_code": "ai-demo", "agent_name": "Demo Agent", "agent_sdk_version": "2.2.3"},
+        settings,
+    )
+    metric_service = mocker.patch.object(apps, "BkPluginMetricService").return_value
+    metric_service.start.return_value = True
+    set_metric_service = mocker.patch.object(apps, "set_metric_service")
+    configure_identity = mocker.patch.object(apps, "configure_metric_identity")
+
+    apps.init_bk_aidev_agent_otel()
+
+    set_metric_service.assert_called_once_with(metric_service)
+    configure_identity.assert_called_once_with("ai-demo", "Demo Agent", "2.2.3")
+    assert otel_config.enable_metrics is True
+    assert otel_config.metric_provider_managed_externally is True
+    instrumentor.instrument.assert_called_once_with()

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -18,7 +18,8 @@ def _mock_otel_inputs(mocker, agent_info, metric_settings):
         metric_provider_managed_externally=False,
     )
     mocker.patch.object(apps, "OTelConfig", return_value=otel_config)
-    mocker.patch.object(apps.MetricExportSettings, "from_agent_info", return_value=metric_settings)
+    metric_export_settings = mocker.patch.object(apps, "MetricExportSettings")
+    metric_export_settings.from_agent_info.return_value = metric_settings
     instrumentor = mocker.patch.object(apps, "BkAidevAgentInstrumentor").return_value
     return otel_config, instrumentor
 

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -27,7 +27,12 @@ def test_init_otel_keeps_direct_metric_export_in_agent_sdk(mocker, monkeypatch):
     # Some installations expose the optional OTel modules only through their
     # fully qualified imports, not as an attribute on ``aidev_agent.packages``.
     monkeypatch.delattr(aidev_agent_packages, "opentelemetry", raising=False)
-    settings = SimpleNamespace(enabled=True, export_via_celery=False)
+    settings = SimpleNamespace(
+        enabled=True,
+        export_via_celery=False,
+        export_interval_millis=1500,
+        export_timeout_millis=7000,
+    )
     otel_config, instrumentor = _mock_otel_inputs(
         mocker,
         {"code": "legacy-code", "name": "legacy-name"},
@@ -44,11 +49,18 @@ def test_init_otel_keeps_direct_metric_export_in_agent_sdk(mocker, monkeypatch):
     configure_identity.assert_called_once_with("agent-service", None, None)
     assert otel_config.enable_metrics is True
     assert otel_config.metric_provider_managed_externally is False
+    assert otel_config.metric_export_interval_millis == 1500
+    assert otel_config.metric_export_timeout_millis == 7000
     instrumentor.instrument.assert_called_once_with()
 
 
 def test_init_otel_uses_bkplugin_metric_provider_for_celery_export(mocker):
-    settings = SimpleNamespace(enabled=True, export_via_celery=True)
+    settings = SimpleNamespace(
+        enabled=True,
+        export_via_celery=True,
+        export_interval_millis=1500,
+        export_timeout_millis=7000,
+    )
     otel_config, instrumentor = _mock_otel_inputs(
         mocker,
         {"agent_code": "ai-demo", "agent_name": "Demo Agent", "agent_sdk_version": "2.2.3"},

--- a/src/plugins/aidev_bkplugin/uv.lock
+++ b/src/plugins/aidev_bkplugin/uv.lock
@@ -53,6 +53,22 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/20/1f/d7f4efe8d98bd1e3ef33b3327d17072fcdfe02cc56a60da24153856db1ad/aidev_agent-2.2.1.post1-py3-none-any.whl", hash = "sha256:5ae3d96fc2c15737a07f9bbffc198442b522795c4396a8c1e8ed46f5fe2f5454", size = 564336, upload-time = "2026-08-13T08:56:37.348Z" },
 ]
 
+[package.optional-dependencies]
+opentelemetry = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-httpx" },
+    { name = "opentelemetry-instrumentation-langchain" },
+    { name = "opentelemetry-instrumentation-threading" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+]
+
 [[package]]
 name = "aidev-bkplugin"
 version = "2.2.1.post1"
@@ -61,6 +77,11 @@ dependencies = [
     { name = "aidev-agent" },
     { name = "blueapps" },
     { name = "django" },
+]
+
+[package.optional-dependencies]
+opentelemetry = [
+    { name = "aidev-agent", extra = ["opentelemetry"] },
 ]
 
 [package.dev-dependencies]
@@ -75,9 +96,11 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aidev-agent", specifier = ">=2.2.1.post1" },
+    { name = "aidev-agent", extras = ["opentelemetry"], marker = "extra == 'opentelemetry'", specifier = ">=2.2.1.post1" },
     { name = "blueapps", specifier = ">=4.15.1,<5.0" },
     { name = "django", specifier = ">=4.2.28,<5.0" },
 ]
+provides-extras = ["opentelemetry"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -376,6 +399,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -468,6 +503,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.2.4"
 source = { registry = "https://pypi.org/simple" }
@@ -483,6 +530,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/67/24/28a5b2fa42d12b3d7e5614145f0bd89714c34c08be6aabe39c14dd52db34/greenlet-3.2.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c9c6de1940a7d828635fbd254d69db79e54619f165ee7ce32fda763a9cb6a58c", size = 1548385, upload-time = "2025-11-04T12:42:11.067Z" },
     { url = "https://files.pythonhosted.org/packages/6a/05/03f2f0bdd0b0ff9a4f7b99333d57b53a7709c27723ec8123056b084e69cd/greenlet-3.2.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:03c5136e7be905045160b1b9fdca93dd6727b180feeafda6818e6496434ed8c5", size = 1613329, upload-time = "2025-11-04T12:42:12.928Z" },
     { url = "https://files.pythonhosted.org/packages/d8/0f/30aef242fcab550b0b3520b8e3561156857c94288f0332a79928c31a52cf/greenlet-3.2.4-cp311-cp311-win_amd64.whl", hash = "sha256:9c40adce87eaa9ddb593ccb0fa6a07caf34015a29bf8d344811665b573138db9", size = 299100, upload-time = "2025-08-07T13:44:12.287Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.81.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/ea/1c2fa386b718ff493225e61cfc052ef400b4d6ffc54cbe261026432624b5/grpcio-1.81.1-cp311-cp311-linux_armv7l.whl", hash = "sha256:d71d30f2d92f67d944631c523713934fee37292469e182ebcd2c1dd8a64ce53f", size = 6093112, upload-time = "2026-06-11T12:44:52.131Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/18/acf45fa8bd1bc5d7b0c2fd3dc4c209379fbd5bb396b440b68a83342226b7/grpcio-1.81.1-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:b137f4bf3ada9dc44d411478decc6ff09a79ed30b306cd2abaa98408c3588137", size = 12074277, upload-time = "2026-06-11T12:44:55.354Z" },
+    { url = "https://files.pythonhosted.org/packages/48/d7/ee86a60699b7db039f772a2c4a7e4facc7138984ff42c0130933a0063884/grpcio-1.81.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:a3acb384427816dd5d470f47e62137b87f74da694faa8a50147012cf40df276a", size = 6640348, upload-time = "2026-06-11T12:44:59.223Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ee/d2de5e47378ffc207d476c230fea3be4d2601edbce9995f4fe45535d4896/grpcio-1.81.1-cp311-cp311-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:f9a0ebbe45c29b5e5866593c12b78bd9035f0f0f0d4bc8361680cd580d99db49", size = 7331842, upload-time = "2026-06-11T12:45:02.001Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d6/abeda5c2b896a0b341584fe5ac411bbf72e197a9a374c355fb90965e08d2/grpcio-1.81.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0a37165cc80b1a368384b383e63a4c38116a10467ae44c904d2d7468c4470ec2", size = 6842229, upload-time = "2026-06-11T12:45:04.76Z" },
+    { url = "https://files.pythonhosted.org/packages/10/1c/1f0da7d590b4aeee006826ba568d0e419ca14b23e18f901a3da3e9fba613/grpcio-1.81.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6282caffb41ec326d4cb67ca9cf53b739d1b2f975a2acb498c7418e9f7d9a416", size = 7446096, upload-time = "2026-06-11T12:45:07.499Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/5c505d508f7c887aa7982d21443a4126597c80d34b0bcf40f9cec576d7f3/grpcio-1.81.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:a35009284d0d3d5c2c9601c164a911b8b4331608d98a9a66d47d97bb2f522b70", size = 8445238, upload-time = "2026-06-11T12:45:10.243Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b2/524847365122ee509ca17bcc4e092198b700e94af7bfd5bb5e6dd9f3ee66/grpcio-1.81.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1b22c80559854b789a01fd89e8929b3798a156c0829b5282a8939f33ad4115ad", size = 7873989, upload-time = "2026-06-11T12:45:13.102Z" },
+    { url = "https://files.pythonhosted.org/packages/18/fa/07c037c50b006909d1d13a5848774f8aa7b242f70dc03a035c64eea0e6db/grpcio-1.81.1-cp311-cp311-win32.whl", hash = "sha256:428bec0161b48d8cf583c068591bc0016d0d9cfff52462b72b3884861ea768c5", size = 4202223, upload-time = "2026-06-11T12:45:16.166Z" },
+    { url = "https://files.pythonhosted.org/packages/41/ed/6bff15376920942fac6b95b9802752b837437172c9e8fc2d3170546b89cc/grpcio-1.81.1-cp311-cp311-win_amd64.whl", hash = "sha256:30e825f6848d9f18bba350ed6c75c1b02a0b5184474a31db9a32b1fa66fd8c79", size = 4941303, upload-time = "2026-06-11T12:45:18.724Z" },
 ]
 
 [[package]]
@@ -538,6 +606,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/08/c1395a292bb23fd03bdf572a1357c5a733d3eecbab877641ceacab23db6e/importlib_metadata-8.6.1.tar.gz", hash = "sha256:310b41d755445d74569f993ccfc22838295d9fe005425094fad953d7f15c8580", size = 55767, upload-time = "2025-01-20T22:21:30.429Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/79/9d/0fb148dc4d6fa4a7dd1d8378168d9b4cd8d4560a6fbf6f0121c5fc34eb68/importlib_metadata-8.6.1-py3-none-any.whl", hash = "sha256:02a89390c1e15fdfdc0d7c6b25cb3e62650d0494005c97d6f148bf5b9787525e", size = 26971, upload-time = "2025-01-20T22:21:29.177Z" },
 ]
 
 [[package]]
@@ -937,6 +1017,197 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d5/e4/42591e356f1d53c568418dc7e30dcda7be31dd5a4d570bca22acb0525862/openai-2.8.1.tar.gz", hash = "sha256:cb1b79eef6e809f6da326a7ef6038719e35aa944c42d081807bfa1be8060f15f", size = 602490, upload-time = "2025-11-17T22:39:59.549Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/4f/dbc0c124c40cb390508a82770fb9f6e3ed162560181a85089191a851c59a/openai-2.8.1-py3-none-any.whl", hash = "sha256:c6c3b5a04994734386e8dad3c00a393f56d3b68a27cd2e8acae91a59e4122463", size = 1022688, upload-time = "2025-11-17T22:39:57.675Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "importlib-metadata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8d/1f5a45fbcb9a7d87809d460f09dc3399e3fbd31d7f3e14888345e9d29951/opentelemetry_api-1.33.1.tar.gz", hash = "sha256:1c6055fc0a2d3f23a50c7e17e16ef75ad489345fd3df1f8b8af7c0bbf8a109e8", size = 65002, upload-time = "2025-05-16T18:52:41.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/44/4c45a34def3506122ae61ad684139f0bbc4e00c39555d4f7e20e0e001c8a/opentelemetry_api-1.33.1-py3-none-any.whl", hash = "sha256:4db83ebcf7ea93e64637ec6ee6fabee45c5cbe4abd9cf3da95c43828ddb50b83", size = 65771, upload-time = "2025-05-16T18:52:17.419Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/3f/c8ad4f1c3aaadcea2b0f1b4d7970e7b7898c145699769a789f3435143f69/opentelemetry_exporter_otlp-1.33.1.tar.gz", hash = "sha256:4d050311ea9486e3994575aa237e32932aad58330a31fba24fdba5c0d531cf04", size = 6189, upload-time = "2025-05-16T18:52:43.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/32/b9add70dd4e845654fc9fcd1401a705477743880be6c3e62acb1ad0d8662/opentelemetry_exporter_otlp-1.33.1-py3-none-any.whl", hash = "sha256:9bcf1def35b880b55a49e31ebd63910edac14b294fd2ab884953c4deaff5b300", size = 7045, upload-time = "2025-05-16T18:52:21.022Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7a/18/a1ec9dcb6713a48b4bdd10f1c1e4d5d2489d3912b80d2bcc059a9a842836/opentelemetry_exporter_otlp_proto_common-1.33.1.tar.gz", hash = "sha256:c57b3fa2d0595a21c4ed586f74f948d259d9949b58258f11edb398f246bec131", size = 20828, upload-time = "2025-05-16T18:52:43.795Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/09/52/9bcb17e2c29c1194a28e521b9d3f2ced09028934c3c52a8205884c94b2df/opentelemetry_exporter_otlp_proto_common-1.33.1-py3-none-any.whl", hash = "sha256:b81c1de1ad349785e601d02715b2d29d6818aed2c809c20219f3d1f20b038c36", size = 18839, upload-time = "2025-05-16T18:52:22.447Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/5f/75ef5a2a917bd0e6e7b83d3fb04c99236ee958f6352ba3019ea9109ae1a6/opentelemetry_exporter_otlp_proto_grpc-1.33.1.tar.gz", hash = "sha256:345696af8dc19785fac268c8063f3dc3d5e274c774b308c634f39d9c21955728", size = 22556, upload-time = "2025-05-16T18:52:44.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/ec/6047e230bb6d092c304511315b13893b1c9d9260044dd1228c9d48b6ae0e/opentelemetry_exporter_otlp_proto_grpc-1.33.1-py3-none-any.whl", hash = "sha256:7e8da32c7552b756e75b4f9e9c768a61eb47dee60b6550b37af541858d669ce1", size = 18591, upload-time = "2025-05-16T18:52:23.772Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/48/e4314ac0ed2ad043c07693d08c9c4bf5633857f5b72f2fefc64fd2b114f6/opentelemetry_exporter_otlp_proto_http-1.33.1.tar.gz", hash = "sha256:46622d964a441acb46f463ebdc26929d9dec9efb2e54ef06acdc7305e8593c38", size = 15353, upload-time = "2025-05-16T18:52:45.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/ba/5a4ad007588016fe37f8d36bf08f325fe684494cc1e88ca8fa064a4c8f57/opentelemetry_exporter_otlp_proto_http-1.33.1-py3-none-any.whl", hash = "sha256:ebd6c523b89a2ecba0549adb92537cc2bf647b4ee61afbbd5a4c6535aa3da7cf", size = 17733, upload-time = "2025-05-16T18:52:25.137Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/fd/5756aea3fdc5651b572d8aef7d94d22a0a36e49c8b12fcb78cb905ba8896/opentelemetry_instrumentation-0.54b1.tar.gz", hash = "sha256:7658bf2ff914b02f246ec14779b66671508125c0e4227361e56b5ebf6cef0aec", size = 28436, upload-time = "2025-05-16T19:03:22.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/89/0790abc5d9c4fc74bd3e03cb87afe2c820b1d1a112a723c1163ef32453ee/opentelemetry_instrumentation-0.54b1-py3-none-any.whl", hash = "sha256:a4ae45f4a90c78d7006c51524f57cd5aa1231aef031eae905ee34d5423f5b198", size = 31019, upload-time = "2025-05-16T19:02:15.611Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-httpx"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/64/65b2e599c5043a5dbd14c251d48dec4947e2ec8713f601df197ea9b51246/opentelemetry_instrumentation_httpx-0.54b1.tar.gz", hash = "sha256:37e1cd0190f98508d960ec1667c9f148f8c8ad9a6cab127b57c9ad92c37493c3", size = 17734, upload-time = "2025-05-16T19:03:47.762Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/63/f92e93b613b51344a979dc6674641f2c0d24b031f6a08557304398962e41/opentelemetry_instrumentation_httpx-0.54b1-py3-none-any.whl", hash = "sha256:99b8e43ebf1d945ca298d84d32298ba26d1c3431738cea9f69a26c442661745f", size = 14129, upload-time = "2025-05-16T19:02:45.418Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-langchain"
+version = "0.38.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-semantic-conventions-ai" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/fb/499334b03a7f9a274da5f7b9b8674479800f402bf1792cafc944c87b00bd/opentelemetry_instrumentation_langchain-0.38.10.tar.gz", hash = "sha256:d63ebba00d6741d69d7ee68b186fa353364b94d781827b848d32fdc21e60286c", size = 8838, upload-time = "2025-03-05T14:22:26.834Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/46/dfa63ef4e0bfba712f7395aeba592a6f7214b7190c5a276a99503a9a268d/opentelemetry_instrumentation_langchain-0.38.10-py3-none-any.whl", hash = "sha256:d3f71da783a6771a15bc282e09f58e6155a7d8e537bd10f8d5a899f0072dc60b", size = 10277, upload-time = "2025-03-05T14:21:44.42Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-threading"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/bd/561245292e7cc78ac7a0a75537873aea87440cb9493d41371421b3308c2b/opentelemetry_instrumentation_threading-0.54b1.tar.gz", hash = "sha256:3a081085b59675baf7bd93126a681903e6304a5f283df5eaecdd44bcb66df578", size = 8774, upload-time = "2025-05-16T19:04:04.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/10/d87ec07d69546adaad525ba5d40d27324a45cba29097d9854a53d9af5047/opentelemetry_instrumentation_threading-0.54b1-py3-none-any.whl", hash = "sha256:bc229e6cd3f2b29fafe0a8dd3141f452e16fcb4906bca4fbf52609f99fb1eb42", size = 9314, upload-time = "2025-05-16T19:03:09.527Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/dc/791f3d60a1ad8235930de23eea735ae1084be1c6f96fdadf38710662a7e5/opentelemetry_proto-1.33.1.tar.gz", hash = "sha256:9627b0a5c90753bf3920c398908307063e4458b287bb890e5c1d6fa11ad50b68", size = 34363, upload-time = "2025-05-16T18:52:52.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/29/48609f4c875c2b6c80930073c82dd1cafd36b6782244c01394007b528960/opentelemetry_proto-1.33.1-py3-none-any.whl", hash = "sha256:243d285d9f29663fc7ea91a7171fcc1ccbbfff43b48df0774fd64a37d98eda70", size = 55854, upload-time = "2025-05-16T18:52:36.269Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/67/12/909b98a7d9b110cce4b28d49b2e311797cffdce180371f35eba13a72dd00/opentelemetry_sdk-1.33.1.tar.gz", hash = "sha256:85b9fcf7c3d23506fbc9692fd210b8b025a1920535feec50bd54ce203d57a531", size = 161885, upload-time = "2025-05-16T18:52:52.832Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/8e/ae2d0742041e0bd7fe0d2dcc5e7cce51dcf7d3961a26072d5b43cc8fa2a7/opentelemetry_sdk-1.33.1-py3-none-any.whl", hash = "sha256:19ea73d9a01be29cacaa5d6c8ce0adc0b7f7b4d58cc52f923e4413609f670112", size = 118950, upload-time = "2025-05-16T18:52:37.297Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "opentelemetry-api" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/2c/d7990fc1ffc82889d466e7cd680788ace44a26789809924813b164344393/opentelemetry_semantic_conventions-0.54b1.tar.gz", hash = "sha256:d1cecedae15d19bdaafca1e56b29a66aa286f50b5d08f036a145c7f3e9ef9cee", size = 118642, upload-time = "2025-05-16T18:52:53.962Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/80/08b1698c52ff76d96ba440bf15edc2f4bc0a279868778928e947c1004bdd/opentelemetry_semantic_conventions-0.54b1-py3-none-any.whl", hash = "sha256:29dab644a7e435b58d3a3918b58c333c92686236b30f7891d5e51f02933ca60d", size = 194938, upload-time = "2025-05-16T18:52:38.796Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions-ai"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/8f/7fb173fd1928398b81d0952f7a9f30381ce3215817e3ac6e92f180434874/opentelemetry_semantic_conventions_ai-0.4.3.tar.gz", hash = "sha256:761a68a7e99436dfc53cfe1f99507316aa0114ac480f0c42743b9320b7c94831", size = 4540, upload-time = "2025-03-04T16:33:13.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/56/b178de82b650526ff5d5e67037786008ea0acd043051d535c483dabd3cc4/opentelemetry_semantic_conventions_ai-0.4.3-py3-none-any.whl", hash = "sha256:9ff60bbf38c8a891c20a355b4ca1948380361e27412c3ead264de0d050fa2570", size = 5384, upload-time = "2025-03-04T16:33:11.784Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a8/9f/1d8a1d1f34b9f62f2b940b388bf07b8167a8067e70870055bd05db354e5c/opentelemetry_util_http-0.54b1.tar.gz", hash = "sha256:f0b66868c19fbaf9c9d4e11f4a7599fa15d5ea50b884967a26ccd9d72c7c9d15", size = 8044, upload-time = "2025-05-16T19:04:10.79Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/ef/c5aa08abca6894792beed4c0405e85205b35b8e73d653571c9ff13a8e34e/opentelemetry_util_http-0.54b1-py3-none-any.whl", hash = "sha256:b1c91883f980344a1c3c486cffd47ae5c9c1dd7323f9cbe9fdb7cadb401c87c9", size = 7301, upload-time = "2025-05-16T19:03:18.18Z" },
 ]
 
 [[package]]
@@ -1713,6 +1984,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/50/55/15a7b8a56590e66ccd374bbfa3f9ffc45b810886c8c3b614e3f90bd2367c/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:881b47fc47e051b37d94d13e7455131054b56749b91b508b0907eb07900d1c13", size = 36251, upload-time = "2025-10-02T14:37:04.44Z" },
     { url = "https://files.pythonhosted.org/packages/62/b2/5ac99a041a29e58e95f907876b04f7067a0242cb85b5f39e726153981503/xxhash-3.6.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c6dc31591899f5e5666f04cc2e529e69b4072827085c1ef15294d91a004bc1bd", size = 32481, upload-time = "2025-10-02T14:37:05.869Z" },
     { url = "https://files.pythonhosted.org/packages/7b/d9/8d95e906764a386a3d3b596f3c68bb63687dfca806373509f51ce8eea81f/xxhash-3.6.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:15e0dac10eb9309508bfc41f7f9deaa7755c69e35af835db9cb10751adebc35d", size = 31565, upload-time = "2025-10-02T14:37:06.966Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/d8/eab98a517c14134c0b2eb4e2387bc5f457334293ec5d2dd3857ec2966802/zipp-4.1.0.tar.gz", hash = "sha256:4cb57381f544315db7688e976e922a2b18cdb513d21cc194eb42232ba2a3e602", size = 26214, upload-time = "2026-05-18T20:08:57.967Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/13/547360d81e6d88d58492968ffda9f9542854f11310ee556fef14260cc886/zipp-4.1.0-py3-none-any.whl", hash = "sha256:25ad4e16390cd314347dd8f1de67a2ac538ae658ed4ab9db16029c07c188e97f", size = 10238, upload-time = "2026-05-18T20:08:57.045Z" },
 ]
 
 [[package]]

--- a/template/{{cookiecutter.project_name}}/support-files/env.template
+++ b/template/{{cookiecutter.project_name}}/support-files/env.template
@@ -11,6 +11,12 @@ export AIDEV_SPACE_ID={{ cookiecutter.extra_fields.space_id }}
 export AIDEV_GATEWAY_NAME={{ cookiecutter.aidev_gateway_name }}
 export BK_APIGW_STAGE={{ cookiecutter.bk_apigw_stage }}
 
+# Agent 指标本地上报（BKM 自定义指标协议；请从监控平台获取实际配置）
+export BKAI_AGENT_METRICS_HOST=
+export BKAI_AGENT_METRICS_DATA_ID=
+export BKAI_AGENT_METRICS_TOKEN=
+export BKAI_AGENT_METRICS_TARGET=
+
 # 平台内置环境变量：可在【开发者中心 > 模块配置 > 环境变量 > 查看内置环境变量】获取
 export BK_APIGW_MANAGER_URL_TMPL={{cookiecutter.apigw_manager_url_tmpl}}
 export BK_API_URL_TMPL={{cookiecutter.apigw_manager_url_tmpl}}


### PR DESCRIPTION
## 背景

Agent SDK 需要提供统一的运行时指标，并由插件侧完成生产环境导出，以便观测 Agent、LLM、工具调用、SSE 与消息 Broker 的运行状态。

## 原因

现有链路以 Trace 为主，缺少适合聚合查询的低基数指标，也缺少与应用凭据隔离的异步指标上报实现。

## 改动内容

- 在 Agent SDK 中增加 Agent、LLM、Tool、SSE 与 Broker 指标埋点，保留原有 Trace 上报逻辑。
- 在 bkplugin 中增加周期指标快照、Celery 异步任务和 BKM 自定义指标协议导出。
- 增加独立的 `dev/otel` 本地观测环境，包含 Collector、Prometheus、Grafana、Mock 数据与自动化检查。
- 本地 Grafana 锁定为 10.4.19，并使用该版本重新生成 schema 39 仪表盘以对齐线上 10.x。
- 增加相关单元测试与消息 Handler 指标覆盖。
- 根据评审修复直连 OTLP Histogram 分桶，使耗时和消息大小与 bkplugin 使用同一套边界。
- Trace 关闭时仍保留 LLM 请求模型指标维度。
- 兼容 develop 新增的 Token Trace 采集，保留原有 input/output/total 与 reasoning 语义，仅补充 cache creation/read 字段。
- 直连模式正确应用指标导出间隔和超时配置。
- BKM 指标保持进程内周期聚合后通过 Celery 异步上报，生产默认周期调整为 10 秒；显式配置仍可覆盖。

## 收益

- 可统一观察活跃 Agent、阶段分布、耗时、首 Token、迭代次数、工具调用和 Broker 应用侧压力。
- 指标凭据留在插件 Worker，Celery 任务只传递端点指纹和无凭据指标数据。
- 可在不影响业务源码目录的情况下快速启动本地仪表盘进行验证。

## 测试验证

- 最新 develop rebase 后 Agent OpenTelemetry、Token 与四类消息 Handler：147 passed，33 skipped。
- bkplugin 指标服务：33 passed。
- 本地观测配置与查询：41 passed。
- Grafana 10.4.19 实际加载：34 个面板、6 个过滤器，浏览器渲染无控制台错误。
- PR 差异级 Ruff、Ruff format、冲突标记检查及提交钩子通过。

## 不包含

- 不采集 Broker 服务端队列积压、磁盘和网络等基础设施指标。
- 不改变现有 Trace 数据上报协议。
