### PR TITLE
feat: 补充 stop 请求的生产者状态 --story=1070093903136621156

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -300,9 +300,17 @@ class ChatSessionContentViewSet(PluginViewSet):
 
         # 获取 message_handler 用于清理
         message_handler = message_handler_factory.get()
+        producer_active = None
 
         # 停止 agent 侧的流式生产者
         if session_code:
+            # 在发送 cancel 前记录 producer 状态；发送后 producer 可能立即退出，无法区分
+            # “本次被停止”与“请求到达前已无 producer”两种场景。
+            try:
+                producer_active = bool(message_handler.has_active_producer(session_code))
+            except Exception:
+                logger.exception(f"Error checking active producer for session_code={session_code}")
+
             # 1. 先清理上一轮完成通知，避免误消费旧通知
             if hasattr(message_handler, "clear_cancelled_signal"):
                 try:
@@ -364,6 +372,8 @@ class ChatSessionContentViewSet(PluginViewSet):
 
         platform_payload = request.data.copy()
         platform_payload.pop("run_id", None)
+        if producer_active is not None:
+            platform_payload["producer_active"] = producer_active
         result = client.api.stop_chat_session_content(json=platform_payload, headers={"X-BKAIDEV-USER": username})
 
         return Response(data=result["data"])

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
@@ -124,6 +124,7 @@ def test_stop_clears_stale_notification_before_sending_cancel(monkeypatch, run_i
     session_code = "session-stop-order"
     call_order = []
     handler = MagicMock()
+    handler.has_active_producer.return_value = False
     handler.clear_cancelled_signal.side_effect = lambda code, run_id=None: call_order.append(("clear", code, run_id))
     handler.wait_for_consumer_cancelled.side_effect = lambda code, timeout, run_id=None: (
         call_order.append(("wait", code, run_id)) or True
@@ -152,7 +153,29 @@ def test_stop_clears_stale_notification_before_sending_cancel(monkeypatch, run_i
         ("wait", session_code, run_id),
     ]
     api.stop_chat_session_content.assert_called_once_with(
-        json={"session_code": session_code},
+        json={"session_code": session_code, "producer_active": False},
         headers={"X-BKAIDEV-USER": "alice"},
     )
     handler.mark_stopped.assert_not_called()
+
+
+def test_stop_omits_producer_state_when_detection_fails(monkeypatch):
+    """broker 查询异常时保持旧协议，避免平台误判为无 producer。"""
+    handler = MagicMock()
+    handler.has_active_producer.side_effect = RuntimeError("broker unavailable")
+    handler.wait_for_consumer_cancelled.return_value = True
+    api = MagicMock()
+    api.stop_chat_session_content.return_value = {"data": {"stopped": True}}
+
+    monkeypatch.setattr(session_mod.message_handler_factory, "get", lambda: handler)
+    monkeypatch.setattr(session_mod.GeneratorStreamingHelper, "cancel", lambda *args, **kwargs: True)
+    monkeypatch.setattr(session_mod.AgentConfigFetcher, "get_info", lambda **kwargs: {"agent_type": "chat"})
+    monkeypatch.setattr(session_mod, "client", SimpleNamespace(api=api))
+
+    response = session_mod.ChatSessionContentViewSet().stop(_request(data={"session_code": "session-stop"}))
+
+    assert response.data == {"stopped": True}
+    api.stop_chat_session_content.assert_called_once_with(
+        json={"session_code": "session-stop"},
+        headers={"X-BKAIDEV-USER": "alice"},
+    )


### PR DESCRIPTION
## 背景

失败会话在已无流式生产者时再次点击停止，平台需要区分“请求到达前已无 producer”和“本次 stop 正在取消活跃 producer”。

## 改动内容

- 在发送 cancel 前读取 message handler 的 producer 活跃状态
- 将 producer_active 作为可选字段透传给平台 stop 接口
- producer 状态查询异常时不传该字段，保持旧逻辑并避免误判
- 保留原有 clear cancel signal、cancel、等待消费者退出和 mark_stopped 流程

## 测试验证

- session view 定向回归：7 passed
- 目标文件 pre-commit hooks：通过
- 最新 develop 基线 diff check：通过

## 配套 PR 与发布顺序

- 平台 PR：https://github.com/TencentBlueKing/bk-aidev/pull/1871
- 建议先发布平台侧，再发布本 PR；任一侧单独滚动发布均保持旧行为。
