### PR TITLE
feat: 固定 pdm-backend 构建版本 --story=1070093903137213444

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend==2.4.9"]
 build-backend = "pdm.backend"
 
 [tool.ruff]

--- a/src/agent/pyproject.toml
+++ b/src/agent/pyproject.toml
@@ -79,7 +79,7 @@ dev = [
 includes = ["aidev_agent"]
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend==2.4.9"]
 build-backend = "pdm.backend"
 
 [tool.ruff]

--- a/src/plugins/aidev_ai_blueking/pyproject.toml
+++ b/src/plugins/aidev_ai_blueking/pyproject.toml
@@ -14,5 +14,5 @@ dependencies = [
 includes = ["aidev_ai_blueking"]
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend==2.4.9"]
 build-backend = "pdm.backend"

--- a/src/plugins/aidev_bkplugin/pyproject.toml
+++ b/src/plugins/aidev_bkplugin/pyproject.toml
@@ -23,7 +23,7 @@ dev = [
 includes = ["aidev_bkplugin"]
 
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend==2.4.9"]
 build-backend = "pdm.backend"
 
 [tool.pytest.ini_options]

--- a/template/{{cookiecutter.project_name}}/pyproject.toml
+++ b/template/{{cookiecutter.project_name}}/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
 [tool.pdm.build]
 includes = ["aidev"]
 [build-system]
-requires = ["pdm-backend"]
+requires = ["pdm-backend==2.4.9"]
 build-backend = "pdm.backend"
 
 [tool.pyright]


### PR DESCRIPTION
## 背景

The repository declared `pdm-backend` without a version constraint in five Python package build configurations. An incompatible package-index result can therefore break PEP 660 editable installation before project dependencies are installed.

## 原因

Build-system requirements are resolved in an isolated environment and are not constrained by the project lockfile. Leaving the backend unconstrained made builds depend on whichever artifact the configured index selected.

## 改动内容

- Pin `pdm-backend==2.4.9` in the repository root, Agent SDK, BK plugin, and AI Blueking plugin.
- Apply the same pin to the generated project template.
- Keep runtime dependencies and lockfiles unchanged.

## 收益

- Make editable builds reproducible across package indexes.
- Prevent the same backend-resolution failure from recurring in plugins and generated projects.

## 测试验证

- Parsed all five `pyproject.toml` files and asserted the expected build backend and exact requirement.
- Built and installed all five projects in editable mode with CPython 3.11.10; all succeeded with `pdm-backend 2.4.9`.
- Changed-file pre-commit hooks and `git diff --check` passed.
- Full-repository pre-commit was also attempted; it remains blocked by unrelated pre-existing Ruff violations on the base branch.
