### PR TITLE
feat(chat-x): 输入框最大高度 280px 与未激活灰色边框

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.spec.ts
@@ -191,6 +191,7 @@ vi.mock('./constants', () => ({
   tagSchema: {},
 }));
 
+// style-note: chat-x PR4 — wrapper min-height:0 配合父级 max-height 内部滚动
 describe('AiSlashInput', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/ai-slash-input/ai-slash-input.vue
@@ -471,8 +471,8 @@
     flex: 1;
     flex-direction: column;
     width: 100%;
+    min-height: 0; // 父级触达 max-height 后允许收缩并内部滚动
     height: fit-content;
-    max-height: 400px;
     overflow: auto;
 
     @each $type, $color in variables.$resourceTypeMap {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -294,6 +294,7 @@ vi.mock('../ai-buttons/file-upload-btn/file-upload-btn.vue', () => ({
   }),
 }));
 
+// style-note: chat-x PR4 — inputMaxHeight 默认 280 / 未激活灰边框
 describe('ChatInput', () => {
   let wrapper: VueWrapper;
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -146,7 +146,7 @@
   const selectedModel = defineModel<string>('selectedModel', {
     required: false,
   });
-  const maxHeight = shallowRef(200);
+  const maxHeight = shallowRef(280);
   export type ChatInputEmits = {
     (e: 'selectShortcut', shortcut: Shortcut): void;
     (e: 'deleteShortcut'): void;
@@ -191,7 +191,7 @@ Use Shift + Enter to enter a new line`
     prompts: () => [],
     resources: () => [],
     skills: () => [],
-    inputMaxHeight: 200,
+    inputMaxHeight: 280,
     supportUpload: true,
   });
   const emit = defineEmits<ChatInputEmits>();
@@ -216,7 +216,7 @@ Use Shift + Enter to enter a new line`
   });
 
   watchPostEffect(() => {
-    const defaultHeight = props.inputMaxHeight || 200;
+    const defaultHeight = props.inputMaxHeight || 280;
     if (uploadFiles.value.length < 1 || !filesRef.value) {
       maxHeight.value = defaultHeight;
       return;
@@ -402,15 +402,28 @@ Use Shift + Enter to enter a new line`
       min-width: variables.$chat-input-min-width;
       max-width: variables.$chat-input-max-width;
       min-height: 110px;
-      max-height: 200px;
+      max-height: 280px; // 与 inputMaxHeight 默认一致；有文件时由 inline style 叠加预览区高度
+      overflow: hidden; // 触顶后由内部 ai-slash-input 滚动
       padding-bottom: var(--ai-spacing-comfortable, 8px);
       background: #fff;
+      border: 1px solid #dcdee5; // 未激活：灰色描边
       border-radius: 8px;
 
       &::before {
         z-index: var(--chat-z-index);
+        opacity: 0;
+        transition: opacity 0.15s ease;
 
         @include border.linear-gradient-border(180deg, #6cbaff, #3a84ff);
+      }
+
+      // 激活（编辑区 / 内部控件聚焦）时切换为蓝色渐变描边
+      &:focus-within {
+        border-color: transparent;
+
+        &::before {
+          opacity: 1;
+        }
       }
 
       .chat-input-cite {

--- a/src/frontend/ai-blueking/packages/chat-x/src/styles/border.scss
+++ b/src/frontend/ai-blueking/packages/chat-x/src/styles/border.scss
@@ -1,14 +1,20 @@
-@mixin linear-gradient-border($angle: 145deg, $color1: #b8c6ec, $color2: #e3d2e3) {
+@mixin linear-gradient-border($angle: 145deg, $color1: #b8c6ec, $color2: #e3d2e3, $width: 1px) {
   position: absolute;
   inset: 0;
   z-index: 2;
-  padding: 1px;
+  box-sizing: border-box; // padding 计入尺寸，保证描边稳定为 $width（默认 1px）
+  padding: $width;
   pointer-events: none;
   content: '';
-  background: linear-gradient(145deg, $color1 0%, $color2 100%);
-  border-radius: 8px;
+  background: linear-gradient($angle, $color1 0%, $color2 100%);
+  border-radius: inherit;
   mask:
     linear-gradient(#fff 0 0) content-box,
     linear-gradient(#fff 0 0);
   mask-composite: exclude;
+  // Safari / 旧 Chromium
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
 }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/ai-slash-input.md
@@ -34,6 +34,9 @@ sinceVersion: 1.0.0
 | `\`  | prompt   | `AiPromptList` | `prompts` |
 | `@`  | slash    | `AiSlashMenu` | `resources` |
 
+
+> 输入框触达最大高度后，`.ai-slash-input-wrapper` 以 `min-height:0` 收缩并内部滚动。
+
 ## API 摘要
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -808,7 +808,7 @@ const handleSendMessage = async (
 | models             | `IModelOption[]`                                                           | -        | -    | 可选模型列表，传入后在发送按钮左侧展示模型选择器        |
 | shortcutId         | `string`                                                                   | -        | -    | 当前选中的快捷指令 ID，匹配时列表收起为已选样式         |
 | placeholder        | `string`                                                                   | 见默认值 | -    | 编辑器占位符，支持多行                                  |
-| inputMaxHeight     | `number`                                                                   | `200`    | -    | 框体最大高度（px），有文件时自动加上文件预览区高度      |
+| inputMaxHeight     | `number`                                                                   | `280`    | -    | 框体最大高度（px），有文件时自动加上文件预览区高度      |
 | defaultUploadFiles | `UploadFile[]`                                                             | -        | -    | 预设已上传的文件列表                                    |
 | sendDisabledTip    | `string`                                                                   | -        | -    | 业务阻塞发送时的 tooltip 提示；传入后发送按钮置灰，点击、Enter 与 `triggerSendMessage()` 均不会发送 |
 | supportUpload      | `boolean`                                                                  | `true`   | -    | 是否显示文件上传按钮                                    |


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】输入框最大高度 280px 与未激活灰色边框
ID: 1070093903137208645（短 ID: 137208645）

## 改动
- `chat-input.vue`: `inputMaxHeight` 默认 280；未激活灰边框、focus 蓝色渐变
- `ai-slash-input.vue` / `border.scss`: 触顶后内部滚动与描边 mixin 加固
- wiki 同步

## 影响面
- 影响输入框高度与边框样式；不改变发送/附件协议

## 测试
- [ ] 少内容时框体随内容增高；多行最高约 280px 后内部滚动
- [ ] 未聚焦边框灰色；聚焦后蓝色渐变描边
- [ ] 12px / 14px 主题行为一致
