### PR TITLE
fix: rabbitmq connect error

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
@@ -358,7 +358,7 @@ class RabbitMQStreamMessageHandler(RabbitMQMessageHandler):
             "vhost": env.str("RABBITMQ_VHOST", "/"),
             "heartbeat": env.int("RABBITMQ_STREAM_HEARTBEAT", 60),
             "max_retries": env.int("RABBITMQ_STREAM_MAX_RETRIES", 20),
-            "load_balancer_mode": True
+            "load_balancer_mode": env.bool("RABBITMQ_STREAM_LB_MODE", True)
         }
 
     def _get_stream_name(self, thread_id: str) -> str:

--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq_stream.py
@@ -357,7 +357,8 @@ class RabbitMQStreamMessageHandler(RabbitMQMessageHandler):
             "password": env.str("RABBITMQ_PASSWORD", "guest"),
             "vhost": env.str("RABBITMQ_VHOST", "/"),
             "heartbeat": env.int("RABBITMQ_STREAM_HEARTBEAT", 60),
-            "max_retries": env.int("RABBITMQ_STREAM_MAX_RETRIES", 3),
+            "max_retries": env.int("RABBITMQ_STREAM_MAX_RETRIES", 20),
+            "load_balancer_mode": True
         }
 
     def _get_stream_name(self, thread_id: str) -> str:


### PR DESCRIPTION
- 提高连接重试次数，以来打到正确的 rabbitmq 节点，是官方推荐的解法: https://www.rabbitmq.com/docs/stream-connections
- 打开 'load_balancer_mode'，避免直连节点，而是使用 LB 的地址连接