### PR TITLE
feat(chat-x): Slash/Mention 菜单呼出交互与样式升级

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -36,7 +36,8 @@
       }"
       :resources="MOCK_RESOURCES"
       :shortcuts="shortcuts"
-      :size="'small'"
+      :size="aiSize"
+      :skills="MOCK_SKILLS"
       :support-upload="true"
       :update-tools="customUpdateTools"
       @confirm-share="handleConfirmShare"
@@ -193,6 +194,7 @@
     MOCK_MODELS,
     MOCK_PROMPTS,
     MOCK_RESOURCES,
+    MOCK_SKILLS,
     MOCK_TOOLCALL_STATUS_MESSAGES,
     mockArtifactClick,
   } from './mock';
@@ -203,6 +205,10 @@
 
   import '../src/styles/global.scss';
 
+  // 预览字号：?size=normal → 14px；默认 / ?size=small → 12px
+  const aiSize = (new URLSearchParams(location.search).get('size') === 'normal' ? 'normal' : 'small') as
+    | 'normal'
+    | 'small';
   const chatMode = shallowRef<RenderMode>(RenderMode.Chat);
   const openingRemark = shallowRef(`你好，我是小鲸
 我是由蓝鲸智云开发的智能助手
@@ -215,12 +221,14 @@
   const handleModelChange = (model: IModelOption) => {
     console.log('model change:', model);
   };
+  // TODO(style-verify): 样式调试期间暂时隐藏输入框上方 UserQuestion 折叠条；调试完成后改回 true
+  const SHOW_USER_QUESTION_MOCK = false;
   // Info 分隔提示 + ToolCall 各状态 + 含 toolCalls 的会话 mock + 待回答 UserQuestion
   const messages = deepRef<Message[]>([
     ...MOCK_INFO_MESSAGES,
     ...MOCK_TOOLCALL_STATUS_MESSAGES,
     ...(MOCK_MESSAGES as Message[]),
-    ...MOCK_USER_QUESTION_PENDING_MESSAGES,
+    ...(SHOW_USER_QUESTION_MOCK ? MOCK_USER_QUESTION_PENDING_MESSAGES : []),
   ]);
 
   const handleInterruptResume: OnInterruptResume = (payload, interrupt) => {

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -30,6 +30,7 @@ import {
   type AIFileInfo,
   type IAiSlashMenuItem,
   type IModelOption,
+  type ISkillListItem,
   // type InfoMessage,
   type Message,
   type Shortcut,
@@ -611,55 +612,130 @@ export const MOCK_TOOLCALL_STATUS_MESSAGES = [
   },
 ] as Message[];
 
-// @ 资源列表
+// @ 资源列表（工具 / MCP / 知识库 / 快捷指令，条数足够验证菜单滚动）
 export const MOCK_RESOURCES = [
-  {
-    type: 'tool',
-    name: '工具1撒旦法收到了客服',
-    id: 'tool1',
-    icon: 'icon-tool1',
-  },
-  {
-    type: 'shortcut',
-    name: '快捷1撒旦法收到',
-    id: 'shortcut1',
-    icon: 'icon-shortcut1',
-  },
-  {
-    type: 'doc',
-    name: '文档1',
-    id: 'doc1',
-    icon: 'icon-doc1',
-  },
-  {
-    type: 'mcp',
-    name: 'MCP1',
-    id: 'mcp1',
-    icon: 'icon-mcp1',
-  },
-  {
-    type: 'tool',
-    name: '工具2',
-    id: 'tool2',
-    icon: 'icon-tool2',
-  },
-
-  {
-    type: 'shortcut',
-    name: '快捷2',
-    id: 'shortcut2',
-    icon: 'icon-shortcut2',
-  },
-
-  {
-    type: 'doc',
-    name: '文档2',
-    id: 'doc2',
-    icon: 'icon-doc2',
-  },
+  // 工具
+  { type: 'tool', name: '日志查询', id: 'tool-log-query', icon: null },
+  { type: 'tool', name: '告警策略配置', id: 'tool-alert-policy', icon: null },
+  { type: 'tool', name: '容器编排', id: 'tool-container-orchestrate', icon: null },
+  { type: 'tool', name: '数据可视化', id: 'tool-data-viz', icon: null },
+  { type: 'tool', name: '接口压测', id: 'tool-api-pressure', icon: null },
+  { type: 'tool', name: '链路追踪分析', id: 'tool-trace-analysis', icon: null },
+  { type: 'tool', name: '配置中心检索', id: 'tool-config-search', icon: null },
+  { type: 'tool', name: '工单状态查询', id: 'tool-itsm-status', icon: null },
+  // MCP
+  { type: 'mcp', name: 'TAPD MCP', id: 'mcp-tapd', icon: null },
+  { type: 'mcp', name: '蓝鲸监控 MCP', id: 'mcp-bk-monitor', icon: null },
+  { type: 'mcp', name: '工蜂 Git MCP', id: 'mcp-git', icon: null },
+  { type: 'mcp', name: 'BKBASE 查询 MCP', id: 'mcp-bkbase', icon: null },
+  { type: 'mcp', name: '文档中心 MCP', id: 'mcp-docs', icon: null },
+  // 知识库
+  { type: 'doc', name: 'AI 小鲸产品文档', id: 'doc-ai-blueking', icon: null },
+  { type: 'doc', name: 'Chat X 组件指南', id: 'doc-chat-x', icon: null },
+  { type: 'doc', name: '蓝鲸可观测最佳实践', id: 'doc-observability', icon: null },
+  { type: 'doc', name: '故障排查手册', id: 'doc-troubleshooting', icon: null },
+  { type: 'doc', name: 'API 开放平台说明', id: 'doc-api-open', icon: null },
+  { type: 'knowledgebase', name: '内部知识库 · 运维', id: 'kb-ops', icon: null },
+  { type: 'knowledgebase', name: '内部知识库 · 研发', id: 'kb-dev', icon: null },
+  // 快捷指令
+  { type: 'shortcut', name: 'Trace 分析', id: 'shortcut-trace', icon: null },
+  { type: 'shortcut', name: '深度思考', id: 'shortcut-deep-think', icon: null },
+  { type: 'shortcut', name: '重新生成', id: 'shortcut-regenerate', icon: null },
+  { type: 'shortcut', name: '翻译成英文', id: 'shortcut-translate-en', icon: null },
+  { type: 'shortcut', name: '生成周报', id: 'shortcut-weekly-report', icon: null },
 ] as IAiSlashMenuItem[];
-// @ 提示词列表
-export const MOCK_PROMPTS = ['你好', '你好啊', '你好啊', '你好啊', '你好啊', '你好啊', '你好啊', '你好啊', '你好啊'];
+
+// \ 提示词列表
+export const MOCK_PROMPTS = [
+  '帮我总结一下当前会话的关键结论',
+  '把上面的方案改写成实施步骤',
+  '解释这段代码的作用与风险点',
+  '生成一份可直接发给业务方的更新说明',
+  '按表格对比两种实现方案的优劣',
+  '帮我写一个单元测试用例清单',
+  '把报错信息翻译成更易懂的排查建议',
+  '基于当前上下文给出下一步行动建议',
+  '润色这段文案，语气更专业简洁',
+  '列出需要确认的前置条件与依赖',
+  '把需求拆成可执行的开发任务',
+  '生成一份 Review Checklist',
+];
+
+// / Skill 列表（图标为空时走首字母 fallback，方便验样式）
+export const MOCK_SKILLS: ISkillListItem[] = [
+  {
+    skill_code: 'code_review',
+    skill_name: 'Code Review',
+    description: '审查代码变更并给出风险与改进建议',
+    icon: '',
+  },
+  {
+    skill_code: 'log_diagnosis',
+    skill_name: '日志诊断',
+    description: '根据日志片段定位异常根因',
+    icon: '',
+  },
+  {
+    skill_code: 'api_design',
+    skill_name: 'API 设计助手',
+    description: '辅助设计 REST / RPC 接口草案',
+    icon: '',
+  },
+  {
+    skill_code: 'release_checklist',
+    skill_name: '发布检查清单',
+    description: '生成上线前检查项并核对风险',
+    icon: '',
+  },
+  {
+    skill_code: 'sql_optimize',
+    skill_name: 'SQL 优化',
+    description: '分析慢查询并给出索引与改写建议',
+    icon: '',
+  },
+  {
+    skill_code: 'ui_polish',
+    skill_name: 'UI 样式打磨',
+    description: '根据截图与规范给出样式优化建议',
+    icon: '',
+  },
+  {
+    skill_code: 'incident_summary',
+    skill_name: '故障复盘',
+    description: '整理故障时间线与改进动作',
+    icon: '',
+  },
+  {
+    skill_code: 'doc_writer',
+    skill_name: '文档撰写',
+    description: '把零散信息整理成结构化文档',
+    icon: '',
+  },
+  {
+    skill_code: 'test_case_gen',
+    skill_name: '用例生成',
+    description: '根据需求/接口生成测试用例',
+    icon: '',
+  },
+  {
+    skill_code: 'prompt_refine',
+    skill_name: 'Prompt 精炼',
+    description: '优化提示词结构与约束条件',
+    icon: '',
+  },
+  {
+    skill_code: 'mcp_debug',
+    skill_name: 'MCP 调试助手',
+    description: '排查 MCP 工具调用与鉴权问题',
+    icon: '',
+  },
+  {
+    skill_code: 'i18n_check',
+    skill_name: '多语言检查',
+    description: '检查文案遗漏与中英对照一致性',
+    icon: '',
+  },
+];
 
 export const MOCK_MARKDOWN_CONTENT = `
 ---

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-editor/ai-slash-editor.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-editor/ai-slash-editor.vue
@@ -14,13 +14,16 @@
       :arrow="false"
       :hide-on-click="true"
       :interactive="true"
-      :offset="[0, 0]"
-      placement="right-start"
+      :max-width="'none'"
+      :offset="[0, 8]"
+      :popper-options="menuPopperOptions"
+      placement="top-start"
       theme="light ai-slash-editor-theme"
       trigger="manual"
       :trigger-target="editorRef!"
       :z-index="EDITOR_MENU_Z_INDEX"
       @hidden="handleTippyHidden"
+      @show="handleTippyShow"
     >
       <template #content>
         <AiSlashMenu
@@ -86,6 +89,42 @@
   const editorRef = useTemplateRef<HTMLDivElement>('editorRef');
   const tippyRef = useTemplateRef<InstanceType<typeof Tippy> & ReturnType<typeof useTippy>>('tippyRef');
   const getBody = () => document.body;
+
+  /** 禁止 flip，避免面板翻转到输入框上挡住文字 */
+  const menuPopperOptions = {
+    modifiers: [
+      { name: 'flip', enabled: false },
+      { name: 'preventOverflow', options: { altAxis: false, padding: 8 } },
+    ],
+  };
+
+  const getInputMenuRect = (): DOMRect => {
+    const el =
+      editorRef.value?.closest('.chat-input') ||
+      editorRef.value?.closest('.ai-slash-editor-wrapper') ||
+      editorRef.value;
+    return el?.getBoundingClientRect() ?? new DOMRect();
+  };
+
+  const syncMenuWidthToInput = (instance?: { popper?: HTMLElement }) => {
+    const width = getInputMenuRect().width;
+    if (!width) return;
+    const box =
+      (instance?.popper?.querySelector?.('.tippy-box') as HTMLElement | null | undefined) ||
+      (document.querySelector('.tippy-box[data-theme~="ai-slash-editor-theme"]') as HTMLElement | null);
+    if (box) {
+      box.style.width = `${width}px`;
+      box.style.maxWidth = `${width}px`;
+    }
+  };
+
+  const handleTippyShow = (instance?: { popper?: HTMLElement }): false | void => {
+    if (menuType.value === 'slash' && filteredResourceList.value.length < 1) return false;
+    if (menuType.value === 'prompt' && filteredPrompts.value.length < 1) return false;
+    syncMenuWidthToInput(instance);
+    requestAnimationFrame(() => syncMenuWidthToInput(instance));
+    return undefined;
+  };
 
   let mentionDecorations: monacoEditor.IEditorDecorationsCollection | null = null;
 
@@ -539,22 +578,12 @@
       return;
     }
 
-    // 设置 tippy 位置（仅在 keyword 为空时，即刚输入 '/' 或 '@' 时）
-    if (!keyword.value) {
-      const offset = editor.getOffsetForColumn(position.lineNumber, position.column);
-      const rect = editor.getDomNode()!.getBoundingClientRect();
-      tippyRef.value?.setProps({
-        getReferenceClientRect: () => {
-          const scrollTop = editor.getScrollTop();
-          return {
-            left: rect.left + offset + 10 - editor.getScrollLeft(),
-            top: rect.top + position.lineNumber * aiSlashEditorOptions.lineHeight! - scrollTop + 6,
-            width: 0,
-            height: 0,
-          };
-        },
-      });
-    }
+    // 锚定输入框上方，宽度与输入框一致
+    tippyRef.value?.setProps({
+      placement: 'top-start',
+      maxWidth: 'none',
+      getReferenceClientRect: getInputMenuRect,
+    });
     tippyRef.value?.show();
   };
   const handleTippyHidden = () => {
@@ -585,27 +614,29 @@
       border-radius: 8px;
 
       @each $type, $color in variables.$resourceTypeMap {
-        $iconColor: list.nth($color, 3);
         .mention-tag-#{$type} {
           position: relative;
           display: inline-flex;
           align-items: center;
           height: 18px;
-          padding: 0 2px 0 6px;
+          padding: 0 6px;
           font-size: var(--ai-font-size, 12px);
           color: list.nth($color, 2);
           background: list.nth($color, 1);
           border-radius: 2px;
 
           &::after {
-            display: inline-flex;
+            position: absolute;
+            top: -7px;
+            right: -7px;
+            display: none;
             align-items: center;
             justify-content: center;
-            width: 18px;
-            height: 18px;
+            width: 14px;
+            height: 14px;
             cursor: pointer;
             content: ' ';
-            background-color: $iconColor;
+            background-color: #4d4f56;
             mask-image: url('data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%220%200%201024%201024%22%20version%3D%221.1%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20xmlns%3Axlink%3D%22http%3A%2F%2Fwww.w3.org%2F1999%2Fxlink%22%20width%3D%22200%22%20height%3D%22200%22%3E%3Cpath%20d%3D%22M678.4%20297.6L512%20467.2l-166.4-169.6-48%2048%20169.6%20166.4-169.6%20166.4%2048%2048%20166.4-169.6%20166.4%20169.6%2048-48-169.6-166.4%20169.6-166.4z%22%3E%3C%2Fpath%3E%3C%2Fsvg%3E');
             mask-repeat: no-repeat;
             mask-position: center;
@@ -614,11 +645,11 @@
 
           .mention-tag-x {
             position: absolute;
-            top: 0;
-            right: 0;
+            top: -7px;
+            right: -7px;
             z-index: 1;
-            width: 18px;
-            height: 18px;
+            width: 14px;
+            height: 14px;
             cursor: pointer;
           }
 
@@ -627,7 +658,8 @@
             background: list.nth($color, 4);
 
             &::after {
-              background-color: list.nth($color, 6);
+              display: flex;
+              background-color: #4d4f56;
             }
           }
         }
@@ -667,10 +699,24 @@
   }
 
   .tippy-box[data-theme~='ai-slash-editor-theme'] {
-    box-shadow: none !important;
+    width: 100%;
+    max-width: none !important;
+    overflow: hidden !important;
+    background-color: #fff !important;
+    border: 1px solid #dcdee5 !important;
+    border-radius: 8px !important; // 与聊天输入框一致
+    outline: none !important;
+    box-shadow: 0 2px 16px 0 #00000029 !important;
 
     .tippy-content {
+      width: 100%;
       padding: 0 !important;
+      box-sizing: border-box;
+
+      > span {
+        display: block;
+        width: 100%;
+      }
     }
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-editor/theme.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-editor/theme.ts
@@ -93,18 +93,18 @@ export const resourceTypeMap = {
     iconColor: '#979BA5',
   },
   shortcut: {
-    background: '#E1ECFF',
-    color: '#3A84FF',
-    iconColor: '#3A84FF',
+    background: '#F0F1F5',
+    color: '#4D4F56',
+    iconColor: '#979BA5',
   },
   doc: {
-    background: '#DAF6E5',
-    color: '#2CAF5E',
-    iconColor: '#2CAF5E',
+    background: '#F0F1F5',
+    color: '#4D4F56',
+    iconColor: '#979BA5',
   },
   mcp: {
-    background: '#FDEED8',
-    color: '#F59500',
-    iconColor: '#F59500',
+    background: '#F0F1F5',
+    color: '#4D4F56',
+    iconColor: '#979BA5',
   },
 } as const;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.spec.ts
@@ -36,6 +36,7 @@ vi.mock('../../../../composables/use-menu-keydown', () => ({
   }),
 }));
 
+// style-note: chat-x PR2
 describe('AiPromptList', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.vue
@@ -34,16 +34,37 @@
   .ai-prompt-list {
     display: flex;
     flex-direction: column;
-    width: 330px;
-    max-height: 258px;
+    box-sizing: border-box;
+    width: 100%;
+    max-height: 320px; // 与 @ 菜单一致：10 * 32px
     padding: 8px;
-    overflow-y: auto;
+    overflow: hidden auto;
     font-size: var(--ai-font-size, 12px);
     color: #4d4f56;
     background: #fff;
-    border: 1px solid #dcdee5;
-    border-radius: 4px;
-    box-shadow: 0 2px 6px 0 #0000001a;
+    border: 0;
+    border-radius: 8px;
+    outline: none;
+    box-shadow: none; // 外阴影由 tippy-box 承担，避免被裁切
+    scrollbar-color: #dcdee5 transparent;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #dcdee5;
+      border-radius: 2px;
+
+      &:hover {
+        background: #c4c6cc;
+      }
+    }
 
     .ai-prompt-list-item {
       display: flex;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-skill-list/ai-skill-list.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-skill-list/ai-skill-list.spec.ts
@@ -68,6 +68,17 @@ describe('AiSkillList', () => {
       expect(wrapper.find('.ai-skill-list').exists()).toBe(true);
     });
 
+    it('应该显示 Skill 标题与数量', () => {
+      wrapper = mount(AiSkillList, {
+        props: {
+          skills: defaultSkills,
+          onSelect: vi.fn(),
+        },
+      });
+
+      expect(wrapper.find('.ai-skill-list-title').text()).toBe('Skill（2）');
+    });
+
     it('应该渲染所有 skills', () => {
       wrapper = mount(AiSkillList, {
         props: {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-skill-list/ai-skill-list.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-skill-list/ai-skill-list.vue
@@ -3,6 +3,7 @@
     ref="skillListRef"
     class="ai-skill-list"
   >
+    <div class="ai-skill-list-title">Skill（{{ skills.length }}）</div>
     <div
       v-for="(skill, index) in skills"
       :key="skill.skill_code"
@@ -62,16 +63,46 @@
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
-    width: 365px;
-    max-height: 258px;
+    width: 100%;
+    max-height: 320px; // 与 @ 菜单一致：10 * 32px
     padding: 4px 0;
-    overflow-y: auto;
+    overflow: hidden auto;
     font-size: var(--ai-font-size, 12px);
     color: #4d4f56;
     background: #fff;
-    border: 1px solid #dcdee5;
-    border-radius: 4px;
-    box-shadow: 0 2px 6px 0 #0000001a;
+    border: 0;
+    border-radius: 8px;
+    outline: none;
+    box-shadow: none; // 外阴影由 tippy-box 承担，避免被裁切
+    scrollbar-color: #dcdee5 transparent;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #dcdee5;
+      border-radius: 2px;
+
+      &:hover {
+        background: #c4c6cc;
+      }
+    }
+
+    .ai-skill-list-title {
+      display: flex;
+      flex-shrink: 0;
+      align-items: center;
+      height: 32px;
+      padding: 0 10px;
+      color: #979ba5; // 与 @ 菜单分组标题一致
+      white-space: nowrap;
+    }
 
     .ai-skill-list-item {
       display: flex;
@@ -99,7 +130,7 @@
         height: 20px;
         margin-right: 8px;
         object-fit: contain;
-        border-radius: 2px;
+        border-radius: 2px; // 与 @ 菜单 / MCP 等资源图标一致，用方形
 
         &--fallback {
           display: flex;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.spec.ts
@@ -149,8 +149,12 @@ vi.mock('./ai-slash-menu/ai-slash-menu.vue', () => ({
       onSelect: { type: Function, default: null },
       resourceList: { type: Array, default: () => [] },
     },
-    setup() {
-      return () => h('div', { class: 'mock-ai-slash-menu' });
+    setup(props) {
+      return () =>
+        h('div', {
+          class: 'mock-ai-slash-menu',
+          'data-resources-count': String(props.resourceList?.length ?? 0),
+        });
     },
   }),
 }));
@@ -185,6 +189,7 @@ vi.mock('./command', () => ({
   InsertSkillTag: 'InsertSkillTag',
   InsertTag: 'InsertTag',
   InsertText: 'InsertText',
+  SetCaret: 'SetCaret',
 }));
 
 vi.mock('./constants', () => ({
@@ -388,6 +393,167 @@ describe('AiSlashInput', () => {
       expect(tag.exists()).toBe(true);
       expect(tag.attributes('data-tag-value')).toBe('test_skill');
     });
+
+    it('skill 标签应显示图标与文案', () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: [
+            [
+              {
+                type: 'tag',
+                data: {
+                  label: '发布检查清单',
+                  value: 'release_checklist',
+                  type: 'skill',
+                  icon: '',
+                },
+              },
+            ],
+          ],
+        },
+      });
+
+      const tag = wrapper.find('.mention-tag-skill');
+      expect(tag.exists()).toBe(true);
+      expect(tag.find('.mention-tag-icon--fallback').exists()).toBe(true);
+      expect(tag.find('.mention-tag-icon--fallback').text()).toBe('发');
+      expect(tag.find('.mention-tag-label').text()).toBe('发布检查清单');
+      expect(tag.attributes('data-tag-label')).toBe('发布检查清单');
+    });
+
+    it('skill 标签有 icon 时应渲染 img', () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: [
+            [
+              {
+                type: 'tag',
+                data: {
+                  label: 'Code Review',
+                  value: 'code_review',
+                  type: 'skill',
+                  icon: 'https://example.com/skill.png',
+                },
+              },
+            ],
+          ],
+        },
+      });
+
+      const img = wrapper.find('.mention-tag-skill img.mention-tag-icon');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://example.com/skill.png');
+    });
+
+    it('@ 资源标签也应显示图标与文案', () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: [
+            [
+              {
+                type: 'tag',
+                data: {
+                  label: '日志查询',
+                  value: 'tool-log-query',
+                  type: 'tool',
+                  icon: '',
+                },
+              },
+            ],
+          ],
+        },
+      });
+
+      const tag = wrapper.find('.mention-tag-tool');
+      expect(tag.exists()).toBe(true);
+      expect(tag.find('.mention-tag-icon--fallback').exists()).toBe(true);
+      expect(tag.find('.mention-tag-icon--fallback').text()).toBe('日');
+      expect(tag.find('.mention-tag-label').text()).toBe('日志查询');
+    });
+  });
+
+  describe('输入过程实时检索过滤', () => {
+    const setEditorQuery = async (text: string) => {
+      const editor = wrapper.find('.ai-slash-input').element as HTMLElement;
+      editor.textContent = text;
+      const textNode = editor.firstChild as Text;
+      const range = document.createRange();
+      range.setStart(textNode, text.length);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      editor.dispatchEvent(new KeyboardEvent('keyup', { bubbles: true }));
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(20);
+      await nextTick();
+    };
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('输入 @ 后继续输入应实时过滤工具列表', async () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: '',
+          resources: [
+            { id: '1', name: '日志查询', type: 'tool', icon: null },
+            { id: '2', name: '数据可视化', type: 'tool', icon: null },
+            { id: '3', name: 'TAPD MCP', type: 'mcp', icon: null },
+          ],
+        },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await setEditorQuery('@日志');
+
+      const menu = wrapper.findComponent({ name: 'AiSlashMenu' });
+      expect(menu.exists()).toBe(true);
+      expect(menu.props('resourceList')).toHaveLength(1);
+      expect(menu.props('resourceList')[0].name).toBe('日志查询');
+    });
+
+    it('输入 / 后继续输入应实时过滤 Skill 列表', async () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: '',
+          skills: [
+            { skill_code: 'code_review', skill_name: 'Code Review', description: '', icon: '' },
+            { skill_code: 'log_diag', skill_name: '日志诊断', description: '', icon: '' },
+          ],
+        },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await setEditorQuery('/Code');
+
+      const skillList = wrapper.findComponent({ name: 'AiSkillList' });
+      expect(skillList.exists()).toBe(true);
+      expect(skillList.props('skills')).toHaveLength(1);
+      expect(skillList.props('skills')[0].skill_code).toBe('code_review');
+    });
+
+    it('输入 \\ 后继续输入应实时过滤 Prompt 列表', async () => {
+      wrapper = mount(AiSlashInput, {
+        props: {
+          modelValue: '',
+          prompts: ['帮我总结一下当前会话', '生成周报', '翻译成英文'],
+        },
+        attachTo: document.body,
+      });
+      await nextTick();
+      await setEditorQuery('\\总结');
+
+      const promptList = wrapper.findComponent({ name: 'AiPromptList' });
+      expect(promptList.exists()).toBe(true);
+      expect(promptList.props('prompts')).toHaveLength(1);
+      expect(promptList.props('prompts')[0]).toContain('总结');
+    });
   });
 
   describe('Skill 过滤与插入', () => {
@@ -442,6 +608,8 @@ describe('AiSlashInput', () => {
         call => (call[0] as unknown) === 'InsertSkillTag',
       );
       expect(insertSkillCalls.length).toBeGreaterThan(0);
+      const setCaretCalls = editorCommand.mock.calls.filter(call => (call[0] as unknown) === 'SetCaret');
+      expect(setCaretCalls.length).toBeGreaterThan(0);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
@@ -16,15 +16,33 @@
               v-for="(item, columnIndex) in line"
               :key="columnIndex"
             >
-              <span v-if="item.type === 'text'">{{ item.text }}</span>
+              <span
+                v-if="item.type === 'text'"
+                :class="{ 'ai-slash-input-spacer': !item.text?.trim() }"
+              >{{ item.text }}</span>
               <span
                 v-else-if="item.type === 'tag'"
                 :class="`mention-tag-${item.data.type}`"
                 contenteditable="false"
                 :data-tag-type="item.data.type"
                 :data-tag-value="item.data.value"
+                :data-tag-label="item.data.label"
+                :data-tag-icon="item.data.icon || ''"
               >
-                {{ item.data.label }}
+                <img
+                  v-if="item.data.icon && !failedTagIcons.has(`${item.data.type}:${item.data.value}`)"
+                  :src="item.data.icon"
+                  alt=""
+                  class="mention-tag-icon"
+                  @error="failedTagIcons.add(`${item.data.type}:${item.data.value}`)"
+                />
+                <span
+                  v-else
+                  class="mention-tag-icon mention-tag-icon--fallback"
+                >
+                  {{ item.data.label?.[0]?.toUpperCase() }}
+                </span>
+                <span class="mention-tag-label">{{ item.data.label }}</span>
                 <RemoveIcon
                   class="mention-tag-remove-icon"
                   @click="handleRemoveTag(line, item, columnIndex, index)"
@@ -44,8 +62,10 @@
       :arrow="false"
       :hide-on-click="true"
       :interactive="true"
-      :offset="[0, 0]"
-      placement="right-start"
+      :max-width="'none'"
+      :offset="[0, 8]"
+      :popper-options="menuPopperOptions"
+      placement="top-start"
       theme="light ai-slash-editor-theme"
       trigger="manual"
       :trigger-target="editorRef!"
@@ -74,7 +94,7 @@
   </div>
 </template>
 <script setup lang="ts">
-  import { customRef, onMounted, onUnmounted, shallowRef, useTemplateRef, watch, watchEffect } from 'vue';
+  import { customRef, nextTick, onMounted, onUnmounted, reactive, shallowRef, useTemplateRef, watch, watchEffect } from 'vue';
 
   import { Tippy, useTippy } from 'vue-tippy';
 
@@ -85,11 +105,11 @@
   import AiPromptList from './ai-prompt-list/ai-prompt-list.vue';
   import AiSkillList from './ai-skill-list/ai-skill-list.vue';
   import AiSlashMenu from './ai-slash-menu/ai-slash-menu.vue';
-  import { DeleteTag, InsertSkillTag, InsertTag, InsertText } from './command';
+  import { DeleteTag, InsertSkillTag, InsertTag, InsertText, SetCaret } from './command';
   import { tagSchema } from './constants';
 
   import type { IAiSlashMenuItem, ISkillListItem } from '../../../types/editor';
-  import type { MentionState, TagSchema } from '../../../types/input';
+  import type { MentionMenuType, MentionState, TagSchema } from '../../../types/input';
 
   import 'tippy.js/dist/tippy.css';
 
@@ -147,11 +167,26 @@
     };
   });
 
-  const menuType = shallowRef<'' | 'prompt' | 'skill' | 'slash'>('slash');
+  /** 禁止 flip，避免面板翻转到输入框上挡住文字 */
+  const menuPopperOptions = {
+    modifiers: [
+      { name: 'flip', enabled: false },
+      { name: 'preventOverflow', options: { altAxis: false, padding: 8 } },
+    ],
+  };
+
+  const menuType = shallowRef<'' | MentionMenuType>('slash');
   const keyword = shallowRef<string>('');
   const filteredResourceList = shallowRef<IAiSlashMenuItem[]>([]);
   const filteredSkills = shallowRef<ISkillListItem[]>([]);
   const filteredPrompts = shallowRef<string[]>([]);
+  const failedTagIcons = reactive(new Set<string>());
+
+  const TRIGGER_MENU_MAP = {
+    '@': 'slash',
+    '/': 'skill',
+    '\\': 'prompt',
+  } as const satisfies Record<string, MentionMenuType>;
 
   let editor: ReturnType<typeof createEditor>;
   /* 清理编辑器 */
@@ -159,6 +194,11 @@
   // 卸载前需清理延迟任务，避免 setTimeout 回调在 window 已销毁后仍执行
   let suggestionTimer: null | ReturnType<typeof setTimeout> = null;
   let focusTimer: null | ReturnType<typeof setTimeout> = null;
+  /** 菜单关闭后再聚焦，避免 tippy 抢走焦点 */
+  type PendingFocus =
+    | { kind: 'end' }
+    | { caretOffset: number; kind: 'tag'; line: number; tagType: string; tagValue: string };
+  let pendingFocus: null | PendingFocus = null;
   const clearPendingTimers = () => {
     if (suggestionTimer !== null) {
       clearTimeout(suggestionTimer);
@@ -168,8 +208,30 @@
       clearTimeout(focusTimer);
       focusTimer = null;
     }
+    pendingFocus = null;
   };
   const getBody = () => document.body;
+
+  /** 菜单锚定整个聊天输入框，宽度与输入框一致 */
+  const getInputMenuRect = (): DOMRect => {
+    const el =
+      editorRef.value?.closest('.chat-input') ||
+      editorRef.value?.closest('.ai-slash-input-wrapper') ||
+      editorRef.value;
+    return el?.getBoundingClientRect() ?? new DOMRect();
+  };
+
+  const syncMenuWidthToInput = (instance?: { popper?: HTMLElement }) => {
+    const width = getInputMenuRect().width;
+    if (!width) return;
+    const box =
+      (instance?.popper?.querySelector?.('.tippy-box') as HTMLElement | null | undefined) ||
+      (document.querySelector('.tippy-box[data-theme~="ai-slash-editor-theme"]') as HTMLElement | null);
+    if (box) {
+      box.style.width = `${width}px`;
+      box.style.maxWidth = `${width}px`;
+    }
+  };
 
   const { commandSelection, GetCursorPosition, GetDocSnapshot, docSnapshot } = useCommandSelection();
 
@@ -186,26 +248,31 @@
       deep: false,
     },
   );
+  /** 同步解析触发符后的检索词，供输入过程实时过滤 */
+  const refreshMentionQuery = (): MentionState => {
+    const mentionState = getMentionState();
+    if (mentionState.menuType) {
+      menuType.value = mentionState.menuType;
+    }
+    keyword.value = mentionState.query || '';
+    return mentionState;
+  };
   /* 显示提示 */
   const handleShowSuggestions = () => {
+    // 先同步更新 keyword，保证列表即时过滤（含中文 IME 组合过程）
+    refreshMentionQuery();
     if (suggestionTimer !== null) {
       clearTimeout(suggestionTimer);
     }
     suggestionTimer = setTimeout(() => {
       suggestionTimer = null;
-      const mentionState = getMentionState();
-      keyword.value = mentionState.query || '';
-      // 设置 tippy 位置（仅在 keyword 为空时，即刚输入 '/' 或 '@' 时）
+      const mentionState = refreshMentionQuery();
+      // 锚定输入框上方，宽度与输入框一致
       if (mentionState.isActive) {
         tippyRef.value?.setProps({
-          getReferenceClientRect: () => {
-            return {
-              left: mentionState.coordinates?.left || 0,
-              top: mentionState.coordinates?.top || 0,
-              width: 0,
-              height: 0,
-            };
-          },
+          placement: 'top-start',
+          maxWidth: 'none',
+          getReferenceClientRect: getInputMenuRect,
         });
         tippyRef.value?.show();
       } else {
@@ -222,21 +289,148 @@
       event.preventDefault?.();
       return false;
     }
-    if (event.key === '@') {
-      menuType.value = 'slash';
-      handleShowSuggestions();
-    }
-    if (event.key === '/') {
-      menuType.value = 'skill';
-      handleShowSuggestions();
-    }
-    if (event.key === '\\') {
-      menuType.value = 'prompt';
+    if (event.key === '@' || event.key === '/' || event.key === '\\') {
+      if (event.key === '@') menuType.value = 'slash';
+      if (event.key === '/') menuType.value = 'skill';
+      if (event.key === '\\') menuType.value = 'prompt';
       handleShowSuggestions();
     }
   };
+  /** 输入 / IME 组合过程中持续刷新过滤（edix 组合阶段不会触发 onChange） */
+  const handleEditorQueryRefresh = () => {
+    handleShowSuggestions();
+  };
+  const escapeSelectorValue = (value: string) => {
+    if (typeof CSS !== 'undefined' && typeof CSS.escape === 'function') {
+      return CSS.escape(value);
+    }
+    return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  };
+
+  /** 光标落到 tag 后 spacer 文本起点；与 tag 的 4px 间距由 mention-tag margin-right 保证 */
+  const placeCaretAfterTagElement = (tagEl: HTMLElement): boolean => {
+    const selection = window.getSelection();
+    if (!selection) return false;
+    const range = document.createRange();
+    const next = tagEl.nextSibling;
+    if (next) {
+      const textNode =
+        next.nodeType === Node.TEXT_NODE
+          ? (next as Text)
+          : next.firstChild?.nodeType === Node.TEXT_NODE
+            ? (next.firstChild as Text)
+            : null;
+      if (textNode) {
+        range.setStart(textNode, 0);
+      } else {
+        range.setStartAfter(next);
+      }
+    } else {
+      range.setStartAfter(tagEl);
+    }
+    range.collapse(true);
+    selection.removeAllRanges();
+    selection.addRange(range);
+    return true;
+  };
+
+  const placeCaretAtEnd = (el: HTMLElement) => {
+    const selection = window.getSelection();
+    if (!selection) return;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  };
+
+  /** 等 Vue 渲染出 tag 后聚焦；focus 会 syncSelection 覆盖 SetCaret，需在 commit 后再写回 DOM */
+  const scheduleFocusAfterTag = (options: {
+    caretOffset: number;
+    line: number;
+    tagType: string;
+    tagValue: string;
+  }) => {
+    if (focusTimer !== null) {
+      clearTimeout(focusTimer);
+      focusTimer = null;
+    }
+
+    const tryFocus = (retriesLeft: number) => {
+      focusTimer = null;
+      const el = editorRef.value;
+      if (!el || typeof window === 'undefined') return;
+
+      const selector = `span.mention-tag-${escapeSelectorValue(options.tagType)}[data-tag-value="${escapeSelectorValue(String(options.tagValue))}"]`;
+      const tags = el.querySelectorAll(selector);
+      const tagEl = tags[tags.length - 1] as HTMLElement | undefined;
+
+      if (!tagEl) {
+        if (retriesLeft > 0) {
+          focusTimer = setTimeout(() => tryFocus(retriesLeft - 1), 16);
+          return;
+        }
+        el.focus({ preventScroll: true });
+        placeCaretAtEnd(el);
+        return;
+      }
+
+      el.focus({ preventScroll: true });
+      // 纠正 onFocus → syncSelection 覆盖的编辑器选区
+      editor.command(SetCaret, [options.line, options.caretOffset]);
+      // 等 SetCaret commit 后再落到 DOM，避免 mutationObserver 用脏选区把光标拉走
+      queueMicrotask(() => {
+        placeCaretAfterTagElement(tagEl);
+      });
+    };
+
+    void nextTick(() => {
+      tryFocus(30);
+    });
+  };
+
+  const scheduleFocusToEnd = () => {
+    if (focusTimer !== null) {
+      clearTimeout(focusTimer);
+      focusTimer = null;
+    }
+    void nextTick(() => {
+      const el = editorRef.value;
+      if (!el || typeof window === 'undefined') return;
+      el.focus({ preventScroll: true });
+      queueMicrotask(() => {
+        placeCaretAtEnd(el);
+      });
+    });
+  };
+
+  const flushPendingFocus = () => {
+    if (!pendingFocus) return;
+    const pending = pendingFocus;
+    pendingFocus = null;
+    if (pending.kind === 'tag') {
+      scheduleFocusAfterTag(pending);
+    } else {
+      scheduleFocusToEnd();
+    }
+  };
+
+  const requestFocusAfterInsert = (pending: PendingFocus) => {
+    pendingFocus = pending;
+    tippyRef.value?.hide();
+    // tippy @hidden 优先；未展示或 hidden 未触发时用短延迟兜底
+    if (focusTimer !== null) {
+      clearTimeout(focusTimer);
+    }
+    focusTimer = setTimeout(() => {
+      focusTimer = null;
+      flushPendingFocus();
+    }, 80);
+  };
+
   const handleTippyHidden = () => {
     keyword.value = '';
+    flushPendingFocus();
   };
   const getMentionState = (): MentionState => {
     const defaultState: MentionState = {
@@ -248,53 +442,43 @@
 
     if (typeof window === 'undefined') return defaultState;
 
+    const editorEl = editorRef.value;
     const selection = window.getSelection();
-    if (!selection || selection.rangeCount === 0) return defaultState;
+    if (!editorEl || !selection || selection.rangeCount === 0) return defaultState;
+    if (!selection.anchorNode || !editorEl.contains(selection.anchorNode)) return defaultState;
 
-    const range = selection.getRangeAt(0);
-    const node = range.startContainer;
-    const offset = range.startOffset;
-    if (node.nodeType !== Node.TEXT_NODE) return defaultState;
-    const text = node.textContent || '';
-    const textBeforeCursor = text.slice(0, offset);
-
-    // 2. 正则匹配：查找光标前的最后一个触发字符
-    const triggerChar = menuType.value === 'slash' ? '@' : menuType.value === 'skill' ? '/' : '\\';
-    const escapedChar = triggerChar === '\\' ? '\\\\' : triggerChar;
-    const regex = new RegExp(`(${escapedChar}[^\\s]*)$`);
-    const match = textBeforeCursor.match(regex);
-
-    if (!match) return defaultState;
-
-    // match[1] 是捕获到的 "@xxx"
-    const matchText = match[1];
-    const query = matchText?.slice(1); // 去掉 @，得到搜索词
-
-    // 3. 计算 "@" 符号在文本节点中的精确索引
-    // match.index 是匹配开始的位置（可能包含前导空格），我们需要调整到 @ 的位置
-    const matchIndex = match.index! + match[0].indexOf(triggerChar);
-
+    // 取编辑器内光标前的全部文本（跨 text/span 节点，兼容 Vue 重渲染与 IME）
+    let textBeforeCursor = '';
     try {
-      const rangeOfAt = document.createRange();
-      rangeOfAt.setStart(node, matchIndex);
-      rangeOfAt.setEnd(node, matchIndex + 1);
-
-      // 5. 获取 "@" 的物理坐标
-      const rect = rangeOfAt.getBoundingClientRect();
-
-      return {
-        isActive: true,
-        query: query,
-        rect: rect,
-        coordinates: {
-          top: rect.bottom,
-          left: rect.left,
-          height: rect.height,
-        },
-      };
+      const preRange = selection.getRangeAt(0).cloneRange();
+      preRange.selectNodeContents(editorEl);
+      preRange.setEnd(selection.anchorNode, selection.anchorOffset);
+      textBeforeCursor = preRange.toString();
     } catch {
       return defaultState;
     }
+
+    // 光标前最后一个触发符及其后的检索词（遇空白则中断）
+    const match = textBeforeCursor.match(/([@/\\])([^\s]*)$/);
+    if (!match) return defaultState;
+
+    const triggerChar = match[1] as keyof typeof TRIGGER_MENU_MAP;
+    const query = match[2] || '';
+    const detectedType = TRIGGER_MENU_MAP[triggerChar];
+    if (!detectedType) return defaultState;
+
+    const inputRect = getInputMenuRect();
+    return {
+      isActive: true,
+      menuType: detectedType,
+      query,
+      rect: inputRect,
+      coordinates: {
+        top: inputRect.bottom,
+        left: inputRect.left,
+        height: inputRect.height,
+      },
+    };
   };
   const getStartPosition = (line: TagSchema[number], columnIndex: number) => {
     const startIndex = line.reduce((acc, item, index) => {
@@ -314,42 +498,46 @@
   const insertTagAtCursor = (tag: IAiSlashMenuItem) => {
     editor.command(GetCursorPosition);
     const { column, line } = commandSelection.value;
-    editor.command(DeleteTag, [line, column - keyword.value.length - 1], [line, column]);
-    editor.command(InsertTag, [line, column], tag);
-    editor.command(InsertText, [line, column + keyword.value.length + 1 + 1], ' ');
-    tippyRef.value?.hide();
-    focusToEnd();
+    // 删除触发符 + 检索词后，在原起始位插入 tag，并在其后补一个空格
+    const startColumn = Math.max(column - keyword.value.length - 1, 0);
+    editor.command(DeleteTag, [line, startColumn], [line, column]);
+    editor.command(InsertTag, [line, startColumn], tag);
+    editor.command(InsertText, [line, startColumn + 1], ' ');
+    // 光标在 tag 后空格起点；与 tag 的 4px 间距由 mention-tag margin-right 提供
+    const caretOffset = startColumn + 1;
+    editor.command(SetCaret, [line, caretOffset]);
+    requestFocusAfterInsert({
+      kind: 'tag',
+      tagType: tag.type,
+      tagValue: String(tag.id ?? tag.name),
+      line,
+      caretOffset,
+    });
   };
   const focusToEnd = () => {
-    if (focusTimer !== null) {
-      clearTimeout(focusTimer);
-    }
-    focusTimer = setTimeout(() => {
-      focusTimer = null;
-      if (typeof window === 'undefined') return;
-
-      const selection = window.getSelection();
-      const range = document.createRange();
-      if (editorRef.value && selection) {
-        range.selectNodeContents(editorRef.value);
-        range.collapse(false);
-        selection.removeAllRanges();
-        selection.addRange(range);
-      }
-    }, 100);
+    requestFocusAfterInsert({ kind: 'end' });
   };
   const insertPromptAtCursor = (prompt: string) => {
     editor.command(ReplaceAll, prompt);
-    focusToEnd();
+    requestFocusAfterInsert({ kind: 'end' });
   };
   const insertSkillAtCursor = (skill: ISkillListItem) => {
     editor.command(GetCursorPosition);
     const { column, line } = commandSelection.value;
-    editor.command(DeleteTag, [line, column - keyword.value.length - 1], [line, column]);
-    editor.command(InsertSkillTag, [line, column], skill);
-    editor.command(InsertText, [line, column + keyword.value.length + 1 + 1], ' ');
-    tippyRef.value?.hide();
-    focusToEnd();
+    // 删除触发符 + 检索词后，在原起始位插入 tag，并在其后补一个空格，保证 tag 间距一致
+    const startColumn = Math.max(column - keyword.value.length - 1, 0);
+    editor.command(DeleteTag, [line, startColumn], [line, column]);
+    editor.command(InsertSkillTag, [line, startColumn], skill);
+    editor.command(InsertText, [line, startColumn + 1], ' ');
+    const caretOffset = startColumn + 1;
+    editor.command(SetCaret, [line, caretOffset]);
+    requestFocusAfterInsert({
+      kind: 'tag',
+      tagType: 'skill',
+      tagValue: skill.skill_code,
+      line,
+      caretOffset,
+    });
   };
   watchEffect(() => {
     const resourceList = props.resources?.filter(
@@ -369,24 +557,29 @@
           ),
         ),
     );
-    if (!keyword.value) {
+    const query = keyword.value.trim().toLowerCase();
+    if (!query) {
       filteredResourceList.value = resourceList;
       filteredSkills.value = skillList;
       filteredPrompts.value = props.prompts;
     } else {
-      filteredResourceList.value = resourceList.filter(item =>
-        item.name.toLowerCase().includes(keyword.value.toLowerCase()),
-      );
+      filteredResourceList.value = resourceList.filter(item => {
+        const name = item.name?.toLowerCase() || '';
+        const code = String(item.code ?? item.id ?? '').toLowerCase();
+        return name.includes(query) || code.includes(query);
+      });
       filteredSkills.value = skillList.filter(
         skill =>
-          skill.skill_name.toLowerCase().includes(keyword.value.toLowerCase()) ||
-          skill.skill_code.toLowerCase().includes(keyword.value.toLowerCase()),
+          skill.skill_name.toLowerCase().includes(query) || skill.skill_code.toLowerCase().includes(query),
       );
-      filteredPrompts.value = props.prompts.filter(prompt =>
-        prompt.toLowerCase().includes(keyword.value.toLowerCase()),
-      );
+      filteredPrompts.value = props.prompts.filter(prompt => prompt.toLowerCase().includes(query));
     }
-    if (!filteredResourceList.value.length && !filteredSkills.value.length && !filteredPrompts.value.length) {
+    // 仅根据当前菜单类型判断是否隐藏，避免其它列表干扰
+    const currentEmpty =
+      (menuType.value === 'slash' && !filteredResourceList.value.length) ||
+      (menuType.value === 'skill' && !filteredSkills.value.length) ||
+      (menuType.value === 'prompt' && !filteredPrompts.value.length);
+    if (currentEmpty) {
       tippyRef.value?.hide();
     }
   });
@@ -436,24 +629,34 @@
     });
     cleanup = editor.input(editorRef.value!);
   };
-  const handleTippyShow = (): false | void => {
+  const handleTippyShow = (instance?: { popper?: HTMLElement }): false | void => {
     if (menuType.value === 'slash') {
-      return filteredResourceList.value.length < 1 ? false : undefined;
+      if (filteredResourceList.value.length < 1) return false;
+    } else if (menuType.value === 'skill') {
+      if (filteredSkills.value.length < 1) return false;
+    } else if (filteredPrompts.value.length < 1) {
+      return false;
     }
-    if (menuType.value === 'skill') {
-      return filteredSkills.value.length < 1 ? false : undefined;
-    }
-    return filteredPrompts.value.length < 1 ? false : undefined;
+    syncMenuWidthToInput(instance);
+    requestAnimationFrame(() => syncMenuWidthToInput(instance));
+    return undefined;
   };
   onMounted(() => {
     initEditor();
     editorRef.value?.addEventListener('paste', handlePaste);
+    // keyup / composition*：覆盖连续输入与中文 IME，保证检索词实时更新
+    editorRef.value?.addEventListener('keyup', handleEditorQueryRefresh);
+    editorRef.value?.addEventListener('compositionupdate', handleEditorQueryRefresh);
+    editorRef.value?.addEventListener('compositionend', handleEditorQueryRefresh);
   });
   onUnmounted(() => {
     clearPendingTimers();
     editor.command(ReplaceAll, '');
     cleanup?.();
     editorRef.value?.removeEventListener('paste', handlePaste);
+    editorRef.value?.removeEventListener('keyup', handleEditorQueryRefresh);
+    editorRef.value?.removeEventListener('compositionupdate', handleEditorQueryRefresh);
+    editorRef.value?.removeEventListener('compositionend', handleEditorQueryRefresh);
   });
   defineExpose({
     cleanup: () => {
@@ -476,22 +679,53 @@
     overflow: auto;
 
     @each $type, $color in variables.$resourceTypeMap {
-      $iconColor: list.nth($color, 3);
       .mention-tag-#{$type} {
         position: relative;
         display: inline-flex;
+        gap: 4px;
         align-items: center;
-        height: 18px;
-        padding: 0 2px 0 6px;
+        box-sizing: border-box;
+        // 高度跟随主题行高：small=20px / normal=24px；左右 8px / 图标 16px
+        height: var(--ai-line-height, 20px);
+        padding: 0 8px;
+        // 与左右文字均保持 4px；后继 spacer 不再额外加 padding，避免叠成 8px
+        margin: 0 4px;
         font-size: var(--ai-font-size, 12px);
+        line-height: var(--ai-line-height, 20px);
         color: list.nth($color, 2);
         background: list.nth($color, 1);
         border-radius: 2px;
+        vertical-align: middle;
+
+        .mention-tag-icon {
+          flex-shrink: 0;
+          width: 16px;
+          height: 16px;
+          object-fit: contain;
+          border-radius: 2px;
+
+          &--fallback {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 10px;
+            font-weight: 700;
+            line-height: 16px;
+            color: #fff;
+            background: #3a84ff;
+          }
+        }
+
+        .mention-tag-label {
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
 
         .mention-tag-remove-icon {
           position: absolute;
           top: -7px;
-          right: -7px;
+          right: -7px; // 所有类型 tag 删除按钮统一落在右上角
           z-index: 1;
           display: none;
           align-items: center;
@@ -518,15 +752,30 @@
       box-sizing: border-box;
       width: 100%;
 
-      // 默认保持 4 行高度，避免输入内容后 placeholder 消失导致高度抖动
-      min-height: calc(var(--ai-line-height-compact, 20px) * 4 + var(--ai-spacing-comfortable, 8px) * 2);
+      // 固定 4 行底高（与主题 line-height 一致），内容未超出时高度不变，超出后再撑开
+      min-height: calc(var(--ai-line-height, 20px) * 4 + var(--ai-spacing-comfortable, 8px) * 2);
       padding: var(--ai-spacing-comfortable, 8px);
       font-size: var(--ai-font-size, 12px);
-      line-height: var(--ai-line-height-compact, 20px);
+      // 跟随主题：small=20px / normal=24px；与 mention tag 高度一致
+      line-height: var(--ai-line-height, 20px);
       color: #4d4f56;
       outline: none;
       border: none;
       border-radius: 8px;
+
+      // 行内文字与 tag 共用 middle 对齐，避免基线导致上下错位
+      > div > span {
+        vertical-align: middle;
+      }
+    }
+
+    .ai-slash-input-spacer {
+      // 插入 tag 后的空格节点：裁掉空格字形，避免额外占宽；
+      // 与 tag / 光标的 4px 间距由 mention-tag 的 margin: 0 4px 承担
+      display: inline-block;
+      width: 0;
+      overflow: hidden;
+      vertical-align: middle;
     }
 
     [contenteditable='true']:empty::before {
@@ -537,14 +786,29 @@
   }
 
   .tippy-box[data-theme~='ai-slash-editor-theme'] {
-    box-shadow: none !important;
+    width: 100%;
+    max-width: none !important;
+    overflow: hidden !important;
+    background-color: #fff !important;
+    border: 1px solid #dcdee5 !important;
+    border-radius: 8px !important; // 与聊天输入框一致
+    outline: none !important;
+    // 外阴影放在 tippy-box，避免被 overflow:hidden 裁切
+    box-shadow: 0 2px 16px 0 #00000029 !important;
 
     &[data-theme~='light'] {
-      background-color: white;
+      background-color: #fff !important;
     }
 
     .tippy-content {
+      width: 100%;
       padding: 0 !important;
+      box-sizing: border-box;
+
+      > span {
+        display: block;
+        width: 100%;
+      }
     }
   }
 </style>

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.spec.ts
@@ -122,7 +122,7 @@ describe('AiSlashMenu', () => {
     it('应该显示分组标题', () => {
       wrapper = mount(AiSlashMenu, {
         props: {
-          resourceList: [{ id: '1', name: 'Tool 1', type: 'tool' }],
+          resourceList: [{ id: '1', name: 'Tool 1', type: 'tool', icon: null }],
           onSelect: vi.fn(),
         },
         global: {
@@ -135,12 +135,29 @@ describe('AiSlashMenu', () => {
       expect(wrapper.find('.ai-slash-group-title').exists()).toBe(true);
     });
 
+    it('分组标题不应显示类型色块', () => {
+      wrapper = mount(AiSlashMenu, {
+        props: {
+          resourceList: [{ id: '1', name: 'Tool 1', type: 'tool', icon: null }],
+          onSelect: vi.fn(),
+        },
+        global: {
+          directives: {
+            overflowTips: {},
+          },
+        },
+      });
+
+      expect(wrapper.find('.mark-tool').exists()).toBe(false);
+      expect(wrapper.find('[class^="mark-"]').exists()).toBe(false);
+    });
+
     it('应该显示分组内项目数量', () => {
       wrapper = mount(AiSlashMenu, {
         props: {
           resourceList: [
-            { id: '1', name: 'Tool 1', type: 'tool' },
-            { id: '2', name: 'Tool 2', type: 'tool' },
+            { id: '1', name: 'Tool 1', type: 'tool', icon: null },
+            { id: '2', name: 'Tool 2', type: 'tool', icon: null },
           ],
           onSelect: vi.fn(),
         },
@@ -152,6 +169,45 @@ describe('AiSlashMenu', () => {
       });
 
       expect(wrapper.find('.ai-slash-group-title').text()).toContain('(2)');
+    });
+  });
+
+  describe('选项图标测试', () => {
+    it('无 icon 时应渲染首字母 fallback 图标', () => {
+      wrapper = mount(AiSlashMenu, {
+        props: {
+          resourceList: [{ id: '1', name: 'Tool 1', type: 'tool', icon: null }],
+          onSelect: vi.fn(),
+        },
+        global: {
+          directives: {
+            overflowTips: {},
+          },
+        },
+      });
+
+      expect(wrapper.find('.ai-slash-group-item-icon--fallback').exists()).toBe(true);
+      expect(wrapper.find('.ai-slash-group-item-icon--fallback').text()).toBe('T');
+    });
+
+    it('有 icon 时应渲染 img 元素', () => {
+      wrapper = mount(AiSlashMenu, {
+        props: {
+          resourceList: [
+            { id: '1', name: 'Tool 1', type: 'tool', icon: 'https://example.com/icon.png' },
+          ],
+          onSelect: vi.fn(),
+        },
+        global: {
+          directives: {
+            overflowTips: {},
+          },
+        },
+      });
+
+      const img = wrapper.find('img.ai-slash-group-item-icon');
+      expect(img.exists()).toBe(true);
+      expect(img.attributes('src')).toBe('https://example.com/icon.png');
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.vue
@@ -21,7 +21,6 @@
           >
             <path d="M800 512L288 928V96z"></path>
           </svg>
-          <span :class="`mark-${groupItems.type}`"></span>
           {{ groupItems.name }}
           ({{ groupItems.items.length }})
         </div>
@@ -33,6 +32,19 @@
             :class="{ 'is-active': sortedResourceList?.[activeIndex]?.id === item.id }"
             @click="onSelect(item)"
           >
+            <img
+              v-if="item.icon && !failedIcons.has(String(item.id))"
+              :src="item.icon"
+              alt=""
+              class="ai-slash-group-item-icon"
+              @error="failedIcons.add(String(item.id))"
+            />
+            <div
+              v-else
+              class="ai-slash-group-item-icon ai-slash-group-item-icon--fallback"
+            >
+              {{ item.name?.[0]?.toUpperCase() }}
+            </div>
             <span
               v-overflow-tips="{
                 text: item.name,
@@ -52,7 +64,7 @@
   </div>
 </template>
 <script setup lang="ts">
-  import { ref as deepRef, shallowRef, useTemplateRef, watchEffect } from 'vue';
+  import { reactive, ref as deepRef, shallowRef, useTemplateRef, watchEffect } from 'vue';
 
   import { useMenuKeydown } from '../../../../composables/use-menu-keydown';
   import { OverflowTips as vOverflowTips } from '../../../../directives';
@@ -63,6 +75,7 @@
   }>();
 
   const menuRef = useTemplateRef<HTMLElement>('menuRef');
+  const failedIcons = reactive(new Set<string>());
 
   const expandList = deepRef<ResourceType[]>(['tool', 'shortcut', 'doc', 'knowledgebase', 'mcp'] as ResourceType[]);
   const sortedResourceList = shallowRef<IAiSlashMenuItem[]>([]);
@@ -105,18 +118,37 @@
   };
 </script>
 <style lang="scss">
-  @use 'sass:list';
-  @use '../../../../styles/variables.scss' as variables;
-
   .ai-slash-menu {
-    width: 260px;
-    max-height: 200px;
-    overflow-y: auto;
+    box-sizing: border-box;
+    width: 100%;
+    // 最多展示 10 个选项（每项 32px），超出再滚动
+    max-height: 320px;
+    overflow: hidden auto;
     font-size: var(--ai-font-size, 12px);
     background: #fff;
-    border: 1px solid #dcdee5;
-    border-radius: 2px;
-    box-shadow: 0 2px 6px 0 #0000001a;
+    border: 0;
+    border-radius: 8px; // 与聊天输入框一致
+    outline: none;
+    box-shadow: none; // 外阴影由 tippy-box 承担，避免被裁切
+    scrollbar-color: #dcdee5 transparent;
+    scrollbar-width: thin;
+
+    &::-webkit-scrollbar {
+      width: 4px;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: #dcdee5;
+      border-radius: 2px;
+
+      &:hover {
+        background: #c4c6cc;
+      }
+    }
 
     .ai-slash-item {
       display: flex;
@@ -142,18 +174,6 @@
       display: flex;
       flex-direction: column;
       color: #979ba5;
-
-      @each $type, $color in variables.$resourceTypeMap {
-        .mark-#{$type} {
-          display: flex;
-          flex: 0 0 10px;
-          width: 10px;
-          height: 10px;
-          margin-right: 6px;
-          background-color: list.nth($color, 3);
-          border-radius: 2px;
-        }
-      }
 
       .ai-slash-group-title {
         .title-icon {
@@ -182,13 +202,34 @@
 
       .ai-slash-group-item {
         width: 100%;
-        padding: 0 16px 0 32px;
+        padding: 0 16px 0 24px;
         color: #4d4f56;
         cursor: pointer;
 
         &.is-active,
         &:hover {
           background-color: #f5f7fa;
+        }
+
+        &-icon {
+          flex-shrink: 0;
+          width: 20px;
+          height: 20px;
+          margin-right: 8px;
+          object-fit: contain;
+          border-radius: 2px;
+
+          &--fallback {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: var(--ai-font-size, 12px);
+            font-weight: 700;
+            line-height: var(--ai-line-height-compact, 20px);
+            color: #fff;
+            background: #3a84ff;
+            border-radius: 2px;
+          }
         }
       }
     }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/command.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/command.ts
@@ -45,8 +45,9 @@ export const InsertTag: EditorCommand<[Position, IAiSlashMenuItem]> = (
       {
         data: {
           label: tag.name,
-          value: tag.name,
+          value: tag.id ?? tag.name,
           type: tag.type,
+          icon: tag.icon || '',
         },
       },
     ],
@@ -76,8 +77,14 @@ export const InsertSkillTag: EditorCommand<[Position, ISkillListItem]> = (
           label: skill.skill_name,
           value: skill.skill_code,
           type: 'skill',
+          icon: skill.icon || '',
         },
       },
     ],
   ]);
+};
+
+/** 将光标移动到指定文档位置（不修改内容） */
+export const SetCaret: EditorCommand<[Position]> = (_doc, _selection, pos: Position) => {
+  return new Transaction().select(pos, pos);
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/constants.ts
@@ -29,6 +29,7 @@ import type { VoidNode } from '../../../edix/doc/types';
 import type { TagSchema } from '../../../types/input';
 
 type TagNodeData = {
+  icon?: string;
   label: string;
   type: string;
   value: string;
@@ -51,7 +52,13 @@ export const tagSchema = schema({
       is: node => {
         return node.contentEditable === 'false' && node.dataset.tagType !== undefined;
       },
-      data: e => ({ label: e.textContent!, value: e.dataset.tagValue!, type: e.dataset.tagType! }),
+      data: e => ({
+        // 优先读 data-tag-label，避免 icon 首字母 fallback 混入 textContent
+        label: e.dataset.tagLabel || e.querySelector('.mention-tag-label')?.textContent || e.textContent || '',
+        value: e.dataset.tagValue || '',
+        type: e.dataset.tagType || '',
+        icon: e.dataset.tagIcon || '',
+      }),
       plain: d => (d.type === 'skill' ? `/${d.value}` : d.label),
     }),
   },

--- a/src/frontend/ai-blueking/packages/chat-x/src/styles/menu.scss
+++ b/src/frontend/ai-blueking/packages/chat-x/src/styles/menu.scss
@@ -11,6 +11,25 @@
   border: 1px solid #dcdee5;
   border-radius: 2px;
   box-shadow: 0 2px 6px 0 #0000001a;
+  scrollbar-color: #dcdee5 transparent;
+  scrollbar-width: thin;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: #dcdee5;
+    border-radius: 2px;
+
+    &:hover {
+      background: #c4c6cc;
+    }
+  }
 
   &-item {
     display: flex;

--- a/src/frontend/ai-blueking/packages/chat-x/src/styles/variables.scss
+++ b/src/frontend/ai-blueking/packages/chat-x/src/styles/variables.scss
@@ -1,53 +1,20 @@
 // background, color, icon-color, hover-background, hover-color, hover-icon-color
+// 各类型 mention tag 统一灰底样式，不再按类型区分配色
+$mention-tag-colors: (
+  #f0f1f5,
+  #4d4f56,
+  #979ba5,
+  #dcdee5,
+  #4d4f56,
+  #4d4f56,
+);
 $resourceTypeMap: (
-  tool: (
-    #f0f1f5,
-    #4d4f56,
-    #979ba5,
-    #dcdee5,
-    #4d4f56,
-    #4d4f56,
-  ),
-  skill: (
-    #f0f1f5,
-    #4d4f56,
-    #979ba5,
-    #dcdee5,
-    #4d4f56,
-    #4d4f56,
-  ),
-  shortcut: (
-    #e1ecff,
-    #3a84ff,
-    #3a84ff,
-    #cddffe,
-    #1768ef,
-    #3a84ff,
-  ),
-  doc: (
-    #daf6e5,
-    #2caf5e,
-    #2caf5e,
-    #cbf0da,
-    #14a568,
-    #1cab88,
-  ),
-  knowledgebase: (
-    #daf6e5,
-    #2caf5e,
-    #2caf5e,
-    #cbf0da,
-    #14a568,
-    #1cab88,
-  ),
-  mcp: (
-    #fdeed8,
-    #f59500,
-    #f59500,
-    #fce5c0,
-    #e38b02,
-    #f59500,
-  ),
+  tool: $mention-tag-colors,
+  skill: $mention-tag-colors,
+  shortcut: $mention-tag-colors,
+  doc: $mention-tag-colors,
+  knowledgebase: $mention-tag-colors,
+  mcp: $mention-tag-colors,
 );
 
 // toolcall status color map

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/input.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/input.ts
@@ -40,6 +40,8 @@ export enum UploadStatus {
   Success = 'success',
 }
 
+export type MentionMenuType = 'prompt' | 'skill' | 'slash';
+
 export type MentionState = {
   coordinates: null | {
     height: number;
@@ -47,6 +49,8 @@ export type MentionState = {
     top: number;
   };
   isActive?: boolean;
+  /** 由光标前触发符解析出的菜单类型 */
+  menuType?: MentionMenuType;
   query?: string;
   rect: DOMRect | null;
 };

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-prompt-list.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-prompt-list.md
@@ -22,6 +22,9 @@ sinceVersion: 1.0.0
 - **源码位置**：`src/components/chat-input/ai-slash-input/ai-prompt-list/ai-prompt-list.vue`
 - **能力说明**：`\` Prompt 选择列表，供 AiSlashInput 插入模板文本。
 
+
+> Prompt 列表面板样式与 Slash/Skill 面板统一。
+
 ## API 摘要
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-skill-list.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-skill-list.md
@@ -34,6 +34,9 @@ sinceVersion: 1.0.0
   - 有 `icon` 且未加载失败：渲染 `<img>`
   - 无 `icon`，或 `<img>` 触发 `@error`：渲染首字母 fallback（`skill_name[0]` 大写，蓝底白字）
 
+
+> Skill 列表图标为方形（与 MCP 等一致），无 icon 时显示首字母 fallback。
+
 ## API 摘要
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-editor.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-editor.md
@@ -20,6 +20,9 @@ sinceVersion: 1.0.0
 - **源码位置**：`src/components/chat-input/ai-slash-editor/ai-slash-editor.vue`
 - **能力说明**：旧版富文本编辑器实现，封装 command selection 与提示菜单。
 
+
+> 编辑器主题与 mention tag 行高跟随 `--ai-line-height`；tag 支持图标与左右间距。
+
 ## API 摘要
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-input.md
@@ -34,6 +34,9 @@ sinceVersion: 1.0.0
 | `\`  | prompt   | `AiPromptList` | `prompts` |
 | `@`  | slash    | `AiSlashMenu` | `resources` |
 
+
+> Slash/Mention 菜单锚定整框输入、禁止 flip；支持实时过滤、tag 图标/首字母 fallback、灰底 tag 与左右 4px 间距；行高跟随 `--ai-line-height`（small=20 / normal=24）。
+
 ## API 摘要
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-menu.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-menu.md
@@ -20,6 +20,9 @@ sinceVersion: 1.0.0
 - **源码位置**：`src/components/chat-input/ai-slash-input/ai-slash-menu/ai-slash-menu.vue`
 - **能力说明**：@ 资源选择菜单，展示资源项供 AiSlashInput 插入标签。
 
+
+> 菜单面板满宽、圆角与细滚动条样式与输入框对齐。
+
 ## API 摘要
 
 ### Props


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】Slash/Mention 菜单呼出交互与样式升级
ID: 1070093903137208626（短 ID: 137208626）

## 改动
- `ai-slash-input*` / `ai-slash-menu*` / `ai-skill-list*` / `ai-prompt-list*`: 菜单锚定、实时过滤、方形图标、tag 间距、主题行高
- `playground/*`: 丰富 Skill/资源/Prompt mock，支持 `?size=small|normal`
- wiki / 单测同步

## 影响面
- 影响输入区 Slash/Mention 菜单交互与样式；不改变消息发送协议

## 测试
- [ ] 输入 `/` `\\` `@` 可呼出对应菜单，宽度与输入框一致且不翻到上方
- [ ] 连续输入可实时过滤；无 icon 时显示首字母方形图标
- [ ] tag 与左右文字间距 4px；12/14 主题行高分别为 20/24
- [ ] 相关 vitest（ai-slash-input / menu / skill-list）
