### PR TITLE
fix: 统一附件模型出站处理并修正错误终态 --bug=162190756

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
+++ b/src/agent/aidev_agent/core/ag_ui/aidev_agent.py
@@ -497,12 +497,11 @@ class AidevAGUIAgent(LangGraphAGUIAgent):
             logger.exception(f"Failed to handle stream events: {e}")
             error_chunk = extract_model_error_message(e)
             yield self._dispatch_event(RunErrorEvent(message=error_chunk))
-            # 补发 RunFinishedEvent 确保前端和 BaseSessionWriter 收到完整的结束信号
+            # 补发结束事件以完成前端和会话回写收尾；错误路径不得携带 success outcome。
             yield self._dispatch_event(
                 RunFinishedEvent(
                     type=EventType.RUN_FINISHED,
                     thread_id=input.thread_id,
                     run_id=self.active_run.get("id", "") if self.active_run else "",
-                    outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
                 )
             )

--- a/src/agent/aidev_agent/core/ag_ui/utils.py
+++ b/src/agent/aidev_agent/core/ag_ui/utils.py
@@ -34,6 +34,7 @@ from langchain_core.messages import (
 from .events import ExtendToolCallResultEvent, ExtendToolCallStartEvent
 from .event_builders import TOOL_CALLING_PLACEHOLDER
 from aidev_agent.utils.event import RunId
+from aidev_agent.packages.langchain_core.models.attachments import get_binary_mime_type
 from .types import (
     ActivityMessage,
     InfoMessage,
@@ -172,7 +173,7 @@ def convert_langchain_multimodal_to_agui(
                 agui_content.append(
                     BinaryInputContent(
                         type="binary",
-                        mime_type=item.get("mime_type") or "application/octet-stream",
+                        mime_type=get_binary_mime_type(item),
                         url=item.get("url"),
                         data=item.get("data"),
                         filename=item.get("filename"),
@@ -197,7 +198,7 @@ def convert_langchain_multimodal_to_agui(
                     agui_content.append(
                         BinaryInputContent(
                             type="binary",
-                            mime_type="image/png",  # Default MIME type
+                            mime_type=get_binary_mime_type({"url": url}),
                             url=url,
                         )
                     )
@@ -367,20 +368,17 @@ def convert_agui_multimodal_to_langchain(
         if isinstance(item, TextInputContent):
             langchain_content.append({"type": "text", "text": item.text})
         elif isinstance(item, BinaryInputContent):
-            # LangChain uses image_url format (OpenAI-style)
-            content_dict = {"type": "image_url"}
-
-            # Prioritize url, then data, then id
-            if item.url:
-                content_dict["image_url"] = {"url": item.url}
-            elif item.data:
-                # Construct data URL from base64 data
-                content_dict["image_url"] = {"url": f"data:{item.mime_type};base64,{item.data}"}
-            elif item.id:
-                # Use id as a reference (some providers may support this)
-                content_dict["image_url"] = {"url": item.id}
-
-            langchain_content.append(content_dict)
+            # 保留 binary 的真实语义；最终 provider 映射统一由 ChatModel 完成。
+            langchain_content.append(
+                {
+                    "type": "binary",
+                    "mime_type": item.mime_type,
+                    "url": item.url,
+                    "data": item.data,
+                    "filename": item.filename,
+                    "id": item.id,
+                }
+            )
 
     return langchain_content
 

--- a/src/agent/aidev_agent/core/nodes/model/model_chain.py
+++ b/src/agent/aidev_agent/core/nodes/model/model_chain.py
@@ -31,6 +31,7 @@ from openai import RateLimitError
 from tenacity import RetryError
 
 from aidev_agent.config import settings
+from aidev_agent.exceptions import AIDevException
 from aidev_agent.packages.langchain_core.output_parsers import StructuredOutputToToolMessageParser
 
 from .pydantic_models import (
@@ -52,36 +53,34 @@ def _promote_message(message: AnyMessage, allowed_tool_names: set[str]) -> AnyMe
 
 
 def _extract_query_text_and_images(query: Any) -> tuple[Any, list[dict[str, Any]]]:
-    """从 query 中提取文本和图片（OpenAI 风格内容列表）。
+    """从 query 中提取文本和附件内容。
 
-    支持 ``image_url`` 与前端 ``binary``（image/*）。binary 原样挂载，
-    由 ``ChatModel._get_request_payload`` 统一转 ``image_url``（与 history 一致），
-    此处只负责在进 prompt 前剥离，避免被 ``str()`` 进文本。
+    附件保留原始 canonical（规范化）结构，统一由 ``ChatModel`` 的 provider 出站闸门
+    做能力映射，避免当前轮与历史轮使用不同的 MIME（媒体类型）判断逻辑。
     """
 
     if not isinstance(query, list):
         return query, []
 
     text_parts: list[str] = []
-    image_contents: list[dict[str, Any]] = []
+    attachment_contents: list[dict[str, Any]] = []
     for item in query:
         if not isinstance(item, dict):
-            continue
+            raise AIDevException(message="不支持的消息内容：内容块必须是对象")
         item_type = item.get("type")
         if item_type == "text":
             text = item.get("text")
-            if isinstance(text, str):
-                text_parts.append(text)
-        elif item_type == "image_url":
-            image_contents.append(item)
-        elif item_type == "binary" and str(item.get("mime_type") or "").startswith("image/"):
-            image_contents.append(item)
+            if not isinstance(text, str):
+                raise AIDevException(message="不支持的消息内容：text 内容必须是字符串")
+            text_parts.append(text)
+        else:
+            attachment_contents.append(dict(item))
 
-    return "\n".join(text_parts), image_contents
+    return "\n".join(text_parts), attachment_contents
 
 
 def _attach_images_to_last_human_message(messages: list[BaseMessage], image_contents: list[dict[str, Any]]) -> None:
-    """将图片内容挂载到最后一条 HumanMessage，避免丢失多模态输入。"""
+    """将附件内容挂载到最后一条 HumanMessage，避免丢失多模态输入。"""
 
     if not image_contents:
         return

--- a/src/agent/aidev_agent/packages/langchain_core/models/attachments.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/attachments.py
@@ -1,0 +1,287 @@
+"""附件内容的规范化与 provider（模型服务商）映射。"""
+
+import base64
+import mimetypes
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+from aidev_agent.exceptions import AIDevException
+
+_GENERIC_BINARY_MIME_TYPE = "application/octet-stream"
+_DOCUMENT_MIME_TYPES = frozenset(
+    {
+        "application/epub+zip",
+        "application/json",
+        "application/msword",
+        "application/rtf",
+        "application/sql",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.oasis.opendocument.presentation",
+        "application/vnd.oasis.opendocument.spreadsheet",
+        "application/vnd.oasis.opendocument.text",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "application/pdf",
+        "application/xml",
+        "application/x-yaml",
+        "application/yaml",
+    }
+)
+_DEFAULT_CAPABILITIES = {"image": True, "audio": False, "video": False}
+
+
+@dataclass(frozen=True)
+class CanonicalAttachment:
+    """模型边界使用的统一附件描述。"""
+
+    filename: str
+    mime_type: str
+    source_url: str
+    extracted_text: str
+
+    @property
+    def kind(self) -> str:
+        if self.mime_type.startswith("image/"):
+            return "image"
+        if self.mime_type.startswith("audio/"):
+            return "audio"
+        if self.mime_type.startswith("video/"):
+            return "video"
+        if self.mime_type.startswith("text/") or self.mime_type in _DOCUMENT_MIME_TYPES:
+            return "document"
+        return "unknown"
+
+
+def normalize_mime_type(value: object) -> str:
+    """清理 MIME（媒体类型）参数和大小写。"""
+    if not isinstance(value, str):
+        return ""
+    return value.split(";", 1)[0].strip().lower()
+
+
+def _guess_mime_type(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        return ""
+    mime_type, _ = mimetypes.guess_type(value)
+    return mime_type or ""
+
+
+def _get_data_url_mime_type(value: object) -> str:
+    if not isinstance(value, str) or not value.lower().startswith("data:"):
+        return ""
+    return normalize_mime_type(value[5:].split(",", 1)[0].split(";", 1)[0])
+
+
+def get_binary_mime_type(content: Mapping[str, object]) -> str:
+    """从 canonical 字段、data URL 与名称推导附件 MIME。"""
+    mime_type = normalize_mime_type(
+        content.get("mime_type")
+        or content.get("mimeType")
+        or content.get("content_type")
+        or content.get("contentType")
+    )
+    if mime_type and mime_type != _GENERIC_BINARY_MIME_TYPE:
+        return mime_type
+
+    url = content.get("url")
+    url_path = urlparse(url).path.rstrip("/") if isinstance(url, str) else ""
+    return (
+        _get_data_url_mime_type(url)
+        or _guess_mime_type(content.get("filename"))
+        or _guess_mime_type(url_path)
+        or mime_type
+        or _GENERIC_BINARY_MIME_TYPE
+    )
+
+
+def _get_attachment_source_url(content: Mapping[str, object], mime_type: str) -> str:
+    url = content.get("url")
+    if isinstance(url, str) and url:
+        return url
+
+    data = content.get("data")
+    if isinstance(data, str) and data:
+        return f"data:{mime_type};base64,{data}"
+    return ""
+
+
+def _get_extracted_text(content: Mapping[str, object], mime_type: str) -> str:
+    extracted_text = content.get("extracted_text") or content.get("extractedText")
+    if isinstance(extracted_text, str) and extracted_text.strip():
+        return extracted_text
+
+    if not mime_type.startswith("text/"):
+        return ""
+
+    data = content.get("data")
+    if not isinstance(data, str) or not data:
+        return ""
+    try:
+        return base64.b64decode(data, validate=True).decode("utf-8")
+    except (UnicodeDecodeError, ValueError):
+        return ""
+
+
+def canonicalize_binary_attachment(content: Mapping[str, object]) -> CanonicalAttachment:
+    """将前端或历史中的 binary 附件归一为统一结构。"""
+    filename = content.get("filename")
+    return CanonicalAttachment(
+        filename=filename if isinstance(filename, str) else "",
+        mime_type=get_binary_mime_type(content),
+        source_url=_get_attachment_source_url(content, get_binary_mime_type(content)),
+        extracted_text=_get_extracted_text(content, get_binary_mime_type(content)),
+    )
+
+
+def _attachment_error(message: str) -> AIDevException:
+    return AIDevException(message=f"不支持的附件：{message}")
+
+
+def _require_user_attachment(role: object) -> None:
+    if role != "user":
+        raise _attachment_error("仅支持用户消息中的附件")
+
+
+def _require_capability(capabilities: Mapping[str, bool], kind: str) -> None:
+    if not capabilities.get(kind, False):
+        raise _attachment_error(f"当前模型未声明 {kind} 输入能力")
+
+
+def _attachment_to_provider_part(
+    attachment: CanonicalAttachment,
+    *,
+    role: object,
+    capabilities: Mapping[str, bool],
+) -> dict[str, Any]:
+    _require_user_attachment(role)
+
+    if attachment.kind == "document":
+        if not attachment.extracted_text:
+            raise _attachment_error(
+                f"{attachment.filename or attachment.mime_type} 尚未解析为文本，不能直接发送给模型"
+            )
+        label = attachment.filename or attachment.mime_type
+        return {"type": "text", "text": f"[附件：{label}]\n{attachment.extracted_text}"}
+
+    if attachment.kind == "unknown":
+        raise _attachment_error(f"无法识别 MIME 类型 {attachment.mime_type}")
+
+    _require_capability(capabilities, attachment.kind)
+    if not attachment.source_url:
+        raise _attachment_error(f"{attachment.filename or attachment.mime_type} 缺少可访问内容")
+
+    provider_key = f"{attachment.kind}_url"
+    return {"type": provider_key, provider_key: {"url": attachment.source_url}}
+
+
+def _normalize_provider_image_part(content: Mapping[str, object], role: object) -> dict[str, Any]:
+    _require_user_attachment(role)
+    image_url = content.get("image_url")
+    if isinstance(image_url, str):
+        image_url = {"url": image_url}
+    if not isinstance(image_url, dict) or not isinstance(image_url.get("url"), str) or not image_url["url"]:
+        raise _attachment_error("图片内容缺少 URL")
+    return {"type": "image_url", "image_url": image_url}
+
+
+def _normalize_provider_media_part(
+    content: Mapping[str, object],
+    *,
+    role: object,
+    capabilities: Mapping[str, bool],
+    kind: str,
+) -> dict[str, Any]:
+    _require_user_attachment(role)
+    _require_capability(capabilities, kind)
+    provider_key = f"{kind}_url"
+    media_url = content.get(provider_key)
+    if isinstance(media_url, str):
+        media_url = {"url": media_url}
+    if not isinstance(media_url, dict) or not isinstance(media_url.get("url"), str) or not media_url["url"]:
+        raise _attachment_error(f"{kind} 内容缺少 URL")
+    return {"type": provider_key, provider_key: media_url}
+
+
+def normalize_content_for_provider(
+    content: list[object],
+    *,
+    role: object,
+    capabilities: Mapping[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """把消息内容映射为当前 provider 可接受的严格白名单。"""
+    resolved_capabilities = {**_DEFAULT_CAPABILITIES, **dict(capabilities or {})}
+    normalized: list[dict[str, Any]] = []
+
+    for item in content:
+        if isinstance(item, str):
+            normalized.append({"type": "text", "text": item})
+            continue
+        if not isinstance(item, dict):
+            raise AIDevException(message="不支持的消息内容：内容块必须是对象或文本")
+
+        item_type = item.get("type")
+        if item_type == "text":
+            text = item.get("text")
+            if not isinstance(text, str):
+                raise AIDevException(message="不支持的消息内容：text 内容必须是字符串")
+            normalized.append({"type": "text", "text": text})
+        elif item_type == "image_url":
+            _require_capability(resolved_capabilities, "image")
+            normalized.append(_normalize_provider_image_part(item, role))
+        elif item_type == "audio_url":
+            normalized.append(
+                _normalize_provider_media_part(
+                    item,
+                    role=role,
+                    capabilities=resolved_capabilities,
+                    kind="audio",
+                )
+            )
+        elif item_type == "video_url":
+            normalized.append(
+                _normalize_provider_media_part(
+                    item,
+                    role=role,
+                    capabilities=resolved_capabilities,
+                    kind="video",
+                )
+            )
+        elif item_type == "binary":
+            normalized.append(
+                _attachment_to_provider_part(
+                    canonicalize_binary_attachment(item),
+                    role=role,
+                    capabilities=resolved_capabilities,
+                )
+            )
+        else:
+            raise AIDevException(message=f"不支持的消息内容类型：{item_type!r}")
+
+    return normalized
+
+
+def normalize_messages_for_provider(
+    messages: list[object],
+    *,
+    capabilities: Mapping[str, bool] | None = None,
+) -> list[dict[str, Any]]:
+    """统一处理所有进入 provider 的消息，禁止原样透传非白名单 content part。"""
+    normalized_messages: list[dict[str, Any]] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            raise AIDevException(message="不支持的模型消息：消息必须是对象")
+
+        normalized_message = dict(message)
+        content = normalized_message.get("content")
+        if isinstance(content, list):
+            normalized_message["content"] = normalize_content_for_provider(
+                content,
+                role=normalized_message.get("role"),
+                capabilities=capabilities,
+            )
+        normalized_messages.append(normalized_message)
+    return normalized_messages

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -29,11 +29,15 @@ from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
 from langchain_openai.embeddings import OpenAIEmbeddings as RawOpenAIEmbeddings
-from pydantic import BaseModel, PrivateAttr, model_validator
+from pydantic import BaseModel, Field, PrivateAttr, model_validator
 
 from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
 from aidev_agent.exceptions import AIDevException
+from aidev_agent.packages.langchain_core.models.attachments import (
+    normalize_content_for_provider,
+    normalize_messages_for_provider,
+)
 from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
 
 
@@ -65,6 +69,7 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     remote_tokenizer: bool = True
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
+    attachment_capabilities: dict[str, bool] = Field(default_factory=lambda: {"image": True})
     _owns_http_async_client: bool = PrivateAttr(default=False)
 
     @classmethod
@@ -123,32 +128,63 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     def get_num_tokens_from_messages(self, messages: list[BaseMessage]) -> int:
         if not self.remote_tokenizer:
             return super().get_num_tokens_from_messages(messages)
-        messages_dict = [_convert_message_to_dict(m) for m in messages]
-        return self.get_num_tokens(json.dumps(messages_dict))
+        normalized_input = self._normalize_input_messages_for_provider(messages)
+        messages_dict = [_convert_message_to_dict(m) for m in normalized_input]
+        normalized_messages = normalize_messages_for_provider(
+            messages_dict,
+            capabilities=self.attachment_capabilities,
+        )
+        return self.get_num_tokens(json.dumps(normalized_messages))
+
+    def _normalize_input_messages_for_provider(self, input_: object) -> object:
+        """在 LangChain 转 OpenAI content block 前完成附件能力映射。"""
+        if not isinstance(input_, list) or not all(isinstance(message, BaseMessage) for message in input_):
+            return input_
+
+        role_mapping = {
+            "ai": "assistant",
+            "chat": "user",
+            "function": "function",
+            "human": "user",
+            "system": "system",
+            "tool": "tool",
+        }
+        normalized_messages: list[BaseMessage] = []
+        for message in input_:
+            if not isinstance(message.content, list):
+                normalized_messages.append(message)
+                continue
+            normalized_messages.append(
+                message.model_copy(
+                    update={
+                        "content": normalize_content_for_provider(
+                            message.content,
+                            role=role_mapping.get(message.type, message.type),
+                            capabilities=self.attachment_capabilities,
+                        )
+                    }
+                )
+            )
+        return normalized_messages
 
     def _get_request_payload(self, *args, **kwargs) -> dict:
+        if args:
+            args = (self._normalize_input_messages_for_provider(args[0]), *args[1:])
+        else:
+            for key in ("input", "input_"):
+                if key in kwargs:
+                    kwargs[key] = self._normalize_input_messages_for_provider(kwargs[key])
+                    break
+
         payload = super()._get_request_payload(*args, **kwargs)
         # 部分 langchain-openai 版本会将子类扩展字段合并到 OpenAI 请求参数中。
-        # fallback_model 仅用于 SDK 内部切换，不能透传给 OpenAI 客户端。
+        # fallback_model / attachment_capabilities 仅用于 SDK 内部，不能透传给 OpenAI 客户端。
         payload.pop("fallback_model", None)
-        for message in payload.get("messages", []):
-            if message.get("role") != "user" or not isinstance(message.get("content"), list):
-                continue
-            content = []
-            for item in message["content"]:
-                if (
-                    isinstance(item, dict)
-                    and item.get("type") == "binary"
-                    and str(item.get("mime_type") or "").startswith("image/")
-                ):
-                    image_url = item.get("url")
-                    if not image_url and item.get("data"):
-                        image_url = f"data:{item['mime_type']};base64,{item['data']}"
-                    if image_url:
-                        content.append({"type": "image_url", "image_url": {"url": image_url}})
-                        continue
-                content.append(item)
-            message["content"] = content
+        payload.pop("attachment_capabilities", None)
+        payload["messages"] = normalize_messages_for_provider(
+            payload.get("messages", []),
+            capabilities=self.attachment_capabilities,
+        )
         return payload
 
     def _create_chat_result(

--- a/src/agent/aidev_agent/packages/langchain_core/models/utils.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/utils.py
@@ -16,11 +16,6 @@ We undertake not to change the open source license (MIT license) applicable
 to the current version of the project delivered to anyone in the future.
 """
 
-import logging
-
-logger = logging.getLogger(__name__)
-
-
 def remove_thinking_process(resp_content):
     if resp_content.startswith("<think>\n") and "\n</think>\n\n" in resp_content:
         return resp_content.split("\n</think>\n\n")[-1]

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1285,15 +1285,10 @@ class ChatCompletionAgent(BaseModel):
                     if multimodal is not None:
                         each.content = multimodal
                     if isinstance(each.content, list):
-                        new_content = []
-                        for each_content in each.content:
-                            if each_content.get("type") == "binary":
-                                new_content.append(each_content)
-                            elif each_content.get("url"):
-                                new_content.append({"type": "image_url", "image_url": {"url": each_content.get("url")}})
-                            else:
-                                new_content.append(each_content)
-                        each.content = new_content
+                        each.content = [
+                            dict(each_content) if isinstance(each_content, dict) else each_content
+                            for each_content in each.content
+                        ]
                         messages.append(HumanMessage(id=each.id, content=each.content, additional_kwargs=turn_kwargs))
                     else:
                         messages.append(
@@ -1443,6 +1438,7 @@ class ChatAgentBuilder:
             "model": config.chat_model,
             "fallback_model": config.fallback_model,
             "base_url": settings.LLM_GW_ENDPOINT,
+            "attachment_capabilities": self.build_attachment_capabilities(),
         }
 
         temperature = chat.temperature if chat.temperature is not None else config.temperature
@@ -1949,6 +1945,15 @@ class ChatAgentBuilder:
         """从 prompt_setting.support_upload.vision 构建 support_vision"""
         support_upload = self.ctx.agent_config.model_context_options_data.get("support_upload") or {}
         return bool(support_upload.get("vision", False))
+
+    def build_attachment_capabilities(self) -> dict[str, bool]:
+        """从模型配置构建附件能力映射。"""
+        support_upload = self.ctx.agent_config.model_context_options_data.get("support_upload") or {}
+        return {
+            "image": bool(support_upload.get("vision", False)),
+            "audio": bool(support_upload.get("audio", False)),
+            "video": bool(support_upload.get("video", False)),
+        }
 
     def build_executor_info(self) -> dict:
         """构建执行用户信息，包含 access_token / app_code / app_secret 用于沙箱认证和 MCP 调用"""

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -361,6 +361,17 @@ class GeneratorStreamingHelper:
             and not payload.get("resume_replay", False)
         )
 
+    @staticmethod
+    def _is_run_error_event_chunk(chunk: Any) -> bool:
+        """判断 chunk 是否为 AG-UI RUN_ERROR 事件。"""
+        if not isinstance(chunk, str) or not chunk.startswith("data:"):
+            return False
+        try:
+            payload = json.loads(chunk.removeprefix("data:").strip())
+        except (TypeError, json.JSONDecodeError):
+            return False
+        return isinstance(payload, dict) and payload.get("type") == EventType.RUN_ERROR.value
+
     def _is_cancelled(self, cancel_event: threading.Event) -> bool:
         """检查是否被取消（同时检查进程内事件和跨进程信号）
 
@@ -700,6 +711,7 @@ class GeneratorStreamingHelper:
             thread_id=self.thread_id,
             run_id="error",
             event_handler=event_handler,
+            include_success_outcome=False,
         )
 
     def _build_terminal_cancel_events(self) -> tuple[tuple[Any, str], tuple[Any, str]]:
@@ -1212,6 +1224,7 @@ class GeneratorStreamingHelper:
         draining = False
         done_event_seen = False
         producer_error = False
+        run_error_seen = False
         run_finished_seen = False
         cancel_error_emitted = False
         cancel_finished_emitted = False
@@ -1312,6 +1325,8 @@ class GeneratorStreamingHelper:
 
                 if self._is_done_event_chunk(chunk):
                     done_event_seen = True
+                if self._is_run_error_event_chunk(chunk):
+                    run_error_seen = True
                 is_run_finished = self._is_run_finished_event_chunk(chunk)
                 if is_run_finished:
                     run_finished_seen = True
@@ -1357,7 +1372,7 @@ class GeneratorStreamingHelper:
             logger.info(
                 f"[PRODUCER] finally enter thread_id={self.thread_id} "
                 f"producer_error={producer_error} done_event_seen={done_event_seen} "
-                f"draining={draining} "
+                f"run_error_seen={run_error_seen} draining={draining} "
                 f"elapsed={time.monotonic() - _producer_start:.1f}s"
             )
             heartbeat_stop_event.set()
@@ -1379,9 +1394,11 @@ class GeneratorStreamingHelper:
                     _emit_cancel_and_complete()
                 elif expected_run_id and not producer_error and not run_finished_seen:
                     logger.warning(
-                        "[RUN_FINISHED] missing from normal producer stream; emitting fallback thread_id=%s run_id=%s",
+                        "[RUN_FINISHED] missing from producer stream; emitting fallback "
+                        "thread_id=%s run_id=%s run_error_seen=%s",
                         self.thread_id,
                         expected_run_id,
+                        run_error_seen,
                     )
                     self.message_handler.put(
                         self.thread_id,
@@ -1389,6 +1406,7 @@ class GeneratorStreamingHelper:
                             thread_id=self.thread_id,
                             run_id=expected_run_id,
                             event_handler=event_handler,
+                            include_success_outcome=not run_error_seen,
                         ),
                     )
                     _complete_session()

--- a/src/agent/aidev_agent/utils/event.py
+++ b/src/agent/aidev_agent/utils/event.py
@@ -54,6 +54,8 @@ def emit_run_finished_event(
     thread_id: str,
     run_id: str,
     event_handler: Callable[[RunFinishedEvent], None] | None = None,
+    *,
+    include_success_outcome: bool = True,
 ) -> str:
     """
     发送 RUN_FINISHED 事件
@@ -63,6 +65,8 @@ def emit_run_finished_event(
         thread_id: 会话线程 ID
         run_id: 运行标识，可使用 RunId.CANCELLED 或 RunId.STOPPED 等常量
         event_handler: 可选的事件处理器回调，用于分发事件
+        include_success_outcome: 是否写入 ``outcome.type=success``。错误终态必须为 False，
+            以免错误流被误标记为成功。
 
     Returns:
         SSE 编码的事件字符串
@@ -87,12 +91,14 @@ def emit_run_finished_event(
         ```
     """
     encoder = EventEncoder()
-    finished_event = RunFinishedEvent(
-        type=EventType.RUN_FINISHED,
-        thread_id=thread_id,
-        run_id=run_id,
-        outcome=serialize_run_finished_outcome(RunFinishedSuccessOutcome()),
-    )
+    event_kwargs: dict[str, object] = {
+        "type": EventType.RUN_FINISHED,
+        "thread_id": thread_id,
+        "run_id": run_id,
+    }
+    if include_success_outcome:
+        event_kwargs["outcome"] = serialize_run_finished_outcome(RunFinishedSuccessOutcome())
+    finished_event = RunFinishedEvent(**event_kwargs)
     stamp_round_end_event(finished_event)
 
     # 如果提供了事件处理器，调用它分发事件

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot_multimodal.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot_multimodal.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """MESSAGES_SNAPSHOT 多模态 content 格式单测。"""
 
+import asyncio
 import json
 
 from unittest.mock import MagicMock
@@ -11,7 +12,12 @@ from ag_ui.encoder import EventEncoder
 from langchain_core.messages import HumanMessage
 
 from aidev_agent.core.ag_ui.types import MessageSnapshotEventExtend
-from aidev_agent.core.ag_ui.utils import langchain_messages_to_agui, parse_multimodal_content
+from aidev_agent.core.ag_ui.utils import (
+    convert_agui_multimodal_to_langchain,
+    langchain_messages_to_agui,
+    parse_multimodal_content,
+)
+from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
 from aidev_agent.pydantic_models import ChatPrompt
 from aidev_agent.services.agent.chat import ChatCompletionAgent
 
@@ -66,6 +72,23 @@ def test_messages_snapshot_sse_encodes_multimodal_as_array():
     assert user_message["content"][1]["type"] == "text"
 
 
+def test_agui_binary_round_trip_preserves_binary_semantics():
+    """AG-UI 回放不得在模型出站前把所有附件伪装成图片。"""
+    agui_content = langchain_messages_to_agui([HumanMessage(id="user-1", content=MULTIMODAL_CONTENT)])[0].content
+
+    assert convert_agui_multimodal_to_langchain(agui_content) == [
+        {
+            "type": "binary",
+            "mime_type": "image/jpeg",
+            "url": "https://example.com/files/upload_file.jpeg/",
+            "data": None,
+            "filename": "upload_file_1785756353687_fjdwe7.jpeg",
+            "id": None,
+        },
+        {"type": "text", "text": "图片内容是啥"},
+    ]
+
+
 def test_chat_history_to_langchain_parses_json_string_multimodal():
     """DB 落库的 JSON 字符串多模态 content 应在历史转换时被解析。"""
     chat_prompt = ChatPrompt(
@@ -78,6 +101,30 @@ def test_chat_history_to_langchain_parses_json_string_multimodal():
 
     assert isinstance(messages[0].content, list)
     assert messages[0].content[0]["type"] == "binary"
+
+
+def test_history_binary_image_is_normalized_before_llm_request():
+    """历史中的事故格式图片在模型边界必须转换为 image_url。"""
+    content = [
+        {
+            "type": "binary",
+            "mimeType": "application/octet-stream",
+            "url": "https://example.com/files/upload_file.png/",
+            "filename": "image.png",
+        }
+    ]
+    history = ChatCompletionAgent._chat_history_to_langchain_messages(
+        MagicMock(), [ChatPrompt(id="1", role="user", content=json.dumps(content))]
+    )
+    model = ChatModel.get_setup_instance(model="test", base_url="https://llm-gateway.example.com/v1")
+    try:
+        payload = model._get_request_payload(history)
+    finally:
+        asyncio.run(model.http_async_client.aclose())
+
+    assert payload["messages"][0]["content"] == [
+        {"type": "image_url", "image_url": {"url": "https://example.com/files/upload_file.png/"}}
+    ]
 
 
 def test_parse_multimodal_content_rejects_plain_text():

--- a/src/agent/tests/core/nodes/model/test_model_chain.py
+++ b/src/agent/tests/core/nodes/model/test_model_chain.py
@@ -757,14 +757,14 @@ class TestCallLlmInvokeTimePayload:
 
 
 class TestExtractQueryTextAndImages:
-    """当前轮 query 的 multimodal 提取：只剥离挂载，转换复用 llm_gateway。"""
+    """当前轮 query 的 multimodal 提取：保留附件供统一出站闸门处理。"""
 
-    def test_extracts_binary_image_as_is_with_text(self):
+    def test_converts_incident_binary_image_with_text(self):
         binary = {
-            "filename": "a.jpeg",
-            "mime_type": "image/jpeg",
+            "filename": "image.png",
+            "mimeType": "application/octet-stream",
             "type": "binary",
-            "url": "https://example.com/a.jpeg",
+            "url": "https://example.com/files/upload_file.png/",
         }
         text, images = _extract_query_text_and_images(
             [binary, {"type": "text", "text": "图片内容是啥呀"}]
@@ -772,22 +772,24 @@ class TestExtractQueryTextAndImages:
         assert text == "图片内容是啥呀"
         assert images == [binary]
 
-    def test_keeps_image_url_and_ignores_non_image_binary(self):
+    def test_preserves_non_image_binary_for_provider_boundary(self):
         query = [
             {"type": "image_url", "image_url": {"url": "https://example.com/old.png"}},
             {"type": "binary", "mime_type": "application/pdf", "url": "https://example.com/a.pdf"},
             {"type": "text", "text": "看这张"},
         ]
-        text, images = _extract_query_text_and_images(query)
-        assert text == "看这张"
-        assert images == [{"type": "image_url", "image_url": {"url": "https://example.com/old.png"}}]
+        text, attachments = _extract_query_text_and_images(query)
 
-    def test_render_attaches_binary_image_to_last_human_message(self):
-        """_render_messages：binary 图片从 query 剥离后原样挂到最后一条 HumanMessage。"""
+        assert text == "看这张"
+        assert attachments == query[:2]
+
+    def test_render_attaches_converted_image_to_last_human_message(self):
+        """_render_messages：附件从 query 剥离后保留原始语义并挂到最后一条 HumanMessage。"""
         binary = {
             "type": "binary",
-            "mime_type": "image/jpeg",
-            "url": "https://example.com/curr.jpeg",
+            "mimeType": "application/octet-stream",
+            "filename": "curr.png",
+            "url": "https://example.com/curr.png/",
         }
         ca = Mock()
         ca.get_choice_tools = Mock(return_value=[])

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -24,8 +24,9 @@ from pathlib import Path
 import openai
 import pytest
 from aidev_agent.config import settings
+from aidev_agent.exceptions import AIDevException
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 # 测试模型列表
 TEST_MODELS = ["hunyuan-turbo", "qwen3", "deepseek-v3", "deepseek-r1"]
@@ -105,6 +106,99 @@ def test_chat_model_payload_converts_binary_images_to_image_url():
         {"type": "image_url", "image_url": {"url": "data:image/png;base64,aW1hZ2U="}},
         {"type": "text", "text": "描述图片"},
     ]
+
+
+def test_chat_model_payload_normalizes_incident_binary_image():
+    model = ChatModel.get_setup_instance(model="test", base_url=TEST_BASE_URL)
+    messages = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "binary",
+                    "mimeType": "application/octet-stream",
+                    "url": "https://example.com/files/upload_file.png/",
+                    "filename": "image.png",
+                },
+                {"type": "binary", "mime_type": "application/octet-stream", "data": "aW1hZ2U=", "filename": "a.png"},
+            ]
+        )
+    ]
+
+    try:
+        payload = model._get_request_payload(messages)
+    finally:
+        asyncio.run(model.http_async_client.aclose())
+
+    assert payload["messages"][0]["content"] == [
+        {"type": "image_url", "image_url": {"url": "https://example.com/files/upload_file.png/"}},
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,aW1hZ2U="}},
+    ]
+
+
+@pytest.mark.parametrize(
+    ("message", "expected_message"),
+    [
+        (
+            HumanMessage(content=[{"type": "binary", "mime_type": "application/pdf", "url": "https://example.com/a.pdf"}]),
+            "尚未解析为文本",
+        ),
+        (
+            AIMessage(content=[{"type": "binary", "mime_type": "image/png", "url": "https://example.com/a.png"}]),
+            "仅支持用户消息中的附件",
+        ),
+    ],
+)
+def test_chat_model_payload_rejects_unmappable_binary_content(message, expected_message):
+    model = ChatModel.get_setup_instance(model="test", base_url=TEST_BASE_URL)
+    try:
+        with pytest.raises(AIDevException, match=expected_message):
+            model._get_request_payload([message])
+    finally:
+        asyncio.run(model.http_async_client.aclose())
+
+
+def test_chat_model_payload_maps_enabled_audio_video_and_extracted_document():
+    model = ChatModel.get_setup_instance(
+        model="test",
+        base_url=TEST_BASE_URL,
+        attachment_capabilities={"image": True, "audio": True, "video": True},
+    )
+    messages = [
+        HumanMessage(
+            content=[
+                {"type": "binary", "mime_type": "audio/mpeg", "url": "https://example.com/audio.mp3"},
+                {"type": "binary", "mime_type": "video/mp4", "url": "https://example.com/video.mp4"},
+                {
+                    "type": "binary",
+                    "mime_type": "application/pdf",
+                    "url": "https://example.com/report.pdf",
+                    "filename": "report.pdf",
+                    "extracted_text": "报告正文",
+                },
+            ]
+        )
+    ]
+
+    try:
+        payload = model._get_request_payload(messages)
+    finally:
+        asyncio.run(model.http_async_client.aclose())
+
+    assert payload["messages"][0]["content"] == [
+        {"type": "audio_url", "audio_url": {"url": "https://example.com/audio.mp3"}},
+        {"type": "video_url", "video_url": {"url": "https://example.com/video.mp4"}},
+        {"type": "text", "text": "[附件：report.pdf]\n报告正文"},
+    ]
+    assert "attachment_capabilities" not in payload
+
+
+def test_chat_model_payload_rejects_unknown_content_part():
+    model = ChatModel.get_setup_instance(model="test", base_url=TEST_BASE_URL)
+    try:
+        with pytest.raises(AIDevException, match="不支持的消息内容类型"):
+            model._get_request_payload([HumanMessage(content=[{"type": "file", "url": "https://example.com/a"}])])
+    finally:
+        asyncio.run(model.http_async_client.aclose())
 
 
 @pytest.mark.skipif(

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -508,8 +508,7 @@ class TestCommonAgentChatStreaming:
             result = agent.execute(ExecuteKwargs(stream=True))
             result_content = list(result)
 
-            # 验证错误消息被正确捕获
-            # 当前实现：RUN_ERROR 后跟 RUN_FINISHED 作为结束信号
+            # 验证错误消息被正确捕获，结束帧仅负责关闭流，不得错误标记为成功。
             error_events = [
                 c for c in result_content if c.startswith("data: ") and json.loads(c[6:]).get("type") == "RUN_ERROR"
             ]
@@ -519,7 +518,9 @@ class TestCommonAgentChatStreaming:
             # 最后一条事件应为 RUN_FINISHED
             last_content = result_content[-1]
             assert last_content.startswith("data: ")
-            assert json.loads(last_content[6:])["type"] == "RUN_FINISHED"
+            last_payload = json.loads(last_content[6:])
+            assert last_payload["type"] == "RUN_FINISHED"
+            assert "outcome" not in last_payload
 
     def test_tool_call_error_case(self):
         """case 6: 工具调用错误处理

--- a/src/agent/tests/services/test_in_memory_handler.py
+++ b/src/agent/tests/services/test_in_memory_handler.py
@@ -8,7 +8,7 @@ from contextvars import ContextVar
 
 import aidev_agent.services.messages_handler.streaming_helper as streaming_helper_module
 import pytest
-from ag_ui.core import EventType, RunFinishedEvent
+from ag_ui.core import EventType, RunErrorEvent, RunFinishedEvent
 from ag_ui.encoder import EventEncoder
 from aidev_agent.enums import MessageHandlerType
 from aidev_agent.services.messages_handler import (
@@ -284,6 +284,23 @@ class TestReplayFromStartStreamingHelper:
         assert result[0] == "chunk_0"
         assert _event_types(result[1:]) == [EventType.RUN_FINISHED]
         assert [event.type for event in dispatched] == [EventType.RUN_FINISHED]
+        assert json.loads(result[1].removeprefix("data: "))["outcome"] == {"type": "success"}
+
+    def test_run_error_fallback_does_not_mark_outcome_success(self):
+        handler = ReplayFromStartHandler()
+        run_error = EventEncoder().encode(
+            RunErrorEvent(type=EventType.RUN_ERROR, message="模型调用失败"),
+        )
+
+        result = list(
+            GeneratorStreamingHelper(handler, thread_id="thread-1").stream(
+                iter([run_error]),
+                expected_run_id="run-1",
+            )
+        )
+
+        assert _event_types(result) == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
+        assert "outcome" not in json.loads(result[-1].removeprefix("data: "))
 
     def test_normal_agui_stream_does_not_duplicate_existing_run_finished(self):
         handler = ReplayFromStartHandler()
@@ -1000,6 +1017,7 @@ class TestInMemoryQueueMessageHandler:
         assert _event_types(result[1:]) == ["RUN_ERROR", "RUN_FINISHED"]
         assert [event.type for event in dispatched] == [EventType.RUN_ERROR, EventType.RUN_FINISHED]
         assert completed == [True]
+        assert "outcome" not in json.loads(result[-1].removeprefix("data: "))
 
     def test_cancel_terminal_events_retry_after_partial_queue_failure(self, handler, monkeypatch):
         """取消终态第二帧首次入队失败时，只重试缺失帧且完成回调仅执行一次。"""


### PR DESCRIPTION
## 背景

TAPD #162190756：工作台历史消息中的内部 `binary` 附件可能以非权威 MIME 元数据进入模型调用，最终被 provider 拒绝；错误流随后又可能被错误标记为成功。

根因：

- 附件在历史消息、AG-UI 与模型请求之间存在多套转换分支，非图片 `binary` 可绕过原有图片转换。
- 模型 provider 不接受内部 `type=binary` 内容块。
- `RUN_ERROR` 后的兜底 `RUN_FINISHED` 路径仍可能写入 `outcome.type=success`。

## 改动

- 新增统一附件出站闸门，规范所有模型消息，并按模型能力映射图片、音频、视频；文档仅在已提取文本时转为 text，未知类型显式拒绝。
- 统一历史消息与 AG-UI 的 `binary` 语义，避免在中间层提前伪装为 `image_url`。
- 将模型的图片、音频、视频能力传递到 Gateway payload 规范化逻辑。
- 修正错误终态：`RUN_ERROR` 后的 `RUN_FINISHED` 只关闭流，不再声明 success outcome。

## 前端适配（不含本 PR）

- 上传成功后应以服务端返回的 canonical（规范化）`mime_type` 写入 `binary` 内容，不能继续以浏览器 `File.type` 或固定 `application/octet-stream` 作为权威值。
- 持久化/请求字段使用 API 形态的 `mime_type`；同时透传 `declared_mime_type`、`detected_mime_type`、`mime_source`、`extracted_text` 与 `extracted_text_truncated`，避免历史轮丢失附件语义。
- 上传入口和文件选择范围应根据 `support_upload.vision`、`audio`、`video`、`file` 决定；不支持的类型应在 UI 提示，但服务端仍是最终校验边界。
- 前端应继续发送内部 `binary` 内容块，由本 PR 的模型边界转换为 provider 格式，不应自行把所有附件强制转换为 `image_url`。

## 测试

- `uv run --no-sync pytest tests/packages/langchain_core/models/test_llm_gateway.py tests/core/nodes/model/test_model_chain.py tests/core/ag_ui/test_messages_snapshot_multimodal.py tests/services/test_in_memory_handler.py tests/services/test_chat.py::TestCommonAgentChatStreaming::test_model_error_case -q --maxfail=1`
  - `99 passed, 17 skipped, 1 xfailed`

## 兼容性

- 新增附件元数据字段与音频、视频能力字段；未声明能力的模型会在出站边界明确拒绝对应媒体类型。

## 关联

tapd: #162190756

发起人：
- cursoragent
- @Vellun7

Made with [Cursor](https://cursor.com)