### PR TITLE
feat: 支持模板强制关闭智能体指标 --story=1070093903136959970

### DIFF
--- a/dev/otel/README.md
+++ b/dev/otel/README.md
@@ -232,10 +232,12 @@ OTel Counter 转成 BKM 的 `*_total`；Histogram 转成累计 `*_bucket`（`le`
 生产默认周期为 10 秒；显式下发 `export_interval_millis` 时仍以配置值为准。本地 mock 为了缩短
 仪表盘验证等待时间，继续使用 1 秒周期。
 
-本地生成项目的 `.env` 可只配置以下三项；未显式配置 `metrics.enabled` 时，三项齐全会自动启用
-BKM 指标。平台下发的 `otel_info.metrics.agent_*` 优先级高于环境变量：
+本地生成项目默认使用 `BKAI_AGENT_ENABLE_METRICS=false` 强制关闭指标，该显式环境变量的优先级
+高于平台下发的 `otel_info.metrics.enabled`。需要联调 BKM 时改为 `true` 并配置以下参数；平台下发的
+`otel_info.metrics.agent_*` 仍优先于同名连接参数环境变量：
 
 ```bash
+BKAI_AGENT_ENABLE_METRICS=true
 BKAI_AGENT_METRICS_HOST=proxy.example
 BKAI_AGENT_METRICS_DATA_ID=1001
 BKAI_AGENT_METRICS_TOKEN=<本地密钥>

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/otel_metrics.py
@@ -106,7 +106,12 @@ class MetricExportSettings:
         has_bkm_config = data_id not in (None, "") and bool(access_token and push_url)
         if export_via_celery is None:
             export_via_celery = has_bkm_config
-        enabled = metrics_info.get("enabled", otel_info.get("enable_metrics", default_enabled or has_bkm_config))
+        environment_enabled = os.getenv("BKAI_AGENT_ENABLE_METRICS")
+        enabled = (
+            environment_enabled
+            if environment_enabled is not None
+            else metrics_info.get("enabled", otel_info.get("enable_metrics", default_enabled or has_bkm_config))
+        )
         return cls(
             enabled=_as_bool(enabled),
             export_interval_millis=max(1000, int(interval)),

--- a/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_otel_metrics.py
@@ -225,6 +225,26 @@ def test_metric_settings_parse_false_string_safely():
     assert settings.enabled is False
 
 
+def test_metric_settings_explicit_environment_disable_overrides_agent_info(monkeypatch):
+    monkeypatch.setenv("BKAI_AGENT_ENABLE_METRICS", "false")
+
+    settings = MetricExportSettings.from_agent_info(
+        {
+            "otel_info": {
+                "metrics": {
+                    "enabled": True,
+                    "agent_data_id": 1001,
+                    "agent_access_token": "platform-secret",
+                    "agent_push_url": "http://platform-proxy:10205/v2/push/",
+                }
+            }
+        },
+        default_enabled=True,
+    )
+
+    assert settings.enabled is False
+
+
 def test_metric_resource_uses_agent_sdk_version_without_agent_type():
     service = BkPluginMetricService(
         service_name="ai-demo",

--- a/template/builtin/{{cookiecutter.project_name}}/readme.md
+++ b/template/builtin/{{cookiecutter.project_name}}/readme.md
@@ -29,6 +29,9 @@ cp ./support-files/env.template .env
 
 **注意：support-files/env.template 是环境变量模板，会提交到代码仓库，请勿配置敏感信息**
 
+模板默认设置 `BKAI_AGENT_ENABLE_METRICS=false`，本地运行时会强制关闭指标，即使平台下发的
+`agent_info.otel_info.metrics` 为启用状态也不会上报；需要联调指标时再显式改为 `true`。
+
 ### 1.4 启动服务并测试
 
 #### 1.4.1 UNIX 系统

--- a/template/builtin/{{cookiecutter.project_name}}/support-files/env.template
+++ b/template/builtin/{{cookiecutter.project_name}}/support-files/env.template
@@ -11,7 +11,9 @@ export AIDEV_SPACE_ID={{ cookiecutter.extra_fields.space_id }}
 export AIDEV_GATEWAY_NAME={{ cookiecutter.aidev_gateway_name }}
 export BK_APIGW_STAGE={{ cookiecutter.bk_apigw_stage }}
 
-# Agent 指标本地上报（BKM 自定义指标协议；请从监控平台获取实际配置）
+# Agent 指标本地上报（显式 false 优先于平台下发的 Agent 配置）
+export BKAI_AGENT_ENABLE_METRICS=false
+# BKM 自定义指标协议；启用时改为 true，并从监控平台获取实际配置
 export BKAI_AGENT_METRICS_HOST=
 export BKAI_AGENT_METRICS_DATA_ID=
 export BKAI_AGENT_METRICS_TOKEN=


### PR DESCRIPTION
## Background

Generated Agent projects should be able to disable metric export locally even when the downloaded Agent configuration enables it.

## Changes

- treat an explicitly configured `BKAI_AGENT_ENABLE_METRICS` value as the highest-priority metric switch
- default the generated template environment to `BKAI_AGENT_ENABLE_METRICS=false`
- document how to opt in to local metric validation
- cover the case where the environment disables metrics while Agent configuration and exporter credentials enable them

## Validation

- plugin exporter and local observability tests: 43 passed
- changed-file lint, formatting, merge-conflict, and diff checks passed
- full repository pre-commit was executed; it remains blocked by existing lint findings outside this change

