### PR TITLE
feat(chat-x): 文件上传类型扩展与消息内预览体验优化

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
@@ -66,7 +66,7 @@ file.url 存在？
 
 ## 图片文件预览
 
-设置了 `url` 字段时，渲染为 48×48 的图片缩略图（`cursor: zoom-in`）。点击图片可打开全屏预览（内部集成 `ImagePreview` 组件），支持缩放、旋转、下载等操作：
+设置了 `url` 字段时，渲染为固定行高（60px）、宽度按原图比例自适应且不超过 `max-width: 240px` 的缩略图（`object-fit: contain`，`cursor: zoom-in`）。点击图片可打开全屏预览（内部集成 `ImagePreview` 组件），支持缩放、旋转、下载等操作：
 
 ```vue
 <script setup lang="ts">

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
@@ -26,7 +26,7 @@
 ├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
 │     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
 └── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）
-      v-tippy: "上传图片, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
+      v-tippy: "上传文件（图片 / Markdown / Word 等）, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
       @click → fileInputRef.click()
       └── <slot> 默认：FileUploadIcon
 ```
@@ -126,7 +126,7 @@
 
 | 属性名       | 类型           | 默认值      | 说明                                                                 |
 | ------------ | -------------- | ----------- | -------------------------------------------------------------------- |
-| accept       | `string`       | `'image/*'` | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
+| accept       | `string`       | `DEFAULT_UPLOAD_ACCEPT`（图片 + `.md/.markdown/.doc/.docx` 等） | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
 | maxFiles     | `number`       | `3`         | 预留字段，**当前不在按钮内生效**；个数上限见 `ChatInput` 与全局常量 |
 | multiple     | `boolean`      | `true`      | 声明属性（当前版本未实际绑定到 input，始终多选）                     |
 | tippyOptions | `AITippyProps` | —           | 扩展 tooltip 配置，会与内置配置合并                                |

--- a/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
@@ -128,6 +128,25 @@ export const MAX_UPLOAD_FILES = 3; // 最大上传文件数量
 export const MAX_UPLOAD_FILE_SIZE = 2.4 * 1024 * 1024; // 最大上传文件大小 2.5MB
 
 /**
+ * 默认上传文件类型：图片 + Markdown / Word 等常见文档
+ * 遵循 `<input accept>` 规范，仅影响系统文件选择框过滤
+ */
+export const DEFAULT_UPLOAD_ACCEPT = [
+  'image/*',
+  '.md',
+  '.markdown',
+  '.doc',
+  '.docx',
+  '.txt',
+  '.pdf',
+  '.ppt',
+  '.pptx',
+  '.xls',
+  '.xlsx',
+  '.csv',
+].join(',');
+
+/**
  * 关键词高亮类名
  */
 export const HIGHLIGHT_KEYWORD_CLASS_NAME = 'ai-is-keyword';

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -163,11 +163,15 @@ describe('FileUploadBtn', () => {
 
   // ---------- Props 测试 ----------
   describe('Props 测试', () => {
-    it('accept 默认值应该为 image/*（含 SVG）', () => {
+    it('accept 默认值应包含图片与 Markdown / Word 等文档类型', async () => {
+      const { DEFAULT_UPLOAD_ACCEPT } = await import('../../../common');
       wrapper = mount(FileUploadBtn);
 
       const input = wrapper.find('input[type="file"]');
-      expect(input.attributes('accept')).toBe('image/*');
+      expect(input.attributes('accept')).toBe(DEFAULT_UPLOAD_ACCEPT);
+      expect(input.attributes('accept')).toContain('image/*');
+      expect(input.attributes('accept')).toContain('.md');
+      expect(input.attributes('accept')).toContain('.docx');
     });
 
     it('应该支持自定义 accept', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.vue
@@ -11,7 +11,7 @@
     <span
       v-tippy="{
         ...tippyOptions,
-        content: t('上传图片, 最多支持上传 3 个, 最大支持 2.4MB'),
+        content: t('上传文件（图片 / Markdown / Word 等）, 最多支持上传 3 个, 最大支持 2.4MB'),
         theme: 'ai-chat-box',
         offset: [0, 16],
       }"
@@ -30,7 +30,7 @@
   import { Message } from 'bkui-vue';
   import { directive as vTippy } from 'vue-tippy';
 
-  import { isEn, MAX_UPLOAD_FILE_SIZE } from '../../../common';
+  import { DEFAULT_UPLOAD_ACCEPT, isEn, MAX_UPLOAD_FILE_SIZE } from '../../../common';
   import { FileUploadIcon } from '../../../icons';
   import { t } from '../../../lang/lang';
   import { formatUploadNotAddedMessage } from '../../../utils';
@@ -46,7 +46,7 @@
     tippyOptions?: AITippyProps;
   };
   withDefaults(defineProps<FileUploadBtnProps>(), {
-    accept: 'image/*', // 默认允许常见图片类型（含 SVG）
+    accept: DEFAULT_UPLOAD_ACCEPT, // 图片 + Markdown / Word 等常见文档
     maxFiles: 3, // 预留/文档用；实际上传个数由上层（如 ChatInput）校验
     multiple: true,
   });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.spec.ts
@@ -186,6 +186,38 @@ describe('FileContent', () => {
       expect(wrapper.emitted('deleteFile')?.[0]).toEqual([file]);
     });
 
+    it('点击加载失败的图片也应打开预览', async () => {
+      const files: Partial<UploadFile>[] = [
+        { url: 'https://example.com/broken.png', filename: 'broken.png', mimeType: 'image/png' },
+      ];
+
+      wrapper = mount(FileContent, {
+        props: { files },
+      });
+
+      await wrapper.find('img.file-content-image').trigger('error');
+      await wrapper.find('.file-content-image.image-error').trigger('click');
+
+      const preview = wrapper.findComponent({ name: 'ImagePreview' });
+      expect(preview.props('visible')).toBe(true);
+    });
+
+    it('远程 url 加载失败且有本地 File 时应回退到本地预览', async () => {
+      const file = new File(['img'], 'photo.png', { type: 'image/png' });
+      const files: Partial<UploadFile>[] = [
+        { url: 'https://example.com/broken.png', filename: 'photo.png', mimeType: 'image/png', file },
+      ];
+
+      wrapper = mount(FileContent, {
+        props: { files },
+      });
+
+      await wrapper.find('img.file-content-image').trigger('error');
+
+      expect(wrapper.find('.file-content-image.image-error').exists()).toBe(false);
+      expect(wrapper.find('img.file-content-image').attributes('src')).toBe('blob:preview-photo.png');
+    });
+
     it('点击图片应该打开预览', async () => {
       const files: Partial<UploadFile>[] = [{ file: new File(['img'], 'photo.png', { type: 'image/png' }) }];
 
@@ -198,6 +230,38 @@ describe('FileContent', () => {
       const preview = wrapper.findComponent({ name: 'ImagePreview' });
       expect(preview.props('visible')).toBe(true);
       expect(preview.props('current')).toBe(0);
+    });
+
+    it('点击非图片文件应在新窗口打开', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+      const file = new File(['# hello'], 'readme.md', { type: 'text/markdown' });
+
+      wrapper = mount(FileContent, {
+        props: {
+          files: [{ file }],
+        },
+      });
+
+      await wrapper.find('.file-content-object').trigger('click');
+
+      expect(openSpy).toHaveBeenCalled();
+      expect(openSpy.mock.calls[0]?.[1]).toBe('_blank');
+      openSpy.mockRestore();
+    });
+
+    it('点击带 url 的非图片文件应打开该地址', async () => {
+      const openSpy = vi.spyOn(window, 'open').mockReturnValue(null);
+
+      wrapper = mount(FileContent, {
+        props: {
+          files: [{ url: 'https://example.com/readme.md', filename: 'readme.md' }],
+        },
+      });
+
+      await wrapper.find('.file-content-object').trigger('click');
+
+      expect(openSpy).toHaveBeenCalledWith('https://example.com/readme.md', '_blank', 'noopener,noreferrer');
+      openSpy.mockRestore();
     });
 
     it('点击第二张图片应该预览对应索引', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="ai-files-content">
     <div
-      v-for="file in files"
-      :key="file.file?.name"
+      v-for="(file, index) in files"
+      :key="getFileKey(file) || index"
       class="file-content"
       :class="{
         'is-file-object': !isImage(file) || imageErrorMap[getFileKey(file)],
@@ -12,19 +12,22 @@
         v-if="isImage(file) && !imageErrorMap[getFileKey(file)]"
         :alt="file.filename || file.file?.name"
         class="file-content-image"
-        :src="file.url || getFilePreviewUrl(file.file)"
+        :src="getImageSrc(file)"
         @click="handlePreview(file)"
         @error="handleImageError(file)"
       />
       <div
         v-else-if="isImage(file) && imageErrorMap[getFileKey(file)]"
         class="file-content-image image-error"
+        @click="handlePreview(file)"
       >
         <ImageErrorIcon class="file-error-icon" />
       </div>
       <div
         v-else
         class="file-content-object"
+        :class="{ 'is-clickable': canOpenFile(file) }"
+        @click="handleOpenFile(file)"
       >
         <div class="file-description">
           <DocumentIcon class="file-icon" />
@@ -78,18 +81,46 @@
   // 记录图片加载错误状态
   const imageErrorMap = reactive<Record<string, boolean>>({});
 
+  const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i;
+
   const isImage = (file: Partial<UploadFile>) => {
+    if (isImageFile(file.mimeType || file.file?.type)) return true;
+    const name = file.filename || file.file?.name || file.url || '';
+    return IMAGE_EXT_RE.test(name);
+  };
+
+  const canOpenFile = (file: Partial<UploadFile>) => Boolean(file.url || file.file);
+
+  const handleOpenFile = (file: Partial<UploadFile>) => {
     if (file.url) {
-      return true;
+      window.open(file.url, '_blank', 'noopener,noreferrer');
+      return;
     }
-    return isImageFile(file.mimeType || file.file?.type);
+    if (file.file) {
+      const blobUrl = URL.createObjectURL(file.file);
+      window.open(blobUrl, '_blank', 'noopener,noreferrer');
+    }
   };
 
   const getFileKey = (file: Partial<UploadFile>) => {
-    return file.url || file.file?.name || '';
+    return file.url || file.file?.name || file.filename || '';
   };
+
+  const imageSrcMap = reactive<Record<string, string>>({});
+
+  const getImageSrc = (file: Partial<UploadFile>) => {
+    const key = getFileKey(file);
+    if (imageSrcMap[key]) return imageSrcMap[key];
+    return file.url || getFilePreviewUrl(file.file);
+  };
+
   const handleImageError = (file: Partial<UploadFile>) => {
-    imageErrorMap[getFileKey(file)] = true;
+    const key = getFileKey(file);
+    if (!imageSrcMap[key] && file.file) {
+      imageSrcMap[key] = getFilePreviewUrl(file.file);
+      return;
+    }
+    imageErrorMap[key] = true;
   };
   const handleDeleteFile = (file: Partial<UploadFile>) => {
     emit('deleteFile', file);
@@ -98,23 +129,27 @@
   const previewVisible = shallowRef(false);
   const previewIndex = shallowRef(0);
 
-  const imageFiles = computed(() => props.files.filter(f => isImage(f) && !imageErrorMap[getFileKey(f)]));
+  const imageFiles = computed(() => props.files.filter(f => isImage(f)));
 
   const previewImages = computed<(File | ImageItem | string)[]>(() =>
     imageFiles.value
       .map(f => {
-        if (f.url) return f.url;
         if (f.file) return f.file;
+        if (f.url) return f.url;
         return '';
       })
       .filter(Boolean),
   );
 
   const handlePreview = (file: Partial<UploadFile>) => {
-    const idx = imageFiles.value.indexOf(file);
-    if (idx < 0) return;
-    previewIndex.value = idx;
-    previewVisible.value = true;
+    const src = file.file || file.url;
+    const idx = src ? previewImages.value.findIndex(img => img === src) : -1;
+    if (idx >= 0) {
+      previewIndex.value = idx;
+      previewVisible.value = true;
+      return;
+    }
+    handleOpenFile(file);
   };
 </script>
 <style lang="scss">
@@ -122,82 +157,120 @@
     display: flex;
     flex-wrap: wrap;
     gap: 8px;
+    align-items: flex-start;
     width: 100%;
 
     .file-content {
       position: relative;
+      height: 60px; // 每一行统一高度
+      max-height: 60px;
 
       .file-delete-icon {
         position: absolute;
-        top: -8px;
-        right: -8px;
+        top: 4px;
+        right: 4px;
+        z-index: 1;
         display: none;
+        align-items: center;
+        justify-content: center;
         width: 16px;
         height: 16px;
         font-size: 16px;
         color: #4d4f56;
         cursor: pointer;
-        outline: 1px solid transparent;
         background-color: #fff;
         border-radius: 50%;
+        box-shadow: 0 1px 4px #00000026;
       }
 
       &:hover {
         .file-delete-icon {
           display: flex;
-          cursor: pointer;
         }
       }
 
+      // 图片缩略图：行高固定，宽度按比例自适应并限制最大宽度，contain 尽量看全
       &-image {
-        display: flex;
-        flex: 0 0 48px;
-        align-items: center;
-        justify-content: center;
-        width: 48px;
-        height: 48px;
+        display: block;
+        box-sizing: border-box;
+        width: auto;
+        height: 100%;
+        max-width: 240px;
         cursor: zoom-in;
         object-fit: contain;
-        border-radius: 4px;
+        vertical-align: top;
+        background: #f5f7fa;
+        border: 1px solid #dcdee5;
+        border-radius: 10px;
+        transition:
+          border-color 0.15s ease,
+          box-shadow 0.15s ease;
+
+        &:hover {
+          border-color: #3a84ff;
+          box-shadow: 0 2px 8px #00000014;
+        }
 
         &.image-error {
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          width: 60px;
+          height: 100%;
+          cursor: zoom-in;
           background: #fff0f0;
-          border: 1px solid #ea3636;
-          border-radius: 4px;
+          border-color: #ea3636;
 
           .file-error-icon {
-            width: 18px;
-            height: 18px;
+            width: 24px;
+            height: 24px;
             color: #979ba5;
           }
         }
       }
 
+      // 非图片文件卡片
       &-object {
         display: flex;
-        flex: 1;
         flex-direction: column;
         justify-content: center;
-        max-width: 170px;
-        height: 48px;
-        padding: 4px 8px;
+        gap: 4px;
+        box-sizing: border-box;
+        width: 200px;
+        max-width: 240px;
+        height: 100%;
+        padding: 8px 12px;
         font-size: var(--ai-font-size, 12px);
-        background: #eaebf0;
-        border-radius: 4px;
+        background: #f5f7fa;
+        border: 1px solid #dcdee5;
+        border-radius: 8px;
+        box-sizing: border-box;
+        transition:
+          border-color 0.15s ease,
+          box-shadow 0.15s ease;
+
+        &.is-clickable {
+          cursor: pointer;
+        }
+
+        &:hover {
+          border-color: #c4c6cc;
+          box-shadow: 0 2px 8px #0000000a;
+        }
 
         .file-description {
           display: flex;
-          gap: 4px;
+          gap: 6px;
           align-items: center;
           width: 100%;
-          height: 20px;
-          color: #4d4f56;
+          color: #313238;
 
           .file-icon {
-            flex: 0 0 12px;
-            width: 12px;
-            height: 12px;
-            font-size: 12px; // 图标尺寸固定，不随 size 主题缩放
+            flex: 0 0 16px;
+            width: 16px;
+            height: 16px;
+            font-size: 16px;
+            color: #979ba5;
           }
 
           .file-name {
@@ -205,16 +278,18 @@
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
+            font-weight: 500;
           }
 
           .file-type {
-            font-size: var(--ai-font-size, 12px);
-            color: #4d4f56;
+            flex-shrink: 0;
+            color: #979ba5;
+            text-transform: uppercase;
           }
         }
 
         .file-size {
-          margin-left: 16px;
+          margin-left: 22px;
           color: #979ba5;
         }
       }

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -696,6 +696,27 @@ describe('ChatInput', () => {
       expect(onSendMessage).toHaveBeenCalled();
     });
 
+        it('发送附件时应保留 File 以便消息内预览', async () => {
+      const onSendMessage = vi.fn();
+      const imageFile = new File(['img'], 'photo.png', { type: 'image/png' });
+
+      wrapper = mount(ChatInput, {
+        props: {
+          modelValue: '看这张图',
+          defaultUploadFiles: [{ file: imageFile, url: 'http://example.com/photo.png' }],
+          onSendMessage,
+        },
+      });
+
+      await wrapper.find('.send-btn').trigger('click');
+
+      expect(onSendMessage).toHaveBeenCalled();
+      const content = onSendMessage.mock.calls[0]?.[0] as Array<{ file?: File; url?: string }>;
+      expect(content[0]?.file).toBeInstanceOf(File);
+      expect(content[0]?.file?.name).toBe('photo.png');
+      expect(content[0]?.url).toBe('http://example.com/photo.png');
+    });
+
     it('存在发送阻断提示时应阻止点击发送', async () => {
       const onSendMessage = vi.fn();
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -240,9 +240,10 @@ Use Shift + Enter to enter a new line`
         content = uploadFiles.value?.slice().map(file => ({
           type: MessageContentType.Binary,
           url: file.url,
-          mimeType: file.file?.type || '',
-          filename: file.file?.name || '',
-        }));
+          mimeType: file.file?.type || file.mimeType || '',
+          filename: file.file?.name || file.filename || '',
+          file: file.file,
+        })) as UserMessage['content'];
         // 如果输入框有值，则将输入框的值作为内容
         if (props.modelValue) {
           content.push({

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.spec.ts
@@ -424,15 +424,18 @@ describe('UserMessage', () => {
       expect(fileContents.length).toBe(2);
     });
 
-    it('有 url 的文件应被识别为图片文件', () => {
+    it('有 url 的图片应按图片归类，文档即使有 url 也不应按图片归类', () => {
       wrapper = mount(UserMessage, {
         props: {
-          content: [{ type: 'binary', url: 'http://example.com/file', filename: 'file' }],
+          content: [
+            { type: 'binary', url: 'http://example.com/photo.png', filename: 'photo.png', mimeType: 'image/png' },
+            { type: 'binary', url: 'http://example.com/readme.md', filename: 'readme.md', mimeType: 'text/markdown' },
+          ],
         } as any,
       });
 
       const fileContents = wrapper.findAll('.mock-file-content');
-      expect(fileContents.length).toBe(1);
+      expect(fileContents.length).toBe(2);
     });
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -194,7 +194,12 @@
     return null;
   }) as Partial<Shortcut>;
 
-  const isBinaryImage = (file: UploadFile) => !!file.url || isImageFile(file.mimeType || file.file?.type);
+  const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i;
+  const isBinaryImage = (file: UploadFile) => {
+    if (isImageFile(file.mimeType || file.file?.type)) return true;
+    const name = file.filename || file.file?.name || file.url || '';
+    return IMAGE_EXT_RE.test(name);
+  };
 
   // 二进制文件
   const binaryFiles = computed(() => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/lang/lang.ts
@@ -159,6 +159,8 @@ export const lang = {
   全选: 'Select All',
   确定: 'Confirm',
   '上传图片, 最多支持上传 3 个, 最大支持 2.4MB': 'Upload Image, up to 3 images supported, max 2.4MB each',
+  '上传文件（图片 / Markdown / Word 等）, 最多支持上传 3 个, 最大支持 2.4MB':
+    'Upload files (images / Markdown / Word, etc.), up to 3 files, max 2.4MB each',
   '你好，我是小鲸': 'Hello, I am BlueKing AI Bot',
   清空搜索: 'Clear Search',
   搜索结果为空: 'Search Result is Empty',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -496,12 +496,14 @@ const handleSendMessage = async (
 ```typescript
 // onSendMessage 的 content 参数变为数组：
 [
-  { type: 'binary', url: '...', mimeType: 'image/png', filename: 'a.png' },
-  { type: 'binary', url: '...', mimeType: 'application/pdf', filename: 'b.pdf' },
+  { type: 'binary', url: '...', mimeType: 'image/png', filename: 'a.png', file: File },
+  { type: 'binary', url: '...', mimeType: 'application/pdf', filename: 'b.pdf', file: File },
   // 若输入框也有文字，则最后追加：
   { type: 'text', text: '请帮我分析这两个文件' },
 ];
 ```
+
+> 发送时会保留本地 `File`，用户消息里的图片即使远程 `url` 加载失败，也能回退到本地预览并支持点击查看。
 
 ```vue
 <template>
@@ -902,7 +904,7 @@ type SendContent =
   | string // 无文件时：纯文本
   | Array<
       // 有文件时：数组
-      { type: 'binary'; url?: string; mimeType: string; filename: string } | { type: 'text'; text: string }
+      { type: 'binary'; url?: string; mimeType: string; filename: string; file?: File } | { type: 'text'; text: string }
     >;
 
 // onSendMessage 完整签名（第三参数由 ChatContainer 在 UserQuestion 场景注入）

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
@@ -43,7 +43,7 @@ sinceVersion: 1.0.0
 ├── input[type="file"]（.file-upload-btn-input，display: none，multiple，:accept）
 │     触发后走 handleFileInputChange → 校验 → emit upload → target.value = ''
 └── span.ai-shortcut-btn.file-upload-btn-icon（24×24px，color: #979ba5，hover: cursor: pointer）
-      v-tippy: "上传图片, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
+      v-tippy: "上传文件（图片 / Markdown / Word 等）, 最多支持上传 3 个, 最大支持 2.4MB"（theme: ai-chat-box，offset: [0, 16]，可通过 tippyOptions 扩展）
       @click → fileInputRef.click()
       └── <slot> 默认：FileUploadIcon
 ```
@@ -159,7 +159,7 @@ sinceVersion: 1.0.0
 
 | 属性名       | 类型           | 默认值      | 说明                                                                 |
 | ------------ | -------------- | ----------- | -------------------------------------------------------------------- |
-| accept       | `string`       | `'image/*'` | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
+| accept       | `string`       | `DEFAULT_UPLOAD_ACCEPT`（图片 + `.md/.markdown/.doc/.docx` 等） | 文件选择框过滤类型，遵循 `<input accept>` 规范                       |
 | maxFiles     | `number`       | `3`         | 预留字段，**当前不在按钮内生效**；个数上限见 `ChatInput` 与全局常量 |
 | multiple     | `boolean`      | `true`      | 声明属性（当前版本未实际绑定到 input，始终多选）                     |
 | tippyOptions | `AITippyProps` | —           | 扩展 tooltip 配置，会与内置配置合并                                |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/file-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/file-content.md
@@ -92,18 +92,15 @@ sinceVersion: 1.0.0
 
 ## 渲染决策逻辑
 
-每个文件按以下优先级决定渲染方式：
+每个文件按 MIME / 扩展名决定渲染方式（`url` 不再单独强制图片模式）：
 
 ```
-file.url 存在？
-├── 是 → 图片模式（用 file.url 作为 <img src>，点击可全屏预览）
-│        图片加载失败 → 错误占位（粉色背景 + 红色边框 + 灰色图标）
-└── 否 → 检查 mimeType 或 file.file?.type
-         ├── 以 'image/' 开头 → 图片模式（用 getFilePreviewUrl(file.file) 作为 src，点击可全屏预览）
-         └── 其他            → 文档卡片模式（图标 + 文件名 + 扩展名 + 大小）
+mimeType / file.type 以 image/ 开头，或 filename / url 带图片扩展名？
+├── 是 → 图片模式
+│        src 优先 file.url，失败且有本地 File 时回退 blob URL
+│        仍失败 → 错误占位（粉色背景 + 红色边框），点击仍可打开预览
+└── 否 → 文档卡片模式（图标 + 文件名 + 扩展名 + 大小，有 url / File 时可点击打开）
 ```
-
-> **注意**：`file.url` 存在时**无论文件 MIME 类型是什么**都会走图片模式。若要将 PDF 等非图片文件显示为文档卡片，确保不设置 `url` 字段（或设为 `undefined`）。
 
 ## 基础用法（文档文件）
 
@@ -141,7 +138,7 @@ file.url 存在？
 
 ## 图片文件预览
 
-设置了 `url` 字段时，渲染为 48×48 的图片缩略图（`cursor: zoom-in`）。点击图片可打开全屏预览（内部集成 `ImagePreview` 组件），支持缩放、旋转、下载等操作：
+设置了 `url` 字段时，渲染为固定行高（60px）、宽度按原图比例自适应且不超过 `max-width: 240px` 的缩略图（`object-fit: contain`，`cursor: zoom-in`）。点击图片可打开全屏预览（内部集成 `ImagePreview` 组件），支持缩放、旋转、下载等操作：
 
 ```vue
 <script setup lang="ts">
@@ -173,7 +170,7 @@ file.url 存在？
 
 ## 图片点击预览
 
-图片模式下点击缩略图会打开全屏预览弹窗。多张图片时支持左右切换。加载失败的图片不会出现在预览列表中：
+图片模式下点击缩略图（含加载失败占位）会打开全屏预览弹窗。多张图片时支持左右切换。预览源优先使用本地 `File`，否则使用 `url`：
 
 ```vue
 <template>
@@ -195,11 +192,11 @@ file.url 存在？
   <FileContentComp :files="imageFiles" />
 </div>
 
-> **预览行为**：组件内部自动维护 `ImagePreview` 实例，无需外部管理预览状态。只有加载成功的图片才会进入预览列表，加载失败的图片被自动过滤。
+> **预览行为**：组件内部自动维护 `ImagePreview` 实例，无需外部管理预览状态。缩略图加载失败时，若仍有 `url` 或本地 `File`，点击占位仍会打开预览。
 
 ## 图片加载失败
 
-`<img>` 触发 `onerror` 时，切换为粉色背景 + 红色边框的错误占位：
+`<img>` 触发 `onerror` 时：若有本地 `File`，先改用 blob URL 重试；仍失败则切换为粉色背景 + 红色边框的错误占位（可点击预览）：
 
 <div class="demo">
   <FileContentComp :files="errorImageFiles" @delete-file="handleDeleteFile" />
@@ -311,11 +308,12 @@ file.url 存在？
 
 ### 图片模式
 
-| 条件                               | 图片 src                         | 点击行为       |
-| ---------------------------------- | -------------------------------- | -------------- |
-| `file.url` 有值（优先）            | `file.url`                       | 打开全屏预览   |
-| MIME 以 `image/` 开头（无 url 时） | `URL.createObjectURL(file.file)` | 打开全屏预览   |
-| 图片加载失败                       | 错误占位                         | 不进入预览列表 |
+| 条件                                         | 图片 src                         | 点击行为     |
+| -------------------------------------------- | -------------------------------- | ------------ |
+| MIME 为 `image/*` 或扩展名为图片，且有 url   | `file.url`                       | 打开全屏预览 |
+| 同上且无 url、有 `File`                      | `URL.createObjectURL(file.file)` | 打开全屏预览 |
+| 远程 url 加载失败且有本地 `File`             | 回退为 blob URL                  | 打开全屏预览 |
+| 图片仍加载失败                               | 错误占位                         | 仍可打开预览 |
 
 ### 文档卡片模式
 
@@ -346,7 +344,7 @@ type UploadFile = BinaryInputContent & {
 // 二进制内容基础类型
 interface BinaryInputContent {
   type: 'binary';
-  url?: string; // 文件访问地址，存在时强制走图片模式
+  url?: string; // 文件访问地址，图片模式下作为缩略图 src
   filename?: string; // 文件名（用于文档卡片）
   mimeType?: string; // MIME 类型（用于图片判断和扩展名推断）
 }
@@ -355,11 +353,12 @@ interface BinaryInputContent {
 ## 工具函数（内部使用）
 
 ```typescript
-// 判断是否走图片模式
-// ⚠️ file.url 存在时直接返回 true，不判断 MIME 类型
+// 判断是否走图片模式：MIME 或文件名 / url 扩展名，不再仅因存在 url 就当图片
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|bmp|svg)(\?|$)/i;
 const isImage = (file: Partial<UploadFile>): boolean => {
-  if (file.url) return true;
-  return isImageFile(file.mimeType || file.file?.type);
+  if (isImageFile(file.mimeType || file.file?.type)) return true;
+  const name = file.filename || file.file?.name || file.url || '';
+  return IMAGE_EXT_RE.test(name);
 };
 
 // 判断 MIME 类型是否为图片

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
@@ -202,8 +202,8 @@ sinceVersion: 0.0.20
 
 `content` 为数组时，同时支持文本（`type: 'text'`）和二进制文件（`type: 'binary'`）。组件将 `binary` 项按图片和非图片分为两组：
 
-- **图片文件**（`binaryImageFiles`）：判断 `url` 存在或 `mimeType` / `file.type` 以 `image/` 开头的文件，统一放入一个 `FileContent`（`readonly=true`）中渲染，支持点击缩略图全屏预览
-- **非图片文件**（`binaryNonImageFiles`）：每个文件单独渲染在 `FileContent`（`readonly=true`）中
+- **图片文件**（`binaryImageFiles`）：`mimeType` / `file.type` 以 `image/` 开头，或文件名 / url 带图片扩展名（png/jpg/gif/webp 等）。统一放入一个 `FileContent`（`readonly=true`）中渲染，支持点击缩略图（含加载失败占位）全屏预览
+- **非图片文件**（`binaryNonImageFiles`）：每个文件单独渲染在 `FileContent`（`readonly=true`）中；仅有 `url` 的文档不会被当成图片
 
 `text` 项经 `textParts` 计算属性统一为 `string[]`，按顺序各渲染一个 `TextContent`。
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】文件上传类型扩展与消息内预览体验优化
ID: 1070093903137208651（短 ID: 137208651）

## 改动
- `constants.ts` / `file-upload-btn*`: `DEFAULT_UPLOAD_ACCEPT` 与 tippy/i18n
- `file-content*` / `user-message*` / `chat-input`: 按类型识别图片、本地 File 回退、文档可打开、卡片样式
- wiki / skill / 单测同步（不含 ENABLE_UPLOAD_LIMITS 调试开关）

## 影响面
- 影响默认可选文件类型与消息内文件预览展示；不包含临时关闭上传限制开关

## 测试
- [ ] 文件选择框默认可选文档类型；tooltip 文案正确
- [ ] 仅有 url 的 PDF 等显示为文档卡片而非图片
- [ ] 本地上传图片在 url 失败时仍可预览；文档可点击打开
- [ ] 相关 vitest（file-content / file-upload-btn / chat-input）
