### PR TITLE
feat: 修改 two-step rag 和 aganic rag 的默认值

### DIFF
--- a/src/agent/aidev_agent/core/graphs/react/graph.py
+++ b/src/agent/aidev_agent/core/graphs/react/graph.py
@@ -180,7 +180,7 @@ class ReActAgentBuilder:
         # Graph 运行时参数设置
         self._model_context_options: ModelContextSettings | None = None
         self._knowledge_query_options: KnowledgeSettings | None = None
-        self._enable_agentic_rag_tool: bool = False
+        self._enable_agentic_rag_tool: bool = True
         self._executor_info: dict | None = None
         self._callbacks: list | None = None
         self._file_store: ByteStore | None = None

--- a/src/agent/aidev_agent/core/tools/knowledge.py
+++ b/src/agent/aidev_agent/core/tools/knowledge.py
@@ -63,7 +63,9 @@ def make_knowledge_retrieval_tool(
         >>> if tool:
         ...     result = tool.invoke({"query": "如何部署蓝鲸平台？"})
     """
-    # 如果没有配置知识库，返回 None
+    # 未提供知识配置或未配置知识库时返回 None
+    if not knowledge_query_options:
+        return None
     if not knowledge_query_options.knowledge_bases and not knowledge_query_options.knowledge_items:
         return None
 

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -264,11 +264,11 @@ class KnowledgeSettings(BaseModel):
         description="当用户查询模糊时是否启用查询澄清",
     )
     enable_knowledge_node: bool = Field(
-        default=os.getenv("ENABLE_KNOWLEDGE_NODE", "true").lower() == "true",
+        default=False,
         description="控制是否开启两步 RAG 使用 knowledge",
     )
     enable_agentic_rag_tool: bool = Field(
-        default=os.getenv("ENABLE_AGENTIC_RAG_TOOL", "false").lower() == "true",
+        default=True,
         description="控制是否开启知识库召回工具",
     )
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import uuid
 import warnings
@@ -1869,12 +1870,36 @@ class ChatAgentBuilder:
             logger.info("build_subagents: ping %s → available, is_remote %s", child_agent_code, str(specs))
         return specs
 
-    def build_knowledge_query_options(self):
-        """从 AgentConfig 构建 KnowledgeSettings；新协议为空时兼容旧 agent_options。"""
+    def build_knowledge_query_options(self) -> KnowledgeSettings:
+        """从 AgentConfig 构建 KnowledgeSettings；新协议为空时兼容旧 agent_options。
+        经过评估，现在模型通过 Agentic RAG 进行知识查询能力已经可以媲美两步 RAG
+        以下是现在的开启方式：
+        对于 enable_knowledge_node:
+        1. 有环境变量 ENABLE_KNOWLEDGE_NODE 的时候， 以环境变量为准，仅当 ENABLE_KNOWLEDGE_NODE=true(小写)的时候为 True
+        2. 如果有 self._specific_resources 有 knowledgebase, 开启两步 RAG (这表明用户有意图需要使用两步 RAG)
+        3. 其他情况为默认值(当前为 False)
+
+        对于 ENABLE_AGENTIC_RAG_TOOL:
+        1. 有环境变量 ENABLE_AGENTIC_RAG_TOOL 的时候， 以环境变量为准，仅当 ENABLE_AGENTIC_RAG_TOOL=true(小写)的时候为 True
+        2. 其他情况为默认值(当前为 True)
+        """
         data = self.ctx.agent_config.knowledge_query_options_data
         if data:
-            return KnowledgeSettings.model_validate(data)
-        return migration_knowledge_query_options_from_agent_options_v1(self.ctx.agent_config.agent_options)
+            options = KnowledgeSettings.model_validate(data)
+        else:
+            options = migration_knowledge_query_options_from_agent_options_v1(self.ctx.agent_config.agent_options)
+
+        ekn_env = os.getenv("ENABLE_KNOWLEDGE_NODE")
+        if ekn_env:
+            options.enable_knowledge_node = ekn_env.lower() == "true"
+        elif any(r.get("type") == "knowledgebase" for r in self._specific_resources):
+            options.enable_knowledge_node = True
+
+        eart_env = os.getenv("ENABLE_AGENTIC_RAG_TOOL")
+        if eart_env:
+            options.enable_agentic_rag_tool = eart_env.lower() == "true"
+
+        return options
 
     def build_model_context_options(self) -> ModelContextSettings | None:
         """从 AgentConfig 构建 ModelContextSettings；新协议为空时兼容旧 agent_options。"""

--- a/src/agent/tests/core/graphs/test_react.py
+++ b/src/agent/tests/core/graphs/test_react.py
@@ -429,10 +429,11 @@ class TestReActAgentBuilder:
         )
         assert calculator in tools
 
-    def test_init_enable_agentic_rag_tool_default_false(self):
-        """__init__ 应将 _enable_agentic_rag_tool 默认设为 False"""
+    def test_init_enable_agentic_rag_tool_default_true(self, monkeypatch):
+        """__init__ 应将 _enable_agentic_rag_tool 默认设为 True"""
+        monkeypatch.delenv("ENABLE_AGENTIC_RAG_TOOL", raising=False)
         builder = ReActAgentBuilder()
-        assert builder._enable_agentic_rag_tool is False
+        assert builder._enable_agentic_rag_tool is True
 
     def test_set_bkai_options_maps_enable_agentic_rag_tool(self):
         """set_bkai_options 应从 knowledge_query_options 提取 enable_agentic_rag_tool"""
@@ -443,11 +444,11 @@ class TestReActAgentBuilder:
         builder.set_bkai_options(opts)
         assert builder._enable_agentic_rag_tool is True
 
-        # 不传 knowledge_query_options 时保持 False
+        # 不传 knowledge_query_options 时保持 __init__ 默认（True）
         opts2 = AgentExecutorKwargs()
         builder2 = ReActAgentBuilder()
         builder2.set_bkai_options(opts2)
-        assert builder2._enable_agentic_rag_tool is False
+        assert builder2._enable_agentic_rag_tool is True
 
     def test_prepare_agent_tools_uses_self_enable_agentic_rag_tool(self):
         """_prepare_agent_tools 应根据 self._enable_agentic_rag_tool 决定是否添加知识工具"""
@@ -611,7 +612,7 @@ class TestReActAgentBuilder:
         assert any(isinstance(m, SkillsPromptMiddleware) for m in middlewares)
 
     def test_build_knowledge_node_created_when_knowledge_configured(self):
-        """配置知识库时应创建 knowledge_node"""
+        """配置知识库且显式开启 enable_knowledge_node 时应创建 knowledge_node"""
         llm = MagicMock()
         llm.model_name = "gpt-4o"
         knowledge_llm = MagicMock()
@@ -628,7 +629,15 @@ class TestReActAgentBuilder:
             ),
         ):
             builder = (
-                ReActAgentBuilder().set_llm(llm).set_knowledge_llm(knowledge_llm).set_knowledge_bases([{"id": "kb1"}])
+                ReActAgentBuilder()
+                .set_llm(llm)
+                .set_knowledge_llm(knowledge_llm)
+                .set_knowledge_bases([{"id": "kb1"}])
+                .set_bkai_options(
+                    AgentExecutorKwargs(
+                        knowledge_query_options=KnowledgeSettings(enable_knowledge_node=True),
+                    )
+                )
             )
             builder.build()
             mock_make_kn.assert_called_once()

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -674,7 +674,10 @@ class TestCommonAgentChatStreaming:
                 chat_history=[
                     ChatPrompt(role="user", content="云桌面黑屏怎么处理?"),
                 ],
-                knowledge_query_options=KnowledgeSettings(knowledge_bases=[knowledgebase]),
+                knowledge_query_options=KnowledgeSettings(
+                    enable_knowledge_node=True,
+                    knowledge_bases=[knowledgebase],
+                ),
             )
             results = []
             for each in agent.execute(ExecuteKwargs(stream=True)):
@@ -2757,3 +2760,58 @@ class TestDispatchSessionPersistenceEvents:
         # resume 未被清空（未走 ask_user 路径）
         interrupt_after = next(p for p in agent.chat_history if p.role == PromptRole.INTERRUPT.value)
         assert (interrupt_after.content.get("outcome") or {}).get("type") != "success"
+
+
+class TestBuildKnowledgeQueryOptions:
+    """build_knowledge_query_options 的 env / resources 覆盖逻辑。"""
+
+    @pytest.mark.parametrize(
+        "env_val, resources, expected_ekn",
+        [
+            (None, [{"type": "knowledgebase", "id": 58}], True),   # env 未设 + 含 kb → resources 覆盖为 True
+            (None, [{"type": "mcp", "code": "x"}], False),         # env 未设 + 不含 kb → 保持默认 False
+            (None, [], False),                                     # env 未设 + 无 resources → 默认 False
+            ("false", [{"type": "knowledgebase", "id": 58}], False),  # env 已设 false → 取 env，忽略 resources
+            ("true", [], True),                                    # env 已设 true → 取 env True
+        ],
+    )
+    def test_enable_knowledge_node_env_and_resources_priority(self, monkeypatch, env_val, resources, expected_ekn):
+        """enable_knowledge_node 运行时决策：env 已设取 env，否则按 resources 覆盖，否则保持默认。"""
+        if env_val is None:
+            monkeypatch.delenv("ENABLE_KNOWLEDGE_NODE", raising=False)
+        else:
+            monkeypatch.setenv("ENABLE_KNOWLEDGE_NODE", env_val)
+
+        ctx = _make_dummy_chat_ctx()
+        ctx.agent_config.knowledge_query_options_data = {}
+        ctx.session_context_data = (
+            [{"role": PromptRole.USER.value, "content": "hi", "extra": {"resources": resources}}]
+            if resources
+            else [{"role": PromptRole.USER.value, "content": "hi"}]
+        )
+        builder = ChatAgentBuilder(ctx)
+        options = builder.build_knowledge_query_options()
+        assert options.enable_knowledge_node is expected_ekn
+
+    @pytest.mark.parametrize(
+        "env_val, expected",
+        [
+            (None, True),    # env 未设 → 保持字段默认 True
+            ("true", True),  # env=true → True
+            ("false", False),  # env=false → False
+            ("abc", False),  # 非法值 → False（严格 .lower()=="true" 匹配）
+        ],
+    )
+    def test_enable_agentic_rag_tool_field_default_from_env(self, monkeypatch, env_val, expected):
+        """enable_agentic_rag_tool 运行时决策：env 已设取 env，否则保持字段默认 True。"""
+        if env_val is None:
+            monkeypatch.delenv("ENABLE_AGENTIC_RAG_TOOL", raising=False)
+        else:
+            monkeypatch.setenv("ENABLE_AGENTIC_RAG_TOOL", env_val)
+
+        ctx = _make_dummy_chat_ctx()
+        ctx.agent_config.knowledge_query_options_data = {}
+        ctx.session_context_data = [{"role": PromptRole.USER.value, "content": "hi"}]
+        builder = ChatAgentBuilder(ctx)
+        options = builder.build_knowledge_query_options()
+        assert options.enable_agentic_rag_tool is expected


### PR DESCRIPTION
经过评估，现在模型通过 Agentic RAG 进行知识查询能力已经可以媲美两步 RAG
以下是现在的开启方式：
对于 enable_knowledge_node:
1. 有环境变量 ENABLE_KNOWLEDGE_NODE 的时候， 以环境变量为准，仅当 ENABLE_KNOWLEDGE_NODE=true(小写)的时候为 True
2. 如果有 self._specific_resources 有 knowledgebase, 开启两步 RAG (这表明用户有意图需要使用两步 RAG)
3. 其他情况为默认值(当前为 False)

对于 ENABLE_AGENTIC_RAG_TOOL:
1. 有环境变量 ENABLE_AGENTIC_RAG_TOOL 的时候， 以环境变量为准，仅当 ENABLE_AGENTIC_RAG_TOOL=true(小写)的时候为 True
2. 其他情况为默认值(当前为 True)