### PR TITLE
feat(chat-x): small/normal 主题下上传按钮与工具栏尺寸对齐

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
@@ -25,7 +25,7 @@
 .file-upload-btn（display: flex，align-items: center）
 ├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
 │     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
-└── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）
+└── span.ai-shortcut-btn.file-upload-btn-icon（热区 32×32px / 圆角 8px；图标字号跟随 --ai-icon-size-sm：small=16px、normal=18px；color: #979ba5；hover: #f0f1f5）
       v-tippy: "上传图片, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
       @click → fileInputRef.click()
       └── <slot> 默认：FileUploadIcon

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -107,6 +107,7 @@ function triggerFileChange(wrapper: VueWrapper, files: File[]) {
 
 // ============= 测试主体 =============
 
+// style-note: chat-x PR3 — 上传按钮热区 32×32 / --ai-icon-size-sm
 describe('FileUploadBtn', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
@@ -100,14 +100,18 @@
     .file-upload-btn-icon {
       display: flex;
       align-items: center;
-      justify-content: flex-start;
-      width: 24px;
-      height: 24px;
-      font-size: var(--ai-icon-size, 16px);
+      justify-content: center;
+      width: 32px;
+      height: 32px;
+      padding: 0;
+      font-size: var(--ai-icon-size-sm, 16px); // small=16px / normal=18px
       color: #979ba5;
+      border-radius: 8px;
+      transition: background-color 0.2s;
 
       &:hover {
         cursor: pointer;
+        background: #f0f1f5;
       }
     }
   }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
@@ -42,7 +42,7 @@ sinceVersion: 1.0.0
 .ai-file-upload-btn（display: flex，align-items: center）
 ├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
 │     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
-└── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）
+└── span.ai-shortcut-btn.file-upload-btn-icon（热区 32×32px / 圆角 8px；图标字号跟随 --ai-icon-size-sm：small=16px、normal=18px；color: #979ba5；hover: #f0f1f5）
       v-tippy: "上传图片, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
       @click → fileInputRef.click()
       └── <slot> 默认：FileUploadIcon


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】small/normal 主题下上传按钮与工具栏尺寸对齐
ID: 1070093903137208635（短 ID: 137208635）


## 改动
- `file-upload-btn.vue`: 热区 32×32、图标跟随 `--ai-icon-size-sm`、hover `#f0f1f5`
- wiki / skill 尺寸说明同步（不含 accept 扩类型）

## 影响面
- 仅工具栏上传按钮视觉尺寸与 hover，不影响上传业务逻辑

## 测试
- [ ] `?size=small` / `?size=normal` 热区均为 32×32，图标字号分别为 16/18
- [ ] hover 有 `#f0f1f5` 背景反馈
