### PR TITLE
feat: 完善智能体运行指标与监控仪表盘 --story=1070093903136959970

### DIFF
--- a/dev/otel/Makefile
+++ b/dev/otel/Makefile
@@ -5,7 +5,11 @@ ROOT_DIR := $(abspath $(OTEL_DIR)/../..)
 PLUGIN_DIR := $(ROOT_DIR)/src/plugins/aidev_bkplugin
 PYTHON ?= $(PLUGIN_DIR)/.venv/bin/python
 PODMAN ?= podman
+JQ ?= jq
 COMPOSE := $(PODMAN) compose -f $(OTEL_DIR)/docker-compose.yml
+PROMETHEUS_DASHBOARD := $(OTEL_DIR)/grafana/dashboards/aidev-agent-metrics.json
+BKMONITOR_DASHBOARD := $(OTEL_DIR)/grafana/components/aidev-agent-metrics-bkmonitor.json
+BKMONITOR_DASHBOARD_FILTER := $(OTEL_DIR)/grafana/generate-bkmonitor-dashboard.jq
 
 N ?= 3
 MODELS ?= mock-log-analysis-a,mock-log-analysis-b,mock-log-analysis-c
@@ -19,7 +23,7 @@ MOCK_COMMAND = env PYTHONPATH="$(ROOT_DIR)/src/agent:$(PLUGIN_DIR):$(ROOT_DIR)" 
 	-n "$(N)" --models "$(MODELS)" --handler "$(HANDLER)" \
 	--iterations "$(ITERATIONS)" --interval "$(INTERVAL)" --seed "$(SEED)"
 
-.PHONY: help start stop up down status logs mock test metrics
+.PHONY: help start stop up down status logs mock test metrics dashboard-bkmonitor
 
 help:
 	@echo "Local OpenTelemetry observability"
@@ -30,6 +34,7 @@ help:
 	@echo "  make mock        Run mock in the foreground"
 	@echo "  make test        Run exporter and local observability tests"
 	@echo "  make metrics     Print the Collector Prometheus endpoint"
+	@echo "  make dashboard-bkmonitor  Regenerate the standalone BK Monitor dashboard"
 	@echo ""
 	@echo "Parameters: N=3 MODELS=a,b,c HANDLER=all ITERATIONS=400 INTERVAL=1.5 SEED=20260809"
 
@@ -59,3 +64,8 @@ test:
 
 metrics:
 	curl -fsS http://localhost:8889/metrics
+
+dashboard-bkmonitor:
+	mkdir -p "$(dir $(BKMONITOR_DASHBOARD))"
+	$(JQ) -f "$(BKMONITOR_DASHBOARD_FILTER)" "$(PROMETHEUS_DASHBOARD)" > "$(BKMONITOR_DASHBOARD).tmp"
+	mv "$(BKMONITOR_DASHBOARD).tmp" "$(BKMONITOR_DASHBOARD)"

--- a/dev/otel/README.md
+++ b/dev/otel/README.md
@@ -27,6 +27,26 @@ Collector 接收端口为 `4317`（gRPC）和 `4318`（HTTP），Prometheus 为
 本地镜像固定为 Grafana `10.4.19`，仪表盘使用该版本生成的 schema 39，保持与线上
 Grafana 10.x 的兼容性；后续编辑和导出也应继续使用 10.x 环境。
 
+## 蓝鲸监控仪表盘
+
+线上蓝鲸监控导入版位于
+`grafana/components/aidev-agent-metrics-bkmonitor.json`。它参考
+`monitor-as-code/grafana/components/bkaidev-resource.json`，使用
+`bkmonitor-timeseries-datasource`、`source/promqlAlias` 查询结构和蓝鲸监控变量协议；
+保留与本地版相同的 34 个面板、过滤维度和 PromQL 计算语义。
+
+该文件不在本地 Grafana provisioning 的 `grafana/dashboards` 目录中，不会覆盖或加载为
+本地 Prometheus 仪表盘。修改本地版面板后，可重新生成独立的蓝鲸监控配置：
+
+```bash
+cd dev/otel
+make dashboard-bkmonitor
+```
+
+该配置固定使用 UID `cfjy28njb6ghsd` 的“蓝鲸监控 - 指标数据”数据源。蓝鲸监控版默认
+查询最近 1 小时，按 1 分钟、5 分钟或 1 小时窗口计算速率和 P95；本地 Prometheus 版
+仍保持最近 15 分钟和 5 秒刷新。
+
 ## 发送 mock 指标
 
 `make start` 默认同时模拟 4 个 Handler。每个 Handler 有一个持续运行的基础槽位，

--- a/dev/otel/grafana/components/aidev-agent-metrics-bkmonitor.json
+++ b/dev/otel/grafana/components/aidev-agent-metrics-bkmonitor.json
@@ -1,0 +1,2838 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Agent 运行态、耗时、LLM、工具以及应用侧 SSE/Broker 写入压力；数据源为蓝鲸监控指标数据。真实 Broker 积压和磁盘/网络 IO 需要接入 RabbitMQ/Redis 原生 exporter。",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "运行态与关键指标",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：至少有一个 Run 正在执行的智能体数量，同一 Agent Code 的多个并发 Run 只计为 1。计算：先按 agent.info.code 汇总 aidev_agent_active，保留大于 0 的分组后计数；无活跃项时返回 0。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 30,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "活跃 Agent Code",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "count(sum by (agent_info_code) (aidev_agent_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}) > 0) or vector(0)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "活跃智能体数量",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：当前仍在执行的 Agent Run 总数，不是累计会话次数；应与各 Agent 阶段并发之和一致。计算：对筛选范围内 aidev_agent_active Gauge 求和；当前无序列时显式回退为 0，避免 Stat 沿用上一个非空值。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "活跃 Run",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum(aidev_agent_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}) or vector(0)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "活跃 Agent Run",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：当前互斥地处于 LLM 阶段的 Agent Run 数量，与 processing、tool、mixed、finalizing 阶段共同构成活跃 Agent Run；mixed 不重复计入本卡片。计算：对 aidev_agent_phase_active Gauge 中 aidev.agent.phase=llm 的序列求和。模型维度属于 Operation，不适用于 Agent 阶段过滤。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 8,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "LLM 阶段 Run",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum(aidev_agent_phase_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_agent_phase=\"llm\"}) or vector(0)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "LLM 阶段 Agent Run",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：当前互斥地处于 Tool 阶段的 Agent Run 数量，与 processing、llm、mixed、finalizing 阶段共同构成活跃 Agent Run；一个 Run 内并行多个工具仍只计 1，mixed 不重复计入本卡片。计算：对 aidev_agent_phase_active Gauge 中 aidev.agent.phase=tool 的序列求和。工具名称属于 Operation，不适用于 Agent 阶段过滤。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 11,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "Tool 阶段 Run",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum(aidev_agent_phase_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_agent_phase=\"tool\"}) or vector(0)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Tool 阶段 Agent Run",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：已结束 Agent Run 的墙钟运行耗时 P95。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 14,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 运行耗时 P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：Agent Run 开始到收到首个流式 LLM Token 的耗时 P95；非流式调用不产生样本。计算：对 gen_ai_invoke_agent_time_to_first_token_seconds Histogram bucket 的窗口速率按 le 汇总，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 17,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 首 Token P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内，单个已完成 Agent Run 的 LLM 调用尝试次数 P95；一次 on_chat_model_start 或 on_llm_start 计为一次迭代，失败与重试调用也计入，未完成 Run 不计入。计算：对 gen_ai_invoke_agent_iteration_count Histogram bucket 在所选时段的增量按 le 汇总，使用 histogram_quantile(0.95, …) 估算并向上取整。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "迭代次数 P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "ceil(histogram_quantile(0.95, sum by (le) (increase(gen_ai_invoke_agent_iteration_count_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 迭代次数 P95",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：当前 Agent Run 在 processing、llm、tool、mixed、finalizing 阶段的并发数及趋势；每个 Run 同时只归属一个阶段，并行 LLM 与 Tool 归入 mixed。计算：按 aidev_agent_phase 对 aidev_agent_phase_active Gauge 求和。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_agent_phase",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (aidev_agent_phase) (aidev_agent_phase_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 阶段并发（当前与趋势）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：各 Agent 阶段已结束片段的互斥墙钟耗时 P95；正在运行的阶段尚未形成 Histogram 样本。计算：按 le 和 aidev_agent_phase 汇总阶段 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_agent_phase P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, aidev_agent_phase) (rate(aidev_agent_phase_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 阶段耗时 P95（已结束阶段）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：Agent Run 每秒进入数与完成数，用于判断流入、流出是否平衡。计算：分别对 gen_ai_invoke_agent_started_total 和 gen_ai_invoke_agent_duration_seconds_count 计算 rate 后求和。",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 14
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "进入速率",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum(rate(gen_ai_invoke_agent_started_total{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "完成速率",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "sum(rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 进入与完成速率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按 Agent Code 展示当前正在执行的 Agent Run 数；在同一会话同一时刻最多运行一个 Run 时，该值等价于运行中会话数。为避免高基数，不采集 session_code，无法区分同一会话并发多个 Run 的情况。计算：按 agent_info_code、agent_info_name、agent_info_sdk_version 汇总 aidev_agent_active，并仅保留大于 0 的智能体。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 33,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_agent_info_code · $tag_agent_info_name · $tag_agent_info_sdk_version",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (agent_info_code, agent_info_name, agent_info_sdk_version) (aidev_agent_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}) > 0",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "当前运行智能体及会话数",
+      "type": "bargauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 101,
+      "panels": [],
+      "title": "Agent 耗时",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：已结束 Agent Run 墙钟运行耗时 P95 的时间走势。计算：对 gen_ai_invoke_agent_duration_seconds Histogram bucket 的窗口速率按 le 汇总，再使用 histogram_quantile(0.95, …) 估算。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le) (rate(gen_ai_invoke_agent_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 墙钟耗时 P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按 Agent Code 拆分的 Agent Run 首 Token 耗时 P95，即 Run 开始到收到首个流式 LLM Token 的时间；非流式调用不产生样本。计算：按 le 和 agent.info.code 汇总 gen_ai_invoke_agent_time_to_first_token_seconds bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 32,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_agent_info_code P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, agent_info_code) (rate(gen_ai_invoke_agent_time_to_first_token_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 首 Token P95（流式调用，按 Agent Code）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内 processing、llm、tool、mixed、finalizing 各阶段累计耗时占比，互斥阶段合计约 100%。计算：各阶段 duration sum 的 increase 除以所有阶段 increase 总和。",
+      "fieldConfig": {
+        "defaults": {
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 12,
+      "options": {
+        "displayLabels": [
+          "name",
+          "percent"
+        ],
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "values": [
+            "value",
+            "percent"
+          ]
+        },
+        "pieType": "donut",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_agent_phase",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (aidev_agent_phase) (increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])) / ignoring(aidev_agent_phase) group_left clamp_min(sum(increase(aidev_agent_phase_duration_seconds_sum{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Agent 阶段累计时间占比（所选时段）",
+      "type": "piechart"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 39
+      },
+      "id": 102,
+      "panels": [],
+      "title": "LLM",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按请求模型拆分的已结束 LLM 调用耗时 P95。计算：按 le 和 gen_ai.request.model 汇总 LLM duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)；响应模型过滤只作用于已结束调用。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_request_model P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\",gen_ai_response_model=~\"$response_model\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "LLM 耗时 P95（已结束调用，按请求模型）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按请求模型拆分的 LLM 首 Token/首 Chunk 耗时 P95，仅统计产生流式回调的调用。计算：按 le 和 gen_ai.request.model 汇总 time_to_first_chunk bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 40
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_request_model P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, gen_ai_request_model) (rate(gen_ai_client_operation_time_to_first_chunk_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "LLM 首 Token P95（流式调用，按请求模型）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按请求模型拆分的当前 LLM 并发数及趋势；响应模型只有调用结束后才能确定，因此不用于活跃调用过滤。计算：按 gen_ai.request.model 对 gen_ai_client_operation_active Gauge 求和。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 48
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_request_model",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (gen_ai_request_model) (gen_ai_client_operation_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "LLM 并发（当前与趋势，按请求模型）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按请求模型拆分的 LLM 每秒完成调用数。计算：对 gen_ai_client_operation_duration_seconds_count 计算 rate，再按 gen_ai.request.model 求和；可按请求模型和已确定的响应模型过滤。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 48
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_request_model",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (gen_ai_request_model) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\",gen_ai_response_model=~\"$response_model\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "LLM 完成速率（按请求模型）",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 103,
+      "panels": [],
+      "title": "Tool",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按工具名称拆分的当前工具调用并发数及趋势。计算：按 gen_ai.tool.name 对 gen_ai_execute_tool_active Gauge 求和。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 29,
+      "options": {
+        "legend": {
+          "calcs": [
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_tool_name",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (gen_ai_tool_name) (gen_ai_execute_tool_active{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_tool_name=~\"$tool_name\"})",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "工具并发（当前与趋势，按工具名称）",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按工具名称拆分的已结束工具调用耗时 P95。计算：按 le 和 gen_ai.tool.name 汇总工具 duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      },
+      "id": 18,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_gen_ai_tool_name P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, gen_ai_tool_name) (rate(gen_ai_execute_tool_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_tool_name=~\"$tool_name\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "工具耗时 P95（已结束调用，按工具名称）",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 73
+      },
+      "id": 104,
+      "panels": [],
+      "title": "SSE 输出与物理消息",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：每个查询窗口内的 SSE 逻辑事件数量与实际提交给 Handler 的物理消息数量，均按 Handler 展示且不按 SSE 事件类型拆分。计算：分别对 aidev_sse_event_count total 和 aidev_message_publish_count total 使用 increase([$window]) 后按 Handler 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 25,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "C",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "D",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "E",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"SSE\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "SSE 事件与物理消息数量",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：每个查询窗口内每条物理消息平均承载的 SSE 事件数，数值越大表示事件合并程度越高。计算：按 Handler 汇总 SSE 事件 increase，除以物理消息 increase；分母最小取 0.000001 以避免除零，查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 2,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 31,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "C",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "D",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "E",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_sse_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])) / clamp_min(sum by (aidev_message_handler_type) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), 0.000001)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "SSE/物理消息压缩比",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 82
+      },
+      "id": 106,
+      "panels": [],
+      "title": "Broker 发布侧",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：逻辑事件表示合并前进入 flush 的事件速率，物理消息表示合并后实际提交给 Handler/Broker 的写入速率。计算：分别对 publish_event_count sum 和 publish_count total 计算 rate，再按 Handler 和 messaging.system 求和；查询序列与图例均按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "eps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 83
+      },
+      "id": 20,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true,
+          "sortBy": "Name",
+          "sortDesc": false
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "C",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "D",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type $tag_aidev_message_kind",
+          "query_configs": [],
+          "refId": "E",
+          "showLastPoint": false,
+          "source": "label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_event_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"logical\", \"\", \"\") or label_replace(sum by (aidev_message_handler_type, messaging_system) (rate({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])), \"aidev_message_kind\", \"physical\", \"\", \"\")",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "逻辑事件与物理消息速率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内各 Handler 上实际发布过物理消息的 Agent Code 去重分布；同一个 Agent 在同一 Handler 上无论发布多少消息只计 1，在多个 Handler 上发布则分别计入对应 Handler。计算：先按 Handler 和 agent.info.code 汇总 aidev_message_publish_count increase 并过滤零值，再按 Handler 计数并除以全部 Handler-Agent 去重组合数；按 Handler 名称升序，未知 Handler 追加在末尾。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "max": 1,
+          "min": 0,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 83
+      },
+      "id": 21,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"inmemory\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0), 0.000001))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0), 0.000001))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "C",
+          "showLastPoint": false,
+          "source": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"rabbitmq_stream\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0), 0.000001))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "D",
+          "showLastPoint": false,
+          "source": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=\"redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0), 0.000001))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "E",
+          "showLastPoint": false,
+          "source": "count by (aidev_message_handler_type) (sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type!~\"inmemory|rabbitmq|rabbitmq_stream|redis\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0) / scalar(clamp_min(count(sum by (aidev_message_handler_type, agent_info_code) (increase({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])) > 0), 0.000001))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Handler 分布（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：应用序列化后提交给 Handler 的 Payload 吞吐量（bytes/s），不等同于 Broker 实际网络或磁盘 IO。计算：对 publish_size Histogram sum 计算 rate，再按 Handler 求和。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 91
+      },
+      "id": 22,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_sum\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "应用写入 Payload IO",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按 Handler 拆分的单条物理消息 Payload 大小 P95。计算：按 le 和 Handler 汇总 publish_size bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 91
+      },
+      "id": 23,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_size.*_bucket\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "物理消息大小 P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按 Handler 拆分的单次应用侧消息写入耗时 P95，不包含 Broker 消费耗时。计算：按 le 和 Handler 汇总 publish_duration bucket 的窗口速率，再计算 histogram_quantile(0.95, …)。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 91
+      },
+      "id": 24,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_aidev_message_handler_type P95",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, aidev_message_handler_type) (rate({__name__=~\"aidev_message_publish_duration.*_bucket\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Handler 写入耗时 P95",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 99
+      },
+      "id": 105,
+      "panels": [],
+      "title": "错误",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内 Agent、LLM、Tool 和 Handler 已结束错误记录的总数；同一次失败如果同时形成多类错误指标，会分别计数，因此它表示错误指标事件数而不是失败会话去重数。计算：分别对四类带非空 error_type 的 duration count 计算 increase，通过来源标签合并后求和。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 100
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "错误计数",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum(label_replace(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"agent\", \"\", \".*\") or label_replace(sum(increase(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\",gen_ai_response_model=~\"$response_model\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"llm\", \"\", \".*\") or label_replace(sum(increase(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_tool_name=~\"$tool_name\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"tool\", \"\", \".*\") or label_replace(sum(increase(aidev_message_publish_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"handler\", \"\", \".*\")) or vector(0)",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "错误计数（所选时段）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内各 Agent Code 产生的 Agent、LLM、Tool 和 Handler 错误指标事件总数，用于识别错误集中在哪些智能体；error.type 与指标来源细分见右侧错误速率图。计算：四类错误 duration count 分别按 Agent 聚合 increase，增加临时来源标签避免集合冲突，再按 Agent 求和并降序排列。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 4,
+        "y": 100
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_agent_info_code",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sort_desc(sum by (agent_info_code) (label_replace(sum by (agent_info_code) (increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"agent\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\",gen_ai_response_model=~\"$response_model\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"llm\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_tool_name=~\"$tool_name\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"tool\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(aidev_message_publish_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\",error_type!=\"\"}[$window])), \"aidev_error_source\", \"handler\", \"agent_info_code\", \".*\")))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "错误智能体分布（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：按 Agent、LLM、Tool 和 Handler 指标来源以及 error.type 拆分的每秒错误完成数，仅覆盖带非空 error_type 标签的已结束操作。计算：分别对四类 duration count 错误序列计算 rate，再按 error_type 求和；拆分查询可避免 rate 移除指标名后不同来源发生标签冲突。",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 100
+      },
+      "id": 28,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "Agent · $tag_error_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (error_type) (rate(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",error_type!=\"\"}[$window]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "LLM · $tag_error_type",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "sum by (error_type) (rate(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\",gen_ai_response_model=~\"$response_model\",error_type!=\"\"}[$window]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "Tool · $tag_error_type",
+          "query_configs": [],
+          "refId": "C",
+          "showLastPoint": false,
+          "source": "sum by (error_type) (rate(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_tool_name=~\"$tool_name\",error_type!=\"\"}[$window]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "Handler · $tag_error_type",
+          "query_configs": [],
+          "refId": "D",
+          "showLastPoint": false,
+          "source": "sum by (error_type) (rate(aidev_message_publish_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",aidev_message_handler_type=~\"$handler_type\",error_type!=\"\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "错误速率（指标来源与 error.type）",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "tags": [
+    "agent",
+    "aidev",
+    "bkmonitor",
+    "opentelemetry"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent Code",
+        "multi": true,
+        "name": "agent_code",
+        "options": [],
+        "query": {
+          "promql": "label_values(gen_ai_invoke_agent_duration_seconds_count, agent_info_code)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Agent Version",
+        "multi": true,
+        "name": "agent_version",
+        "options": [],
+        "query": {
+          "promql": "label_values(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"$agent_code\"}, agent_info_sdk_version)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Request Model",
+        "multi": true,
+        "name": "request_model",
+        "options": [],
+        "query": {
+          "promql": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}, gen_ai_request_model)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Response Model",
+        "multi": true,
+        "name": "response_model",
+        "options": [],
+        "query": {
+          "promql": "label_values(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\",gen_ai_request_model=~\"$request_model\"}, gen_ai_response_model)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Tool Name",
+        "multi": true,
+        "name": "tool_name",
+        "options": [],
+        "query": {
+          "promql": "label_values(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}, gen_ai_tool_name)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "bkmonitor-timeseries-datasource",
+          "uid": "cfjy28njb6ghsd"
+        },
+        "definition": "- Blueking Monitor - prometheus",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Message Handler",
+        "multi": true,
+        "name": "handler_type",
+        "options": [],
+        "query": {
+          "promql": "label_values({__name__=~\"aidev_message_publish_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}, aidev_message_handler_type)",
+          "queryType": "prometheus"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "1m",
+          "value": "1m"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "multi": false,
+        "name": "window",
+        "options": [
+          {
+            "selected": true,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          }
+        ],
+        "query": "1m,5m,1h",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "custom"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "AIDev Agent Metrics (BK Monitor)",
+  "uid": "aidev-agent-metrics-bkmonitor",
+  "version": 1,
+  "weekStart": "",
+  "__requires": [
+    {
+      "type": "datasource",
+      "id": "bkmonitor-timeseries-datasource",
+      "name": "蓝鲸监控 - 指标数据"
+    }
+  ]
+}

--- a/dev/otel/grafana/dashboards/aidev-agent-metrics.json
+++ b/dev/otel/grafana/dashboards/aidev-agent-metrics.json
@@ -187,7 +187,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "含义：当前正在执行的 LLM Operation 数量。计算：对筛选范围内 gen_ai_client_operation_active Gauge 求和；按请求模型过滤，不使用调用结束后才确定的响应模型。",
+      "description": "含义：当前互斥地处于 LLM 阶段的 Agent Run 数量，与 processing、tool、mixed、finalizing 阶段共同构成活跃 Agent Run；mixed 不重复计入本卡片。计算：对 aidev_agent_phase_active Gauge 中 aidev.agent.phase=llm 的序列求和。模型维度属于 Operation，不适用于 Agent 阶段过滤。",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -240,13 +240,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(gen_ai_client_operation_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\"}) or vector(0)",
-          "legendFormat": "活跃 LLM",
+          "expr": "sum(aidev_agent_phase_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_agent_phase=\"llm\"}) or vector(0)",
+          "legendFormat": "LLM 阶段 Run",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "活跃 LLM Operation",
+      "title": "LLM 阶段 Agent Run",
       "type": "stat"
     },
     {
@@ -254,7 +254,7 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "含义：当前正在执行的工具 Operation 数量。计算：对筛选范围内 gen_ai_execute_tool_active Gauge 求和，可按工具名称过滤。",
+      "description": "含义：当前互斥地处于 Tool 阶段的 Agent Run 数量，与 processing、llm、mixed、finalizing 阶段共同构成活跃 Agent Run；一个 Run 内并行多个工具仍只计 1，mixed 不重复计入本卡片。计算：对 aidev_agent_phase_active Gauge 中 aidev.agent.phase=tool 的序列求和。工具名称属于 Operation，不适用于 Agent 阶段过滤。",
       "fieldConfig": {
         "defaults": {
           "decimals": 0,
@@ -307,13 +307,13 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(gen_ai_execute_tool_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\"}) or vector(0)",
-          "legendFormat": "活跃 Tool",
+          "expr": "sum(aidev_agent_phase_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_agent_phase=\"tool\"}) or vector(0)",
+          "legendFormat": "Tool 阶段 Run",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "活跃 Tool Operation",
+      "title": "Tool 阶段 Agent Run",
       "type": "stat"
     },
     {
@@ -453,10 +453,10 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
-      "description": "含义：所选时段内每个已完成 Agent Run 的平均迭代次数，一次 LLM 推理调用计为一次迭代。计算：inference_calls_total 的 increase 总和除以 Agent duration count 的 increase 总和，分母最小取 1。",
+      "description": "含义：所选时段内，单个已完成 Agent Run 的 LLM 调用尝试次数 P95；一次 on_chat_model_start 或 on_llm_start 计为一次迭代，失败与重试调用也计入，未完成 Run 不计入。计算：对 gen_ai_invoke_agent_iteration_count Histogram bucket 在所选时段的增量按 le 汇总，使用 histogram_quantile(0.95, …) 估算并向上取整。",
       "fieldConfig": {
         "defaults": {
-          "decimals": 2,
+          "decimals": 0,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -506,13 +506,14 @@
             "uid": "prometheus"
           },
           "editorMode": "code",
-          "expr": "sum(increase(gen_ai_invoke_agent_inference_calls_total{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])) / clamp_min(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])), 1)",
-          "legendFormat": "迭代/Run",
-          "range": true,
+          "expr": "ceil(histogram_quantile(0.95, sum by (le) (increase(gen_ai_invoke_agent_iteration_count_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range]))))",
+          "instant": true,
+          "legendFormat": "迭代次数 P95",
+          "range": false,
           "refId": "A"
         }
       ],
-      "title": "平均 Agent 迭代次数",
+      "title": "Agent 迭代次数 P95",
       "type": "stat"
     },
     {
@@ -777,8 +778,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 14
       },
       "id": 9,
@@ -824,6 +825,61 @@
       ],
       "title": "Agent 进入与完成速率",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：按 Agent Code 展示当前正在执行的 Agent Run 数；在同一会话同一时刻最多运行一个 Run 时，该值等价于运行中会话数。为避免高基数，不采集 session_code，无法区分同一会话并发多个 Run 的情况。计算：按 agent_info_code、agent_info_name、agent_info_sdk_version 汇总 aidev_agent_active，并仅保留大于 0 的智能体。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 14
+      },
+      "id": 33,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (agent_info_code, agent_info_name, agent_info_sdk_version) (aidev_agent_active{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}) > 0",
+          "instant": true,
+          "legendFormat": "{{agent_info_code}} · {{agent_info_name}} · {{agent_info_sdk_version}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "当前运行智能体及会话数",
+      "type": "bargauge"
     },
     {
       "collapsed": false,
@@ -2000,6 +2056,129 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "description": "含义：所选时段内 Agent、LLM、Tool 和 Handler 已结束错误记录的总数；同一次失败如果同时形成多类错误指标，会分别计数，因此它表示错误指标事件数而不是失败会话去重数。计算：分别对四类带非空 error_type 的 duration count 计算 increase，通过来源标签合并后求和。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 100
+      },
+      "id": 34,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "10.4.19",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(label_replace(sum(increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"agent\", \"\", \".*\") or label_replace(sum(increase(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"llm\", \"\", \".*\") or label_replace(sum(increase(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"tool\", \"\", \".*\") or label_replace(sum(increase(aidev_message_publish_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"handler\", \"\", \".*\")) or vector(0)",
+          "instant": true,
+          "legendFormat": "错误计数",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "错误计数（所选时段）",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：所选时段内各 Agent Code 产生的 Agent、LLM、Tool 和 Handler 错误指标事件总数，用于识别错误集中在哪些智能体；error.type 与指标来源细分见右侧错误速率图。计算：四类错误 duration count 分别按 Agent 聚合 increase，增加临时来源标签避免集合冲突，再按 Agent 求和并降序排列。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 4,
+        "y": 100
+      },
+      "id": 35,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(sum by (agent_info_code) (label_replace(sum by (agent_info_code) (increase(gen_ai_invoke_agent_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"agent\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(gen_ai_client_operation_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_request_model=~\"${request_model:regex}\",gen_ai_response_model=~\"${response_model:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"llm\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(gen_ai_execute_tool_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",gen_ai_tool_name=~\"${tool_name:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"tool\", \"agent_info_code\", \".*\") or label_replace(sum by (agent_info_code) (increase(aidev_message_publish_duration_seconds_count{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\",aidev_message_handler_type=~\"${handler_type:regex}\",error_type!=\"\"}[$__range])), \"aidev_error_source\", \"handler\", \"agent_info_code\", \".*\")))",
+          "instant": true,
+          "legendFormat": "{{agent_info_code}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "错误智能体分布（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "description": "含义：按 Agent、LLM、Tool 和 Handler 指标来源以及 error.type 拆分的每秒错误完成数，仅覆盖带非空 error_type 标签的已结束操作。计算：分别对四类 duration count 错误序列计算 rate，再按 error_type 求和；拆分查询可避免 rate 移除指标名后不同来源发生标签冲突。",
       "fieldConfig": {
         "defaults": {
@@ -2009,8 +2188,8 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
+        "w": 12,
+        "x": 12,
         "y": 100
       },
       "id": 28,

--- a/dev/otel/grafana/generate-bkmonitor-dashboard.jq
+++ b/dev/otel/grafana/generate-bkmonitor-dashboard.jq
@@ -1,0 +1,103 @@
+def bkmonitor_datasource:
+  {
+    "type": "bkmonitor-timeseries-datasource",
+    "uid": "cfjy28njb6ghsd"
+  };
+
+def bkmonitor_promql:
+  gsub("\\$\\{agent_code:regex\\}"; "$agent_code")
+  | gsub("\\$\\{agent_version:regex\\}"; "$agent_version")
+  | gsub("\\$\\{request_model:regex\\}"; "$request_model")
+  | gsub("\\$\\{response_model:regex\\}"; "$response_model")
+  | gsub("\\$\\{tool_name:regex\\}"; "$tool_name")
+  | gsub("\\$\\{handler_type:regex\\}"; "$handler_type")
+  | gsub("\\$__range"; "$window")
+  | gsub("\\$__rate_interval"; "$window");
+
+def bkmonitor_alias:
+  gsub("\\{\\{(?<label>[A-Za-z0-9_]+)\\}\\}"; "$tag_\(.label)");
+
+def bkmonitor_target:
+  . as $target
+  | {
+      "cluster": [],
+      "datasource": bkmonitor_datasource,
+      "enableDownSampling": true,
+      "expressionList": [],
+      "format": "time_series",
+      "host": [],
+      "mode": "code",
+      "module": [],
+      "promqlAlias": (($target.legendFormat // "") | bkmonitor_alias),
+      "query_configs": [],
+      "refId": $target.refId,
+      "showLastPoint": false,
+      "source": ($target.expr | bkmonitor_promql),
+      "step": "",
+      "type": "range"
+    };
+
+def bkmonitor_variable:
+  . as $variable
+  | $variable
+  | .allValue = ".*"
+  | .current = {"selected": true, "text": "All", "value": "$__all"}
+  | .datasource = bkmonitor_datasource
+  | .definition = "- Blueking Monitor - prometheus"
+  | .includeAll = true
+  | .multi = true
+  | .options = []
+  | .query = {
+      "promql": ($variable.query.query | bkmonitor_promql),
+      "queryType": "prometheus"
+    }
+  | .refresh = 2
+  | .regex = ""
+  | .skipUrlSync = false
+  | .sort = 0;
+
+def window_variable:
+  {
+    "current": {"text": "1m", "value": "1m"},
+    "hide": 0,
+    "includeAll": false,
+    "multi": false,
+    "name": "window",
+    "options": [
+      {"selected": true, "text": "1m", "value": "1m"},
+      {"selected": false, "text": "5m", "value": "5m"},
+      {"selected": false, "text": "1h", "value": "1h"}
+    ],
+    "query": "1m,5m,1h",
+    "queryValue": "",
+    "skipUrlSync": false,
+    "type": "custom"
+  };
+
+.
+| del(.__inputs)
+| .__requires = [
+    {
+      "type": "datasource",
+      "id": "bkmonitor-timeseries-datasource",
+      "name": "蓝鲸监控 - 指标数据"
+    }
+  ]
+| .description = "Agent 运行态、耗时、LLM、工具以及应用侧 SSE/Broker 写入压力；数据源为蓝鲸监控指标数据。真实 Broker 积压和磁盘/网络 IO 需要接入 RabbitMQ/Redis 原生 exporter。"
+| .editable = true
+| .refresh = "1m"
+| .tags = ((.tags + ["bkmonitor"]) | unique)
+| .time = {"from": "now-1h", "to": "now"}
+| .title = "AIDev Agent Metrics (BK Monitor)"
+| .uid = "aidev-agent-metrics-bkmonitor"
+| .version = 1
+| .panels |= map(
+    if .type == "row" then
+      del(.datasource, .targets)
+    else
+      .datasource = bkmonitor_datasource
+      | .description |= (gsub("\\$__range"; "$window") | gsub("\\$__rate_interval"; "$window"))
+      | .targets |= map(bkmonitor_target)
+    end
+  )
+| .templating.list = ((.templating.list | map(bkmonitor_variable)) + [window_variable])

--- a/dev/otel/tests/test_local_observability.py
+++ b/dev/otel/tests/test_local_observability.py
@@ -25,10 +25,12 @@ from dev.otel.mock_agent_metrics import (
 )
 
 OTEL_ROOT = Path(__file__).resolve().parents[1]
+PROMETHEUS_DASHBOARD = OTEL_ROOT / "grafana/dashboards/aidev-agent-metrics.json"
+BKMONITOR_DASHBOARD = OTEL_ROOT / "grafana/components/aidev-agent-metrics-bkmonitor.json"
 
 
 def test_local_dashboard_covers_required_filters_and_metric_groups():
-    dashboard = json.loads((OTEL_ROOT / "grafana/dashboards/aidev-agent-metrics.json").read_text())
+    dashboard = json.loads(PROMETHEUS_DASHBOARD.read_text())
     compose = (OTEL_ROOT / "docker-compose.yml").read_text()
     variables = {item["name"] for item in dashboard["templating"]["list"]}
     panels_by_id = {panel["id"]: panel for panel in dashboard["panels"]}
@@ -39,7 +41,7 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert "grafana/grafana:10.4.19" in compose
     assert dashboard["schemaVersion"] == 39
     assert dashboard["graphTooltip"] == 1
-    assert len(dashboard["panels"]) == 34
+    assert len(dashboard["panels"]) == 37
 
     for panel in dashboard["panels"]:
         if panel.get("type") == "row":
@@ -59,6 +61,7 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
         "aidev_agent_phase_active",
         "aidev_agent_phase_duration",
         "gen_ai_invoke_agent_time_to_first_token",
+        "gen_ai_invoke_agent_iteration_count",
         "gen_ai_client_operation_active",
         "gen_ai_execute_tool_active",
         "aidev_sse_event_count",
@@ -72,6 +75,12 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert "sum(aidev_agent_active" in panels_by_id[1]["targets"][0]["expr"]
     assert "or vector(0)" in panels_by_id[1]["targets"][0]["expr"]
     assert panels_by_id[30]["title"] == "活跃智能体数量"
+    assert panels_by_id[2]["title"] == "LLM 阶段 Agent Run"
+    assert 'aidev_agent_phase="llm"' in panels_by_id[2]["targets"][0]["expr"]
+    assert "gen_ai_client_operation_active" not in panels_by_id[2]["targets"][0]["expr"]
+    assert panels_by_id[3]["title"] == "Tool 阶段 Agent Run"
+    assert 'aidev_agent_phase="tool"' in panels_by_id[3]["targets"][0]["expr"]
+    assert "gen_ai_execute_tool_active" not in panels_by_id[3]["targets"][0]["expr"]
     assert "or vector(0)" in panels_by_id[2]["targets"][0]["expr"]
     assert "or vector(0)" in panels_by_id[3]["targets"][0]["expr"]
     assert panels_by_id[30]["gridPos"]["x"] == 0
@@ -89,13 +98,25 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert "sum by (le, agent_info_code)" in panels_by_id[32]["targets"][0]["expr"]
     assert "gen_ai_invoke_agent_time_to_first_token_seconds_bucket" in panels_by_id[32]["targets"][0]["expr"]
     assert panels_by_id[32]["gridPos"] == {"h": 8, "w": 12, "x": 12, "y": 23}
+    assert panels_by_id[6]["title"] == "Agent 迭代次数 P95"
+    assert panels_by_id[6]["targets"][0]["instant"] is True
+    assert "histogram_quantile(0.95" in panels_by_id[6]["targets"][0]["expr"]
+    assert "gen_ai_invoke_agent_iteration_count_bucket" in panels_by_id[6]["targets"][0]["expr"]
+    assert panels_by_id[33]["title"] == "当前运行智能体及会话数"
+    assert panels_by_id[33]["type"] == "bargauge"
+    assert panels_by_id[33]["targets"][0]["instant"] is True
+    assert "sum by (agent_info_code, agent_info_name, agent_info_sdk_version)" in panels_by_id[33]["targets"][0]["expr"]
+    assert panels_by_id[33]["gridPos"] == {"h": 8, "w": 12, "x": 0, "y": 14}
+    assert panels_by_id[9]["gridPos"] == {"h": 8, "w": 12, "x": 12, "y": 14}
     assert panels_by_id[12]["gridPos"] == {"h": 8, "w": 24, "x": 0, "y": 31}
     assert panels_by_id[16]["title"].startswith("LLM 并发")
+    assert "gen_ai_client_operation_active" in panels_by_id[16]["targets"][0]["expr"]
     for panel_id in (2, 14, 16):
         assert all("gen_ai_response_model" not in target["expr"] for target in panels_by_id[panel_id]["targets"])
     for panel_id in (13, 15):
         assert any("gen_ai_response_model" in target["expr"] for target in panels_by_id[panel_id]["targets"])
     assert panels_by_id[29]["title"].startswith("工具并发")
+    assert "gen_ai_execute_tool_active" in panels_by_id[29]["targets"][0]["expr"]
     assert panels_by_id[29]["gridPos"]["w"] == 24
     assert 19 not in panels_by_id
     assert 17 not in panels_by_id
@@ -133,6 +154,16 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert 27 not in panels_by_id
     assert panels_by_id[105]["gridPos"]["y"] == 99
     assert panels_by_id[28]["gridPos"]["y"] == 100
+    assert panels_by_id[34]["title"] == "错误计数（所选时段）"
+    assert panels_by_id[34]["type"] == "stat"
+    assert panels_by_id[34]["targets"][0]["instant"] is True
+    assert "increase(gen_ai_invoke_agent_duration_seconds_count" in panels_by_id[34]["targets"][0]["expr"]
+    assert panels_by_id[35]["title"] == "错误智能体分布（所选时段）"
+    assert panels_by_id[35]["type"] == "bargauge"
+    assert "sum by (agent_info_code)" in panels_by_id[35]["targets"][0]["expr"]
+    assert panels_by_id[34]["gridPos"] == {"h": 8, "w": 4, "x": 0, "y": 100}
+    assert panels_by_id[35]["gridPos"] == {"h": 8, "w": 8, "x": 4, "y": 100}
+    assert panels_by_id[28]["gridPos"] == {"h": 8, "w": 12, "x": 12, "y": 100}
     assert [target["legendFormat"] for target in panels_by_id[28]["targets"]] == [
         "Agent · {{error_type}}",
         "LLM · {{error_type}}",
@@ -167,6 +198,46 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert panels_by_id[20]["gridPos"]["y"] == panels_by_id[21]["gridPos"]["y"] == 83
     panel_order = [panel["id"] for panel in dashboard["panels"]]
     assert panel_order.index(104) < panel_order.index(25) < panel_order.index(106) < panel_order.index(20)
+
+
+def test_bkmonitor_dashboard_is_a_separate_importable_component():
+    local = json.loads(PROMETHEUS_DASHBOARD.read_text())
+    dashboard = json.loads(BKMONITOR_DASHBOARD.read_text())
+    datasource = {"type": "bkmonitor-timeseries-datasource", "uid": "cfjy28njb6ghsd"}
+    panels = [panel for panel in dashboard["panels"] if panel.get("type") != "row"]
+    targets = [target for panel in panels for target in panel["targets"]]
+    variables = {item["name"]: item for item in dashboard["templating"]["list"]}
+
+    assert local["uid"] == "aidev-agent-metrics"
+    assert dashboard["uid"] == "aidev-agent-metrics-bkmonitor"
+    assert dashboard["title"] == "AIDev Agent Metrics (BK Monitor)"
+    assert dashboard["schemaVersion"] == 39
+    assert len(dashboard["panels"]) == len(local["panels"]) == 37
+    assert "__inputs" not in dashboard
+    assert dashboard["__requires"][0]["id"] == "bkmonitor-timeseries-datasource"
+    rows = [panel for panel in dashboard["panels"] if panel["type"] == "row"]
+    assert all("datasource" not in panel and "targets" not in panel for panel in rows)
+    assert all(panel["datasource"] == datasource for panel in panels)
+    assert all(target["datasource"] == datasource and target["type"] == "range" for target in targets)
+    assert all("source" in target and "expr" not in target for target in targets)
+    assert all(
+        "${" not in target["source"]
+        and "$__rate_interval" not in target["source"]
+        and "$__range" not in target["source"]
+        for target in targets
+    )
+    assert any("$window" in target["source"] for target in targets)
+    assert set(variables) == {
+        "agent_code",
+        "agent_version",
+        "request_model",
+        "response_model",
+        "tool_name",
+        "handler_type",
+        "window",
+    }
+    assert variables["window"]["query"] == "1m,5m,1h"
+    assert all(variable["datasource"] == datasource for name, variable in variables.items() if name != "window")
 
 
 def test_log_query_mock_is_sanitized_and_models_broker_coalescing():

--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -321,7 +321,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         # 工具调用计数器
         self.tool_call_counter = 0
         self.rag_call_counter = 0
-        self.inference_call_counter = 0
+        self.agent_iteration_counter = 0
 
         # Metric state uses monotonic clocks and contains no session/user data.
         self._metrics = metric_recorder or (get_agent_metrics() if enable_metrics else None)
@@ -385,7 +385,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
                     try:
                         self._metrics.record_agent(
                             duration=time.monotonic() - started_at,
-                            inference_calls=self.inference_call_counter,
+                            iteration_count=self.agent_iteration_counter,
                             attributes=self._metric_agent_attributes,
                             error=error,
                         )
@@ -913,7 +913,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             max_attribute_length=self.max_attribute_length,
         )
         if self._metrics is not None:
-            self.inference_call_counter += 1
+            self.agent_iteration_counter += 1
             self._llm_started_at[run_id] = time.monotonic()
             active_attributes = self._llm_metric_attributes(run_id)
             self._llm_active_attributes[run_id] = active_attributes
@@ -952,7 +952,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             max_attribute_length=self.max_attribute_length,
         )
         if self._metrics is not None:
-            self.inference_call_counter += 1
+            self.agent_iteration_counter += 1
             self._llm_started_at[run_id] = time.monotonic()
             active_attributes = self._llm_metric_attributes(run_id)
             self._llm_active_attributes[run_id] = active_attributes

--- a/src/agent/aidev_agent/packages/opentelemetry/metrics.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/metrics.py
@@ -16,6 +16,7 @@ from opentelemetry import metrics
 METER_NAME = "aidev_agent"
 DURATION_HISTOGRAM_BOUNDARIES = (0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300)
 MESSAGE_SIZE_HISTOGRAM_BOUNDARIES = (64, 256, 1024, 4096, 16384, 65536, 262144, 1048576)
+AGENT_ITERATION_HISTOGRAM_BOUNDARIES = (0, 1, 2, 3, 4, 5, 6, 8, 10, 15, 20, 30, 50, 100)
 
 
 def _as_int(value: Any) -> int:
@@ -111,8 +112,10 @@ class AgentMetrics:
             unit="s",
             description="Agent invocation time to the first streamed LLM token",
         )
-        self.agent_inference_calls = meter.create_counter(
-            "gen_ai.invoke_agent.inference_calls", unit="{call}", description="LLM calls per agent invocation"
+        self.agent_iteration_count = meter.create_histogram(
+            "gen_ai.invoke_agent.iteration_count",
+            unit="{iteration}",
+            description="LLM invocation attempts in one completed agent invocation",
         )
         self.active_agents = meter.create_up_down_counter(
             "aidev.agent.active",
@@ -181,7 +184,7 @@ class AgentMetrics:
     def record_agent(
         self,
         duration: float,
-        inference_calls: int,
+        iteration_count: int,
         attributes: dict[str, str],
         error: BaseException | None = None,
     ) -> None:
@@ -189,7 +192,7 @@ class AgentMetrics:
         if error is not None:
             attrs["error.type"] = type(error).__name__
         self.agent_duration.record(duration, attrs)
-        self.agent_inference_calls.add(inference_calls, attributes)
+        self.agent_iteration_count.record(iteration_count, attributes)
 
     def record_active_agent(self, delta: int, attributes: dict[str, str]) -> None:
         """Adjust the number of Agent runs that are currently executing."""

--- a/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/otel_service.py
@@ -46,7 +46,11 @@ except ImportError:
 
 
 from .config import OTelConfig
-from .metrics import DURATION_HISTOGRAM_BOUNDARIES, MESSAGE_SIZE_HISTOGRAM_BOUNDARIES
+from .metrics import (
+    AGENT_ITERATION_HISTOGRAM_BOUNDARIES,
+    DURATION_HISTOGRAM_BOUNDARIES,
+    MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
+)
 from .utils import ExporterType
 
 logger = logging.getLogger(__name__)
@@ -223,6 +227,10 @@ class BkAgentOTelService:
             View(
                 instrument_name="aidev.message.publish.size",
                 aggregation=ExplicitBucketHistogramAggregation(boundaries=MESSAGE_SIZE_HISTOGRAM_BOUNDARIES),
+            ),
+            View(
+                instrument_name="gen_ai.invoke_agent.iteration_count",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=AGENT_ITERATION_HISTOGRAM_BOUNDARIES),
             ),
         ]
 

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -235,6 +235,37 @@ class TestBkAidevAgentCallbackHandler:
         assert end_call.args[0] == -1
         assert start_call.args[1] == end_call.args[1]
 
+    def test_agent_iteration_count_equals_llm_start_callbacks_in_one_run(self, tracer_and_exporter):
+        tracer, _ = tracer_and_exporter
+        recorder = MagicMock()
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=recorder)
+        chain_run_id = uuid4()
+        llm_run_id = uuid4()
+        chat_run_id = uuid4()
+
+        asyncio.run(handler.on_chain_start(serialized={"name": "agent"}, inputs={}, run_id=chain_run_id))
+        asyncio.run(
+            handler.on_llm_start(
+                serialized={"name": "model-a"},
+                prompts=["hello"],
+                run_id=llm_run_id,
+                parent_run_id=chain_run_id,
+            )
+        )
+        asyncio.run(handler.on_llm_error(RuntimeError("retry"), run_id=llm_run_id, parent_run_id=chain_run_id))
+        asyncio.run(
+            handler.on_chat_model_start(
+                serialized={"name": "model-b"},
+                messages=[[HumanMessage(content="retry")]],
+                run_id=chat_run_id,
+                parent_run_id=chain_run_id,
+            )
+        )
+        asyncio.run(handler.on_llm_error(RuntimeError("boom"), run_id=chat_run_id, parent_run_id=chain_run_id))
+        asyncio.run(handler.on_chain_end(outputs={}, run_id=chain_run_id))
+
+        assert recorder.record_agent.call_args.kwargs["iteration_count"] == 2
+
     def test_agent_phase_and_first_token_metrics_follow_runtime_callbacks(self, tracer_and_exporter):
         tracer, _ = tracer_and_exporter
         recorder = MagicMock()

--- a/src/agent/tests/packages/opentelemetry/test_metrics.py
+++ b/src/agent/tests/packages/opentelemetry/test_metrics.py
@@ -57,7 +57,7 @@ def test_agent_metrics_only_create_instruments_used_by_the_dashboard():
         "gen_ai.execute_tool.active",
         "gen_ai.execute_tool.duration",
         "gen_ai.invoke_agent.duration",
-        "gen_ai.invoke_agent.inference_calls",
+        "gen_ai.invoke_agent.iteration_count",
         "gen_ai.invoke_agent.started",
         "gen_ai.invoke_agent.time_to_first_token",
     }
@@ -112,7 +112,7 @@ def test_error_type_is_added_only_to_duration_metric():
 
     duration_attrs = meter.instruments["gen_ai.invoke_agent.duration"].calls[0][1]
     assert duration_attrs["error.type"] == "RuntimeError"
-    assert "error.type" not in meter.instruments["gen_ai.invoke_agent.inference_calls"].calls[0][1]
+    assert meter.instruments["gen_ai.invoke_agent.iteration_count"].calls == [(2, attrs)]
     assert "agent.session.session_code" not in duration_attrs
 
 

--- a/src/agent/tests/packages/opentelemetry/test_otel_service.py
+++ b/src/agent/tests/packages/opentelemetry/test_otel_service.py
@@ -2,6 +2,7 @@ from types import SimpleNamespace
 
 from aidev_agent.packages.opentelemetry.config import OTelConfig
 from aidev_agent.packages.opentelemetry.metrics import (
+    AGENT_ITERATION_HISTOGRAM_BOUNDARIES,
     DURATION_HISTOGRAM_BOUNDARIES,
     MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
 )
@@ -58,3 +59,4 @@ def test_direct_metric_provider_uses_configured_reader_and_shared_histogram_view
     views = provider.call_args.kwargs["views"]
     assert tuple(views[0]._aggregation._boundaries) == DURATION_HISTOGRAM_BOUNDARIES
     assert tuple(views[1]._aggregation._boundaries) == MESSAGE_SIZE_HISTOGRAM_BOUNDARIES
+    assert tuple(views[2]._aggregation._boundaries) == AGENT_ITERATION_HISTOGRAM_BOUNDARIES

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse, urlunparse
 
 import requests
 from aidev_agent.packages.opentelemetry.metrics import (
+    AGENT_ITERATION_HISTOGRAM_BOUNDARIES,
     DURATION_HISTOGRAM_BOUNDARIES,
     MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
 )
@@ -412,6 +413,10 @@ class BkPluginMetricService:
             View(
                 instrument_name="aidev.message.publish.size",
                 aggregation=ExplicitBucketHistogramAggregation(boundaries=MESSAGE_SIZE_HISTOGRAM_BOUNDARIES),
+            ),
+            View(
+                instrument_name="gen_ai.invoke_agent.iteration_count",
+                aggregation=ExplicitBucketHistogramAggregation(boundaries=AGENT_ITERATION_HISTOGRAM_BOUNDARIES),
             ),
         ]
 

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -11,6 +11,7 @@ import requests
 pytest.importorskip("opentelemetry.sdk.metrics")
 
 from aidev_agent.packages.opentelemetry.metrics import (
+    AGENT_ITERATION_HISTOGRAM_BOUNDARIES,
     DURATION_HISTOGRAM_BOUNDARIES,
     MESSAGE_SIZE_HISTOGRAM_BOUNDARIES,
 )
@@ -258,6 +259,7 @@ def test_metric_service_uses_agent_sdk_histogram_boundaries():
 
     assert tuple(views[0]._aggregation._boundaries) == DURATION_HISTOGRAM_BOUNDARIES
     assert tuple(views[1]._aggregation._boundaries) == MESSAGE_SIZE_HISTOGRAM_BOUNDARIES
+    assert tuple(views[2]._aggregation._boundaries) == AGENT_ITERATION_HISTOGRAM_BOUNDARIES
 
 
 def test_bkm_records_preserve_counter_and_histogram_semantics():


### PR DESCRIPTION
## Background

Improve Agent runtime observability and provide dashboards for both local Prometheus/Grafana validation and BK Monitor imports.

## Changes

- report Agent iteration count as a histogram and expose P95 iteration count
- use mutually exclusive Agent phase metrics for LLM and Tool phase cards
- add running Agent/session counts, total error events, and error distribution by Agent
- add a separately generated BK Monitor dashboard using the configured time-series datasource
- let the generated template explicitly disable metric export regardless of the downloaded Agent configuration
- extend tests for metric views, callback behavior, and both dashboard formats

## Validation

- Agent OpenTelemetry tests: 39 passed
- plugin exporter and local observability tests: 43 passed
- changed-file lint, formatting, merge-conflict, JSON, and diff checks passed
