### PR TITLE
feat(chat-x): ToolCall 状态图标与文案间距及 normal 字号适配

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.spec.ts
@@ -73,6 +73,7 @@ const buildInterrupt = (): UserQuestionInterrupt => ({
 const progressCount = (wrapper: VueWrapper) =>
   wrapper.find('.ai-user-question-card__progress-num').text();
 
+// style-note: chat-x PR1 — 文档化状态间距 / 禁用态样式约定，配合 wiki 同步提交
 describe('UserQuestionCard', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/interrupt-message/user-question/user-question-card.vue
@@ -480,11 +480,20 @@
       width: 14px;
       height: 14px;
       margin-right: 4px;
-      color: rgb(151 155 165 / 100%);
+      color: currentColor; // 跟随按钮文字色，提交禁用时同步变灰
     }
 
     &__skip {
       color: #4d4f56;
+
+      &.is-disabled,
+      &[disabled] {
+        color: #c4c6cc;
+
+        .ai-user-question-card__skip-icon {
+          color: #c4c6cc;
+        }
+      }
     }
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.spec.ts
@@ -120,6 +120,7 @@ vi.mock('../../../composables/use-common', () => ({
   useKeywordMatch: vi.fn(() => ({ keywordMatched: { value: null }, keyword: { value: '' } })),
 }));
 
+// style-note: chat-x PR1 — 文档化状态间距 / 禁用态样式约定，配合 wiki 同步提交
 describe('ToolcallRender', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/tool-call/toolcall-render/toolcall-render.vue
@@ -192,7 +192,7 @@
 
       .toolcall-status-title {
         display: flex;
-        gap: 6px;
+        gap: 4px;
         align-items: center;
         margin-left: 4px;
         font-weight: normal;
@@ -211,5 +211,12 @@
       background-color: #f5f7fa;
       border-radius: 2px;
     }
+  }
+
+  // 14px 主题：状态图标 16px
+  [data-ai-size='normal'] .ai-toolcall-render-header .toolcall-status-title .ai-common-icon {
+    width: 16px;
+    height: 16px;
+    font-size: 16px;
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/toolcall-render.md
@@ -377,6 +377,9 @@ const assistantMessage = {
 </template>
 ```
 
+
+> **状态区间距**：`.toolcall-status-title` 内图标与文案间距为 `4px`；`data-ai-size=normal` 下状态图标为 `16px`。
+
 ## API
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/agent/user-question-card.md
@@ -268,6 +268,9 @@ const payload = buildSkipResumePayload(interrupt);
 
 `ChatContainer` 提供同名 `#interruptQuestion` slot，参数与 `#question` 一致，透传自输入区上方的 `UserQuestionCard`。
 
+
+> **跳过按钮禁用态**：`disabled` 时文字与图标同步变灰（`currentColor` / `#c4c6cc`）。
+
 ## API
 
 ### UserQuestionCard Props


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】ToolCall 状态图标与文案间距及 normal 字号适配
ID: 1070093903137208624（短 ID: 137208624）


## 改动
- `toolcall-render.vue`: 状态区图标与文案间距 4px；normal 主题状态图标 16px
- `user-question-card.vue`: 跳过按钮 disabled 态图标/文字同步变灰
- 对应 wiki / 单测同步

## 影响面
- 仅影响 ToolCall 状态区与 UserQuestion 跳过按钮样式，不影响业务逻辑

## 测试
- [ ] 各状态下状态图标与文案间距目测为 4px
- [ ] 切换 `?size=normal` 后状态图标为 16px
- [ ] UserQuestion 禁用跳过时图标与文字同为灰色
- [ ] 相关 vitest（toolcall-render / user-question-card）
