### PR TITLE
fix: 辅助模型透传 trace headers --story=1070093903133528178

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1405,6 +1405,8 @@ class ChatAgentBuilder:
         chat = self.ctx.chat or ChatBuildExtras()
         if chat.auth_headers:
             kwargs["auth_headers"] = chat.auth_headers
+        if chat.default_headers:
+            kwargs["default_headers"] = chat.default_headers
 
         if settings.LLM_RETRY_STRATEGY == "sdk":
             kwargs["max_retries"] = 0
@@ -1430,6 +1432,8 @@ class ChatAgentBuilder:
         chat = self.ctx.chat or ChatBuildExtras()
         if chat.auth_headers:
             kwargs["auth_headers"] = chat.auth_headers
+        if chat.default_headers:
+            kwargs["default_headers"] = chat.default_headers
 
         if settings.LLM_RETRY_STRATEGY == "sdk":
             kwargs["max_retries"] = 0

--- a/src/agent/tests/services/test_chat_bkaidev_attributes.py
+++ b/src/agent/tests/services/test_chat_bkaidev_attributes.py
@@ -4,6 +4,7 @@ import json
 import warnings
 from unittest.mock import MagicMock, patch
 
+import pytest
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.agent.chat import ChatAgentBuilder
@@ -69,6 +70,29 @@ class TestBuildChatModelNonThinking:
         builder = ChatAgentBuilder(ctx)
         result = builder.build_chat_model_non_thinking()
         assert result is None
+
+
+@pytest.mark.parametrize(
+    ("method_name", "model_name"),
+    [
+        ("build_chat_model_non_thinking", "nt-model-v1"),
+        ("build_chat_model_fast", "fast-model-v1"),
+    ],
+)
+def test_auxiliary_chat_models_forward_default_headers(method_name, model_name):
+    headers = {"traceparent": "00-992eea94222b572e883ab78b23e73d64-99e019654b49749a-01"}
+    ctx = _make_builder_ctx(agent_info={}, non_thinking_llm=model_name)
+    ctx.chat = ChatBuildExtras(default_headers=headers)
+    builder = ChatAgentBuilder(ctx)
+
+    with (
+        patch("aidev_agent.services.agent.chat.settings.JUDGMENT_LLM_MODEL", model_name),
+        patch("aidev_agent.services.agent.chat.settings.LLM_GW_ENDPOINT", "https://llm-gateway.example.com"),
+        patch("aidev_agent.services.agent.chat.ChatModel.get_setup_instance") as mock_setup,
+    ):
+        getattr(builder, method_name)()
+
+    assert mock_setup.call_args.kwargs["default_headers"] == headers
 
 
 class TestBuildNonThinkingLlmDeprecation:


### PR DESCRIPTION
## What

- build_chat_model_non_thinking 继承 ChatBuildExtras.default_headers
- build_chat_model_fast 继承 ChatBuildExtras.default_headers
- 补充两个辅助模型构建路径的 traceparent 透传回归测试

## Why

主聊天模型已经传递 default_headers，但 non-thinking 与 fast 辅助模型此前只传 auth_headers，导致 traceparent 等调用链 header 在辅助 LLM 请求中丢失。

## Test

- tests/services/test_chat_bkaidev_attributes.py: 14 passed
- pre-commit: ruff、ruff format、merge conflict scan 均通过
