### PR TITLE
feat: 知识库工具检索后派发 KNOWLEDGE_RAG_RESULT 事件 --story=162806728

### DIFF
--- a/src/agent/aidev_agent/core/tools/knowledge.py
+++ b/src/agent/aidev_agent/core/tools/knowledge.py
@@ -19,11 +19,16 @@ to the current version of the project delivered to anyone in the future.
 from __future__ import annotations
 
 import logging
+import time
+import uuid
 from typing import TYPE_CHECKING, Annotated, Optional
 
+from langchain_core.callbacks import dispatch_custom_event
+from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import StructuredTool
 from pydantic import BaseModel
 
+from aidev_agent.core.ag_ui.types import CustomMessageType
 from aidev_agent.packages.langchain_core.retrievers.bk_retriever import BkRetriever
 from aidev_agent.packages.langchain_core.retrievers.kb_rag import KnowledgeRag
 from aidev_agent.pydantic_models import KnowledgeSettings
@@ -73,7 +78,7 @@ def make_knowledge_retrieval_tool(
     kb_names = []
     if knowledge_query_options.knowledge_bases:
         kb_names = [kb.get("name", "") for kb in knowledge_query_options.knowledge_bases if kb.get("name")]
-    
+
     # 构建工具描述
     base_description = "检索私域知识库以获取相关信息。当需要查询企业内部知识、文档或历史问答时使用此工具。"
     if kb_names:
@@ -82,7 +87,7 @@ def make_knowledge_retrieval_tool(
     else:
         description = base_description
 
-    def knowledge_retrieval(query: str) -> list:
+    def knowledge_retrieval(query: str, config: RunnableConfig) -> list:
         """执行知识库检索。
 
         Args:
@@ -95,8 +100,46 @@ def make_knowledge_retrieval_tool(
         kb_retriever = BkRetriever()
         retriever = KnowledgeRag(llm, kb_retriever)
 
-        # 执行知识库检索
-        ret = retriever.retrieve(query, knowledge_query_options, input=query, chat_history=chat_history)
+        # 流处理：仅在存在回调时派发自定义事件
+        dispatch_config = config if config and config.get("callbacks") else None
+        t1 = time.time()
+        if dispatch_config:
+            dispatch_custom_event(
+                CustomMessageType.KNOWLEDGE_RAG_START.value,
+                data={},
+                config=dispatch_config,
+            )
+
+        # 检索异常会被 ToolNode 转为错误 ToolMessage 并继续执行，
+        # 用 finally 保证 END 始终派发，避免前端知识检索状态无法结束
+        try:
+            # 执行知识库检索
+            ret = retriever.retrieve(query, knowledge_query_options, input=query, chat_history=chat_history)
+
+            # 处理引用文档，用于前端统一消费
+            reference_doc = ret.get("reference_doc") or []
+            if reference_doc:
+                reference_doc = [each["metadata"] for each in reference_doc]
+                reference_doc = [
+                    {"originFile": each["preview_path"], "url": each["path"], "name": each["display_name"]}
+                    for each in reference_doc
+                ]
+
+            if dispatch_config:
+                duration = round(time.time() - t1, 4) * 1000
+                dispatch_custom_event(
+                    CustomMessageType.KNOWLEDGE_RAG_RESULT.value,
+                    data={"message_id": uuid.uuid4().hex, "data": reference_doc, "duration": duration},
+                    config=dispatch_config,
+                )
+        finally:
+            if dispatch_config:
+                dispatch_custom_event(
+                    CustomMessageType.KNOWLEDGE_RAG_END.value,
+                    data={},
+                    config=dispatch_config,
+                )
+
         return ret.get("knowledge_content", [])
 
     return StructuredTool.from_function(

--- a/src/agent/tests/core/tools/test_knowledge.py
+++ b/src/agent/tests/core/tools/test_knowledge.py
@@ -1,7 +1,9 @@
 import json
+from unittest.mock import MagicMock, patch
 
 import pytest
 from aidev_agent.config import settings
+from aidev_agent.core.ag_ui.types import CustomMessageType
 from aidev_agent.core.tools.knowledge import make_knowledge_retrieval_tool
 from aidev_agent.packages.langchain_core.models import ChatModel
 from aidev_agent.pydantic_models import KnowledgeSettings
@@ -22,3 +24,72 @@ def test_knowledge_tool():
     tool = make_knowledge_retrieval_tool(llm, knowledge_settings)
     result = tool.invoke(input={"query": "私有化部署deepseek"})
     print(result)
+
+
+class TestMakeKnowledgeRetrievalTool:
+    """知识库检索工具事件派发测试。"""
+
+    def _make_tool(self):
+        llm = object()
+        knowledge_settings = KnowledgeSettings(knowledge_bases=[{"name": "kb"}])
+        return make_knowledge_retrieval_tool(llm, knowledge_settings)
+
+    def _patch_retriever(self, reference_doc):
+        patcher_rag = patch("aidev_agent.core.tools.knowledge.KnowledgeRag")
+        patcher_bk = patch("aidev_agent.core.tools.knowledge.BkRetriever")
+        mock_rag = patcher_rag.start()
+        patcher_bk.start()
+        mock_rag.return_value.retrieve.return_value = {
+            "knowledge_content": ["c1"],
+            "reference_doc": reference_doc,
+        }
+        return patcher_rag, patcher_bk, mock_rag
+
+    def test_knowledge_retrieval_dispatches_rag_events(self):
+        reference_doc = [{"metadata": {"preview_path": "/p", "path": "/u", "display_name": "doc"}}]
+        patcher_rag, patcher_bk, _ = self._patch_retriever(reference_doc)
+        with patch("aidev_agent.core.tools.knowledge.dispatch_custom_event") as mock_dispatch:
+            tool = self._make_tool()
+            result = tool.invoke(input={"query": "..."}, config={"callbacks": [MagicMock()]})
+        patcher_rag.stop()
+        patcher_bk.stop()
+
+        assert result == ["c1"]
+        names = [call.args[0] for call in mock_dispatch.call_args_list]
+        assert names == [
+            CustomMessageType.KNOWLEDGE_RAG_START.value,
+            CustomMessageType.KNOWLEDGE_RAG_RESULT.value,
+            CustomMessageType.KNOWLEDGE_RAG_END.value,
+        ]
+        result_data = mock_dispatch.call_args_list[1].kwargs["data"]
+        assert {"message_id", "data", "duration"} <= set(result_data.keys())
+        assert result_data["data"] == [{"originFile": "/p", "url": "/u", "name": "doc"}]
+
+    def test_knowledge_retrieval_no_config_skips_dispatch(self):
+        patcher_rag, patcher_bk, _ = self._patch_retriever(
+            [{"metadata": {"preview_path": "/p", "path": "/u", "display_name": "doc"}}]
+        )
+        with patch("aidev_agent.core.tools.knowledge.dispatch_custom_event") as mock_dispatch:
+            tool = self._make_tool()
+            result = tool.invoke({"query": "..."})
+        patcher_rag.stop()
+        patcher_bk.stop()
+
+        assert result == ["c1"]
+        mock_dispatch.assert_not_called()
+
+    def test_knowledge_retrieval_dispatches_end_on_error(self):
+        patcher_rag, patcher_bk, mock_rag = self._patch_retriever([])
+        mock_rag.return_value.retrieve.side_effect = RuntimeError("kb timeout")
+        with patch("aidev_agent.core.tools.knowledge.dispatch_custom_event") as mock_dispatch:
+            tool = self._make_tool()
+            with pytest.raises(RuntimeError, match="kb timeout"):
+                tool.invoke(input={"query": "..."}, config={"callbacks": [MagicMock()]})
+        patcher_rag.stop()
+        patcher_bk.stop()
+
+        names = [call.args[0] for call in mock_dispatch.call_args_list]
+        assert names == [
+            CustomMessageType.KNOWLEDGE_RAG_START.value,
+            CustomMessageType.KNOWLEDGE_RAG_END.value,
+        ]


### PR DESCRIPTION
- 检索后按节点结构内联转换 reference_doc，派发与节点一致的 RESULT 事件
- 以 config 含 callbacks 作为真实调用上下文守卫，避免直接调用抛 RuntimeError
