### PR TITLE
fix: 【chat-x】产物图片预览改用 download_url 并修复全屏 tippy

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -85,7 +85,6 @@
                   class="screen-btn"
                   :tippy-options="{
                     ...commonTippyOptions,
-                    appendTo: isFullScreen ? fullScreenRef! : commonTippyOptions?.appendTo,
                     content: isFullScreen ? t('退出全屏') : t('全屏'),
                   }"
                 >
@@ -476,7 +475,12 @@
       }
   >();
 
-  useCommonTippyProvider({ tippyOptions: computed(() => props.commonTippyOptions ?? {}) });
+  // 全屏时 tippy 默认挂 body 会跑出全屏层，统一把 appendTo 切到全屏容器再注入给子组件
+  const commonTippyOptions = computed<AITippyProps>(() => ({
+    ...props.commonTippyOptions,
+    appendTo: isFullScreen.value && fullScreenRef.value ? fullScreenRef.value : props.commonTippyOptions?.appendTo,
+  }));
+  useCommonTippyProvider({ tippyOptions: commonTippyOptions });
 
   const {
     displayTabs,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
@@ -17,6 +17,7 @@
       />
       <span
         v-overflow-tips="{
+          ...commonTippyOptions,
           text: file.name,
           placement: 'top' as const,
         }"
@@ -53,6 +54,7 @@
   import { directive as vTippy } from 'vue-tippy';
 
   import { triggerArtifactDownload, useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
+  import { useCommonTippyInject } from '../../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
   import { DownloadFileIcon } from '../../../../icons/file';
   import { t } from '../../../../lang/lang';
@@ -76,6 +78,7 @@
 
   // 文件产物侧栏预览上下文（由 ChatContainer 提供），无 Provider 时为 undefined
   const artifactPreview = useArtifactPreviewConsumer();
+  const commonTippyOptions = useCommonTippyInject();
 
   // 有外部 onPreview 或处于可预览的侧栏上下文时，卡片可点击
   const clickable = computed(() => !!props.onPreview || !!artifactPreview);
@@ -89,6 +92,7 @@
   const downloadLoading = shallowRef(false);
 
   const downloadTippy = computed(() => ({
+    ...commonTippyOptions?.value,
     content: t('下载'),
     theme: 'ai-chat-box',
     placement: 'top' as const,

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/artifact-preview-host.vue
@@ -46,7 +46,7 @@
     <ImagePreview
       v-else-if="renderer === 'image'"
       :name="file?.name"
-      :url="previewUrl"
+      :url="downloadUrl"
     />
     <UrlIframePreview
       v-else
@@ -76,7 +76,7 @@
   const props = defineProps<{ file?: AIFileInfo }>();
   const artifactPreview = useArtifactPreviewConsumer();
 
-  const { content, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
+  const { content, downloadUrl, load, previewUrl, renderer, status } = useArtifactPreviewLoader({
     canResolve: () => !!artifactPreview?.canResolveArtifactUrl.value,
     getFile: () => props.file,
     resolveUrls: file => artifactPreview?.resolveArtifactUrls(file) ?? Promise.resolve({}),

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-preview/use-artifact-preview-loader.ts
@@ -47,6 +47,7 @@ export const useArtifactPreviewLoader = (options: {
   const status = shallowRef<ArtifactPreviewStatus>('idle');
   const content = shallowRef('');
   const previewUrl = shallowRef('');
+  const downloadUrl = shallowRef('');
   const renderer = shallowRef<ArtifactPreviewRendererKind>('urlIframe');
 
   let abortController: AbortController | undefined;
@@ -55,6 +56,7 @@ export const useArtifactPreviewLoader = (options: {
   const resetPayload = () => {
     content.value = '';
     previewUrl.value = '';
+    downloadUrl.value = '';
   };
 
   const load = async () => {
@@ -103,11 +105,12 @@ export const useArtifactPreviewLoader = (options: {
         return;
       }
 
-      if (!urls.preview_url) {
+      if (!urls.preview_url || !urls.download_url) {
         status.value = 'empty';
         return;
       }
       previewUrl.value = urls.preview_url;
+      downloadUrl.value = urls.download_url;
       status.value = 'ready';
     } catch {
       if (seq !== loadSeq || abortController?.signal.aborted) {
@@ -124,5 +127,5 @@ export const useArtifactPreviewLoader = (options: {
 
   onBeforeUnmount(dispose);
 
-  return { content, dispose, load, previewUrl, renderer, status };
+  return { content, dispose, downloadUrl, load, previewUrl, renderer, status };
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
@@ -40,7 +40,7 @@
               :file-type="activeArtifact.type"
             />
             <span
-              v-overflow-tips="{ text: activeArtifact.name, placement: 'top' as const }"
+              v-overflow-tips="{ ...commonTippyOptions, text: activeArtifact.name, placement: 'top' as const }"
               class="ai-file-artifact-panel-preview-header-name"
             >
               {{ activeArtifact.name }}
@@ -94,6 +94,7 @@
 
   import { triggerArtifactDownload, useArtifactPreviewConsumer } from '../../../../composables/use-artifact-preview';
   import { useClipboard } from '../../../../composables/use-clipboard';
+  import { useCommonTippyInject } from '../../../../composables/use-common';
   import { OverflowTips as vOverflowTips } from '../../../../directives/overflow-tips';
   import { DownloadFileIcon } from '../../../../icons/file';
   import { CopyIcon } from '../../../../icons/tools';
@@ -125,6 +126,7 @@
   const artifactPreview = useArtifactPreviewConsumer();
   const canResolveArtifactUrl = computed(() => !!artifactPreview?.canResolveArtifactUrl.value);
   const { copy } = useClipboard();
+  const commonTippyOptions = useCommonTippyInject();
   const previewHostRef = useTemplateRef<InstanceType<typeof ArtifactPreviewHost>>('previewHostRef');
 
   // 图标为共享 VNode，每处渲染克隆一份，避免多处复用同一实例
@@ -135,12 +137,14 @@
   const downloadLoading = shallowRef(false);
 
   const copyTippy = computed(() => ({
+    ...commonTippyOptions?.value,
     content: t('复制'),
     placement: 'top' as const,
     theme: 'ai-chat-box',
   }));
 
   const downloadTippy = computed(() => ({
+    ...commonTippyOptions?.value,
     content: t('下载'),
     placement: 'top' as const,
     theme: 'ai-chat-box',


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】产物图片预览误用 preview_url 导致无法显示
ID: 1070093903137111239

## 改动
- artifact-preview-host.vue: ImagePreview 改用 downloadUrl，iframe 仍用 previewUrl
- use-artifact-preview-loader.ts: 增加 downloadUrl，preview_url 路径同时校验 preview_url 与 download_url
- chat-container.vue: 全屏时把 commonTippyOptions.appendTo 切到全屏容器再注入给子组件
- artifact-file-card.vue / file-artifact-panel.vue: overflow/download/copy tippy 合并注入的 commonTippyOptions

## 影响面
- 产物预览中图片渲染取链
- 全屏模式下产物相关 tippy 挂载容器
- 文本/代码/markdown/html 与 iframe 预览路径不变

## 测试
- [ ] 图片产物预览能正常显示
- [ ] 代码/文本/markdown/html 预览不受影响
- [ ] iframe 类预览仍走 preview_url
- [ ] 缺 preview_url 或 download_url 时展示空态
- [ ] 全屏模式下产物名称、下载、复制 tippy 仍显示在全屏层内


Made with [Cursor](https://cursor.com)