### PR TITLE
feat: 支持会话 PV 文件上传并固定使用 file-kit 镜像 --story=136417903

### DIFF
--- a/src/agent/aidev_agent/api/bk_aidev.py
+++ b/src/agent/aidev_agent/api/bk_aidev.py
@@ -267,6 +267,13 @@ class OpenApiGroup(OperationGroup):
         path="/openapi/aidev/resource/v1/agents/skill/{skill_id}/",
     )
 
+    retrieve_latest_skill_version_image = bind_property(
+        Operation,
+        name="retrieve_latest_skill_version_image",
+        method="GET",
+        path="/openapi/aidev/resource/v1/skill_version_images/latest/",
+    )
+
     create_feedback = bind_property(
         Operation,
         name="create_feedback",

--- a/src/agent/aidev_agent/core/nodes/pv.py
+++ b/src/agent/aidev_agent/core/nodes/pv.py
@@ -153,6 +153,26 @@ def make_pv_node(
         if not should_create_pv:
             return {}
 
+        # 步骤 2.5：创建前读会话已绑定的卷，避免覆盖上传路径先写入的 PV
+        if session_code and resource_manager is not None:
+            session = resource_manager.retrieve_chat_session(session_code)
+            if isinstance(session, dict):
+                existing_volume_id = str(
+                    ((session.get("session_property") or {}).get("sandbox_pv_id") or "")
+                ).strip()
+                if existing_volume_id:
+                    return {
+                        "runtime_paas_sbx_pv": [
+                            {
+                                "type": "paas-sbx-pv",
+                                "volume_id": existing_volume_id,
+                                "volume_name": "",
+                                "mount_path": "session",
+                                "source": "platform",
+                            }
+                        ]
+                    }
+
         # 步骤 3：使用 thread_id 构造 volume_name（thread_id 始终存在，session_code 可选）
         volume_name = f"agent-pv-{thread_id}-{str(uuid.uuid4())[:8]}"
 

--- a/src/agent/aidev_agent/core/nodes/pv.py
+++ b/src/agent/aidev_agent/core/nodes/pv.py
@@ -69,20 +69,44 @@ def add_pv_info(existing: list[dict], new: list[dict]) -> list[dict]:
 def _try_writeback(resource_manager, session_code: str, pv: dict) -> dict:
     """尝试将 session PV ID 写回平台。
 
-    写回成功时返回 source="platform" 的 PV dict；
+    写回成功时返回平台最终持久化的 source="platform" PV dict；
     写回失败时返回原始 PV dict（source 不变），不阻断 PV 下发。
     """
     volume_id = pv.get("volume_id")
     if resource_manager is None or not volume_id:
         return pv
     try:
-        resource_manager.update_chat_session_sandbox_pv_id(session_code, volume_id)
+        session = resource_manager.update_chat_session_sandbox_pv_id(session_code, volume_id)
     except Exception:
         logger.warning("PV writeback failed: session_code=%s", session_code, exc_info=True)
         return pv
+
+    session_property = session.get("session_property") if isinstance(session, dict) else None
+    persisted_volume_id = ""
+    if isinstance(session_property, dict):
+        persisted_volume_id = str(session_property.get("sandbox_pv_id") or "").strip()
+    if not persisted_volume_id and isinstance(session, dict):
+        # 兼容旧平台直接返回 sandbox_pv_id 的响应格式。
+        persisted_volume_id = str(session.get("sandbox_pv_id") or "").strip()
+
     updated_pv = copy(pv)
+    if persisted_volume_id and persisted_volume_id != volume_id:
+        # 并发创建时平台采用先写入者的 PV，当前请求必须挂载最终持久化的卷。
+        updated_pv["volume_id"] = persisted_volume_id
+        updated_pv["volume_name"] = ""
     updated_pv["source"] = "platform"
     return updated_pv
+
+
+def _delete_unpersisted_volume(client: Client, app_code: str, volume_id: str) -> None:
+    """尽力清理并发竞争中未被会话持久化的 PV。"""
+    try:
+        response = client.delete_agent_sandbox_volume.request(
+            path_params={"app_code": app_code, "volume_id": volume_id}
+        )
+        response.raise_for_status()
+    except Exception:
+        logger.warning("PV cleanup failed: volume_id=%s", volume_id, exc_info=True)
 
 
 def make_pv_node(
@@ -202,6 +226,8 @@ def make_pv_node(
             "source": "runtime",
         }
         pv = _try_writeback(resource_manager, session_code, runtime_pv) if session_code else runtime_pv
+        if pv.get("source") == "platform" and pv.get("volume_id") != volume_id:
+            _delete_unpersisted_volume(client, app_code, volume_id)
 
         # 步骤 6：返回 PV 信息写入 state
         return {"runtime_paas_sbx_pv": [pv]}

--- a/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
@@ -530,11 +530,17 @@ class PaasSandboxBackend(RuntimeBackend):
         return self.exec_command(sandbox_id, command, timeout=timeout)
 
     def _resolve_path(self, path: str, *, state: dict | None = None) -> str:
-        """将 ``~`` 展开为绝对路径。
+        """将 ``$STORAGE_PATH`` 或 ``~`` 展开为沙箱内绝对路径。
 
         在每个公开方法入口处调用，确保后续所有操作（shell 命令和 HTTP API）
         都只看到绝对路径。
         """
+        storage_path = str(self._env_vars.get("STORAGE_PATH") or "/app/storage").rstrip("/")
+        for prefix in ("$STORAGE_PATH", "${STORAGE_PATH}"):
+            if path == prefix:
+                return storage_path
+            if path.startswith(f"{prefix}/"):
+                return f"{storage_path}{path[len(prefix) :]}"
         if not path.startswith("~"):
             return path
         if self._home_dir is None:

--- a/src/agent/aidev_agent/core/tools/runtime_tools/provider.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/provider.py
@@ -294,7 +294,10 @@ def get_read_file_tool(resolver: RuntimeBackendResolver, custom_description: str
     tool_description = custom_description or READ_FILE_TOOL_DESCRIPTION
 
     def read_file(
-        file_path: Annotated[str, "Absolute path to the file to read. Must be absolute, not relative."],
+        file_path: Annotated[
+            str,
+            "Absolute path to the file to read. PaaS sandbox paths may start with $STORAGE_PATH/.",
+        ],
         target_runtime: str,
         config: RunnableConfig,
         state: Annotated[dict, InjectedState] = None,

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -311,17 +311,16 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
                 continue
             content = []
             for item in message["content"]:
-                if (
-                    isinstance(item, dict)
-                    and item.get("type") == "binary"
-                    and str(item.get("mime_type") or "").startswith("image/")
-                ):
+                if isinstance(item, dict) and item.get("type") == "binary":
+                    # 展示用 binary 不能送给模型；图片转成 image_url，其它类型直接丢弃。
+                    if not str(item.get("mime_type") or "").startswith("image/"):
+                        continue
                     image_url = item.get("url")
                     if not image_url and item.get("data"):
                         image_url = f"data:{item['mime_type']};base64,{item['data']}"
                     if image_url:
                         content.append({"type": "image_url", "image_url": {"url": image_url}})
-                        continue
+                    continue
                 content.append(item)
             message["content"] = content
         return payload

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import posixpath
 import uuid
 import warnings
 from functools import partial
@@ -67,6 +68,14 @@ from aidev_agent.services.common_agent import CommonAgentProtocol, CommonQAAgent
 from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
+from aidev_agent.services.sandbox_pv_files import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+    SESSION_UPLOAD_IMAGE_EXTENSIONS,
+    SESSION_VOLUME_PATH,
+    SandboxFileInvalidArgumentError,
+    SandboxFileServerError,
+    SandboxPvFileService,
+)
 from aidev_agent.utils.async_utils import async_to_sync_generator
 from aidev_agent.utils.loop import run_coro_sync
 from aidev_agent.utils.migrations import (
@@ -114,6 +123,7 @@ class ChatCompletionAgent(BaseModel):
     用于 quality_gate 判断 LLM 等辅助任务。"""
     non_thinking_llm: str | None = Field(default=None, deprecated="使用 chat_model_non_thinking 替代")
     chat_history: list[ChatPrompt] | None = None
+    file_resources: list[dict] = Field(default_factory=list, exclude=True)
     files: list[dict] = Field(default_factory=list)
     tools: Optional[list[StructuredTool]] = None
     skills: Optional[list] = None
@@ -195,6 +205,7 @@ class ChatCompletionAgent(BaseModel):
         # chat_history 由 ChatAgentBuilder 无损承接 ctx.session_context_data（A 源适配层输出），
         # 是 agent 唯一历史事实源：LLM 装配（convert 链）与首帧快照均从它派生。
         self.chat_history = builder.build_chat_history(ctx.session_context_data)
+        self.file_resources = builder.file_resources
         # 构建Agent参数配置
         if ctx.agent_config and ctx.agent_config.agent_options is not None:
             self.agent_options = ctx.agent_config.agent_options
@@ -409,7 +420,7 @@ class ChatCompletionAgent(BaseModel):
         self._prepare_pre_run_history(execute_kwargs)
         if not self.messages:
             self.messages = convert_chat_history_to_messages(
-                self.chat_history,
+                self._build_llm_history(),
                 model_context_options=self.model_context_options,
                 support_vision=self.support_vision,
                 model_name=self.model_name,
@@ -1385,6 +1396,94 @@ class ChatCompletionAgent(BaseModel):
             runtime_backend_resolver=self.runtime_backend_resolver,
         )
 
+    @staticmethod
+    def _normalize_file_resource_path(resource: dict) -> str:
+        raw_path = resource.get("path") or resource.get("outputId") or resource.get("id")
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            raise SandboxFileInvalidArgumentError("文件资源缺少 path")
+
+        path = raw_path.strip().replace("\\", "/")
+        mount_prefix = f"{SESSION_VOLUME_PATH}/"
+        if path.startswith(mount_prefix):
+            path = path[len(mount_prefix) :]
+        elif path.startswith(("/", "$")):
+            raise SandboxFileInvalidArgumentError(f"文件资源 path 不属于会话 PV: {raw_path}")
+        if any(ord(char) < 32 for char in path):
+            raise SandboxFileInvalidArgumentError(f"文件资源 path 含控制字符: {raw_path}")
+        if ".." in path.split("/"):
+            raise SandboxFileInvalidArgumentError(f"文件资源 path 非法: {raw_path}")
+
+        normalized = posixpath.normpath(path)
+        if normalized in {"", "."}:
+            raise SandboxFileInvalidArgumentError("文件资源 path 不能为空")
+        return normalized
+
+    @staticmethod
+    def _is_image_resource(resource: dict, path: str) -> bool:
+        mime_type = str(resource.get("mime_type") or resource.get("mime") or resource.get("content_type") or "").lower()
+        if mime_type:
+            return mime_type.startswith("image/")
+        return posixpath.splitext(path)[1].lower() in SESSION_UPLOAD_IMAGE_EXTENSIONS
+
+    @staticmethod
+    def _find_binary_by_path(content: list[dict], path: str) -> dict | None:
+        """按 PV 相对路径找到对应的展示用 binary。"""
+        for item in content:
+            if not isinstance(item, dict) or item.get("type") != "binary":
+                continue
+            if str(item.get("id") or item.get("path") or "") == path:
+                return item
+        return None
+
+    def _build_llm_history(self) -> list[ChatPrompt]:
+        """构造仅供本轮模型调用使用的历史副本。"""
+        chat_history = [prompt.model_copy(deep=True) for prompt in self.chat_history or []]
+        if not self.file_resources:
+            return chat_history
+
+        last_user_prompt = next(
+            (prompt for prompt in reversed(chat_history) if prompt.role == PromptRole.USER.value),
+            None,
+        )
+        if last_user_prompt is None:
+            return chat_history
+
+        image_paths = []
+        for resource in self.file_resources:
+            path = self._normalize_file_resource_path(resource)
+            if self._is_image_resource(resource, path):
+                image_paths.append(path)
+        if not image_paths:
+            return chat_history
+
+        if isinstance(last_user_prompt.content, str):
+            content: list[dict] = [{"type": "text", "text": last_user_prompt.content}]
+        elif isinstance(last_user_prompt.content, list):
+            content = list(last_user_prompt.content)
+        else:
+            return chat_history
+
+        file_service = SandboxPvFileService(
+            resource_manager=self.resource_manager,
+            executor_info=self.executor_info or {},
+        )
+        for path in dict.fromkeys(image_paths):
+            url_data = file_service.get_download_url(
+                session_code=self.thread_id,
+                path=path,
+                expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+            )
+            image_url = url_data.get("download_url")
+            if not image_url:
+                raise SandboxFileServerError(f"文件 {path} 未返回 download_url")
+            existing = self._find_binary_by_path(content, path)
+            if existing is not None:
+                existing["url"] = image_url
+            else:
+                content.append({"type": "image_url", "image_url": {"url": image_url}})
+        last_user_prompt.content = content
+        return chat_history
+
 
 class ChatAgentBuilder:
     """``ChatCompletionAgent`` 装配器
@@ -1407,6 +1506,7 @@ class ChatAgentBuilder:
     def __init__(self, ctx: AgentBuildContext):
         self.ctx = ctx
         self._specific_resources: list[dict] = []
+        self._file_resources: list[dict] = []
         self._mcp_fetch_failures: list[dict] = []
         self._executor_info: dict | None = None
         self._runtime_backend_resolver: Any | None = None
@@ -1417,6 +1517,11 @@ class ChatAgentBuilder:
     def mcp_fetch_failures(self) -> list[dict]:
         """MCP 工具拉取失败记录，由 ``build_tools`` 写入"""
         return self._mcp_fetch_failures
+
+    @property
+    def file_resources(self) -> list[dict]:
+        """返回当前用户消息中声明的文件资源。"""
+        return list(self._file_resources)
 
     def build_runtime_backend_resolver(self) -> RuntimeBackendResolver:
         """构造 RuntimeBackendResolver。
@@ -1989,6 +2094,7 @@ class ChatAgentBuilder:
             if item.get("role") == PromptRole.USER.value:
                 # item.get("extra") 有可能为 None, 和 item.get("extra", {}) 不等价
                 extra = item.get("extra") or {}
-                if extra.get("resources"):
-                    self._specific_resources = extra.get("resources")
+                resources = extra.get("resources") or []
+                self._file_resources = [resource for resource in resources if resource.get("type") == "file"]
+                self._specific_resources = [resource for resource in resources if resource.get("type") != "file"]
                 break

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1435,6 +1435,13 @@ class ChatCompletionAgent(BaseModel):
                 return item
         return None
 
+    @staticmethod
+    def _build_file_reference_context(paths: list[str]) -> str:
+        """构造当前用户精确引用的会话文件路径说明。"""
+        return "用户本轮引用了以下会话文件，请优先基于这些精确路径处理：\n" + "\n".join(
+            f"- {SESSION_VOLUME_PATH}/{path}" for path in paths
+        )
+
     def _build_llm_history(self) -> list[ChatPrompt]:
         """构造仅供本轮模型调用使用的历史副本。"""
         chat_history = [prompt.model_copy(deep=True) for prompt in self.chat_history or []]
@@ -1449,11 +1456,17 @@ class ChatCompletionAgent(BaseModel):
             return chat_history
 
         image_paths = []
+        referenced_paths = []
+        seen_paths = set()
         for resource in self.file_resources:
             path = self._normalize_file_resource_path(resource)
+            if path in seen_paths:
+                continue
+            seen_paths.add(path)
+            referenced_paths.append(path)
             if self._is_image_resource(resource, path):
                 image_paths.append(path)
-        if not image_paths:
+        if not referenced_paths:
             return chat_history
 
         if isinstance(last_user_prompt.content, str):
@@ -1463,24 +1476,32 @@ class ChatCompletionAgent(BaseModel):
         else:
             return chat_history
 
-        file_service = SandboxPvFileService(
-            resource_manager=self.resource_manager,
-            executor_info=self.executor_info or {},
+        content.append(
+            {
+                "type": "text",
+                "text": self._build_file_reference_context(referenced_paths),
+            }
         )
-        for path in dict.fromkeys(image_paths):
-            url_data = file_service.get_download_url(
-                session_code=self.thread_id,
-                path=path,
-                expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+
+        if image_paths:
+            file_service = SandboxPvFileService(
+                resource_manager=self.resource_manager,
+                executor_info=self.executor_info or {},
             )
-            image_url = url_data.get("download_url")
-            if not image_url:
-                raise SandboxFileServerError(f"文件 {path} 未返回 download_url")
-            existing = self._find_binary_by_path(content, path)
-            if existing is not None:
-                existing["url"] = image_url
-            else:
-                content.append({"type": "image_url", "image_url": {"url": image_url}})
+            for path in image_paths:
+                url_data = file_service.get_download_url(
+                    session_code=self.thread_id,
+                    path=path,
+                    expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+                )
+                image_url = url_data.get("download_url")
+                if not image_url:
+                    raise SandboxFileServerError(f"文件 {path} 未返回 download_url")
+                existing = self._find_binary_by_path(content, path)
+                if existing is not None:
+                    existing["url"] = image_url
+                else:
+                    content.append({"type": "image_url", "image_url": {"url": image_url}})
         last_user_prompt.content = content
         return chat_history
 

--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -148,9 +148,14 @@ PV_PAAS_SANDBOX_GONE_CODES = frozenset({"AGENT_SANDBOX_NOT_FOUND", "SANDBOX_NOT_
 # ---------------------------------------------------------------------------
 # sandbox 容器按 app_code + session_code + volume_id 缓存 sandbox_id，复用期内不再 create/destroy。
 # 凭证（client）每次请求新建，只复用 PaaS 侧的 sandbox 容器，避免缓存过期凭证。
+#
+# 仅做「进程内」复用：Agent SaaS 不假设存在 Redis 等跨进程共享协调组件，多 worker / 多 pod 下
+# 无法保证复用，跨进程复用需引入平台数据库原子注册等额外复杂度、收益有限，故不做。
 _UPLOAD_SANDBOX_CACHE: dict[tuple[str, str, str], tuple[str, float]] = {}
 _UPLOAD_SANDBOX_CACHE_LOCK = threading.Lock()
-# 进程内会话锁：串行化同一进程内的 sandbox exec/upload，避免单容器并发冲突
+# 进程内会话锁：串行化同一进程内的 sandbox exec/upload，避免单容器并发冲突。
+# 锁随缓存条目失效一并清理（见 _get_cached_upload_sandbox / _invalidate_cached_upload_sandbox），
+# 避免长生命周期进程下随会话数持续累积。
 _UPLOAD_SESSION_LOCKS: dict[str, threading.Lock] = {}
 _UPLOAD_SESSION_LOCKS_LOCK = threading.Lock()
 
@@ -175,6 +180,9 @@ def _get_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str)
         sandbox_id, created_at = entry
         if time.monotonic() - created_at >= TEMP_UPLOAD_SANDBOX_TTL_SECONDS:
             _UPLOAD_SANDBOX_CACHE.pop(cache_key, None)
+            # 缓存已过期，对应会话锁一并清理，避免锁对象持续累积
+            with _UPLOAD_SESSION_LOCKS_LOCK:
+                _UPLOAD_SESSION_LOCKS.pop(session_code, None)
             return ""
         return sandbox_id
 
@@ -200,6 +208,9 @@ def _invalidate_cached_upload_sandbox(app_code: str, session_code: str, volume_i
     cache_key = (app_code, session_code, volume_id)
     with _UPLOAD_SANDBOX_CACHE_LOCK:
         _UPLOAD_SANDBOX_CACHE.pop(cache_key, None)
+    # 显式失效时一并清理会话锁，避免锁对象持续累积
+    with _UPLOAD_SESSION_LOCKS_LOCK:
+        _UPLOAD_SESSION_LOCKS.pop(session_code, None)
 
 
 class SandboxUploadFile(TypedDict):
@@ -538,6 +549,7 @@ class SandboxPvFileService:
         files_dir: str,
         absolute_files_dir: str,
         files: list[SandboxUploadFile],
+        sandbox_gone: dict[str, bool] | None = None,
     ) -> list[dict]:
         """在指定 sandbox 的统一 files 目录内上传文件，返回每文件结果。
 
@@ -572,8 +584,15 @@ class SandboxPvFileService:
             try:
                 backend.upload_file(sandbox_id, absolute_path, upload_file["content"])
                 result["status"] = "success"
-            except HTTPResponseError:
-                raise
+            except HTTPResponseError as exc:
+                # 单文件失败不阻断同批：标记失败原因并继续，整批返回部分成功结果。
+                # gone 信号供 upload_files 判断是否需重建 sandbox。
+                if sandbox_gone is not None and self._is_sandbox_gone(exc):
+                    sandbox_gone["flag"] = True
+                result.update(
+                    status="failed",
+                    error=f"上传失败[{self._parse_paas_code(exc)}]: {self._map_paas_error(exc)}",
+                )
             except Exception as exc:  # noqa: BLE001 单文件失败不阻断同批其他文件
                 logger.warning(
                     "上传文件到会话 PV 失败: session_code=%s, file=%s",
@@ -595,6 +614,10 @@ class SandboxPvFileService:
         sandbox 容器按 app_code、session_code 和 volume_id 缓存复用（ttl=TEMP_UPLOAD_SANDBOX_TTL_SECONDS），
         同一进程的复用期内不再 create/destroy，到期由 PaaS 自动回收；复用失败（容器已被回收）
         时 fallback 重建一次。同一进程内的会话操作加锁串行化，避免单容器并发冲突。
+
+        同名文件直接覆盖会话 PV 中已有文件的内容，路径（``files/<filename>``）保持不变；
+        同一请求内若出现多个同名文件，后者追加短 hash 后缀（``files/<stem>-<hash><suffix>``）
+        以避免互相覆盖，跨请求的同名文件不做去重、按原路径覆盖。
         """
         validate_session_upload_files(files)
 
@@ -620,22 +643,17 @@ class SandboxPvFileService:
             if not sandbox_id:
                 sandbox_id, sandbox_created_at = self._create_upload_sandbox(session_code, volume_id, snapshot, backend)
 
+            gone_signal: dict[str, bool] = {}
             try:
                 results = self._write_files_to_sandbox(
-                    session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
-                )
-                _set_cached_upload_sandbox(
-                    app_code,
-                    session_code,
-                    volume_id,
-                    sandbox_id,
-                    created_at=sandbox_created_at,
+                    session_code, sandbox_id, backend, files_dir, absolute_files_dir, files, sandbox_gone=gone_signal
                 )
             except HTTPResponseError as exc:
+                # exec_command(mkdir) 等整批级别失败：sandbox 可能已被 PaaS 回收，
+                # 失效缓存并重建一次后重试；单文件 upload 失败已在内部标记为失败、不冒泡。
                 if self._is_sandbox_gone(exc):
-                    # 缓存的 sandbox 已被 PaaS 回收，清缓存重建一次后重试
                     logger.warning(
-                        "[pv_files] reuse sandbox gone, fallback rebuild session=%s sandbox_id=%s",
+                        "[pv_files] sandbox 疑似已回收，重建重试 session=%s sandbox_id=%s",
                         session_code,
                         sandbox_id,
                     )
@@ -643,22 +661,41 @@ class SandboxPvFileService:
                     sandbox_id, sandbox_created_at = self._create_upload_sandbox(
                         session_code, volume_id, snapshot, backend
                     )
-                    results = self._write_files_to_sandbox(
-                        session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
-                    )
-                    _set_cached_upload_sandbox(
-                        app_code,
-                        session_code,
-                        volume_id,
-                        sandbox_id,
-                        created_at=sandbox_created_at,
-                    )
+                    try:
+                        results = self._write_files_to_sandbox(
+                            session_code, sandbox_id, backend, files_dir, absolute_files_dir, files, sandbox_gone=gone_signal
+                        )
+                    except HTTPResponseError as exc2:
+                        self._raise_mapped_paas_error("upload_files", exc2)
                 else:
                     self._raise_mapped_paas_error("upload_files", exc)
             except SandboxFileError:
                 raise
             except Exception as exc:
                 raise SandboxFileServerError(f"临时 sandbox 上传失败: {exc}") from exc
+
+            # sandbox 已被 PaaS 回收时整批会全部失败：失效缓存并重建一次后重试，
+            # 重试结果同样可能部分成功（逐个文件标记失败原因），不保证原子性。
+            if not any(item["status"] == "success" for item in results) and gone_signal.get("flag"):
+                logger.warning(
+                    "[pv_files] sandbox 疑似已回收，重建重试 session=%s sandbox_id=%s",
+                    session_code,
+                    sandbox_id,
+                )
+                _invalidate_cached_upload_sandbox(app_code, session_code, volume_id)
+                sandbox_id, sandbox_created_at = self._create_upload_sandbox(
+                    session_code, volume_id, snapshot, backend
+                )
+                results = self._write_files_to_sandbox(
+                    session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
+                )
+            _set_cached_upload_sandbox(
+                app_code,
+                session_code,
+                volume_id,
+                sandbox_id,
+                created_at=sandbox_created_at,
+            )
 
         succeeded = sum(item["status"] == "success" for item in results)
         self._attach_image_download_urls(session_code, results)

--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -9,7 +9,7 @@
 Service 层职责：
 - 通过 `ResourceManager` 反查 `session_code → volume_id`
 - 通过 `ResourceManager` 构造 PaaS Sandbox Client
-- 5 个业务方法（list/delete/stat/preview/get_download_url）
+- 6 个业务方法（upload/list/delete/stat/preview/get_download_url）
 - `list_files` 内部分页拉全量 + `time.sleep` 超频保护 + 过滤目录
 - PaaS HTTP 错误 → SDK 侧业务异常映射
 """
@@ -17,12 +17,17 @@ Service 层职责：
 from __future__ import annotations
 
 import logging
+import posixpath
+import threading
 import time
 from datetime import datetime, timezone
-from typing import Optional
+from pathlib import PurePosixPath
+from typing import NotRequired, Optional, TypedDict
+from uuid import uuid4
 
 from bkapi_client_core.exceptions import HTTPResponseError
 
+from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
 from aidev_agent.packages.resource_manager.registry import ResourceManagerProtocol
 
 logger = logging.getLogger(__name__)
@@ -63,12 +68,200 @@ class SandboxFileServerError(SandboxFileError):
 PV_LIST_PAGE_SIZE = 500  # PaaS 上限
 PV_LIST_MAX_PAGES = 20  # 保护上限（20 * 500 = 1w 文件）
 PV_LIST_PAGE_SLEEP_SECONDS = 0.5  # 翻页前预防性等待，避免打爆 PaaS apigw
+SESSION_VOLUME_PATH = "$STORAGE_PATH/session"
+SESSION_FILES_DIR = "files"
+TEMP_UPLOAD_VOLUME_MOUNT_PATH = "/app/.storage/session"
+# 临时上传 sandbox 的 PaaS 存活时长，同时作为进程内复用缓存的过期阈值：
+# 复用期内不再建/销毁，到期由 PaaS 自动回收；临界点若命中已回收 sandbox，由 fallback 重建兜底
+# PaaS sandbox ttl_seconds 上限为 30 分钟（1800s）
+TEMP_UPLOAD_SANDBOX_TTL_SECONDS = 1800
+# 前端 <img> / 视觉模型共用的临时 download_url 有效期
+IMAGE_DOWNLOAD_URL_EXPIRES_IN = 3600
+# 会话 PV 上传限制：平台与 SDK 插件 HTTP 入口共用，只在此维护一份。
+MAX_SESSION_UPLOAD_FILES = 9
+MAX_SESSION_UPLOAD_FILE_SIZE = int(2.4 * 1024 * 1024)
+SESSION_UPLOAD_IMAGE_EXTENSIONS = frozenset({".gif", ".jpeg", ".jpg", ".png", ".webp"})
+SESSION_UPLOAD_FILE_EXTENSIONS = (
+    frozenset(
+        {
+            ".bash",
+            ".c",
+            ".conf",
+            ".cpp",
+            ".cs",
+            ".css",
+            ".csv",
+            ".doc",
+            ".docx",
+            ".epub",
+            ".go",
+            ".h",
+            ".hpp",
+            ".html",
+            ".ini",
+            ".java",
+            ".js",
+            ".json",
+            ".jsx",
+            ".kt",
+            ".log",
+            ".md",
+            ".mobi",
+            ".pdf",
+            ".php",
+            ".ppt",
+            ".pptx",
+            ".py",
+            ".rb",
+            ".rs",
+            ".rst",
+            ".scss",
+            ".sh",
+            ".sql",
+            ".swift",
+            ".toml",
+            ".ts",
+            ".tsx",
+            ".txt",
+            ".vue",
+            ".xls",
+            ".xlsx",
+            ".xml",
+            ".yaml",
+            ".yml",
+        }
+    )
+    | SESSION_UPLOAD_IMAGE_EXTENSIONS
+)
 
 # PaaS 沙箱文件接口错误码 → 语义分组
 PV_PAAS_ERROR_NOT_FOUND_CODES = frozenset({"AGENT_SANDBOX_FILE_NOT_FOUND", "VOLUME_NOT_FOUND"})
 PV_PAAS_ERROR_NOT_PREVIEWABLE_CODES = frozenset({"AGENT_SANDBOX_FILE_NOT_PREVIEWABLE"})
 PV_PAAS_ERROR_TOO_LARGE_CODES = frozenset({"AGENT_SANDBOX_FILE_TOO_LARGE"})
 PV_PAAS_ERROR_INVALID_ARG_CODES = frozenset({"AGENT_SANDBOX_FILE_OPERATION_FAILED"})
+# 复用上传沙箱被回收：只认 404 / 容器不存在，不认 FILE_TOO_LARGE 等业务错误
+PV_PAAS_SANDBOX_GONE_CODES = frozenset({"AGENT_SANDBOX_NOT_FOUND", "SANDBOX_NOT_FOUND"})
+
+
+# ---------------------------------------------------------------------------
+# 进程内复用缓存（sandbox 容器）
+# ---------------------------------------------------------------------------
+# sandbox 容器按 app_code + session_code + volume_id 缓存 sandbox_id，复用期内不再 create/destroy。
+# 凭证（client）每次请求新建，只复用 PaaS 侧的 sandbox 容器，避免缓存过期凭证。
+_UPLOAD_SANDBOX_CACHE: dict[tuple[str, str, str], tuple[str, float]] = {}
+_UPLOAD_SANDBOX_CACHE_LOCK = threading.Lock()
+# 会话级操作锁：串行化同会话的 sandbox exec/upload，避免单容器并发冲突
+_UPLOAD_SESSION_LOCKS: dict[str, threading.Lock] = {}
+_UPLOAD_SESSION_LOCKS_LOCK = threading.Lock()
+
+
+def _get_session_op_lock(session_code: str) -> threading.Lock:
+    """获取会话级操作锁（懒创建）。"""
+    with _UPLOAD_SESSION_LOCKS_LOCK:
+        lock = _UPLOAD_SESSION_LOCKS.get(session_code)
+        if lock is None:
+            lock = threading.Lock()
+            _UPLOAD_SESSION_LOCKS[session_code] = lock
+        return lock
+
+
+def _get_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str) -> str:
+    """返回未过期的缓存 sandbox_id，无则空串。"""
+    cache_key = (app_code, session_code, volume_id)
+    with _UPLOAD_SANDBOX_CACHE_LOCK:
+        entry = _UPLOAD_SANDBOX_CACHE.get(cache_key)
+        if not entry:
+            return ""
+        sandbox_id, created_at = entry
+        if time.monotonic() - created_at >= TEMP_UPLOAD_SANDBOX_TTL_SECONDS:
+            _UPLOAD_SANDBOX_CACHE.pop(cache_key, None)
+            return ""
+        return sandbox_id
+
+
+def _set_cached_upload_sandbox(
+    app_code: str,
+    session_code: str,
+    volume_id: str,
+    sandbox_id: str,
+    created_at: float | None = None,
+) -> None:
+    cache_key = (app_code, session_code, volume_id)
+    with _UPLOAD_SANDBOX_CACHE_LOCK:
+        if created_at is None:
+            existing = _UPLOAD_SANDBOX_CACHE.get(cache_key)
+            if existing and existing[0] == sandbox_id:
+                return
+            created_at = time.monotonic()
+        _UPLOAD_SANDBOX_CACHE[cache_key] = (sandbox_id, created_at)
+
+
+def _invalidate_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str) -> None:
+    cache_key = (app_code, session_code, volume_id)
+    with _UPLOAD_SANDBOX_CACHE_LOCK:
+        _UPLOAD_SANDBOX_CACHE.pop(cache_key, None)
+
+
+class SandboxUploadFile(TypedDict):
+    """上传到会话 PV 的文件。"""
+
+    name: str
+    content: bytes
+    mime_type: NotRequired[str]
+
+
+def validate_session_upload_files(files: list[SandboxUploadFile]) -> None:
+    """校验上传数量、扩展名和单文件大小。HTTP 入口与 Service 共用。"""
+    if not files:
+        raise SandboxFileInvalidArgumentError("上传文件不能为空")
+    if len(files) > MAX_SESSION_UPLOAD_FILES:
+        raise SandboxFileInvalidArgumentError(f"单次上传文件不能超过 {MAX_SESSION_UPLOAD_FILES} 个")
+    for upload_file in files:
+        name = str(upload_file.get("name") or "")
+        extension = PurePosixPath(name.replace("\\", "/")).suffix.lower()
+        if extension not in SESSION_UPLOAD_FILE_EXTENSIONS:
+            raise SandboxFileInvalidArgumentError(f"文件类型 {extension or '无扩展名'} 不支持")
+        if len(upload_file.get("content") or b"") > MAX_SESSION_UPLOAD_FILE_SIZE:
+            raise SandboxFileInvalidArgumentError(
+                f"文件 {name} 超过单文件大小限制 {MAX_SESSION_UPLOAD_FILE_SIZE} 字节"
+            )
+
+
+def iter_user_images_missing_url(payload: dict):
+    """找出用户消息里缺展示 URL 的图片 binary。"""
+    if payload.get("role") != "user":
+        return
+    content = payload.get("content")
+    if not isinstance(content, list):
+        return
+    for item in content:
+        if not isinstance(item, dict) or item.get("type") != "binary" or item.get("url"):
+            continue
+        if not str(item.get("mime_type") or "").startswith("image/"):
+            continue
+        if item.get("id") or item.get("path"):
+            yield item
+
+
+def fill_user_image_urls(file_service: "SandboxPvFileService", payload: dict) -> None:
+    """给缺 url 的用户图片 binary 签发 download_url。"""
+    session_code = payload.get("session_code") or ""
+    if not session_code:
+        return
+    for item in iter_user_images_missing_url(payload):
+        path = item.get("id") or item.get("path")
+        try:
+            url_data = file_service.get_download_url(
+                session_code=session_code,
+                path=path,
+                expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+            )
+        except SandboxFileError:
+            logger.exception("签发用户图片 URL 失败: session=%s path=%s", session_code, path)
+            continue
+        url = url_data.get("download_url")
+        if url:
+            item["url"] = url
 
 
 class SandboxPvFileService:
@@ -107,6 +300,109 @@ class SandboxPvFileService:
         app_code = self._executor_info.get("app_code") or ""
         return {"app_code": app_code, "volume_id": volume_id}
 
+    @staticmethod
+    def _extract_volume_id(session: dict) -> str:
+        volume_id = ((session or {}).get("session_property") or {}).get("sandbox_pv_id")
+        return str(volume_id) if volume_id else ""
+
+    @staticmethod
+    def _extract_created_volume_id(payload) -> str:
+        """兼容 PaaS 直出 `{"uuid": ...}` 与 APIGW 信封 `{"data": {"uuid": ...}}`。"""
+        if not isinstance(payload, dict):
+            return ""
+        # data 为 null / 空时退回顶层，与 pv 节点解析保持一致
+        data = payload.get("data") or payload
+        if not isinstance(data, dict):
+            return ""
+        return str(data.get("uuid") or "")
+
+    @staticmethod
+    def _delete_volume_quietly(client, app_code: str, volume_id: str) -> None:
+        try:
+            response = client.delete_agent_sandbox_volume.request(
+                path_params={"app_code": app_code, "volume_id": volume_id}
+            )
+            response.raise_for_status()
+        except Exception:  # noqa: BLE001
+            logger.warning("清理未关联的 sandbox PV 失败: volume_id=%s", volume_id, exc_info=True)
+
+    def ensure_volume(self, session_code: str, *, cached_volume_id: str | None = None) -> str:
+        """幂等获取会话 PV；不存在时创建并写回会话。
+
+        ``cached_volume_id`` 非 None 表示调用方已读过会话：
+        - 非空：直接使用，不再 retrieve
+        - 空串：已知尚未初始化，跳过 retrieve 直接创建
+        """
+        if cached_volume_id:
+            return cached_volume_id
+        if cached_volume_id is None:
+            try:
+                return self._get_volume_id(session_code)
+            except SandboxFileNotFoundError:
+                pass
+
+        client = self._get_client()
+        app_code = self._executor_info.get("app_code") or ""
+        created_volume_id = ""
+        try:
+            volume_name = f"session-pv-{session_code}-{uuid4().hex[:8]}"
+            response = client.create_agent_sandbox_volume.request(
+                json={"name": volume_name},
+                path_params={"app_code": app_code},
+            )
+            if not response.ok:
+                create_payload = {}
+                try:
+                    create_payload = response.json()
+                except Exception:  # noqa: BLE001
+                    create_payload = {}
+                logger.error(
+                    "create_agent_sandbox_volume failed: status=%s payload=%s",
+                    getattr(response, "status_code", None),
+                    create_payload,
+                )
+                paas_message = ""
+                if isinstance(create_payload, dict):
+                    paas_message = str(create_payload.get("message") or create_payload)
+                raise SandboxFileServerError(
+                    paas_message or f"创建 sandbox PV 失败: HTTP {getattr(response, 'status_code', '')}"
+                )
+
+            create_payload = response.json()
+            created_volume_id = self._extract_created_volume_id(create_payload)
+            if not created_volume_id:
+                logger.error("create_agent_sandbox_volume response missing uuid: %s", create_payload)
+                paas_message = ""
+                if isinstance(create_payload, dict):
+                    paas_message = str(create_payload.get("message") or "")
+                raise SandboxFileServerError(paas_message or "创建 sandbox PV 返回格式异常")
+
+            updated_session = self._rm.update_chat_session_sandbox_pv_id(
+                session_code,
+                created_volume_id,
+            )
+            persisted_volume_id = self._extract_volume_id(updated_session)
+            if not persisted_volume_id:
+                persisted_volume_id = self._extract_volume_id(self._rm.retrieve_chat_session(session_code))
+            if not persisted_volume_id:
+                raise SandboxFileServerError(f"会话 {session_code} 的 sandbox PV 写回失败")
+
+            if persisted_volume_id != created_volume_id:
+                self._delete_volume_quietly(client, app_code, created_volume_id)
+            return persisted_volume_id
+        except HTTPResponseError as exc:
+            if created_volume_id:
+                self._delete_volume_quietly(client, app_code, created_volume_id)
+            self._raise_mapped_paas_error("ensure_volume", exc)
+        except SandboxFileError:
+            if created_volume_id:
+                self._delete_volume_quietly(client, app_code, created_volume_id)
+            raise
+        except Exception as exc:
+            if created_volume_id:
+                self._delete_volume_quietly(client, app_code, created_volume_id)
+            raise SandboxFileServerError(f"创建会话 sandbox PV 失败: {exc}") from exc
+
     # ------------------------------------------------------------------
     # 错误映射
     # ------------------------------------------------------------------
@@ -123,6 +419,17 @@ class SandboxPvFileService:
         if not isinstance(body, dict):
             return ""
         return str(body.get("code") or "")
+
+    @classmethod
+    def _is_sandbox_gone(cls, exc: HTTPResponseError) -> bool:
+        """复用路径上判断 sandbox 容器是否已被 PaaS 回收。
+
+        只认 HTTP 404 或明确的容器不存在错误码，避免 FILE_TOO_LARGE 等业务错误触发重建。
+        """
+        status_code = getattr(getattr(exc, "response", None), "status_code", 0) or 0
+        if status_code == 404:
+            return True
+        return cls._parse_paas_code(exc) in PV_PAAS_SANDBOX_GONE_CODES
 
     @classmethod
     def _map_paas_error(cls, exc: HTTPResponseError) -> SandboxFileError:
@@ -151,9 +458,7 @@ class SandboxPvFileService:
     @classmethod
     def _raise_mapped_paas_error(cls, action: str, exc: HTTPResponseError) -> None:
         mapped = cls._map_paas_error(exc)
-        logger.warning(
-            "call paas sandbox file api failed: action=%s error=%s", action, mapped, exc_info=True
-        )
+        logger.warning("call paas sandbox file api failed: action=%s error=%s", action, mapped, exc_info=True)
         raise mapped from exc
 
     # ------------------------------------------------------------------
@@ -170,9 +475,7 @@ class SandboxPvFileService:
         if value is None:
             return None
         if value.tzinfo is None or value.tzinfo.utcoffset(value) is None:
-            raise SandboxFileInvalidArgumentError(
-                "since/until 必须是 tz-aware datetime（含时区信息）"
-            )
+            raise SandboxFileInvalidArgumentError("since/until 必须是 tz-aware datetime（含时区信息）")
         return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     def _call_single(self, action: str, session_code: str, params: dict):
@@ -193,8 +496,209 @@ class SandboxPvFileService:
             self._raise_mapped_paas_error(action, exc)
 
     # ------------------------------------------------------------------
-    # 5 个业务方法
+    # 6 个业务方法
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_file_name(name: str) -> str:
+        file_name = PurePosixPath(name.replace("\\", "/")).name
+        if not file_name or file_name in {".", ".."}:
+            raise SandboxFileInvalidArgumentError("文件名不能为空")
+        return file_name
+
+    def _resolve_upload_snapshot(self) -> str:
+        """读取平台注入的 snapshot；未注入则报错。"""
+        snapshot = str(self._executor_info.get("snapshot") or "").strip()
+        if snapshot:
+            return snapshot
+        raise SandboxFileInvalidArgumentError("创建临时 sandbox 需要 file-kit Skill 的已构建镜像")
+
+    def _create_upload_sandbox(
+        self,
+        session_code: str,
+        volume_id: str,
+        snapshot: str,
+        backend: PaasSandboxBackend,
+    ) -> tuple[str, float]:
+        """创建临时上传 sandbox，并返回 sandbox_id 与创建时间。"""
+        started = time.monotonic()
+        sandbox_id = backend.create_sandbox(
+            name=f"aidev-upload-{uuid4().hex[:12]}",
+            ttl_seconds=TEMP_UPLOAD_SANDBOX_TTL_SECONDS,
+            snapshot=snapshot,
+            snapshot_entrypoint=[],
+            volume_mounts=[{"volume_id": volume_id, "mount_path": TEMP_UPLOAD_VOLUME_MOUNT_PATH}],
+        )
+        created_at = time.monotonic()
+        logger.info(
+            "[pv_files] create_sandbox session=%s sandbox_id=%s elapsed=%.2fs",
+            session_code,
+            sandbox_id,
+            created_at - started,
+        )
+        return sandbox_id, created_at
+
+    def _write_files_to_sandbox(
+        self,
+        session_code: str,
+        sandbox_id: str,
+        backend: PaasSandboxBackend,
+        files_dir: str,
+        absolute_files_dir: str,
+        files: list[SandboxUploadFile],
+    ) -> list[dict]:
+        """在指定 sandbox 的统一 files 目录内上传文件，返回每文件结果。
+
+        不再固定 sleep 等待 sandbox 就绪：exec_command 自带 NOT_READY 重试，
+        沙箱未就绪时会自动重试，就绪快时省去固定等待。
+        """
+        mkdir_result = backend.exec_command(sandbox_id, ["mkdir", "-p", absolute_files_dir])
+        if mkdir_result.exit_code not in (0, None):
+            raise SandboxFileServerError(
+                f"创建上传目录失败: exit_code={mkdir_result.exit_code}, stderr={mkdir_result.stderr}"
+            )
+
+        used_names: set[str] = set()
+        results: list[dict] = []
+        for upload_file in files:
+            original_name = upload_file["name"]
+            file_name = self._safe_file_name(original_name)
+            if file_name in used_names:
+                stem, suffix = posixpath.splitext(file_name)
+                file_name = f"{stem}-{uuid4().hex[:8]}{suffix}"
+            used_names.add(file_name)
+            relative_path = posixpath.join(files_dir, file_name)
+            absolute_path = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, relative_path)
+            result = {
+                "type": "file",
+                "id": relative_path,
+                "path": relative_path,
+                "name": original_name,
+                "mime_type": upload_file.get("mime_type", ""),
+                "size": len(upload_file["content"]),
+            }
+            try:
+                backend.upload_file(sandbox_id, absolute_path, upload_file["content"])
+                result["status"] = "success"
+            except HTTPResponseError:
+                raise
+            except Exception as exc:  # noqa: BLE001 单文件失败不阻断同批其他文件
+                logger.warning(
+                    "上传文件到会话 PV 失败: session_code=%s, file=%s",
+                    session_code,
+                    original_name,
+                    exc_info=True,
+                )
+                result.update(status="failed", error=str(exc))
+            results.append(result)
+        return results
+
+    def upload_files(
+        self,
+        session_code: str,
+        files: list[SandboxUploadFile],
+        *,
+        cached_volume_id: str | None = None,
+    ) -> dict:
+        """通过会话级复用的临时 sandbox 将一批文件写入会话 PV。
+
+        sandbox 容器按 app_code、session_code 和 volume_id 缓存复用（ttl=TEMP_UPLOAD_SANDBOX_TTL_SECONDS），
+        复用期内不再 create/destroy，到期由 PaaS 自动回收；复用失败（容器已被回收）
+        时 fallback 重建一次。同会话操作加锁串行化，避免单容器并发冲突。
+        """
+        validate_session_upload_files(files)
+
+        snapshot = self._resolve_upload_snapshot()
+        volume_id = self.ensure_volume(session_code, cached_volume_id=cached_volume_id)
+        client = self._get_client()
+        backend = PaasSandboxBackend(
+            app_code=self._executor_info.get("app_code") or "",
+            bk_username=self._executor_info.get("executor") or "",
+            client=client,
+            snapshot=snapshot,
+            snapshot_entrypoint=[],
+            env_vars={},
+        )
+        files_dir = SESSION_FILES_DIR
+        absolute_files_dir = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, files_dir)
+
+        # 会话级操作锁：串行化同会话的 sandbox exec/upload，避免单容器并发冲突
+        with _get_session_op_lock(session_code):
+            app_code = self._executor_info.get("app_code") or ""
+            sandbox_id = _get_cached_upload_sandbox(app_code, session_code, volume_id)
+            sandbox_created_at: float | None = None
+            if not sandbox_id:
+                sandbox_id, sandbox_created_at = self._create_upload_sandbox(session_code, volume_id, snapshot, backend)
+
+            try:
+                results = self._write_files_to_sandbox(
+                    session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
+                )
+                _set_cached_upload_sandbox(
+                    app_code,
+                    session_code,
+                    volume_id,
+                    sandbox_id,
+                    created_at=sandbox_created_at,
+                )
+            except HTTPResponseError as exc:
+                if self._is_sandbox_gone(exc):
+                    # 缓存的 sandbox 已被 PaaS 回收，清缓存重建一次后重试
+                    logger.warning(
+                        "[pv_files] reuse sandbox gone, fallback rebuild session=%s sandbox_id=%s",
+                        session_code,
+                        sandbox_id,
+                    )
+                    _invalidate_cached_upload_sandbox(app_code, session_code, volume_id)
+                    sandbox_id, sandbox_created_at = self._create_upload_sandbox(
+                        session_code, volume_id, snapshot, backend
+                    )
+                    results = self._write_files_to_sandbox(
+                        session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
+                    )
+                    _set_cached_upload_sandbox(
+                        app_code,
+                        session_code,
+                        volume_id,
+                        sandbox_id,
+                        created_at=sandbox_created_at,
+                    )
+                else:
+                    self._raise_mapped_paas_error("upload_files", exc)
+            except SandboxFileError:
+                raise
+            except Exception as exc:
+                raise SandboxFileServerError(f"临时 sandbox 上传失败: {exc}") from exc
+
+        succeeded = sum(item["status"] == "success" for item in results)
+        self._attach_image_download_urls(session_code, results)
+        return {
+            "count": len(results),
+            "succeeded": succeeded,
+            "failed": len(results) - succeeded,
+            "results": results,
+        }
+
+    def _attach_image_download_urls(self, session_code: str, results: list[dict]) -> None:
+        """给成功上传的图片签发 download_url，供输入框和首条 user 消息展示。"""
+        for item in results:
+            if item.get("status") != "success":
+                continue
+            if not str(item.get("mime_type") or "").startswith("image/"):
+                continue
+            path = item.get("path")
+            if not path:
+                continue
+            try:
+                url_data = self.get_download_url(
+                    session_code, path, expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN
+                )
+            except SandboxFileError:
+                logger.exception("签发上传图片 URL 失败: session=%s path=%s", session_code, path)
+                continue
+            url = url_data.get("download_url")
+            if url:
+                item["download_url"] = url
 
     def list_files(
         self,

--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -326,20 +326,12 @@ class SandboxPvFileService:
         except Exception:  # noqa: BLE001
             logger.warning("清理未关联的 sandbox PV 失败: volume_id=%s", volume_id, exc_info=True)
 
-    def ensure_volume(self, session_code: str, *, cached_volume_id: str | None = None) -> str:
-        """幂等获取会话 PV；不存在时创建并写回会话。
-
-        ``cached_volume_id`` 非 None 表示调用方已读过会话：
-        - 非空：直接使用，不再 retrieve
-        - 空串：已知尚未初始化，跳过 retrieve 直接创建
-        """
-        if cached_volume_id:
-            return cached_volume_id
-        if cached_volume_id is None:
-            try:
-                return self._get_volume_id(session_code)
-            except SandboxFileNotFoundError:
-                pass
+    def ensure_volume(self, session_code: str) -> str:
+        """幂等获取会话 PV；不存在时创建并写回会话。"""
+        try:
+            return self._get_volume_id(session_code)
+        except SandboxFileNotFoundError:
+            pass
 
         client = self._get_client()
         app_code = self._executor_info.get("app_code") or ""
@@ -597,8 +589,6 @@ class SandboxPvFileService:
         self,
         session_code: str,
         files: list[SandboxUploadFile],
-        *,
-        cached_volume_id: str | None = None,
     ) -> dict:
         """通过会话级复用的临时 sandbox 将一批文件写入会话 PV。
 
@@ -609,7 +599,7 @@ class SandboxPvFileService:
         validate_session_upload_files(files)
 
         snapshot = self._resolve_upload_snapshot()
-        volume_id = self.ensure_volume(session_code, cached_volume_id=cached_volume_id)
+        volume_id = self.ensure_volume(session_code)
         client = self._get_client()
         backend = PaasSandboxBackend(
             app_code=self._executor_info.get("app_code") or "",

--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -150,13 +150,13 @@ PV_PAAS_SANDBOX_GONE_CODES = frozenset({"AGENT_SANDBOX_NOT_FOUND", "SANDBOX_NOT_
 # 凭证（client）每次请求新建，只复用 PaaS 侧的 sandbox 容器，避免缓存过期凭证。
 _UPLOAD_SANDBOX_CACHE: dict[tuple[str, str, str], tuple[str, float]] = {}
 _UPLOAD_SANDBOX_CACHE_LOCK = threading.Lock()
-# 会话级操作锁：串行化同会话的 sandbox exec/upload，避免单容器并发冲突
+# 进程内会话锁：串行化同一进程内的 sandbox exec/upload，避免单容器并发冲突
 _UPLOAD_SESSION_LOCKS: dict[str, threading.Lock] = {}
 _UPLOAD_SESSION_LOCKS_LOCK = threading.Lock()
 
 
 def _get_session_op_lock(session_code: str) -> threading.Lock:
-    """获取会话级操作锁（懒创建）。"""
+    """获取进程内会话操作锁（懒创建）。"""
     with _UPLOAD_SESSION_LOCKS_LOCK:
         lock = _UPLOAD_SESSION_LOCKS.get(session_code)
         if lock is None:
@@ -590,11 +590,11 @@ class SandboxPvFileService:
         session_code: str,
         files: list[SandboxUploadFile],
     ) -> dict:
-        """通过会话级复用的临时 sandbox 将一批文件写入会话 PV。
+        """通过进程内会话复用的临时 sandbox 将一批文件写入会话 PV。
 
         sandbox 容器按 app_code、session_code 和 volume_id 缓存复用（ttl=TEMP_UPLOAD_SANDBOX_TTL_SECONDS），
-        复用期内不再 create/destroy，到期由 PaaS 自动回收；复用失败（容器已被回收）
-        时 fallback 重建一次。同会话操作加锁串行化，避免单容器并发冲突。
+        同一进程的复用期内不再 create/destroy，到期由 PaaS 自动回收；复用失败（容器已被回收）
+        时 fallback 重建一次。同一进程内的会话操作加锁串行化，避免单容器并发冲突。
         """
         validate_session_upload_files(files)
 
@@ -612,7 +612,7 @@ class SandboxPvFileService:
         files_dir = SESSION_FILES_DIR
         absolute_files_dir = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, files_dir)
 
-        # 会话级操作锁：串行化同会话的 sandbox exec/upload，避免单容器并发冲突
+        # 进程内会话锁：串行化同一进程内的 sandbox exec/upload，避免单容器并发冲突
         with _get_session_op_lock(session_code):
             app_code = self._executor_info.get("app_code") or ""
             sandbox_id = _get_cached_upload_sandbox(app_code, session_code, volume_id)

--- a/src/agent/tests/core/nodes/test_pv.py
+++ b/src/agent/tests/core/nodes/test_pv.py
@@ -115,7 +115,9 @@ def _make_mock_client():
 def _make_mock_resource_manager():
     """创建带有 chat-session PV 写回方法的 mock resource manager。"""
     resource_manager = MagicMock()
-    resource_manager.update_chat_session_sandbox_pv_id.return_value = {"sandbox_pv_id": "test-volume-uuid"}
+    resource_manager.update_chat_session_sandbox_pv_id.side_effect = lambda _session_code, volume_id: {
+        "session_property": {"sandbox_pv_id": volume_id}
+    }
     return resource_manager
 
 
@@ -266,6 +268,35 @@ def test_pv_node_creates_pv_and_writes_back():
     assert pv["volume_name"].startswith("agent-pv-test-thread-")
     assert pv["mount_path"] == "session"
     assert pv["source"] == "platform"
+
+
+def test_pv_node_mounts_persisted_volume_when_concurrent_upload_wins():
+    """上传与 Agent 并发创建 PV 时，Agent 必须挂载平台先持久化的上传卷。"""
+    client = _make_mock_client()
+    resource_manager = _make_mock_resource_manager()
+    resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+    resource_manager.update_chat_session_sandbox_pv_id.side_effect = None
+    resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+        "session_property": {"sandbox_pv_id": "upload-volume-id"}
+    }
+    pv_node = make_pv_node(client=client, app_code="test-app", resource_manager=resource_manager)
+
+    state = {
+        "runtime_paas_sbx_pv": [],
+        "messages": [_make_ai_message_with_paas_sandbox()],
+    }
+    config = _make_config(session_code="test-session")
+
+    result = pv_node(state, config)
+
+    resource_manager.update_chat_session_sandbox_pv_id.assert_called_once_with("test-session", "test-volume-uuid")
+    pv = result["runtime_paas_sbx_pv"][0]
+    assert pv["volume_id"] == "upload-volume-id"
+    assert pv["volume_name"] == ""
+    assert pv["source"] == "platform"
+    client.delete_agent_sandbox_volume.request.assert_called_once_with(
+        path_params={"app_code": "test-app", "volume_id": "test-volume-uuid"}
+    )
 
 
 def test_pv_node_writeback_failure_keeps_runtime_source():

--- a/src/agent/tests/core/nodes/test_pv.py
+++ b/src/agent/tests/core/nodes/test_pv.py
@@ -204,6 +204,38 @@ def test_pv_node_skip_no_paas_sandbox():
     client.create_agent_sandbox_volume.request.assert_not_called()
 
 
+def test_pv_node_reuses_platform_volume_without_create():
+    """创建前读到会话已绑定的卷时，直接复用，不新建。"""
+    client = _make_mock_client()
+    resource_manager = _make_mock_resource_manager()
+    resource_manager.retrieve_chat_session.return_value = {
+        "session_property": {"sandbox_pv_id": "vol-uploaded"}
+    }
+    pv_node = make_pv_node(client=client, app_code="test-app", resource_manager=resource_manager)
+
+    state = {
+        "runtime_paas_sbx_pv": [],
+        "messages": [_make_ai_message_with_paas_sandbox()],
+    }
+    config = _make_config(session_code="test-session")
+
+    result = pv_node(state, config)
+
+    client.create_agent_sandbox_volume.request.assert_not_called()
+    resource_manager.update_chat_session_sandbox_pv_id.assert_not_called()
+    assert result == {
+        "runtime_paas_sbx_pv": [
+            {
+                "type": "paas-sbx-pv",
+                "volume_id": "vol-uploaded",
+                "volume_name": "",
+                "mount_path": "session",
+                "source": "platform",
+            }
+        ]
+    }
+
+
 def test_pv_node_creates_pv_and_writes_back():
     """有 paas_sandbox tool_call 且无现有 PV 时，创建 PV 并写回平台。"""
     client = _make_mock_client()

--- a/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
@@ -471,11 +471,30 @@ def _is_echo_home(cmd) -> bool:
 
 
 class TestResolvePath:
-    """验证 _resolve_path 将 ~ 展开为绝对路径，供 HTTP API 使用。"""
+    """验证 _resolve_path 将路径变量展开为绝对路径，供 HTTP API 使用。"""
 
     def test_absolute_path_unchanged(self, backend, mock_ops):
         """绝对路径原样返回，不触发 shell 调用。"""
         assert backend._resolve_path("/app/test.txt") == "/app/test.txt"
+
+    def test_storage_path_expanded_from_runtime_env(self, backend, mock_ops):
+        """会话文件路径按当前 runtime 的 STORAGE_PATH 展开。"""
+        backend._env_vars["STORAGE_PATH"] = "/app/.storage/"
+
+        assert backend._resolve_path("$STORAGE_PATH/session/files/report.txt") == (
+            "/app/.storage/session/files/report.txt"
+        )
+        assert backend._resolve_path("${STORAGE_PATH}/session/files/report.txt") == (
+            "/app/.storage/session/files/report.txt"
+        )
+
+    def test_storage_path_uses_default_when_runtime_env_missing(self, backend, mock_ops):
+        """runtime 未配置 STORAGE_PATH 时使用后端默认路径。"""
+        backend._env_vars.pop("STORAGE_PATH", None)
+
+        assert backend._resolve_path("$STORAGE_PATH/session/files/report.txt") == (
+            "/app/storage/session/files/report.txt"
+        )
 
     def test_tilde_only(self, backend, mock_ops):
         """单独 ~ 展开为 $HOME。"""

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway.py
@@ -107,6 +107,30 @@ def test_chat_model_payload_converts_binary_images_to_image_url():
     ]
 
 
+def test_chat_model_payload_drops_non_image_binary():
+    model = ChatModel.get_setup_instance(model="test", base_url=TEST_BASE_URL)
+    messages = [
+        HumanMessage(
+            content=[
+                {
+                    "type": "binary",
+                    "id": "files/requirements.txt",
+                    "filename": "requirements.txt",
+                    "mime_type": "text/plain",
+                },
+                {"type": "text", "text": "这个文件内容是啥"},
+            ]
+        )
+    ]
+
+    try:
+        payload = model._get_request_payload(messages)
+    finally:
+        asyncio.run(model.http_async_client.aclose())
+
+    assert payload["messages"][0]["content"] == [{"type": "text", "text": "这个文件内容是啥"}]
+
+
 @pytest.mark.skipif(
     not all([settings.LLM_GW_ENDPOINT, settings.APP_CODE, settings.SECRET_KEY]),
     reason="没有配置足够的环境变量,跳过该测试",

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1081,6 +1081,63 @@ def test_chat_agent_builder_separates_file_resources_from_config_resources():
     assert builder._specific_resources == [{"type": "tool", "code": "search"}]
 
 
+def test_agent_builds_llm_history_with_exact_non_image_file_references():
+    agent = ChatCompletionAgent(
+        chat_history=[
+            ChatPrompt(role=PromptRole.USER.value, content="请分析最新产物"),
+            ChatPrompt(
+                role=PromptRole.USER.value,
+                content="请对比这两个文件",
+                extra={
+                    "resources": [
+                        {"type": "file", "outputId": "outputs/report.pdf", "name": "报告.pdf"},
+                        {"type": "file", "path": "outputs/report.pdf", "name": "重复报告.pdf"},
+                        {"type": "file", "id": "files/data.csv", "name": "数据.csv"},
+                    ]
+                },
+            ),
+        ],
+        file_resources=[
+            {"type": "file", "outputId": "outputs/report.pdf", "name": "报告.pdf"},
+            {"type": "file", "path": "outputs/report.pdf", "name": "重复报告.pdf"},
+            {"type": "file", "id": "files/data.csv", "name": "数据.csv"},
+        ],
+    )
+
+    history = agent._build_llm_history()
+
+    assert history[-1].content == [
+        {"type": "text", "text": "请对比这两个文件"},
+        {
+            "type": "text",
+            "text": "用户本轮引用了以下会话文件，请优先基于这些精确路径处理：\n"
+            "- $STORAGE_PATH/session/outputs/report.pdf\n"
+            "- $STORAGE_PATH/session/files/data.csv",
+        },
+    ]
+    assert agent.chat_history[-1].content == "请对比这两个文件"
+
+
+def test_agent_does_not_attach_previous_file_reference_to_new_input():
+    agent = ChatCompletionAgent(
+        chat_history=[
+            ChatPrompt(
+                role=PromptRole.USER.value,
+                content="分析这个文件",
+                extra={"resources": [{"type": "file", "path": "files/report.pdf"}]},
+            ),
+            ChatPrompt(role=PromptRole.USER.value, content="继续解释上面的结论"),
+        ],
+        file_resources=[],
+    )
+
+    history = agent._build_llm_history()
+
+    assert len(history) == 2
+    assert history[0].content == "分析这个文件"
+    assert history[1].content == "继续解释上面的结论"
+
+
 @patch(
     "aidev_agent.services.agent.chat.SandboxPvFileService.get_download_url",
     return_value={"download_url": "https://example.test/download/image.png"},
@@ -1110,6 +1167,11 @@ def test_agent_builds_llm_history_with_refreshed_pv_image_url(mock_get_download_
     history = agent._build_llm_history()
 
     assert history[0].content[0]["url"] == "https://example.test/download/image.png"
+    assert history[0].content[2] == {
+        "type": "text",
+        "text": "用户本轮引用了以下会话文件，请优先基于这些精确路径处理：\n"
+        "- $STORAGE_PATH/session/files/image.png",
+    }
     assert agent.chat_history[0].content[0]["url"] == "https://example.test/expired-image.png"
     mock_get_download_url.assert_called_once_with(
         session_code="session-1",

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1055,6 +1055,69 @@ def test_chat_agent_builder_ignores_none_extra_in_last_user_message():
     assert builder._specific_resources == []
 
 
+def _make_file_resource_chat_ctx(resources: list[dict]):
+    ctx = _make_dummy_chat_ctx()
+    ctx.session_context_data = [
+        {
+            "role": PromptRole.USER.value,
+            "content": "请分析这些文件",
+            "extra": {"resources": resources},
+        }
+    ]
+    return ctx
+
+
+def test_chat_agent_builder_separates_file_resources_from_config_resources():
+    ctx = _make_file_resource_chat_ctx(
+        [
+            {"type": "file", "path": "files/report.pdf", "name": "report.pdf"},
+            {"type": "tool", "code": "search"},
+        ]
+    )
+
+    builder = ChatAgentBuilder(ctx)
+
+    assert builder.file_resources == [{"type": "file", "path": "files/report.pdf", "name": "report.pdf"}]
+    assert builder._specific_resources == [{"type": "tool", "code": "search"}]
+
+
+@patch(
+    "aidev_agent.services.agent.chat.SandboxPvFileService.get_download_url",
+    return_value={"download_url": "https://example.test/download/image.png"},
+)
+def test_agent_builds_llm_history_with_refreshed_pv_image_url(mock_get_download_url):
+    agent = ChatCompletionAgent(
+        thread_id="session-1",
+        chat_history=[
+            ChatPrompt(
+                role=PromptRole.USER.value,
+                content=[
+                    {
+                        "type": "binary",
+                        "id": "files/image.png",
+                        "url": "https://example.test/expired-image.png",
+                        "mime_type": "image/png",
+                    },
+                    {"type": "text", "text": "描述这张图片"},
+                ],
+            )
+        ],
+        file_resources=[{"type": "file", "path": "files/image.png", "mime_type": "image/png"}],
+        resource_manager=MagicMock(),
+        executor_info={"app_code": "app", "executor": "luka"},
+    )
+
+    history = agent._build_llm_history()
+
+    assert history[0].content[0]["url"] == "https://example.test/download/image.png"
+    assert agent.chat_history[0].content[0]["url"] == "https://example.test/expired-image.png"
+    mock_get_download_url.assert_called_once_with(
+        session_code="session-1",
+        path="files/image.png",
+        expires_in=3600,
+    )
+
+
 def test_build_chat_history_does_not_prepend_config_role_prompts():
     """角色提示词不在 build_chat_history 前置，role/system 交由注入挂点延迟拼接。"""
     from aidev_agent.services.agent.chat import ChatAgentBuilder

--- a/src/agent/tests/services/test_sandbox_pv_files.py
+++ b/src/agent/tests/services/test_sandbox_pv_files.py
@@ -199,22 +199,6 @@ class TestEnsureVolume:
             path_params={"app_code": "test-app", "volume_id": "vol-loser"}
         )
 
-    def test_cached_volume_id_skips_retrieve(self, service, resource_manager, mock_client):
-        assert service.ensure_volume("s1", cached_volume_id="vol-cached") == "vol-cached"
-        resource_manager.retrieve_chat_session.assert_not_called()
-        mock_client.create_agent_sandbox_volume.request.assert_not_called()
-
-    def test_empty_cached_volume_id_creates_without_retrieve(self, service, resource_manager, mock_client):
-        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
-            "session_property": {"sandbox_pv_id": "vol-new"}
-        }
-        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-new"})
-
-        assert service.ensure_volume("s1", cached_volume_id="") == "vol-new"
-        resource_manager.retrieve_chat_session.assert_not_called()
-        mock_client.create_agent_sandbox_volume.request.assert_called_once()
-
-
 # ---------------------------------------------------------------------------
 # _to_iso8601_z / _parse_paas_code / _map_paas_error
 # ---------------------------------------------------------------------------

--- a/src/agent/tests/services/test_sandbox_pv_files.py
+++ b/src/agent/tests/services/test_sandbox_pv_files.py
@@ -4,21 +4,26 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
-from bkapi_client_core.exceptions import HTTPResponseError
-
+from aidev_agent.services import sandbox_pv_files as module
 from aidev_agent.services.sandbox_pv_files import (
+    MAX_SESSION_UPLOAD_FILE_SIZE,
+    MAX_SESSION_UPLOAD_FILES,
     PV_LIST_MAX_PAGES,
     PV_LIST_PAGE_SIZE,
+    SandboxFileError,
     SandboxFileInvalidArgumentError,
     SandboxFileInvalidRequestError,
     SandboxFileNotFoundError,
     SandboxFileServerError,
     SandboxPvFileService,
+    fill_user_image_urls,
+    validate_session_upload_files,
 )
-
+from bkapi_client_core.exceptions import HTTPResponseError
 
 # ---------------------------------------------------------------------------
 # 工具函数 & fixture
@@ -38,6 +43,8 @@ def _mock_http_error(status_code: int, code: str = "") -> HTTPResponseError:
 def _mock_paas_response(json_data=None, headers=None, content: bytes = b""):
     """构造 PaaS 正常响应（含 raise_for_status / json / content / headers）。"""
     resp = MagicMock()
+    resp.ok = True
+    resp.status_code = 200
     resp.raise_for_status.return_value = None
     resp.json.return_value = json_data if json_data is not None else {}
     resp.content = content
@@ -60,11 +67,18 @@ def resource_manager(mock_client):
     return rm
 
 
+DEFAULT_UPLOAD_SNAPSHOT = "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"
+
+
 @pytest.fixture
 def service(resource_manager):
     return SandboxPvFileService(
         resource_manager=resource_manager,
-        executor_info={"app_code": "test-app", "app_secret": "test-secret"},
+        executor_info={
+            "app_code": "test-app",
+            "app_secret": "test-secret",
+            "snapshot": DEFAULT_UPLOAD_SNAPSHOT,
+        },
     )
 
 
@@ -73,6 +87,15 @@ def _no_sleep():
     """所有测试禁用 time.sleep，避免翻页测试变慢。"""
     with patch("aidev_agent.services.sandbox_pv_files.time.sleep") as m:
         yield m
+
+
+@pytest.fixture(autouse=True)
+def _reset_upload_caches():
+    """每个测试前清空会话级 sandbox 复用缓存，避免测试间残留。"""
+    from aidev_agent.services import sandbox_pv_files as mod
+
+    mod._UPLOAD_SANDBOX_CACHE.clear()
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -93,6 +116,103 @@ class TestGetVolumeId:
 
     def test_returns_pv_id(self, service):
         assert service._get_volume_id("s1") == "vol-abc"
+
+
+class TestUploadSandboxCache:
+    def test_cache_isolated_by_volume(self):
+        module._set_cached_upload_sandbox("app-a", "s1", "vol-a", "sandbox-a", created_at=100.0)
+
+        with patch.object(module.time, "monotonic", return_value=100.0):
+            assert module._get_cached_upload_sandbox("app-a", "s1", "vol-a") == "sandbox-a"
+            assert module._get_cached_upload_sandbox("app-a", "s1", "vol-b") == ""
+            assert module._get_cached_upload_sandbox("app-b", "s1", "vol-a") == ""
+
+    def test_successful_reuse_does_not_refresh_creation_time(self):
+        module._set_cached_upload_sandbox("app-a", "s1", "vol-a", "sandbox-a", created_at=100.0)
+        with patch.object(module.time, "monotonic", return_value=200.0):
+            module._set_cached_upload_sandbox("app-a", "s1", "vol-a", "sandbox-a")
+
+        assert module._UPLOAD_SANDBOX_CACHE[("app-a", "s1", "vol-a")] == ("sandbox-a", 100.0)
+
+    def test_cache_expires_from_creation_time(self):
+        module._set_cached_upload_sandbox("app-a", "s1", "vol-a", "sandbox-a", created_at=100.0)
+        with patch.object(module.time, "monotonic", return_value=100.0 + 1800):
+            assert module._get_cached_upload_sandbox("app-a", "s1", "vol-a") == ""
+
+
+class TestEnsureVolume:
+    def test_creates_and_persists_missing_volume(self, service, resource_manager, mock_client):
+        resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+            "session_property": {"sandbox_pv_id": "vol-new"}
+        }
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-new"})
+
+        assert service.ensure_volume("s1") == "vol-new"
+
+        resource_manager.update_chat_session_sandbox_pv_id.assert_called_once_with("s1", "vol-new")
+        mock_client.create_agent_sandbox_volume.request.assert_called_once()
+        call_kwargs = mock_client.create_agent_sandbox_volume.request.call_args.kwargs
+        assert call_kwargs["path_params"] == {"app_code": "test-app"}
+        assert call_kwargs["json"]["name"].startswith("session-pv-s1-")
+
+    def test_creates_volume_from_apigw_wrapped_payload(self, service, resource_manager, mock_client):
+        resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+            "session_property": {"sandbox_pv_id": "vol-wrapped"}
+        }
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response(
+            {"code": 0, "message": "OK", "data": {"uuid": "vol-wrapped"}}
+        )
+
+        assert service.ensure_volume("s1") == "vol-wrapped"
+        resource_manager.update_chat_session_sandbox_pv_id.assert_called_once_with("s1", "vol-wrapped")
+
+    def test_paas_business_error_message_is_surfaced(self, service, resource_manager, mock_client):
+        resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response(
+            {"result": False, "code": 1640001, "message": "user authentication failed", "data": None}
+        )
+        with pytest.raises(SandboxFileServerError, match="user authentication failed"):
+            service.ensure_volume("s1")
+
+    def test_http_400_payload_is_surfaced(self, service, resource_manager, mock_client):
+        resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+        resp = _mock_paas_response({"name": ["This field is required."]})
+        resp.ok = False
+        resp.status_code = 400
+        mock_client.create_agent_sandbox_volume.request.return_value = resp
+        with pytest.raises(SandboxFileServerError, match="This field is required"):
+            service.ensure_volume("s1")
+
+    def test_concurrent_winner_is_reused_and_orphan_is_deleted(self, service, resource_manager, mock_client):
+        resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
+        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+            "session_property": {"sandbox_pv_id": "vol-winner"}
+        }
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-loser"})
+        mock_client.delete_agent_sandbox_volume.request.return_value = _mock_paas_response()
+
+        assert service.ensure_volume("s1") == "vol-winner"
+
+        mock_client.delete_agent_sandbox_volume.request.assert_called_once_with(
+            path_params={"app_code": "test-app", "volume_id": "vol-loser"}
+        )
+
+    def test_cached_volume_id_skips_retrieve(self, service, resource_manager, mock_client):
+        assert service.ensure_volume("s1", cached_volume_id="vol-cached") == "vol-cached"
+        resource_manager.retrieve_chat_session.assert_not_called()
+        mock_client.create_agent_sandbox_volume.request.assert_not_called()
+
+    def test_empty_cached_volume_id_creates_without_retrieve(self, service, resource_manager, mock_client):
+        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+            "session_property": {"sandbox_pv_id": "vol-new"}
+        }
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-new"})
+
+        assert service.ensure_volume("s1", cached_volume_id="") == "vol-new"
+        resource_manager.retrieve_chat_session.assert_not_called()
+        mock_client.create_agent_sandbox_volume.request.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -141,6 +261,16 @@ class TestUtilities:
 class TestErrorMapping:
     """PaaS 状态码/错误码 → 沙箱文件业务异常映射。"""
 
+    def test_is_sandbox_gone_only_for_missing_container(self):
+        """体积超限等业务错误码含 SANDBOX，但不能当成容器已回收。"""
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(404, "AGENT_SANDBOX_NOT_FOUND")) is True
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(404, "")) is True
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(400, "SANDBOX_NOT_FOUND")) is True
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(413, "AGENT_SANDBOX_FILE_TOO_LARGE")) is False
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(415, "AGENT_SANDBOX_FILE_NOT_PREVIEWABLE")) is False
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(400, "AGENT_SANDBOX_FILE_OPERATION_FAILED")) is False
+        assert SandboxPvFileService._is_sandbox_gone(_mock_http_error(502, "AGENT_SANDBOX_SERVICE_NOT_READY")) is False
+
     @pytest.mark.parametrize(
         "status, code, expected",
         [
@@ -159,6 +289,229 @@ class TestErrorMapping:
         exc = _mock_http_error(status, code)
         mapped = SandboxPvFileService._map_paas_error(exc)
         assert isinstance(mapped, expected)
+
+
+class TestUploadFiles:
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_batch_creates_one_sandbox_and_caches_for_reuse(
+        self, mock_backend_cls, service, resource_manager, _no_sleep
+    ):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        result = service.upload_files(
+            "s1",
+            [
+                {"name": "报告.pdf", "content": b"pdf", "mime_type": "application/pdf"},
+                {"name": "image.png", "content": b"png", "mime_type": "image/png"},
+            ],
+        )
+
+        assert result["count"] == 2
+        assert result["succeeded"] == 2
+        assert result["failed"] == 0
+        assert all(item["status"] == "success" for item in result["results"])
+        assert [item["path"] for item in result["results"]] == ["files/报告.pdf", "files/image.png"]
+        assert backend.upload_file.call_count == 2
+        assert [call.args[1] for call in backend.upload_file.call_args_list] == [
+            "/app/.storage/session/files/报告.pdf",
+            "/app/.storage/session/files/image.png",
+        ]
+        assert backend.create_sandbox.call_count == 1
+        # 复用模式下不主动销毁，由 PaaS ttl 兜底回收
+        assert backend.destroy_sandbox.call_count == 0
+        # 不再固定 sleep 等待就绪，由 exec_command 的 NOT_READY 重试兜底
+        assert _no_sleep.call_count == 0
+        create_kwargs = backend.create_sandbox.call_args.kwargs
+        assert create_kwargs["volume_mounts"] == [{"volume_id": "vol-abc", "mount_path": "/app/.storage/session"}]
+        assert create_kwargs["snapshot_entrypoint"] == []
+        assert create_kwargs["ttl_seconds"] == 1800
+        assert create_kwargs["snapshot"] == DEFAULT_UPLOAD_SNAPSHOT
+
+        # 同会话第二次上传复用已缓存 sandbox，不再 create/destroy
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        service.upload_files("s1", [{"name": "more.txt", "content": b"more"}])
+        assert backend.create_sandbox.call_count == 1
+        assert backend.destroy_sandbox.call_count == 0
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_reuse_sandbox_gone_falls_back_to_rebuild(self, mock_backend_cls, service, _no_sleep):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        # 首次创建并缓存
+        service.upload_files("s1", [{"name": "a.txt", "content": b"a"}])
+        assert backend.create_sandbox.call_count == 1
+
+        # 模拟缓存的 sandbox 已被 PaaS 回收：exec 报 404，重建后第二次 exec 成功
+        backend.create_sandbox.return_value = "sandbox-upload-2"
+        backend.exec_command.side_effect = [
+            _mock_http_error(404, "AGENT_SANDBOX_NOT_FOUND"),
+            SimpleNamespace(stdout="", stderr="", exit_code=0),
+        ]
+        result = service.upload_files("s1", [{"name": "b.txt", "content": b"b"}])
+
+        # fallback 重建一次
+        assert backend.create_sandbox.call_count == 2
+        assert result["succeeded"] == 1
+        assert backend.destroy_sandbox.call_count == 0
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_upload_http_error_rebuilds_sandbox(self, mock_backend_cls, service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.side_effect = ["sandbox-upload", "sandbox-upload-2"]
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        backend.upload_file.side_effect = [
+            _mock_http_error(404, "AGENT_SANDBOX_NOT_FOUND"),
+            None,
+        ]
+
+        result = service.upload_files("s1", [{"name": "file.txt", "content": b"content"}])
+
+        assert result["succeeded"] == 1
+        assert backend.create_sandbox.call_count == 2
+        assert backend.upload_file.call_count == 2
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_file_too_large_does_not_rebuild_sandbox(self, mock_backend_cls, service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        backend.upload_file.side_effect = _mock_http_error(413, "AGENT_SANDBOX_FILE_TOO_LARGE")
+
+        with pytest.raises(SandboxFileInvalidRequestError):
+            service.upload_files("s1", [{"name": "huge.txt", "content": b"x"}])
+
+        assert backend.create_sandbox.call_count == 1
+
+    def test_rejects_unsupported_extension_before_sandbox(self, service, mock_client):
+        with pytest.raises(SandboxFileInvalidArgumentError, match=".exe"):
+            service.upload_files("s1", [{"name": "payload.exe", "content": b"x"}])
+        mock_client.create_agent_sandbox_volume.request.assert_not_called()
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_single_file_failure_does_not_abort_batch(self, mock_backend_cls, service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        backend.upload_file.side_effect = [RuntimeError("upload failed"), None]
+
+        result = service.upload_files(
+            "s1",
+            [
+                {"name": "bad.txt", "content": b"bad"},
+                {"name": "good.txt", "content": b"good"},
+            ],
+        )
+
+        assert result["succeeded"] == 1
+        assert result["failed"] == 1
+        assert [item["status"] for item in result["results"]] == ["failed", "success"]
+        # 复用模式下不主动销毁
+        assert backend.destroy_sandbox.call_count == 0
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_setup_failure_does_not_destroy_sandbox(self, mock_backend_cls, service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.side_effect = RuntimeError("mkdir failed")
+
+        with pytest.raises(SandboxFileServerError, match="临时 sandbox 上传失败"):
+            service.upload_files("s1", [{"name": "file.txt", "content": b"content"}])
+
+        # 复用模式下不主动销毁，由 PaaS ttl 兜底回收
+        assert backend.destroy_sandbox.call_count == 0
+        backend.exec_command.side_effect = None
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        service.upload_files("s1", [{"name": "file.txt", "content": b"content"}])
+        assert backend.create_sandbox.call_count == 2
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_attaches_download_url_for_images_only(self, mock_backend_cls, service, mock_client):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        mock_client.get_download_url.request.return_value = _mock_paas_response(
+            {"download_url": "https://cdn/image.png", "preview_url": "https://preview/image.png"}
+        )
+
+        result = service.upload_files(
+            "s1",
+            [
+                {"name": "note.txt", "content": b"txt", "mime_type": "text/plain"},
+                {"name": "image.png", "content": b"png", "mime_type": "image/png"},
+            ],
+        )
+
+        assert "download_url" not in result["results"][0]
+        assert result["results"][1]["download_url"] == "https://cdn/image.png"
+        params = mock_client.get_download_url.request.call_args.kwargs["params"]
+        assert params == {"path": "files/image.png", "expires_in": 3600}
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_does_not_fallback_to_preview_url(self, mock_backend_cls, service, mock_client):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        mock_client.get_download_url.request.return_value = _mock_paas_response(
+            {"preview_url": "https://preview/image.png"}
+        )
+
+        result = service.upload_files(
+            "s1",
+            [{"name": "image.png", "content": b"png", "mime_type": "image/png"}],
+        )
+
+        assert "download_url" not in result["results"][0]
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_image_url_failure_does_not_fail_upload(self, mock_backend_cls, service, mock_client):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        mock_client.get_download_url.request.side_effect = _mock_http_error(500, "UNKNOWN_XYZ")
+
+        result = service.upload_files(
+            "s1",
+            [{"name": "image.png", "content": b"png", "mime_type": "image/png"}],
+        )
+
+        assert result["succeeded"] == 1
+        assert "download_url" not in result["results"][0]
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_uses_executor_info_snapshot(self, mock_backend_cls, resource_manager, _no_sleep):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        service = SandboxPvFileService(
+            resource_manager=resource_manager,
+            executor_info={
+                "app_code": "test-app",
+                "app_secret": "test-secret",
+                "executor": "alice",
+                "snapshot": DEFAULT_UPLOAD_SNAPSHOT,
+            },
+        )
+
+        service.upload_files("s1", [{"name": "file.txt", "content": b"content"}])
+
+        assert backend.create_sandbox.call_args.kwargs["snapshot"] == DEFAULT_UPLOAD_SNAPSHOT
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_missing_upload_snapshot_raises_before_creating_sandbox(self, mock_backend_cls, resource_manager):
+        service = SandboxPvFileService(
+            resource_manager=resource_manager,
+            executor_info={"app_code": "test-app", "app_secret": "test-secret"},
+        )
+
+        with pytest.raises(SandboxFileInvalidArgumentError, match="file-kit"):
+            service.upload_files("s1", [{"name": "file.txt", "content": b"content"}])
+
+        mock_backend_cls.return_value.create_sandbox.assert_not_called()
+        resource_manager.update_chat_session_sandbox_pv_id.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -246,9 +599,7 @@ class TestListFiles:
             "count": 100000,
             "results": [{"path": f"f{i}.txt", "is_dir": False} for i in range(PV_LIST_PAGE_SIZE)],
         }
-        mock_client.list_files.request.side_effect = [
-            _mock_paas_response(page_with_500)
-        ] * PV_LIST_MAX_PAGES
+        mock_client.list_files.request.side_effect = [_mock_paas_response(page_with_500)] * PV_LIST_MAX_PAGES
         result = service.list_files(session_code="s1")
         assert result["count"] == PV_LIST_PAGE_SIZE * PV_LIST_MAX_PAGES
         assert result["truncated"] is True
@@ -305,9 +656,7 @@ class TestOtherServiceMethods:
         assert mock_client.preview_file.request.call_args.kwargs["params"]["max_bytes"] == 1024
 
     def test_preview_file_maps_415(self, service, mock_client):
-        mock_client.preview_file.request.side_effect = _mock_http_error(
-            415, "AGENT_SANDBOX_FILE_NOT_PREVIEWABLE"
-        )
+        mock_client.preview_file.request.side_effect = _mock_http_error(415, "AGENT_SANDBOX_FILE_NOT_PREVIEWABLE")
         with pytest.raises(SandboxFileInvalidRequestError):
             service.preview_file(session_code="s1", path="x.bin")
 
@@ -319,3 +668,74 @@ class TestOtherServiceMethods:
         assert result == {"download_url": "https://cdn/x", "preview_url": "https://cdn/x"}
         params = mock_client.get_download_url.request.call_args.kwargs["params"]
         assert params["expires_in"] == 300
+
+
+class TestValidateSessionUploadFiles:
+    def test_rejects_empty_files(self):
+        with pytest.raises(SandboxFileInvalidArgumentError, match="不能为空"):
+            validate_session_upload_files([])
+
+    def test_rejects_too_many_files(self):
+        files = [{"name": f"{index}.txt", "content": b"x"} for index in range(MAX_SESSION_UPLOAD_FILES + 1)]
+        with pytest.raises(SandboxFileInvalidArgumentError, match="不能超过"):
+            validate_session_upload_files(files)
+
+    def test_rejects_unsupported_extension(self):
+        with pytest.raises(SandboxFileInvalidArgumentError, match=".exe"):
+            validate_session_upload_files([{"name": "payload.exe", "content": b"x"}])
+
+    def test_rejects_oversized_file(self):
+        with pytest.raises(SandboxFileInvalidArgumentError, match="超过单文件大小限制"):
+            validate_session_upload_files(
+                [{"name": "large.txt", "content": b"x" * (MAX_SESSION_UPLOAD_FILE_SIZE + 1)}]
+            )
+
+
+class TestFillUserImageUrls:
+    def test_fills_missing_image_url(self):
+        file_service = MagicMock()
+        file_service.get_download_url.return_value = {"download_url": "https://cdn/a.png"}
+        payload = {
+            "role": "user",
+            "session_code": "s1",
+            "content": [
+                {"type": "text", "text": "hi"},
+                {"type": "binary", "mime_type": "image/png", "id": "files/a.png"},
+            ],
+        }
+
+        fill_user_image_urls(file_service, payload)
+
+        assert payload["content"][1]["url"] == "https://cdn/a.png"
+        file_service.get_download_url.assert_called_once_with(
+            session_code="s1", path="files/a.png", expires_in=3600
+        )
+
+    def test_skips_when_url_exists_or_not_image(self):
+        file_service = MagicMock()
+        payload = {
+            "role": "user",
+            "session_code": "s1",
+            "content": [
+                {"type": "binary", "mime_type": "image/png", "id": "files/a.png", "url": "https://old"},
+                {"type": "binary", "mime_type": "application/pdf", "id": "files/a.pdf"},
+            ],
+        }
+
+        fill_user_image_urls(file_service, payload)
+
+        file_service.get_download_url.assert_not_called()
+        assert payload["content"][0]["url"] == "https://old"
+
+    def test_skips_failed_url_issue(self):
+        file_service = MagicMock()
+        file_service.get_download_url.side_effect = SandboxFileError("boom")
+        payload = {
+            "role": "user",
+            "session_code": "s1",
+            "content": [{"type": "binary", "mime_type": "image/png", "path": "files/a.png"}],
+        }
+
+        fill_user_image_urls(file_service, payload)
+
+        assert "url" not in payload["content"][0]

--- a/src/agent/tests/services/test_sandbox_pv_files.py
+++ b/src/agent/tests/services/test_sandbox_pv_files.py
@@ -365,9 +365,14 @@ class TestUploadFiles:
         backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
         backend.upload_file.side_effect = _mock_http_error(413, "AGENT_SANDBOX_FILE_TOO_LARGE")
 
-        with pytest.raises(SandboxFileInvalidRequestError):
-            service.upload_files("s1", [{"name": "huge.txt", "content": b"x"}])
+        # 单文件超限不再中断整批：该文件标记失败并附带原因，其余文件不受影响
+        result = service.upload_files("s1", [{"name": "huge.txt", "content": b"x"}])
 
+        assert result["succeeded"] == 0
+        assert result["failed"] == 1
+        assert result["results"][0]["status"] == "failed"
+        assert "AGENT_SANDBOX_FILE_TOO_LARGE" in result["results"][0]["error"]
+        # 非 sandbox-gone 业务错误不触发重建
         assert backend.create_sandbox.call_count == 1
 
     def test_rejects_unsupported_extension_before_sandbox(self, service, mock_client):

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -1,28 +1,43 @@
 # -*- coding: utf-8 -*-
 
+import threading
+import time
+from pathlib import PurePosixPath
+
 from aidev_agent.enums import ChannelType
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
 from aidev_agent.services.messages_handler.constants import TimeoutConfig
 from aidev_agent.services.messages_handler.factory import message_handler_factory
 from aidev_agent.services.sandbox_pv_files import (
+    IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+    MAX_SESSION_UPLOAD_FILE_SIZE,
+    MAX_SESSION_UPLOAD_FILES,
+    SESSION_UPLOAD_FILE_EXTENSIONS,
     SandboxFileError,
     SandboxFileInvalidArgumentError,
     SandboxFileInvalidRequestError,
     SandboxFileNotFoundError,
     SandboxPvFileService,
+    fill_user_image_urls,
+    iter_user_images_missing_url,
 )
 from bkapi_client_core.exceptions import HTTPResponseError
 from blueapps.core.exceptions import ClientBlueException
 from django.conf import settings
 from django.http import HttpResponse
 from rest_framework.decorators import action
-from rest_framework.parsers import FileUploadParser
+from rest_framework.parsers import FileUploadParser, MultiPartParser
 from rest_framework.views import Response
 
 from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION, DEFAULT_SESSION_PAGE, DEFAULT_SESSION_PAGE_SIZE
 from aidev_bkplugin.services.agent_config import AgentConfigFetcher
 from aidev_bkplugin.utils import is_local_dev
 from aidev_bkplugin.views.base import PluginResourceManager, PluginViewSet, logger
+
+# file-kit 最新镜像进程内缓存：镜像发布不频繁，避免每次上传都打平台
+_UPLOAD_SNAPSHOT_TTL_SECONDS = 300
+_upload_snapshot_lock = threading.Lock()
+_upload_snapshot_cache: tuple[str, float] | None = None
 
 
 def _parse_positive_int(value, default):
@@ -215,6 +230,45 @@ class ChatSessionViewSet(PluginViewSet):
 
         return SandboxPvFileService(resource_manager=rm, executor_info=executor_info)
 
+    @staticmethod
+    def _resolve_upload_snapshot(rm) -> str:
+        """走平台 image 表查询：取 file-kit 已构建成功的最新镜像。"""
+        global _upload_snapshot_cache
+        now = time.monotonic()
+        with _upload_snapshot_lock:
+            cached = _upload_snapshot_cache
+            if cached and cached[0] and now < cached[1]:
+                return cached[0]
+        try:
+            result = rm.get_client().api.retrieve_latest_skill_version_image()
+        except Exception:
+            logger.exception("[pv_files] resolve_upload_snapshot 调平台失败")
+            raise
+        data = result.get("data") if isinstance(result, dict) else None
+        image = data.get("image") if isinstance(data, dict) else ""
+        image = image.strip() if isinstance(image, str) else ""
+        if image:
+            with _upload_snapshot_lock:
+                _upload_snapshot_cache = (image, time.monotonic() + _UPLOAD_SNAPSHOT_TTL_SECONDS)
+        else:
+            logger.warning("[pv_files] resolve_upload_snapshot empty")
+        return image
+
+    @staticmethod
+    def _validate_pv_upload_files(files) -> None:
+        if not files:
+            raise ClientBlueException(message="files is required")
+        if len(files) > MAX_SESSION_UPLOAD_FILES:
+            raise ClientBlueException(message=f"单次上传文件不能超过 {MAX_SESSION_UPLOAD_FILES} 个")
+        for upload_file in files:
+            extension = PurePosixPath(upload_file.name.replace("\\", "/")).suffix.lower()
+            if extension not in SESSION_UPLOAD_FILE_EXTENSIONS:
+                raise ClientBlueException(message=f"文件类型 {extension or '无扩展名'} 不支持")
+            if upload_file.size > MAX_SESSION_UPLOAD_FILE_SIZE:
+                raise ClientBlueException(
+                    message=f"文件 {upload_file.name} 超过单文件大小限制 {MAX_SESSION_UPLOAD_FILE_SIZE} 字节"
+                )
+
     @action(["GET"], url_path="pv_files", detail=True)
     def pv_files(self, request, pk, **kwargs):
         self._check_session_owner(request, pk, require_access=False)
@@ -275,11 +329,54 @@ class ChatSessionViewSet(PluginViewSet):
             return self._pv_exc_to_response(exc)
         return Response(data=data)
 
+    @action(
+        ["POST"],
+        url_path="pv_files/upload",
+        detail=True,
+        parser_classes=[MultiPartParser],
+    )
+    def pv_files_upload(self, request, pk, **kwargs):
+        """批量上传文件到会话 PV。"""
+        self._check_session_owner(request, pk, require_access=True)
+        uploaded_files = request.FILES.getlist("files")
+        self._validate_pv_upload_files(uploaded_files)
+        files = [
+            {
+                "name": upload_file.name,
+                "content": upload_file.read(),
+                "mime_type": upload_file.content_type or "application/octet-stream",
+            }
+            for upload_file in uploaded_files
+        ]
+        svc = self._make_pv_file_service(request)
+        snapshot = self._resolve_upload_snapshot(PluginResourceManager(username=request.user.username))
+        if snapshot:
+            svc._executor_info["snapshot"] = snapshot
+        try:
+            data = svc.upload_files(session_code=pk, files=files)
+        except SandboxFileError as exc:
+            return self._pv_exc_to_response(exc)
+        return Response(data=data)
+
+
+def _copy_session_content_payload(data):
+    """复制写消息 payload，避免改写原始 request.data。"""
+    if not isinstance(data, dict):
+        return data
+    payload = dict(data)
+    content = payload.get("content")
+    if isinstance(content, list):
+        payload["content"] = [dict(item) if isinstance(item, dict) else item for item in content]
+    return payload
+
 
 class ChatSessionContentViewSet(PluginViewSet):
     def create(self, request):
         username = request.user.username
-        result = self.client.api.create_chat_session_content(json=request.data, headers={"X-BKAIDEV-USER": username})
+        payload = _copy_session_content_payload(request.data)
+        if isinstance(payload, dict) and any(iter_user_images_missing_url(payload)):
+            fill_user_image_urls(ChatSessionViewSet._make_pv_file_service(self, request), payload)
+        result = self.client.api.create_chat_session_content(json=payload, headers={"X-BKAIDEV-USER": username})
         return Response(data=result["data"])
 
     @action(["GET"], url_path="content", detail=False)

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -1,18 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import threading
-import time
-from pathlib import PurePosixPath
-
 from aidev_agent.enums import ChannelType
 from aidev_agent.services.messages_handler import GeneratorStreamingHelper
 from aidev_agent.services.messages_handler.constants import TimeoutConfig
 from aidev_agent.services.messages_handler.factory import message_handler_factory
 from aidev_agent.services.sandbox_pv_files import (
     IMAGE_DOWNLOAD_URL_EXPIRES_IN,
-    MAX_SESSION_UPLOAD_FILE_SIZE,
-    MAX_SESSION_UPLOAD_FILES,
-    SESSION_UPLOAD_FILE_EXTENSIONS,
     SandboxFileError,
     SandboxFileInvalidArgumentError,
     SandboxFileInvalidRequestError,
@@ -20,6 +13,7 @@ from aidev_agent.services.sandbox_pv_files import (
     SandboxPvFileService,
     fill_user_image_urls,
     iter_user_images_missing_url,
+    validate_session_upload_files,
 )
 from bkapi_client_core.exceptions import HTTPResponseError
 from blueapps.core.exceptions import ClientBlueException
@@ -33,11 +27,6 @@ from aidev_bkplugin.constants import AGUI_PROTOCOL_VERSION, DEFAULT_SESSION_PAGE
 from aidev_bkplugin.services.agent_config import AgentConfigFetcher
 from aidev_bkplugin.utils import is_local_dev
 from aidev_bkplugin.views.base import PluginResourceManager, PluginViewSet, logger
-
-# file-kit 最新镜像进程内缓存：镜像发布不频繁，避免每次上传都打平台
-_UPLOAD_SNAPSHOT_TTL_SECONDS = 300
-_upload_snapshot_lock = threading.Lock()
-_upload_snapshot_cache: tuple[str, float] | None = None
 
 
 def _parse_positive_int(value, default):
@@ -233,12 +222,6 @@ class ChatSessionViewSet(PluginViewSet):
     @staticmethod
     def _resolve_upload_snapshot(rm) -> str:
         """走平台 image 表查询：取 file-kit 已构建成功的最新镜像。"""
-        global _upload_snapshot_cache
-        now = time.monotonic()
-        with _upload_snapshot_lock:
-            cached = _upload_snapshot_cache
-            if cached and cached[0] and now < cached[1]:
-                return cached[0]
         try:
             result = rm.get_client().api.retrieve_latest_skill_version_image()
         except Exception:
@@ -247,27 +230,9 @@ class ChatSessionViewSet(PluginViewSet):
         data = result.get("data") if isinstance(result, dict) else None
         image = data.get("image") if isinstance(data, dict) else ""
         image = image.strip() if isinstance(image, str) else ""
-        if image:
-            with _upload_snapshot_lock:
-                _upload_snapshot_cache = (image, time.monotonic() + _UPLOAD_SNAPSHOT_TTL_SECONDS)
-        else:
+        if not image:
             logger.warning("[pv_files] resolve_upload_snapshot empty")
         return image
-
-    @staticmethod
-    def _validate_pv_upload_files(files) -> None:
-        if not files:
-            raise ClientBlueException(message="files is required")
-        if len(files) > MAX_SESSION_UPLOAD_FILES:
-            raise ClientBlueException(message=f"单次上传文件不能超过 {MAX_SESSION_UPLOAD_FILES} 个")
-        for upload_file in files:
-            extension = PurePosixPath(upload_file.name.replace("\\", "/")).suffix.lower()
-            if extension not in SESSION_UPLOAD_FILE_EXTENSIONS:
-                raise ClientBlueException(message=f"文件类型 {extension or '无扩展名'} 不支持")
-            if upload_file.size > MAX_SESSION_UPLOAD_FILE_SIZE:
-                raise ClientBlueException(
-                    message=f"文件 {upload_file.name} 超过单文件大小限制 {MAX_SESSION_UPLOAD_FILE_SIZE} 字节"
-                )
 
     @action(["GET"], url_path="pv_files", detail=True)
     def pv_files(self, request, pk, **kwargs):
@@ -339,7 +304,6 @@ class ChatSessionViewSet(PluginViewSet):
         """批量上传文件到会话 PV。"""
         self._check_session_owner(request, pk, require_access=True)
         uploaded_files = request.FILES.getlist("files")
-        self._validate_pv_upload_files(uploaded_files)
         files = [
             {
                 "name": upload_file.name,
@@ -348,6 +312,11 @@ class ChatSessionViewSet(PluginViewSet):
             }
             for upload_file in uploaded_files
         ]
+        try:
+            validate_session_upload_files(files)
+        except SandboxFileError as exc:
+            return self._pv_exc_to_response(exc)
+
         svc = self._make_pv_file_service(request)
         snapshot = self._resolve_upload_snapshot(PluginResourceManager(username=request.user.username))
         if snapshot:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -16,7 +16,7 @@ from aidev_agent.services.sandbox_pv_files import (
     validate_session_upload_files,
 )
 from bkapi_client_core.exceptions import HTTPResponseError
-from blueapps.core.exceptions import ClientBlueException
+from blueapps.core.exceptions import ClientBlueException, ResourceNotFound, ServerBlueException
 from django.conf import settings
 from django.http import HttpResponse
 from rest_framework.decorators import action
@@ -140,15 +140,13 @@ class ChatSessionViewSet(PluginViewSet):
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _pv_exc_to_response(exc: SandboxFileError) -> Response:
-        """沙箱文件异常 → HTTP 响应。"""
+    def _raise_pv_exc(exc: SandboxFileError) -> None:
+        """沙箱文件异常 → blueapps 异常，与 path is required 等入口同一套信封。"""
         if isinstance(exc, SandboxFileNotFoundError):
-            status_code = 404
-        elif isinstance(exc, (SandboxFileInvalidArgumentError, SandboxFileInvalidRequestError)):
-            status_code = 400
-        else:
-            status_code = 500
-        return Response(data={"message": str(exc)}, status=status_code)
+            raise ResourceNotFound(message=str(exc)) from exc
+        if isinstance(exc, (SandboxFileInvalidArgumentError, SandboxFileInvalidRequestError)):
+            raise ClientBlueException(message=str(exc)) from exc
+        raise ServerBlueException(message=str(exc)) from exc
 
     def _check_session_owner(self, request, session_code: str, require_access: bool = False) -> None:
         """校验 session 归属
@@ -247,7 +245,7 @@ class ChatSessionViewSet(PluginViewSet):
                 until=None,
             )
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
         return Response(data=data)
 
     @action(["GET"], url_path="pv_files/stat", detail=True)
@@ -259,7 +257,7 @@ class ChatSessionViewSet(PluginViewSet):
         try:
             data = self._make_pv_file_service(request).stat_file(session_code=pk, path=path)
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
         return Response(data=data)
 
     @action(["GET"], url_path="pv_files/preview", detail=True)
@@ -274,7 +272,7 @@ class ChatSessionViewSet(PluginViewSet):
                 session_code=pk, path=path, max_bytes=max_bytes
             )
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
         response = HttpResponse(content, content_type="text/plain; charset=utf-8")
         response["X-Truncated"] = "true" if truncated else "false"
         return response
@@ -291,7 +289,7 @@ class ChatSessionViewSet(PluginViewSet):
                 session_code=pk, path=path, expires_in=expires_in
             )
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
         return Response(data=data)
 
     @action(
@@ -315,7 +313,7 @@ class ChatSessionViewSet(PluginViewSet):
         try:
             validate_session_upload_files(files)
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
 
         svc = self._make_pv_file_service(request)
         snapshot = self._resolve_upload_snapshot(PluginResourceManager(username=request.user.username))
@@ -324,7 +322,7 @@ class ChatSessionViewSet(PluginViewSet):
         try:
             data = svc.upload_files(session_code=pk, files=files)
         except SandboxFileError as exc:
-            return self._pv_exc_to_response(exc)
+            self._raise_pv_exc(exc)
         return Response(data=data)
 
 

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
@@ -4,7 +4,7 @@
 覆盖点：
 - 构造沙箱文件 Service 时正确注入 PluginResourceManager + executor_info
 - 5 个 action 参数透传（GET list / stat / preview / download_url / upload）
-- 上传文件类型、数量、大小和会话归属校验
+- 上传会话归属校验与沙箱文件异常映射
 - 沙箱文件异常 → HTTP 状态码映射（404 / 400 / 500）
 - preview 返回 HttpResponse(text/plain) + X-Truncated 头透传
 - path/max_bytes/expires_in 缺失或默认值回退
@@ -110,7 +110,6 @@ def _reset_retrieve_chat_session_mock():
     """
     fake_client.api.retrieve_chat_session.reset_mock(side_effect=True, return_value=True)
     session_mod.PluginResourceManager.return_value.resolve_access_token.return_value = None
-    session_mod._upload_snapshot_cache = None
     latest_image = session_mod.PluginResourceManager.return_value.get_client.return_value.api.retrieve_latest_skill_version_image
     latest_image.reset_mock()
     yield
@@ -192,25 +191,6 @@ class TestMakePvFileService:
             "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"
         )
         rm.get_client.return_value.api.retrieve_latest_skill_version_image.assert_called_once_with()
-
-    def test_upload_snapshot_uses_process_cache(self, view, mock_svc):
-        """TTL 内第二次上传不再打平台 latest image 接口。"""
-        instance, svc_cls = mock_svc
-        rm = session_mod.PluginResourceManager.return_value
-        rm.get_client.return_value.api.retrieve_latest_skill_version_image.return_value = {
-            "data": {"image": "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"}
-        }
-        first = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
-        second = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
-
-        view.pv_files_upload(_request(method="POST", files=[first]), pk="s1")
-        view.pv_files_upload(_request(method="POST", files=[second]), pk="s1")
-
-        assert instance._executor_info["snapshot"] == (
-            "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"
-        )
-        rm.get_client.return_value.api.retrieve_latest_skill_version_image.assert_called_once_with()
-
 
 # ---------------------------------------------------------------------------
 # pv_files (GET / DELETE)
@@ -424,20 +404,18 @@ class TestPvFilesUpload:
             files=[{"name": "report.txt", "content": b"report", "mime_type": "text/plain"}],
         )
 
-    @pytest.mark.parametrize(
-        ("files", "message"),
-        [
-            ([], "files is required"),
-            ([SimpleUploadedFile("payload.exe", b"binary")], "文件类型 .exe 不支持"),
-        ],
-    )
-    def test_upload_rejects_invalid_files(self, view, mock_svc, files, message):
-        from blueapps.core.exceptions import ClientBlueException
-
+    def test_upload_rejects_invalid_files_before_resolving_snapshot(self, view, mock_svc):
         instance, _ = mock_svc
-        with pytest.raises(ClientBlueException, match=message):
-            view.pv_files_upload(_request(method="POST", files=files), pk="s1")
+
+        response = view.pv_files_upload(
+            _request(method="POST", files=[SimpleUploadedFile("payload.exe", b"binary")]),
+            pk="s1",
+        )
+
+        assert response.status_code == 400
+        assert response.data == {"message": "文件类型 .exe 不支持"}
         instance.upload_files.assert_not_called()
+        session_mod.PluginResourceManager.return_value.get_client.return_value.api.retrieve_latest_skill_version_image.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
@@ -3,7 +3,8 @@
 
 覆盖点：
 - 构造沙箱文件 Service 时正确注入 PluginResourceManager + executor_info
-- 5 个 action 参数透传（GET list / DELETE / stat / preview / download_url）
+- 5 个 action 参数透传（GET list / stat / preview / download_url / upload）
+- 上传文件类型、数量、大小和会话归属校验
 - 沙箱文件异常 → HTTP 状态码映射（404 / 400 / 500）
 - preview 返回 HttpResponse(text/plain) + X-Truncated 头透传
 - path/max_bytes/expires_in 缺失或默认值回退
@@ -16,6 +17,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.conf import settings
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import HttpResponse
 
 if not settings.configured:
@@ -62,7 +64,15 @@ from aidev_agent.services.sandbox_pv_files import (  # noqa: E402
 from aidev_bkplugin.views import session as session_mod  # noqa: E402
 
 
-def _request(query_params=None, username="alice", method="GET", cookies=None, meta=None, path="/pv-files"):
+def _request(
+    query_params=None,
+    username="alice",
+    method="GET",
+    cookies=None,
+    meta=None,
+    path="/pv-files",
+    files=None,
+):
     return SimpleNamespace(
         query_params=query_params or {},
         user=SimpleNamespace(username=username),
@@ -70,6 +80,7 @@ def _request(query_params=None, username="alice", method="GET", cookies=None, me
         COOKIES=cookies or {},
         META=meta or {},
         path=path,
+        FILES=SimpleNamespace(getlist=lambda field_name: files or [] if field_name == "files" else []),
     )
 
 
@@ -86,6 +97,7 @@ def mock_svc():
     """打桩沙箱文件 Service 实例；测试点：view 层是否正确构造 + 参数透传。"""
     with patch.object(session_mod, "SandboxPvFileService") as svc_cls:
         instance = MagicMock()
+        instance._executor_info = {}
         svc_cls.return_value = instance
         yield instance, svc_cls
 
@@ -97,6 +109,10 @@ def _reset_retrieve_chat_session_mock():
     side_effect 泄露到后续 TestPvFiles* 用例（那些用例默认应"归属校验通过"）。
     """
     fake_client.api.retrieve_chat_session.reset_mock(side_effect=True, return_value=True)
+    session_mod.PluginResourceManager.return_value.resolve_access_token.return_value = None
+    session_mod._upload_snapshot_cache = None
+    latest_image = session_mod.PluginResourceManager.return_value.get_client.return_value.api.retrieve_latest_skill_version_image
+    latest_image.reset_mock()
     yield
 
 
@@ -159,6 +175,41 @@ class TestMakePvFileService:
         call_kwargs = svc_cls.call_args.kwargs
         assert call_kwargs["executor_info"]["bk_ticket_key"] == "bk_token"
         assert call_kwargs["executor_info"]["bk_ticket_value"] == "open-token-123"
+
+    def test_upload_injects_file_kit_snapshot(self, view, mock_svc):
+        """上传时走平台 latest image 接口，把 file-kit 镜像写入 snapshot。"""
+        instance, svc_cls = mock_svc
+        rm = session_mod.PluginResourceManager.return_value
+        rm.get_client.return_value.api.retrieve_latest_skill_version_image.return_value = {
+            "data": {"image": "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"}
+        }
+        uploaded_file = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
+
+        view.pv_files_upload(_request(method="POST", files=[uploaded_file]), pk="s1")
+
+        assert "snapshot" not in svc_cls.call_args.kwargs["executor_info"]
+        assert instance._executor_info["snapshot"] == (
+            "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"
+        )
+        rm.get_client.return_value.api.retrieve_latest_skill_version_image.assert_called_once_with()
+
+    def test_upload_snapshot_uses_process_cache(self, view, mock_svc):
+        """TTL 内第二次上传不再打平台 latest image 接口。"""
+        instance, svc_cls = mock_svc
+        rm = session_mod.PluginResourceManager.return_value
+        rm.get_client.return_value.api.retrieve_latest_skill_version_image.return_value = {
+            "data": {"image": "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"}
+        }
+        first = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
+        second = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
+
+        view.pv_files_upload(_request(method="POST", files=[first]), pk="s1")
+        view.pv_files_upload(_request(method="POST", files=[second]), pk="s1")
+
+        assert instance._executor_info["snapshot"] == (
+            "mirrors.tencent.com/bkpaas-sandbox/bkaidev/file-kit:0.0.9"
+        )
+        rm.get_client.return_value.api.retrieve_latest_skill_version_image.assert_called_once_with()
 
 
 # ---------------------------------------------------------------------------
@@ -351,6 +402,42 @@ class TestPvFilesDownloadUrl:
 
         with pytest.raises(ClientBlueException):
             view.pv_files_download_url(_request({}), pk="s1")
+
+
+class TestPvFilesUpload:
+    def test_upload_forwards_files_to_local_service(self, view, mock_svc):
+        instance, _ = mock_svc
+        upload_result = {
+            "count": 1,
+            "succeeded": 1,
+            "failed": 0,
+            "results": [{"path": "files/report.txt", "status": "success"}],
+        }
+        instance.upload_files.return_value = upload_result
+        uploaded_file = SimpleUploadedFile("report.txt", b"report", content_type="text/plain")
+
+        response = view.pv_files_upload(_request(method="POST", files=[uploaded_file]), pk="s1")
+
+        assert response.data == upload_result
+        instance.upload_files.assert_called_once_with(
+            session_code="s1",
+            files=[{"name": "report.txt", "content": b"report", "mime_type": "text/plain"}],
+        )
+
+    @pytest.mark.parametrize(
+        ("files", "message"),
+        [
+            ([], "files is required"),
+            ([SimpleUploadedFile("payload.exe", b"binary")], "文件类型 .exe 不支持"),
+        ],
+    )
+    def test_upload_rejects_invalid_files(self, view, mock_svc, files, message):
+        from blueapps.core.exceptions import ClientBlueException
+
+        instance, _ = mock_svc
+        with pytest.raises(ClientBlueException, match=message):
+            view.pv_files_upload(_request(method="POST", files=files), pk="s1")
+        instance.upload_files.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
@@ -5,7 +5,7 @@
 - 构造沙箱文件 Service 时正确注入 PluginResourceManager + executor_info
 - 5 个 action 参数透传（GET list / stat / preview / download_url / upload）
 - 上传会话归属校验与沙箱文件异常映射
-- 沙箱文件异常 → HTTP 状态码映射（404 / 400 / 500）
+- 沙箱文件异常 → blueapps 异常映射（404 / 400 / 500）
 - preview 返回 HttpResponse(text/plain) + X-Truncated 头透传
 - path/max_bytes/expires_in 缺失或默认值回退
 """
@@ -206,10 +206,13 @@ class TestPvFilesGet:
         instance.list_files.assert_called_once_with(session_code="s1", path="sub/", since=None, until=None)
 
     def test_list_translates_not_found(self, view, mock_svc):
+        from blueapps.core.exceptions import ResourceNotFound
+
         instance, _ = mock_svc
         instance.list_files.side_effect = SandboxFileNotFoundError("nf")
-        response = view.pv_files(_request(), pk="s1")
-        assert response.status_code == 404
+        with pytest.raises(ResourceNotFound) as excinfo:
+            view.pv_files(_request(), pk="s1")
+        assert excinfo.value.STATUS_CODE == 404
 
 
 # ---------------------------------------------------------------------------
@@ -299,10 +302,13 @@ class TestPvFilesStat:
             view.pv_files_stat(_request({}), pk="s1")
 
     def test_stat_translates_invalid_arg(self, view, mock_svc):
+        from blueapps.core.exceptions import ClientBlueException
+
         instance, _ = mock_svc
         instance.stat_file.side_effect = SandboxFileInvalidArgumentError("ia")
-        response = view.pv_files_stat(_request({"path": "x.txt"}), pk="s1")
-        assert response.status_code == 400
+        with pytest.raises(ClientBlueException) as excinfo:
+            view.pv_files_stat(_request({"path": "x.txt"}), pk="s1")
+        assert excinfo.value.STATUS_CODE == 400
 
 
 # ---------------------------------------------------------------------------
@@ -340,10 +346,13 @@ class TestPvFilesPreview:
         assert instance.preview_file.call_args.kwargs["max_bytes"] == 65536
 
     def test_preview_translates_415(self, view, mock_svc):
+        from blueapps.core.exceptions import ClientBlueException
+
         instance, _ = mock_svc
         instance.preview_file.side_effect = SandboxFileInvalidRequestError("415")
-        response = view.pv_files_preview(_request({"path": "x.bin"}), pk="s1")
-        assert response.status_code == 400
+        with pytest.raises(ClientBlueException) as excinfo:
+            view.pv_files_preview(_request({"path": "x.bin"}), pk="s1")
+        assert excinfo.value.STATUS_CODE == 400
 
     def test_preview_requires_path(self, view, mock_svc):
         from blueapps.core.exceptions import ClientBlueException
@@ -372,10 +381,13 @@ class TestPvFilesDownloadUrl:
         assert instance.get_download_url.call_args.kwargs["expires_in"] == 600
 
     def test_download_url_translates_server_error(self, view, mock_svc):
+        from blueapps.core.exceptions import ServerBlueException
+
         instance, _ = mock_svc
         instance.get_download_url.side_effect = SandboxFileServerError("boom")
-        response = view.pv_files_download_url(_request({"path": "x.txt"}), pk="s1")
-        assert response.status_code == 500
+        with pytest.raises(ServerBlueException) as excinfo:
+            view.pv_files_download_url(_request({"path": "x.txt"}), pk="s1")
+        assert excinfo.value.STATUS_CODE == 500
 
     def test_download_url_requires_path(self, view, mock_svc):
         from blueapps.core.exceptions import ClientBlueException
@@ -405,37 +417,52 @@ class TestPvFilesUpload:
         )
 
     def test_upload_rejects_invalid_files_before_resolving_snapshot(self, view, mock_svc):
+        from blueapps.core.exceptions import ClientBlueException
+
         instance, _ = mock_svc
 
-        response = view.pv_files_upload(
-            _request(method="POST", files=[SimpleUploadedFile("payload.exe", b"binary")]),
-            pk="s1",
-        )
+        with pytest.raises(ClientBlueException) as excinfo:
+            view.pv_files_upload(
+                _request(method="POST", files=[SimpleUploadedFile("payload.exe", b"binary")]),
+                pk="s1",
+            )
 
-        assert response.status_code == 400
-        assert response.data == {"message": "文件类型 .exe 不支持"}
+        assert excinfo.value.message == "文件类型 .exe 不支持"
+        assert excinfo.value.STATUS_CODE == 400
         instance.upload_files.assert_not_called()
         session_mod.PluginResourceManager.return_value.get_client.return_value.api.retrieve_latest_skill_version_image.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# 异常映射：SandboxFileError 基类兜底为 500
+# 异常映射：SandboxFileError 基类兜底为 ServerBlueException
 # ---------------------------------------------------------------------------
 
 
 class TestExceptionMapping:
     def test_base_error_fallback_to_500(self):
-        response = session_mod.ChatSessionViewSet._pv_exc_to_response(SandboxFileError("unknown"))
-        assert response.status_code == 500
+        from blueapps.core.exceptions import ServerBlueException
+
+        with pytest.raises(ServerBlueException) as excinfo:
+            session_mod.ChatSessionViewSet._raise_pv_exc(SandboxFileError("unknown"))
+        assert excinfo.value.STATUS_CODE == 500
 
     def test_not_found_error_maps_to_404(self):
-        response = session_mod.ChatSessionViewSet._pv_exc_to_response(SandboxFileNotFoundError("nf"))
-        assert response.status_code == 404
+        from blueapps.core.exceptions import ResourceNotFound
+
+        with pytest.raises(ResourceNotFound) as excinfo:
+            session_mod.ChatSessionViewSet._raise_pv_exc(SandboxFileNotFoundError("nf"))
+        assert excinfo.value.STATUS_CODE == 404
 
     def test_invalid_argument_maps_to_400(self):
-        response = session_mod.ChatSessionViewSet._pv_exc_to_response(SandboxFileInvalidArgumentError("ia"))
-        assert response.status_code == 400
+        from blueapps.core.exceptions import ClientBlueException
+
+        with pytest.raises(ClientBlueException) as excinfo:
+            session_mod.ChatSessionViewSet._raise_pv_exc(SandboxFileInvalidArgumentError("ia"))
+        assert excinfo.value.STATUS_CODE == 400
 
     def test_invalid_request_maps_to_400(self):
-        response = session_mod.ChatSessionViewSet._pv_exc_to_response(SandboxFileInvalidRequestError("ir"))
-        assert response.status_code == 400
+        from blueapps.core.exceptions import ClientBlueException
+
+        with pytest.raises(ClientBlueException) as excinfo:
+            session_mod.ChatSessionViewSet._raise_pv_exc(SandboxFileInvalidRequestError("ir"))
+        assert excinfo.value.STATUS_CODE == 400

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_view.py
@@ -200,6 +200,142 @@ def test_stop_clears_stale_notification_before_sending_cancel(monkeypatch, run_i
     handler.mark_stopped.assert_not_called()
 
 
+def test_create_attaches_image_url_to_user_binary(monkeypatch):
+    api = MagicMock()
+    api.create_chat_session_content.return_value = {
+        "data": {
+            "id": 34739,
+            "role": "user",
+            "session_code": "s1",
+            "content": [
+                {
+                    "filename": "角色.png",
+                    "id": "files/角色.png",
+                    "mime_type": "image/png",
+                    "type": "binary",
+                    "url": "https://cdn/role.png",
+                },
+                {"type": "text", "text": "这个图片内容是啥？"},
+            ],
+        }
+    }
+    file_service = MagicMock()
+    file_service.get_download_url.return_value = {"download_url": "https://cdn/role.png"}
+    monkeypatch.setattr(
+        session_mod.ChatSessionViewSet,
+        "_make_pv_file_service",
+        lambda self, request, **kwargs: file_service,
+    )
+
+    payload = {
+        "role": "user",
+        "session_code": "s1",
+        "content": [
+            {"filename": "角色.png", "id": "files/角色.png", "mime_type": "image/png", "type": "binary"},
+            {"type": "text", "text": "这个图片内容是啥？"},
+        ],
+    }
+    response = _view(session_mod.ChatSessionContentViewSet, api).create(_request(data=payload))
+
+    sent = api.create_chat_session_content.call_args.kwargs["json"]
+    assert sent["content"][0]["url"] == "https://cdn/role.png"
+    assert "url" not in sent["content"][1]
+    file_service.get_download_url.assert_called_once_with(
+        session_code="s1",
+        path="files/角色.png",
+        expires_in=session_mod.IMAGE_DOWNLOAD_URL_EXPIRES_IN,
+    )
+    assert response.data["content"][0]["url"] == "https://cdn/role.png"
+
+
+def test_create_skips_signing_for_text_only_message(monkeypatch):
+    api = MagicMock()
+    api.create_chat_session_content.return_value = {"data": {"id": 1, "content": "你好"}}
+    make_service = MagicMock()
+    monkeypatch.setattr(session_mod.ChatSessionViewSet, "_make_pv_file_service", make_service)
+
+    _view(session_mod.ChatSessionContentViewSet, api).create(
+        _request(data={"role": "user", "session_code": "s1", "content": "你好"})
+    )
+
+    make_service.assert_not_called()
+    api.create_chat_session_content.assert_called_once()
+
+
+def test_create_still_writes_when_image_url_sign_fails(monkeypatch):
+    api = MagicMock()
+    api.create_chat_session_content.return_value = {"data": {"id": 1}}
+    file_service = MagicMock()
+    file_service.get_download_url.side_effect = session_mod.SandboxFileError("boom")
+    monkeypatch.setattr(
+        session_mod.ChatSessionViewSet,
+        "_make_pv_file_service",
+        lambda self, request, **kwargs: file_service,
+    )
+
+    payload = {
+        "role": "user",
+        "session_code": "s1",
+        "content": [{"type": "binary", "id": "files/角色.png", "mime_type": "image/png"}],
+    }
+    _view(session_mod.ChatSessionContentViewSet, api).create(_request(data=payload))
+
+    sent = api.create_chat_session_content.call_args.kwargs["json"]
+    assert "url" not in sent["content"][0]
+    api.create_chat_session_content.assert_called_once()
+
+
+def test_create_keeps_existing_image_url(monkeypatch):
+    api = MagicMock()
+    api.create_chat_session_content.return_value = {"data": {"id": 1}}
+    file_service = MagicMock()
+    monkeypatch.setattr(
+        session_mod.ChatSessionViewSet,
+        "_make_pv_file_service",
+        lambda self, request, **kwargs: file_service,
+    )
+
+    payload = {
+        "role": "user",
+        "session_code": "s1",
+        "content": [
+            {
+                "type": "binary",
+                "id": "files/角色.png",
+                "mime_type": "image/png",
+                "url": "https://already/there",
+            }
+        ],
+    }
+    _view(session_mod.ChatSessionContentViewSet, api).create(_request(data=payload))
+
+    sent = api.create_chat_session_content.call_args.kwargs["json"]
+    assert sent["content"][0]["url"] == "https://already/there"
+    file_service.get_download_url.assert_not_called()
+
+
+def test_create_ignores_preview_url_when_download_url_missing(monkeypatch):
+    api = MagicMock()
+    api.create_chat_session_content.return_value = {"data": {"id": 1}}
+    file_service = MagicMock()
+    file_service.get_download_url.return_value = {"preview_url": "https://preview/html"}
+    monkeypatch.setattr(
+        session_mod.ChatSessionViewSet,
+        "_make_pv_file_service",
+        lambda self, request, **kwargs: file_service,
+    )
+
+    payload = {
+        "role": "user",
+        "session_code": "s1",
+        "content": [{"type": "binary", "id": "files/角色.png", "mime_type": "image/png"}],
+    }
+    _view(session_mod.ChatSessionContentViewSet, api).create(_request(data=payload))
+
+    sent = api.create_chat_session_content.call_args.kwargs["json"]
+    assert "url" not in sent["content"][0]
+
+
 def test_stop_omits_producer_state_when_detection_fails(monkeypatch):
     """broker 查询异常时保持旧协议，避免平台误判为无 producer。"""
     handler = MagicMock()


### PR DESCRIPTION
## 背景

TAPD [#136417903](https://tapd.woa.com/tapd_fe/70093903/story/detail/136417903)：会话上传文件需要复用默认 `file-kit` Skill 镜像，并让 Agent 与直接生成的文件使用相同路径。

## 改动

- SDK 直接解析默认 `file-kit` Skill 的已构建镜像，创建临时 sandbox 并通过 PaaS 文件接口写入会话 PV。
- 上传路径统一为 `files/<filename>`，与 Agent 运行时的 `$STORAGE_PATH/session/files/<filename>` 对齐。
- 保留 30 分钟 sandbox 复用；sandbox 失效或上传 HTTP 错误时自动重建并重试。
- 缺少 `file-kit` 镜像时在创建 sandbox 前直接报错。

## 测试

- [x] `src/agent/tests/services/test_sandbox_pv_files.py`：49 passed
- [x] `src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py`：37 passed
- [x] `git diff --check`

## 兼容性

- 不改变前端上传响应中的 `path` 字段语义，仅统一为 `files/<filename>`。
- `file-kit` Skill 未发布镜像时上传请求明确失败。

## 关联

tapd: #136417903

发起人：
- @Vellun7
