### PR TITLE
feat: SNAPSHOT 全量透传消息时间并为真收尾事件打墙钟戳 --story=136435427

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
@@ -24,6 +24,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from aidev_agent.core.nodes.tool.approval_wrapper import TOOL_APPROVAL_REASON
 from aidev_agent.exceptions import extract_model_error_message
+from aidev_agent.utils.event import stamp_round_end_event
 
 from .agent import LangGraphAGUIAgent
 from .approval import ApprovalOutcomeBuilder, ApproveResultLiteral
@@ -398,14 +399,14 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
                 )
 
         # 4) RUN_FINISHED（续流场景不下发 MESSAGES_SNAPSHOT，前端复用已有消息状态 + 上面补发的增量事件）
-        yield encoder.encode(
-            RunFinishedEvent(
-                type=EventType.RUN_FINISHED,
-                thread_id=agent_input.thread_id,
-                run_id=run_id,
-                outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
-            )
+        # 这是 checkpoint 重放，不是本轮真实结束，不打墙钟，避免前端把重连时刻当成轮次结束时间。
+        finished_event = RunFinishedEvent(
+            type=EventType.RUN_FINISHED,
+            thread_id=agent_input.thread_id,
+            run_id=run_id,
+            outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
         )
+        yield encoder.encode(finished_event)
 
     async def _handle_single_event(self, event: Any, state: State) -> AsyncGenerator[BaseEvent, None]:
         """覆写：super + 拦截 TOOL_CALL_* yield，审批抑制 + 工具增强在构造侧完成。
@@ -477,6 +478,8 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
 
     def _dispatch_event(self, event: BaseEvent) -> str:
         """DB + SSE 纯分发（转换已在构造侧 _handle_single_event 覆写完成）。"""
+        if isinstance(event, (RunFinishedEvent, RunErrorEvent)):
+            stamp_round_end_event(event)
         if self._event_handler:
             try:
                 self._event_handler(event)

--- a/src/agent/aidev_agent/core/ag_ui/types.py
+++ b/src/agent/aidev_agent/core/ag_ui/types.py
@@ -184,6 +184,7 @@ class CustomMessageType(Enum):
 
 class ExtendBaseMessage(BaseModel):
     status: Literal["complete", "streaming", "pending", "error", "stop"] = "complete"
+    created_at: str | None = Field(default=None, description="该条消息的创建时间，仅供 MESSAGES_SNAPSHOT 展示")
 
     @computed_field
     def message_id(self) -> str:

--- a/src/agent/aidev_agent/core/ag_ui/utils.py
+++ b/src/agent/aidev_agent/core/ag_ui/utils.py
@@ -219,6 +219,7 @@ def parse_reasoning_content_value(content: Any) -> list[str]:
 def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]:
     agui_messages: list[AGUIMessage] = []
     for message in messages:
+        created_at = (message.additional_kwargs or {}).get("created_at")
         if isinstance(message, HumanMessage):
             # Handle multimodal content
             multimodal = parse_multimodal_content(message.content)
@@ -233,6 +234,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     role="user",
                     content=content,
                     name=message.name,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, AIMessage):
@@ -257,6 +259,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                         id=str(message.id),
                         content=[message.additional_kwargs.get("reasoning_content")],
                         duration=message.additional_kwargs.get("reasoning_time", None),
+                        created_at=created_at,
                     )
                 )
 
@@ -286,6 +289,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     name=message.name,
                     property=message_property,
                     status=assistant_status,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, SystemMessage):
@@ -295,6 +299,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     role="system",
                     content=stringify_if_needed(resolve_message_content(message.content)),
                     name=message.name,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, ToolMessage):
@@ -307,6 +312,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     tool_call_id=message.tool_call_id,
                     error=content if message.status == "error" else None,
                     duration=message.additional_kwargs.get("duration", None),
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, InterruptMessage):
@@ -318,6 +324,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     id=str(message.id),
                     content=message.content,
                     name=message.name,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, ActivityMessage):
@@ -326,6 +333,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     id=str(message.id),
                     content=message.content,
                     activity_type=message.type,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, InfoMessage):
@@ -333,6 +341,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                 AGUIInfoMessage(
                     id=str(message.id),
                     content=message.content,
+                    created_at=created_at,
                 )
             )
         elif isinstance(message, ReasoningLangChainMessage):
@@ -341,6 +350,7 @@ def langchain_messages_to_agui(messages: list[BaseMessage]) -> list[AGUIMessage]
                     id=str(message.id),
                     content=parse_reasoning_content_value(message.content),
                     duration=message.additional_kwargs.get("duration"),
+                    created_at=created_at,
                 )
             )
         else:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1229,6 +1229,9 @@ class ChatCompletionAgent(BaseModel):
                 turn_kwargs["turn_id"] = bp["turn_id"]
             if bp.get("status"):
                 turn_kwargs["status"] = bp["status"]
+            if bp.get("created_at"):
+                # 仅供 MESSAGES_SNAPSHOT 展示；LangChain 转 OpenAI 不会把该键写入模型 payload
+                turn_kwargs["created_at"] = bp["created_at"]
             match each.role:
                 case PromptRole.USER.value:
                     multimodal = parse_multimodal_content(each.content)
@@ -1270,7 +1273,7 @@ class ChatCompletionAgent(BaseModel):
                         )
                     )
                 case PromptRole.SYSTEM.value:
-                    messages.append(SystemMessage(id=each.id, content=each.content))
+                    messages.append(SystemMessage(id=each.id, content=each.content, additional_kwargs=turn_kwargs))
                 case PromptRole.TOOL.value:
                     content = each.content if isinstance(each.content, str) else str(each.content)
                     messages.append(
@@ -1305,7 +1308,9 @@ class ChatCompletionAgent(BaseModel):
                             interrupt_content = {}
                     if not isinstance(interrupt_content, (dict, list)):
                         interrupt_content = {}
-                    messages.append(InterruptMessage(id=each.id, content=interrupt_content))
+                    messages.append(
+                        InterruptMessage(id=each.id, content=interrupt_content, additional_kwargs=turn_kwargs)
+                    )
         return messages
 
     def _convert_contents(self, contents: list[ChatPrompt]) -> list[ChatPrompt]:

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -10,7 +10,7 @@ from ag_ui.core import EventType, RawEvent, RunErrorEvent, RunFinishedEvent
 from ag_ui.encoder import EventEncoder
 
 from aidev_agent.core.ag_ui.types import RunFinishedSuccessOutcome, serialize_run_finished_outcome
-from aidev_agent.utils.event import RunId, emit_run_finished_event
+from aidev_agent.utils.event import RunId, emit_run_finished_event, stamp_round_end_event
 
 from .base import (
     BaseMessageQueueHandler,
@@ -689,6 +689,7 @@ class GeneratorStreamingHelper:
     ) -> Generator[str, None, None]:
         """输出 AG-UI 错误与结束事件，并同步通知会话事件处理器。"""
         error_event = RunErrorEvent(type=EventType.RUN_ERROR, message=message)
+        stamp_round_end_event(error_event)
         if event_handler is not None:
             try:
                 event_handler(error_event)
@@ -711,6 +712,8 @@ class GeneratorStreamingHelper:
             run_id=RunId.CANCELLED,
             outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
         )
+        stamp_round_end_event(error_event)
+        stamp_round_end_event(finished_event)
         return (error_event, encoder.encode(error_event)), (finished_event, encoder.encode(finished_event))
 
     def _emit_retryable_heartbeat_timeout(

--- a/src/agent/aidev_agent/utils/event.py
+++ b/src/agent/aidev_agent/utils/event.py
@@ -4,9 +4,10 @@ AG-UI 事件工具模块
 提供统一的事件发送方法和常量定义
 """
 
+import time
 from typing import Callable, Literal
 
-from ag_ui.core import EventType, RunFinishedEvent
+from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
 from ag_ui.encoder import EventEncoder
 
 from aidev_agent.core.ag_ui.types import RunFinishedSuccessOutcome, serialize_run_finished_outcome
@@ -31,6 +32,22 @@ class RunId:
     CANCELLED: RunIdType = "cancelled"
     STOPPED: RunIdType = "stopped"
     CANCELLED_MESSAGE: str = "用户已取消"
+
+
+def wall_clock_ms() -> int:
+    """当前墙钟，毫秒。"""
+    return int(time.time() * 1000)
+
+
+def stamp_round_end_event(event: RunFinishedEvent | RunErrorEvent) -> None:
+    """为本轮对话收尾事件写入墙钟毫秒。
+
+    续流回放（resume_replay=True）不打戳。终态 checkpoint 重放不要调用本函数。
+    """
+    if getattr(event, "resume_replay", False):
+        return
+    if event.timestamp is None:
+        event.timestamp = wall_clock_ms()
 
 
 def emit_run_finished_event(
@@ -76,6 +93,7 @@ def emit_run_finished_event(
         run_id=run_id,
         outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
     )
+    stamp_round_end_event(finished_event)
 
     # 如果提供了事件处理器，调用它分发事件
     if event_handler:

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_timestamp.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_timestamp.py
@@ -1,0 +1,72 @@
+# -*- coding: utf-8 -*-
+"""MESSAGES_SNAPSHOT 全量回传 createdAt，且不进入模型 payload。"""
+
+import json
+
+from ag_ui.core import EventType
+from ag_ui.encoder import EventEncoder
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_openai.chat_models.base import _convert_message_to_dict
+
+from aidev_agent.core.ag_ui.types import MessageSnapshotEventExtend
+from aidev_agent.core.ag_ui.utils import langchain_messages_to_agui
+from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+
+def test_messages_snapshot_includes_created_at_for_all_roles():
+    agent = ChatCompletionAgent(
+        chat_history=[
+            ChatPrompt(
+                id="user-1",
+                role="user",
+                content="第一轮提问",
+                builtin_property={"created_at": "2026-08-13T10:00:00+00:00"},
+            ),
+            ChatPrompt(
+                id="assistant-1",
+                role="assistant",
+                content="第一轮回答",
+                builtin_property={"created_at": "2026-08-13T10:01:00+00:00"},
+            ),
+            ChatPrompt(
+                id="user-2",
+                role="user",
+                content="本轮提问",
+                builtin_property={"created_at": "2026-08-13T10:05:00+00:00"},
+            ),
+        ]
+    )
+
+    agui_messages = langchain_messages_to_agui(agent.convert_history_to_messages())
+    payload = json.loads(
+        EventEncoder()
+        .encode(MessageSnapshotEventExtend(type=EventType.MESSAGES_SNAPSHOT, messages=agui_messages))
+        .removeprefix("data: ")
+        .strip()
+    )
+
+    assert payload["messages"][0]["createdAt"] == "2026-08-13T10:00:00+00:00"
+    assert payload["messages"][1]["createdAt"] == "2026-08-13T10:01:00+00:00"
+    assert payload["messages"][2]["createdAt"] == "2026-08-13T10:05:00+00:00"
+
+
+def test_created_at_is_not_sent_to_openai_payload():
+    user = HumanMessage(
+        content="主机 bk18 告警分析",
+        additional_kwargs={"created_at": "2026-08-13T10:05:00+00:00"},
+    )
+    assistant = AIMessage(
+        content="告警已收敛",
+        additional_kwargs={"created_at": "2026-08-13T10:06:00+00:00"},
+    )
+    tool = ToolMessage(
+        content="ok",
+        tool_call_id="tc-1",
+        additional_kwargs={"created_at": "2026-08-13T10:05:30+00:00"},
+    )
+
+    for message in (user, assistant, tool):
+        payload = _convert_message_to_dict(message)
+        assert "created_at" not in payload
+        assert "createdAt" not in payload

--- a/src/agent/tests/core/ag_ui/test_round_end_timestamp.py
+++ b/src/agent/tests/core/ag_ui/test_round_end_timestamp.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""本轮对话收尾事件写入墙钟毫秒，续流回放不打戳。"""
+
+import json
+
+from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
+from ag_ui.encoder import EventEncoder
+
+from aidev_agent.utils.event import emit_run_finished_event, stamp_round_end_event
+
+
+def test_stamp_round_end_event_writes_wall_clock_ms(monkeypatch):
+    monkeypatch.setattr("aidev_agent.utils.event.wall_clock_ms", lambda: 1_710_000_000_000)
+    finished = RunFinishedEvent(type=EventType.RUN_FINISHED, thread_id="t1", run_id="run-1")
+    error = RunErrorEvent(type=EventType.RUN_ERROR, message="模型调用异常")
+
+    stamp_round_end_event(finished)
+    stamp_round_end_event(error)
+
+    assert finished.timestamp == 1_710_000_000_000
+    assert error.timestamp == 1_710_000_000_000
+
+
+def test_resume_replay_run_finished_has_no_timestamp(monkeypatch):
+    monkeypatch.setattr("aidev_agent.utils.event.wall_clock_ms", lambda: 1_710_000_000_000)
+    event = RunFinishedEvent(
+        type=EventType.RUN_FINISHED,
+        thread_id="t1",
+        run_id="interrupt-1",
+        resume_replay=True,
+    )
+
+    stamp_round_end_event(event)
+    payload = json.loads(EventEncoder().encode(event).removeprefix("data: ").strip())
+
+    assert event.timestamp is None
+    assert "timestamp" not in payload
+
+
+def test_emit_run_finished_event_includes_timestamp(monkeypatch):
+    monkeypatch.setattr("aidev_agent.utils.event.wall_clock_ms", lambda: 1_710_000_000_000)
+
+    payload = json.loads(
+        emit_run_finished_event(thread_id="t1", run_id="run-1").removeprefix("data: ").strip()
+    )
+
+    assert payload["type"] == "RUN_FINISHED"
+    assert payload["timestamp"] == 1_710_000_000_000

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2130,6 +2130,7 @@ class TestTerminalResumeReplay:
         run_finished = events[-1]
         assert run_finished["runId"] == "r1"
         assert run_finished["threadId"] == "t1"
+        assert "timestamp" not in run_finished
 
     def test_replay_event_stream_run_id_fallback_when_missing(self):
         """agent_input.run_id 缺失时应回退到自动生成的 run_id（RUN_STARTED 与 RUN_FINISHED 一致）"""

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -26,11 +26,6 @@ from aidev_agent.services.messages_handler.factory import _create_handler, _init
 from aidev_agent.utils.event import RunId, emit_run_finished_event
 
 
-def _make_run_finished_chunk(thread_id: str, run_id: str) -> str:
-    """生成 RUN_FINISHED SSE 字符串，用于测试期望值对比。"""
-    return emit_run_finished_event(thread_id=thread_id, run_id=run_id)
-
-
 def _event_types(chunks: list[str]) -> list[str]:
     return [json.loads(chunk.removeprefix("data: "))["type"] for chunk in chunks if chunk.startswith("data: ")]
 
@@ -676,8 +671,12 @@ class TestInMemoryQueueMessageHandler:
 
         result = list(helper.stream(iter(())))
 
-        expected_run_finished = emit_run_finished_event(thread_id=thread_id, run_id=RunId.STOPPED)
-        assert result == ["chunk_0", "chunk_1", expected_run_finished]
+        assert result[:2] == ["chunk_0", "chunk_1"]
+        last_payload = json.loads(result[2].removeprefix("data: ").strip())
+        assert last_payload["type"] == EventType.RUN_FINISHED
+        assert last_payload["threadId"] == thread_id
+        assert last_payload["runId"] == RunId.STOPPED
+        assert isinstance(last_payload["timestamp"], int)
         assert clear_stopped_called
         assert handler.is_empty(thread_id)
 
@@ -713,8 +712,12 @@ class TestInMemoryQueueMessageHandler:
 
         if gen_items == [CANCELLED_CHUNK]:
             # CANCELLED_CHUNK 被消费后，消费者 yield RUN_FINISHED SSE 字符串
-            expected = [_make_run_finished_chunk(thread_id=thread_id, run_id=RunId.CANCELLED)]
-            assert result == expected
+            assert len(result) == 1
+            payload = json.loads(result[0].removeprefix("data: ").strip())
+            assert payload["type"] == EventType.RUN_FINISHED
+            assert payload["threadId"] == thread_id
+            assert payload["runId"] == RunId.CANCELLED
+            assert isinstance(payload["timestamp"], int)
         else:
             assert result == gen_items
 

--- a/src/agent/tests/services/test_stop_stream_sync.py
+++ b/src/agent/tests/services/test_stop_stream_sync.py
@@ -9,6 +9,7 @@
    EOD → Consumer notify → stop wait → 调用平台 API
 """
 
+import json
 import threading
 import time
 
@@ -19,7 +20,25 @@ from aidev_agent.services.messages_handler import (
     InMemoryQueueMessageHandler,
 )
 from aidev_agent.services.messages_handler.constants import TimeoutConfig
-from aidev_agent.utils.event import RunId, emit_run_finished_event
+from aidev_agent.utils.event import RunId
+
+
+def _has_run_finished(chunks: list, thread_id: str, run_id: str) -> bool:
+    """判断流中是否包含指定 RUN_FINISHED，忽略墙钟 timestamp。"""
+    for chunk in chunks:
+        if not isinstance(chunk, str) or not chunk.startswith("data:"):
+            continue
+        try:
+            payload = json.loads(chunk.removeprefix("data:").strip())
+        except json.JSONDecodeError:
+            continue
+        if (
+            payload.get("type") == "RUN_FINISHED"
+            and payload.get("threadId") == thread_id
+            and payload.get("runId") == run_id
+        ):
+            return True
+    return False
 
 
 class TestConsumerNotifyOnCancel:
@@ -293,8 +312,7 @@ class TestEndToEndStopAndResume:
         assert "chunk_0" in collected
         assert "chunk_1" in collected
         # _consume_stopped_session 耗尽消息后 yield RUN_FINISHED SSE，而非 STOPPED_CHUNK
-        expected_run_finished = emit_run_finished_event(thread_id=tid, run_id=RunId.STOPPED)
-        assert expected_run_finished in collected
+        assert _has_run_finished(collected, tid, RunId.STOPPED)
         assert not handler.is_stopped(tid), "恢复后 stopped 标记应清除"
 
     def test_stop_no_cache_restarts_generator(self, handler):
@@ -390,8 +408,7 @@ class TestFullStopSequence:
         collected, finished, tl = self._run_stop_flow(handler, tid, gen_factory)
 
         assert finished, "stop 应成功等到流结束"
-        expected_run_finished = emit_run_finished_event(thread_id=tid, run_id=RunId.CANCELLED)
-        assert expected_run_finished in collected
+        assert _has_run_finished(collected, tid, RunId.CANCELLED)
         assert 0 < sum(1 for c in collected if c.startswith("chunk_")) < 50
         # 时序验证
         assert tl["consumer_exited"] >= tl["cancel_sent"]
@@ -415,7 +432,7 @@ class TestFullStopSequence:
         collected, finished, tl = self._run_stop_flow(handler, tid, gen_factory)
 
         assert finished, "producer 主动收敛取消终态后 Consumer 应退出并通知"
-        assert emit_run_finished_event(thread_id=tid, run_id=RunId.CANCELLED) in collected
+        assert _has_run_finished(collected, tid, RunId.CANCELLED)
 
     def test_consumer_waits_for_live_producer_before_notify(self, handler, monkeypatch):
         """工具仍执行时不能提前通知 stop 已完成，producer 结束后再确认。"""
@@ -448,8 +465,7 @@ class TestFullStopSequence:
         assert not thread.is_alive()
         assert handler.wait_for_consumer_cancelled(tid, timeout=0.5)
         assert "tool_result_after_stop" not in collected
-        expected_run_finished = emit_run_finished_event(thread_id=tid, run_id=RunId.CANCELLED)
-        assert expected_run_finished in collected
+        assert _has_run_finished(collected, tid, RunId.CANCELLED)
 
     def test_stop_timeout_degradation_no_consumer(self, handler):
         """无 Consumer 场景：stop wait 超时 → 降级 mark_stopped → 调 API"""


### PR DESCRIPTION
## 背景

切 AG-UI 后会话页不再显示每轮时间。平台会把落库 `created_at` 放进 `builtin_property`；SDK 需要把它编进 `MESSAGES_SNAPSHOT`，并在真正收尾的事件上打墙钟毫秒。

本期不做 assistant「耗时」展示。需与 `bk-aidev` 同发。

## 改动

### 改动一：SNAPSHOT 全量 `createdAt`

- `ExtendBaseMessage.created_at`：各角色均可带创建时间
- `_chat_history_to_langchain_messages`：从 `builtin_property` 写入 `additional_kwargs["created_at"]`
- `langchain_messages_to_agui`：编码为 SSE `createdAt`（ISO 8601）
- 该键走展示通道，不进入 LLM payload（`_convert_message_to_dict` 单测锁定）

### 改动二：真收尾事件墙钟

- `stamp_round_end_event`：真正结束的 `RUN_FINISHED` / `RUN_ERROR` 写入 Unix 纪元毫秒 `timestamp`
- `resume_replay=True`（审批卡片续流）不打戳
- 终态 checkpoint 重放 `build_terminal_replay_stream` 不打戳，避免前端把重连时刻当成轮次结束时间

## 测试

- `test_messages_snapshot_includes_created_at_for_all_roles`
- `test_created_at_is_not_sent_to_openai_payload`
- `test_round_end_timestamp.py`（真收尾打戳、续流不打戳）
- `TestTerminalResumeReplay.test_replay_event_stream_emits_expected_sequence` 断言终态重放无 `timestamp`

## 兼容性

- 仅 V2 AG-UI；`timestamp` 是 number，不是北京时间字符串
- 前端应 `new Date(createdAt)` / `new Date(timestamp)` 再格式化
- 镜像需升到本 SDK 后，SNAPSHOT 才会带 `createdAt`

## 关联

tapd: #136435427

Made with [Cursor](https://cursor.com)