### PR TITLE
feat: 为 Loop(评估模型是否完成任务) 增加了配置开关

### DIFF
--- a/src/agent/aidev_agent/config.py
+++ b/src/agent/aidev_agent/config.py
@@ -156,7 +156,9 @@ BKAI_A2A_SESSION_TEMPORARY = env.bool("BKAI_A2A_SESSION_TEMPORARY", False)
 # LLM 重试策略: "sdk" 由 aidev 自主控制重试, "llm_gw" 由模型网关 Retry-After 头控制重试
 LLM_RETRY_STRATEGY = env.str("LLM_RETRY_STRATEGY", "llm_gw")
 # 质量判断模型配置（用于 quality_gate 判断模型是否完成任务）
-JUDGMENT_LLM_MODEL = env.str("JUDGMENT_LLM_MODEL", "aidev-chat-fast")
+BKAI_FAST_LLM = env.str("BKAI_FAST_LLM", None)
+# 是否启用任务完成度评估（None 表示不覆盖平台配置）
+BKAI_ENABLE_JUDGE_RESPONSE = env.bool("BKAI_ENABLE_JUDGE_RESPONSE", None)
 # end: 配置
 
 

--- a/src/agent/aidev_agent/core/graphs/react/graph.py
+++ b/src/agent/aidev_agent/core/graphs/react/graph.py
@@ -693,6 +693,8 @@ class ReActAgentBuilder:
                 node_options_kwargs["token_margin"] = model_context_options.token_limit_margin
             if model_context_options.tool_output_compress_thrd is not None:
                 node_options_kwargs["tool_output_compress_thrd"] = model_context_options.tool_output_compress_thrd
+            if model_context_options.enable_judge_response is not None:
+                node_options_kwargs["enable_judge_response"] = model_context_options.enable_judge_response
 
         # 从 knowledge_query_options 提取参数
         knowledge_query_options = self._knowledge_query_options

--- a/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
+++ b/src/agent/aidev_agent/core/nodes/model/pydantic_models.py
@@ -150,7 +150,7 @@ class ModelNodeSettings(BaseModel):
         description="是否启用纯文本工具调用提升（将文本中的工具调用格式解析为原生 tool_calls）",
     )
     enable_judge_response: bool = Field(
-        default=True,
+        default=False,
         description="是否启用任务完成度评估。关闭后 has_content 分支直接返回 NORMAL_COMPLETION，省去每次正常响应的额外判断 LLM 调用",
     )
 

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -322,6 +322,10 @@ class BaseResourceManager(abc.ABC):
         if intent_recognition_data.get("agent_type"):
             model_context_options_data["llm_code_agent_type"] = intent_recognition_data["agent_type"]
 
+        # 环境变量覆盖：BKAI_ENABLE_JUDGE_RESPONSE 不为 None 时覆盖平台配置, 环境变量优先
+        if settings.BKAI_ENABLE_JUDGE_RESPONSE is not None:
+            model_context_options_data["enable_judge_response"] = settings.BKAI_ENABLE_JUDGE_RESPONSE
+
         conversation_settings = res.get("conversation_settings", {}) or {}
         raw_commands = conversation_settings.get("commands", []) or []
         related_agents_raw = res.get("related_agents") or []
@@ -362,6 +366,7 @@ class BaseResourceManager(abc.ABC):
             chat_model=prompt_setting.get("llm_code", ""),
             fallback_model=prompt_setting.get("fallback_model"),
             non_thinking_llm=prompt_setting.get("non_thinking_llm") or prompt_setting.get("llm_code", ""),
+            fast_llm=settings.BKAI_FAST_LLM if settings.BKAI_FAST_LLM else prompt_setting.get("fast_llm", ""),
             role_prompts=role_prompts or None,
             knowledgebase_ids=res["knowledgebase_settings"]["knowledgebases"],
             tool_codes=tool_codes,

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -131,6 +131,7 @@ class ModelContextSettings(BaseModel):
     llm_code_agent_type: str | None = Field(
         default=None, description="模型类型（如 openai / deepseek_r1），从 intent_recognition 获取"
     )
+    enable_judge_response: bool = Field(default=False, description="是否启用任务完成度评估")
 
 
 class KnowledgeSettings(BaseModel):
@@ -414,6 +415,7 @@ class AgentConfig(BaseModel):
     chat_model: str = Field(..., description="LLM模型名称")
     fallback_model: str | None = Field(default=None, description="主模型请求失败时使用的备用模型")
     non_thinking_llm: str = Field(..., description="非深度思考模型")
+    fast_llm: str | None = Field(default=None, description="快速模型")
     role_prompts: list[dict[Literal["role", "content"], str]] | None = Field(None, description="角色提示词(平台)")
     model_context_options_data: dict = Field(
         default_factory=dict, description="模型上下文配置原始数据，待 ChatAgentBuilder 构建 ModelContextSettings"

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1414,12 +1414,12 @@ class ChatAgentBuilder:
     def build_chat_model_fast(self) -> BaseChatModel | None:
         """构建快速/轻量模型（用于 quality_gate 判断 LLM 等辅助任务）。
 
-        当前从环境变量 ``settings.JUDGMENT_LLM_MODEL`` 读取模型名（默认
-        ``SRE3-6-35B-A3B-nothinking``）。待配置平台改造完成后，改为从
-        ``agent_config.fast_llm`` 读取（与 ``build_chat_model_non_thinking``
-        读 ``agent_config.non_thinking_llm`` 对称）。
+        当前从 ``agent_config.fast_llm`` 读取模型名（与
+        ``build_chat_model_non_thinking`` 读 ``agent_config.non_thinking_llm`` 对称），
+        ``agent_config.fast_llm`` 由 resource_manager 填充，未配置时回退到
+        ``non_thinking_llm`` / ``llm_code``。
         """
-        model_name = settings.JUDGMENT_LLM_MODEL
+        model_name = self.ctx.agent_config.fast_llm
         base_url = settings.LLM_GW_ENDPOINT
         if not model_name or not base_url:
             return None

--- a/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
+++ b/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
@@ -80,6 +80,7 @@ def _make_agent_config(agent_code: str = "agent-x") -> AgentConfig:
         agent_name=agent_code,
         chat_model="mock-llm",
         non_thinking_llm="mock-llm",
+        fast_llm="mock-llm",
         agent_options=AgentOptions(),
     )
 

--- a/src/agent/tests/packages/resource_manager/test_agent_config.py
+++ b/src/agent/tests/packages/resource_manager/test_agent_config.py
@@ -385,3 +385,86 @@ def test_document_fragment_count_overrides_rough_recall_topk():
 
     assert cfg.knowledge_query_options_data["knowledge_resource_rough_recall_topk"] == 3
     assert "document_fragment_count" not in cfg.knowledge_query_options_data
+
+
+@pytest.mark.parametrize(
+    "prompt_fast_llm, expected",
+    [
+        ("fast-model", "fast-model"),
+    ],
+)
+def test_fast_llm_from_prompt_setting(prompt_fast_llm, expected):
+    """``get_agent_config`` 返回的 ``fast_llm`` 直接取 ``prompt_setting.fast_llm``，无回退。"""
+    raw = _build_raw(
+        prompt_setting={
+            "llm_code": "llm-code",
+            "non_thinking_llm": "non-thinking",
+            "fast_llm": prompt_fast_llm,
+        }
+    )
+    rm = _StubResourceManager(raw_factory=lambda *_: raw)
+    cfg = rm.get_agent_config("a")
+    assert cfg.fast_llm == expected
+
+
+def test_fast_llm_none_raises_validation_error():
+    """``prompt_setting.fast_llm`` 为 None 时，AgentConfig 必填字段校验失败。"""
+    raw = _build_raw(
+        prompt_setting={
+            "llm_code": "llm-code",
+            "non_thinking_llm": "non-thinking",
+            "fast_llm": None,
+        }
+    )
+    rm = _StubResourceManager(raw_factory=lambda *_: raw)
+    with pytest.raises(ValueError):
+        rm.get_agent_config("a")
+
+
+@pytest.mark.parametrize(
+    "bkai_fast_llm, prompt_fast_llm, expected",
+    [
+        ("env-fast", "platform-fast", "env-fast"),
+        ("env-fast", None, "env-fast"),
+        (None, "platform-fast", "platform-fast"),
+        ("", "platform-fast", "platform-fast"),
+    ],
+)
+def test_fast_llm_env_override(monkeypatch, bkai_fast_llm, prompt_fast_llm, expected):
+    """``BKAI_FAST_LLM`` 环境变量有值时覆盖平台 ``prompt_setting.fast_llm``。"""
+    monkeypatch.setattr("aidev_agent.config.settings.BKAI_FAST_LLM", bkai_fast_llm)
+    raw = _build_raw(
+        prompt_setting={
+            "llm_code": "llm-code",
+            "non_thinking_llm": "non-thinking",
+            "fast_llm": prompt_fast_llm,
+        }
+    )
+    rm = _StubResourceManager(raw_factory=lambda *_: raw)
+    cfg = rm.get_agent_config("a")
+    assert cfg.fast_llm == expected
+
+
+@pytest.mark.parametrize(
+    "bkai_enable, prompt_enable, expected",
+    [
+        (True, False, True),
+        (False, True, False),
+        (None, True, True),
+        (None, False, False),
+    ],
+)
+def test_enable_judge_response_env_override(monkeypatch, bkai_enable, prompt_enable, expected):
+    """``BKAI_ENABLE_JUDGE_RESPONSE`` 非 None 时覆盖 ``model_context_options_data``。"""
+    monkeypatch.setattr("aidev_agent.config.settings.BKAI_ENABLE_JUDGE_RESPONSE", bkai_enable)
+    raw = _build_raw(
+        prompt_setting={
+            "llm_code": "llm-code",
+            "non_thinking_llm": "non-thinking",
+            "fast_llm": "fast-model",
+            "enable_judge_response": prompt_enable,
+        }
+    )
+    rm = _StubResourceManager(raw_factory=lambda *_: raw)
+    cfg = rm.get_agent_config("a")
+    assert cfg.model_context_options_data["enable_judge_response"] == expected

--- a/src/agent/tests/services/test_agent_protocol.py
+++ b/src/agent/tests/services/test_agent_protocol.py
@@ -42,6 +42,7 @@ def _make_agent_config(agent_code: str = "agent-x", **overrides) -> AgentConfig:
         agent_name=agent_code,
         chat_model="mock-llm",
         non_thinking_llm="mock-llm",
+        fast_llm="mock-llm",
     )
     base.update(overrides)
     return AgentConfig(**base)

--- a/src/agent/tests/services/test_build_subagents.py
+++ b/src/agent/tests/services/test_build_subagents.py
@@ -43,6 +43,7 @@ def _make_agent_config(
         agent_name=agent_name,
         chat_model="test-model",
         non_thinking_llm="test-non-thinking",
+        fast_llm="test-non-thinking",
         agent_options=AgentOptions(),
         related_agents=related_agents if related_agents is not None else [],
     )

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -25,9 +25,12 @@ from aidev_agent.pydantic_models import (
     ModelContextSettings,
 )
 from aidev_agent.services.agent import ChatCompletionAgent
+from aidev_agent.services.agent.chat import ChatAgentBuilder
+from aidev_agent.services.agent.registry import AgentBuildContext, ChatBuildExtras
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
 from aidev_agent.services.messages_handler.streaming_helper import GeneratorStreamingHelper
 from aidev_agent.utils.event import RunId
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 from langchain_core.tools import ToolException, tool
 from langgraph.checkpoint.memory import MemorySaver
@@ -1067,6 +1070,39 @@ def test_build_chat_history_prepends_config_role_prompts_once():
     ]
 
 
+class TestBuildChatModelFast:
+    """``ChatAgentBuilder.build_chat_model_fast`` 从 ``agent_config.fast_llm`` 读取模型名。"""
+
+    @staticmethod
+    def _make_ctx(fast_llm: str | None = None):
+        ctx = MagicMock(spec=AgentBuildContext)
+        ctx.session_context_data = []
+        ctx.agent_config.fast_llm = fast_llm
+        ctx.chat = ChatBuildExtras()
+        return ctx
+
+    @patch("aidev_agent.services.agent.chat.ChatModel.get_setup_instance")
+    @patch("aidev_agent.services.agent.chat.settings.LLM_GW_ENDPOINT", "http://gw.test")
+    def test_returns_chat_model_when_fast_llm_set(self, mock_setup):
+        """``agent_config.fast_llm`` 非空时返回 ChatModel 实例并以其为模型名。"""
+        mock_setup.return_value = MagicMock(spec=BaseChatModel)
+        builder = ChatAgentBuilder(self._make_ctx(fast_llm="fast-model-v1"))
+        result = builder.build_chat_model_fast()
+        assert result is not None
+        assert mock_setup.call_args[1]["model"] == "fast-model-v1"
+
+    def test_returns_none_when_fast_llm_empty(self):
+        """``agent_config.fast_llm`` 为空时返回 None。"""
+        builder = ChatAgentBuilder(self._make_ctx(fast_llm=None))
+        assert builder.build_chat_model_fast() is None
+
+    def test_returns_none_when_base_url_empty(self):
+        """``LLM_GW_ENDPOINT`` 为空时返回 None。"""
+        with patch("aidev_agent.services.agent.chat.settings.LLM_GW_ENDPOINT", ""):
+            builder = ChatAgentBuilder(self._make_ctx(fast_llm="fast-model-v1"))
+            assert builder.build_chat_model_fast() is None
+
+
 class TestFilterUnmatchedToolCalls:
     """测试过滤没有匹配工具结果的 assistant 消息"""
 
@@ -1707,6 +1743,7 @@ def _build_legacy_agent_config() -> AgentConfig:
             "agent_name": "Legacy Agent",
             "chat_model": "test-llm-v1",
             "non_thinking_llm": "test-llm-lite",
+            "fast_llm": "test-llm-lite",
             "role_prompts": [{"role": "system", "content": "legacy role"}],
             "knowledgebase_ids": [10],
             "knowledge_ids": [100],


### PR DESCRIPTION
改功能转为默认关闭
1. 新增环境变量 BKAI_FAST_LLM、BKAI_ENABLE_JUDGE_RESPONSE
2. graph.py 中的 _prepare_agent_model_node 添加 enable_judge_response 的传递
3. get_agent_config 添加该配置获取方式