### PR TITLE
feat: 【chat-x】LoadingMessage 挂载时自动贴底并恢复跟随滚动 --story=137038750

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/loading-message/loading-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/loading-message/loading-message.spec.ts
@@ -47,11 +47,20 @@ vi.mock('../../../lang/lang', () => ({
   t: (key: string) => key,
 }));
 
+/** 滚动上下文的贴底方法；mockScrollConsumer 置空可模拟无 Provider 的独立使用场景 */
+const mockJumpToBottom = vi.hoisted(() => vi.fn());
+const mockScrollConsumer = vi.hoisted(() => ({ value: undefined as undefined | { jumpToBottom: () => void } }));
+
+vi.mock('../../../composables', () => ({
+  useContainerScrollConsumer: () => mockScrollConsumer,
+}));
+
 describe('LoadingMessage', () => {
   let wrapper: VueWrapper;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockScrollConsumer.value = { jumpToBottom: mockJumpToBottom };
   });
 
   afterEach(() => {
@@ -110,6 +119,23 @@ describe('LoadingMessage', () => {
       expect(wrapper.find('.complex-slot').exists()).toBe(true);
       expect(wrapper.text()).toContain('正在');
       expect(wrapper.text()).toContain('思考中...');
+    });
+  });
+
+  describe('自动贴底测试', () => {
+    it('挂载时应触发滚动容器贴底', () => {
+      wrapper = mount(LoadingMessage);
+
+      expect(mockJumpToBottom).toHaveBeenCalledTimes(1);
+    });
+
+    it('无滚动 Provider 时挂载不应报错', () => {
+      mockScrollConsumer.value = undefined;
+
+      wrapper = mount(LoadingMessage);
+
+      expect(wrapper.find('.ai-loading-message').exists()).toBe(true);
+      expect(mockJumpToBottom).not.toHaveBeenCalled();
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/loading-message/loading-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/loading-message/loading-message.vue
@@ -7,8 +7,20 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { onMounted } from 'vue';
+
+  import { useContainerScrollConsumer } from '../../../composables';
   import { t } from '../../../lang/lang';
   import AiLoading from '../../ai-loading/ai-loading.vue';
+
+  const containerScrollConsumer = useContainerScrollConsumer();
+
+  // 本组件仅在用户刚发出消息、等待回复时出现，其挂载即「新一轮对话开始」的信号。
+  // 此时无条件贴底并恢复自动跟随（jumpToBottom 内部会重置 autoScrollEnabled），
+  // 保证用户此前手动上滑翻历史后再发消息也能看到新内容。
+  onMounted(() => {
+    containerScrollConsumer?.value?.jumpToBottom?.();
+  });
 </script>
 <style lang="scss">
   .ai-loading-message {


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】LoadingMessage 挂载时自动贴底并恢复跟随滚动
ID: 1070093903137038750

## 改动
- `loading-message.vue`: 挂载时通过 `useContainerScrollConsumer` 调用 `jumpToBottom`，恢复自动跟随
- `loading-message.spec.ts`: 补充贴底触发与无 Provider 场景单测

## 影响面
- 影响对话区 Loading 占位出现时的滚动行为；无 Provider 时独立使用保持兼容

## 测试
- [x] LoadingMessage 挂载触发一次 `jumpToBottom`
- [x] 无滚动 Provider 时独立挂载不报错、不调用贴底
- [x] `loading-message` 相关单测通过

Made with [Cursor](https://cursor.com)