### PR TITLE
fix: 修正会话分享勾选框与消息首行的垂直对齐 --story=137249323

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/message-container/message-container.vue
@@ -22,6 +22,7 @@
         <Checkbox
           v-if="enableSelection && group.type !== MessageRole.Loading"
           class="message-group-checkbox"
+          :class="{ 'is-user-group': group.type === MessageRole.User }"
           :model-value="group.checked"
           @update:model-value="(checked: boolean) => handleCheckboxChange(group, checked)"
         />
@@ -366,9 +367,18 @@
 
       &-checkbox {
         flex: 0 0 16px;
-        align-self: baseline;
+
+        // 兄弟节点 .message-group-messages 未参与基线对齐组，baseline 会退化为贴组顶部，
+        // 错位程度随首个内容结构变化。改为顶部对齐 + 定量补偿，使勾选框在首行行高内垂直居中
+        align-self: flex-start;
         height: 16px;
+        margin-top: calc((var(--ai-line-height, 20px) - 16px) / 2);
         margin-right: auto;
+
+        // 用户消息是带 8px 纵向内边距的气泡，需再下移一个内边距才能对齐气泡内首行文字
+        &.is-user-group {
+          margin-top: calc((var(--ai-line-height, 20px) - 16px) / 2 + 8px);
+        }
       }
 
       &-messages {


### PR DESCRIPTION
## 背景
TAPD: 【小鲸】会话分享勾选框与文字未对齐（错位）
ID: 1070093903137249323

## 改动
- chat-x/message-container: 勾选框由 `align-self: baseline` 改为 `flex-start` 加定量补偿，使其在首行行高内垂直居中。baseline 因兄弟节点未参与基线对齐组而退化为贴组顶部，错位程度随首个内容结构变化
- chat-x/message-container: 用户消息组勾选框新增 `is-user-group` 修饰类，额外补偿气泡 8px 纵向内边距

## 影响面
- 仅影响会话分享多选态（enableSelection）下勾选框的垂直位置，不改动勾选逻辑与消息渲染
- 补偿量基于 --ai-line-height，small(20px) / normal(24px) 两档字号主题均生效

## 测试
- [x] 分享多选态下，助手回复行勾选框与首行文字垂直居中
- [x] 分享多选态下，用户气泡行勾选框与气泡内首行文字垂直居中
- [x] normal 字号主题下两类行的对齐仍然一致
- [x] 勾选、全选、确认分享等原有交互无回归

Made with [Cursor](https://cursor.com)