### PR TITLE
chore: 同步模板 ai-blueking 2.2.4b1 锁文件 --story=137253604

### DIFF
--- a/template/{{cookiecutter.project_name}}/uv.lock
+++ b/template/{{cookiecutter.project_name}}/uv.lock
@@ -51,7 +51,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aidev-agent", extras = ["opentelemetry"], specifier = "==2.2.1.post1" },
-    { name = "aidev-ai-blueking", specifier = "==2.2.3b3" },
+    { name = "aidev-ai-blueking", specifier = "==2.2.4b1" },
     { name = "aidev-bkplugin", specifier = "==2.2.1.post1" },
     { name = "aidev-wxbot", specifier = "==2.2.1.post1" },
     { name = "bk-plugin-framework", specifier = "==2.3.15" },
@@ -136,15 +136,15 @@ opentelemetry = [
 
 [[package]]
 name = "aidev-ai-blueking"
-version = "2.2.3b3"
+version = "2.2.4b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aidev-agent" },
     { name = "django" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/66/f90f176f6358a53e8a8a55879c90daa7597714b8ba1544d415779b24da0a/aidev_ai_blueking-2.2.3b3.tar.gz", hash = "sha256:edf2ed4c22c479d51ebc22a0feaca0b13b0484d718e64939f04b8fdd98d983ac", size = 3652389, upload-time = "2026-08-18T08:43:43.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/79/96f372d08765725159a9acf2a2e5330bf91e3a3c20666f5fb853d3cb6351/aidev_ai_blueking-2.2.4b1.tar.gz", hash = "sha256:11de4447d31b48b8b4515162edef5f1391b48c5a96fa6a6ebf48245677fcd918", size = 3652365, upload-time = "2026-08-20T09:54:19.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/f8/e39d64c2f4dee06e31f8b4ec518cb5b02fa1874cdf359685314ec4cf3aa3/aidev_ai_blueking-2.2.3b3-py3-none-any.whl", hash = "sha256:ba127f3a90ef05cf57e2bbfb294c0a51ae167907b8ef8b20c67be42ab570e7e0", size = 3706783, upload-time = "2026-08-18T08:43:41.705Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/a3/f7ee8cf000e8a74bd81a16533250ae0039af5d1e57e64a3ed947b5a2e300/aidev_ai_blueking-2.2.4b1-py3-none-any.whl", hash = "sha256:c67f4da2c59c45df370afd60b2c8c7dd4d7f7f3cd79865dc10a8d56c111849fd", size = 3706966, upload-time = "2026-08-20T09:54:18.018Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

TAPD #137253604：同步模板 `aidev-ai-blueking` 2.2.4b1 的依赖锁定信息。

现状：

- `pyproject.toml` 与 `requirements.txt` 已在最新 `develop` 基线中更新到 `2.2.4b1`。
- `uv.lock` 仍解析到 `2.2.3b3`，与源依赖版本不一致。

## 改动

- 更新 `template/{{cookiecutter.project_name}}/uv.lock` 的 `aidev-ai-blueking` 版本。
- 更新对应 sdist、wheel 下载地址、哈希、大小和发布时间元数据。
- 不修改业务代码和接口。

## 测试

- `uv lock --check`：通过，解析 211 个包。
- `make requirements`：通过。
- `git diff --check`：通过。

## 兼容性

- 无 API 或业务行为变更；模板依赖安装将与 `aidev-ai-blueking==2.2.4b1` 保持一致。

## 关联

tapd: #137253604

发起人：
- cursoragent
- @Vellun7

Made with [Cursor](https://cursor.com)