### PR TITLE
feat: 补齐 MCP 工具与 Sandbox Trace 链路 --story=1070093903137679449

### DIFF
--- a/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
@@ -41,6 +41,7 @@ from langchain_core.runnables import RunnableConfig
 from requests.exceptions import HTTPError
 
 from aidev_agent.config import settings
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span
 
 from .types import (
     EditResult,
@@ -157,6 +158,27 @@ def _paas_retry_on_not_ready(func):
     return wrapper
 
 
+def _trace_sandbox_operation(operation: str):
+    """Trace one logical sandbox API operation, including all retries."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with recording_span(
+                f"sandbox.{operation}",
+                kind=CLIENT_SPAN_KIND,
+                attributes={
+                    "sandbox.operation.name": operation,
+                    "sandbox.backend": "paas",
+                },
+            ):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
 # ---------------------------------------------------------------------------
 # 数据结构
 # ---------------------------------------------------------------------------
@@ -270,6 +292,7 @@ class PaasSandboxBackend(RuntimeBackend):
 
     # ---- PaaS HTTP API（原 PaasSandboxClient 公开方法） ----
 
+    @_trace_sandbox_operation("create")
     @_paas_retry_on_not_ready
     def create_sandbox(
         self,
@@ -333,6 +356,7 @@ class PaasSandboxBackend(RuntimeBackend):
             return str(data["uuid"])
         raise ValueError(f"创建沙箱返回格式异常: {data}")
 
+    @_trace_sandbox_operation("destroy")
     @_paas_retry_on_not_ready
     def destroy_sandbox(self, sandbox_id: str, *, timeout: int = 10) -> None:
         """销毁沙箱。
@@ -344,6 +368,7 @@ class PaasSandboxBackend(RuntimeBackend):
         response = self.client.delete_sandbox.request(path_params={"sandbox_id": sandbox_id}, timeout=timeout)
         response.raise_for_status()
 
+    @_trace_sandbox_operation("execute")
     @_paas_retry_on_not_ready
     def exec_command(
         self,
@@ -380,6 +405,7 @@ class PaasSandboxBackend(RuntimeBackend):
         # 兼容：如果 data 不是 dict，将其作为 stdout
         return ExecResult(stdout=str(data or ""), stderr="", exit_code=None)
 
+    @_trace_sandbox_operation("upload_file")
     @_paas_retry_on_not_ready
     def upload_file(self, sandbox_id: str, path: str, content: bytes) -> None:
         """上传文件到沙箱。
@@ -401,6 +427,7 @@ class PaasSandboxBackend(RuntimeBackend):
         )
         response.raise_for_status()
 
+    @_trace_sandbox_operation("download_file")
     @_paas_retry_on_not_ready
     def download_file(self, sandbox_id: str, path: str) -> bytes:
         """从沙箱下载文件。
@@ -615,9 +642,7 @@ class PaasSandboxBackend(RuntimeBackend):
         # 通过文件上传 API 写入
         file_bytes = content.encode("utf-8")
         if not file_bytes:
-            raise ValueError(
-                "Cannot write empty content. Provide non-empty content or use execute to create the file."
-            )
+            raise ValueError("Cannot write empty content. Provide non-empty content or use execute to create the file.")
         self.upload_file(sandbox_id, file_path, file_bytes)
 
         return WriteResult(path=file_path, files_update=None)

--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -1116,6 +1116,20 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             "tool.call_index": self.tool_call_counter,
             "tool.input": input_str,
         }
+        metadata = metadata or {}
+        if mcp_name := metadata.get("mcp_name"):
+            attributes.update(
+                {
+                    "tool.type": "mcp",
+                    "rpc.system": "mcp",
+                    "mcp.operation.name": "tools/call",
+                    "mcp.server.name": str(mcp_name),
+                    "mcp.tool.name": tool_name,
+                    "mcp.transport": str(metadata.get("mcp_transport") or "unknown"),
+                }
+            )
+        elif tool_code := metadata.get("tool_code"):
+            attributes.update({"tool.type": "http_api", "tool.code": str(tool_code)})
         self._create_span(
             run_id=run_id,
             parent_run_id=parent_run_id,

--- a/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
@@ -26,6 +26,7 @@ from opentelemetry.instrumentation.utils import unwrap
 from wrapt import wrap_function_wrapper
 
 from aidev_agent.pydantic_models import ExecuteKwargs
+from aidev_agent.utils.tracing import set_agent_tracer
 
 from .callback_handler import BkAidevAgentCallbackHandler, BkAidevAgentInjector
 from .config import OTelConfig
@@ -90,6 +91,7 @@ class BkAidevAgentInstrumentor(BaseInstrumentor):
         if tracer is None:
             self.start_otel_service()
             tracer = self._otel_service.get_tracer(__name__)
+        set_agent_tracer(tracer)
         # 在 _get_agent 阶段一次性完成：
         #   1. 创建 root span（HTTP 线程，便于同步 RPC 关联）
         #   2. 注入 caller_trace_context 用于跨服务传播
@@ -118,6 +120,7 @@ class BkAidevAgentInstrumentor(BaseInstrumentor):
             bool: 是否成功取消插桩
         """
         self.stop_otel_service()
+        set_agent_tracer(None)
         unwrap("aidev_agent.services.agent.chat", "ChatCompletionAgent._get_agent")
         unwrap("aidev_agent.core.nodes.knowledge", "AgentKnowledgeNode.__call__")
 

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -35,6 +35,7 @@ from aidev_agent.packages.langchain_core.tools.base import (
 )
 from aidev_agent.pydantic_models import AgentConfig
 from aidev_agent.utils.loop import run_coro_sync
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span
 
 try:
     import bkoauth
@@ -537,10 +538,24 @@ class BaseResourceManager(abc.ABC):
 
         async def _load_tool(server_name, selected_tools_map, index) -> tuple[list[StructuredTool], Any | None]:
             _start = time.monotonic()
+            server_config = new_server_config[server_name]
+            transport = str(server_config.get("transport") or "unknown")
             for _i in range(2):
                 client = MultiServerMCPClient(new_server_config)
                 try:
-                    tools: list[StructuredTool] = await client.get_tools(server_name=server_name)
+                    with recording_span(
+                        "mcp.tools.list",
+                        kind=CLIENT_SPAN_KIND,
+                        attributes={
+                            "rpc.system": "mcp",
+                            "mcp.operation.name": "tools/list",
+                            "mcp.server.name": server_name,
+                            "mcp.transport": transport,
+                            "mcp.retry.count": _i,
+                        },
+                    ) as span:
+                        tools: list[StructuredTool] = await client.get_tools(server_name=server_name)
+                        span.set_attribute("mcp.tool.count", len(tools))
                     total_count = len(tools)
                     if selected_tools_map.get(server_name):
                         tools = [each for each in tools if each.name in selected_tools_map[server_name]]
@@ -557,6 +572,7 @@ class BaseResourceManager(abc.ABC):
                         if not each.metadata:
                             each.metadata = {}
                         each.metadata["mcp_name"] = server_name
+                        each.metadata["mcp_transport"] = transport
                     return (tools, None)
                 except Exception as err:
                     error_detail = _extract_mcp_tools_error_detail(err)

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -91,6 +91,7 @@ class SessionContentProperty(BaseModel):
     """会话内容的一些额外属性"""
 
     turn_id: str = Field(default="", description="同一次 user-ai 回复的轮次 ID")
+    trace_id: str = Field(default="", description="创建会话内容时的 Trace ID")
     extra: SessionContentExtra | None = None
 
 

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""Optional OpenTelemetry helpers shared by Agent SDK integrations."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
+except ImportError:  # OpenTelemetry is an optional Agent SDK extra.
+    trace = None
+    SpanKind = None
+    Status = None
+    StatusCode = None
+    Tracer = Any
+
+_agent_tracer: Tracer | None = None
+CLIENT_SPAN_KIND = SpanKind.CLIENT if SpanKind is not None else None
+
+
+class _NoOpSpan:
+    """Minimal span surface used when the OpenTelemetry extra is absent."""
+
+    @staticmethod
+    def is_recording() -> bool:
+        return False
+
+    @staticmethod
+    def set_attribute(name: str, value: Any) -> None:
+        return None
+
+
+def set_agent_tracer(tracer: Tracer | None) -> None:
+    """Register the tracer owned by ``BkAidevAgentInstrumentor``.
+
+    The agent exporter intentionally uses a private ``TracerProvider``. Code
+    outside the LangChain callback therefore cannot rely on the global tracer
+    provider when it needs to create a child span.
+    """
+
+    global _agent_tracer
+    _agent_tracer = tracer
+
+
+def get_agent_tracer(name: str) -> Tracer | None:
+    """Return the agent tracer, falling back to the global no-op capable API."""
+
+    return _agent_tracer or (trace.get_tracer(name) if trace is not None else None)
+
+
+@contextmanager
+def recording_span(
+    name: str,
+    *,
+    attributes: dict[str, Any] | None = None,
+    kind: Any = None,
+) -> Iterator[Any]:
+    """Create an agent span and consistently record its final status."""
+
+    tracer = get_agent_tracer(__name__)
+    if tracer is None:
+        yield _NoOpSpan()
+        return
+
+    start_kwargs: dict[str, Any] = {"attributes": attributes or {}}
+    if kind is not None:
+        start_kwargs["kind"] = kind
+    with tracer.start_as_current_span(name, **start_kwargs) as span:
+        try:
+            yield span
+        except Exception as exc:
+            if span.is_recording():
+                span.record_exception(exc)
+                span.set_status(Status(StatusCode.ERROR, str(exc)))
+            raise
+        else:
+            if span.is_recording():
+                span.set_status(Status(StatusCode.OK))

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -9,12 +9,10 @@ from typing import Any
 
 try:
     from opentelemetry import trace
-    from opentelemetry.trace import SpanKind, Status, StatusCode, Tracer
+    from opentelemetry.trace import SpanKind, Tracer
 except ImportError:  # OpenTelemetry is an optional Agent SDK extra.
     trace = None
     SpanKind = None
-    Status = None
-    StatusCode = None
     Tracer = Any
 
 _agent_tracer: Tracer | None = None
@@ -58,7 +56,7 @@ def recording_span(
     attributes: dict[str, Any] | None = None,
     kind: Any = None,
 ) -> Iterator[Any]:
-    """Create an agent span and consistently record its final status."""
+    """Create a span with the Agent tracer, or safely no-op without OTel."""
 
     tracer = get_agent_tracer(__name__)
     if tracer is None:
@@ -69,13 +67,4 @@ def recording_span(
     if kind is not None:
         start_kwargs["kind"] = kind
     with tracer.start_as_current_span(name, **start_kwargs) as span:
-        try:
-            yield span
-        except Exception as exc:
-            if span.is_recording():
-                span.record_exception(exc)
-                span.set_status(Status(StatusCode.ERROR, str(exc)))
-            raise
-        else:
-            if span.is_recording():
-                span.set_status(Status(StatusCode.OK))
+        yield span

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -49,6 +49,15 @@ def get_agent_tracer(name: str) -> Tracer | None:
     return _agent_tracer or (trace.get_tracer(name) if trace is not None else None)
 
 
+def get_current_trace_id() -> str | None:
+    """Return the active OpenTelemetry trace ID without requiring the OTel extra."""
+
+    if trace is None:
+        return None
+    context = trace.get_current_span().get_span_context()
+    return format(context.trace_id, "032x") if context.trace_id else None
+
+
 @contextmanager
 def recording_span(
     name: str,

--- a/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 import pytest
 from aidev_agent.core.tools.runtime_tools.paas_backend import ExecResult, PaasSandboxBackend
 from aidev_agent.core.tools.runtime_tools.types import EditResult, ExecuteResult, WriteResult
+from aidev_agent.utils.tracing import set_agent_tracer
 from requests.exceptions import HTTPError
 
 # ---------------------------------------------------------------------------
@@ -742,6 +743,31 @@ class TestPaasSandboxBackendErrors:
 
 class TestPaasSandboxBackendHTTPMethods:
     """测试各 HTTP API 方法（通过 mock client）。"""
+
+    def test_exec_command_records_sandbox_client_span(self, http_backend):
+        TracerProvider = pytest.importorskip("opentelemetry.sdk.trace").TracerProvider
+        SimpleSpanProcessor = pytest.importorskip("opentelemetry.sdk.trace.export").SimpleSpanProcessor
+        InMemorySpanExporter = pytest.importorskip(
+            "opentelemetry.sdk.trace.export.in_memory_span_exporter"
+        ).InMemorySpanExporter
+        exporter = InMemorySpanExporter()
+        provider = TracerProvider()
+        provider.add_span_processor(SimpleSpanProcessor(exporter))
+        set_agent_tracer(provider.get_tracer(__name__))
+        http_backend.client.exec_command.request.return_value = _make_http_response(
+            json_data={"stdout": "ok", "stderr": "", "exit_code": 0}
+        )
+
+        try:
+            http_backend.exec_command("sb-123", "echo hello")
+        finally:
+            set_agent_tracer(None)
+
+        span = exporter.get_finished_spans()[0]
+        assert span.name == "sandbox.execute"
+        assert span.kind.name == "CLIENT"
+        assert span.attributes["sandbox.operation.name"] == "execute"
+        assert "echo hello" not in str(span.attributes)
 
     @pytest.fixture()
     def http_backend(self):

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -478,8 +478,39 @@ def test_make_mcp_tools_basic(mock_mcp_client_class, sample_mcp_config):
     assert len(result.tools) == 1
     assert result.tools[0].name == "test-mcp-tool"
     assert result.tools[0].metadata["mcp_name"] == "tencentcloud-doc-mcp"
+    assert result.tools[0].metadata["mcp_transport"] == "streamable_http"
     assert result.fetch_failures == []
     mock_mcp_client_class.assert_called_once()
+
+
+@patch("aidev_agent.packages.resource_manager.base.recording_span")
+@patch("aidev_agent.packages.resource_manager.base.MultiServerMCPClient")
+def test_make_mcp_tools_records_list_semantics(mock_mcp_client_class, mock_recording_span, sample_mcp_config):
+    from aidev_agent.utils.tracing import CLIENT_SPAN_KIND
+
+    mock_tool = MagicMock(spec=StructuredTool)
+    mock_tool.name = "test-mcp-tool"
+    mock_tool.coroutine = AsyncMock()
+    mock_tool.metadata = {}
+    mock_client = MagicMock()
+    mock_client.get_tools = AsyncMock(return_value=[mock_tool])
+    mock_mcp_client_class.return_value = mock_client
+    span = mock_recording_span.return_value.__enter__.return_value
+
+    make_mcp_tools(sample_mcp_config)
+
+    mock_recording_span.assert_called_once_with(
+        "mcp.tools.list",
+        kind=CLIENT_SPAN_KIND,
+        attributes={
+            "rpc.system": "mcp",
+            "mcp.operation.name": "tools/list",
+            "mcp.server.name": "tencentcloud-doc-mcp",
+            "mcp.transport": "streamable_http",
+            "mcp.retry.count": 0,
+        },
+    )
+    span.set_attribute.assert_called_once_with("mcp.tool.count", 1)
 
 
 @patch("aidev_agent.packages.resource_manager.base.MultiServerMCPClient")

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -579,6 +579,48 @@ class TestBkAidevAgentCallbackHandler:
         assert span.attributes["tool.input"] == '{"action": "process", "data": [1, 2, 3]}'
         assert span.attributes["tool.execution_status"] == "success"
 
+    def test_mcp_tool_execution_span_has_mcp_semantic_attributes(self, tracer_and_exporter):
+        tracer, exporter = tracer_and_exporter
+        handler = BkAidevAgentCallbackHandler(tracer=tracer)
+        run_id = uuid4()
+
+        asyncio.run(
+            handler.on_tool_start(
+                serialized={"name": "search"},
+                input_str='{"query": "blueking"}',
+                run_id=run_id,
+                metadata={"mcp_name": "resource", "mcp_transport": "streamable_http"},
+            )
+        )
+        asyncio.run(handler.on_tool_end(output="ok", run_id=run_id))
+
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["tool.type"] == "mcp"
+        assert span.attributes["rpc.system"] == "mcp"
+        assert span.attributes["mcp.operation.name"] == "tools/call"
+        assert span.attributes["mcp.server.name"] == "resource"
+        assert span.attributes["mcp.tool.name"] == "search"
+        assert span.attributes["mcp.transport"] == "streamable_http"
+
+    def test_http_tool_execution_span_has_interface_attributes(self, tracer_and_exporter):
+        tracer, exporter = tracer_and_exporter
+        handler = BkAidevAgentCallbackHandler(tracer=tracer)
+        run_id = uuid4()
+
+        asyncio.run(
+            handler.on_tool_start(
+                serialized={"name": "get_ticket"},
+                input_str="{}",
+                run_id=run_id,
+                metadata={"tool_code": "get_ticket"},
+            )
+        )
+        asyncio.run(handler.on_tool_end(output="ok", run_id=run_id))
+
+        span = exporter.get_finished_spans()[0]
+        assert span.attributes["tool.type"] == "http_api"
+        assert span.attributes["tool.code"] == "get_ticket"
+
     def test_rag_retrieval_span_attributes(self, tracer_and_exporter):
         """测试 rag.retrieval span 包含 rag.knowledge_bases 和 rag.knowledge_items 属性"""
         tracer, exporter = tracer_and_exporter

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -1,7 +1,6 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from aidev_agent.pydantic_models import (
     AgentExecutorKwargs,
     AgentOptions,
@@ -10,6 +9,7 @@ from aidev_agent.pydantic_models import (
     IntentRecognition,
     KnowledgebaseSettings,
     SessionContentExtra,
+    SessionContentProperty,
 )
 from aidev_agent.services.common_agent import CommonQAAgent
 
@@ -54,6 +54,12 @@ def test_chat_prompt():
 
     chat_prompt = ChatPrompt(role="system", content="aaa")
     assert chat_prompt.content == "aaa"
+
+
+def test_session_content_property_keeps_trace_id():
+    trace_id = "a" * 32
+
+    assert SessionContentProperty(trace_id=trace_id).model_dump()["trace_id"] == trace_id
 
 
 def test_legacy_agent_options_allow_extra_fields():

--- a/src/agent/tests/utils/test_tracing.py
+++ b/src/agent/tests/utils/test_tracing.py
@@ -1,0 +1,20 @@
+from unittest.mock import MagicMock
+
+from aidev_agent.utils import tracing
+
+
+def test_get_current_trace_id_returns_active_trace_id(monkeypatch):
+    context = MagicMock(trace_id=int("a" * 32, 16))
+    span = MagicMock()
+    span.get_span_context.return_value = context
+    trace_api = MagicMock()
+    trace_api.get_current_span.return_value = span
+    monkeypatch.setattr(tracing, "trace", trace_api)
+
+    assert tracing.get_current_trace_id() == "a" * 32
+
+
+def test_get_current_trace_id_without_otel(monkeypatch):
+    monkeypatch.setattr(tracing, "trace", None)
+
+    assert tracing.get_current_trace_id() is None

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/drf/renderers.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/drf/renderers.py
@@ -18,6 +18,7 @@ to the current version of the project delivered to anyone in the future.
 
 import json
 
+from aidev_agent.utils.tracing import get_current_trace_id
 from pydantic import BaseModel
 from rest_framework import status
 from rest_framework.renderers import JSONRenderer
@@ -30,6 +31,12 @@ class BKAIDevJSONRenderer(encoders.JSONEncoder):
         if isinstance(obj, BaseModel):
             return obj.model_dump()
         return super().default(obj)
+
+
+def get_response_trace_id(request) -> str | None:
+    """Resolve the request trace ID, falling back to the active OTel span."""
+
+    return getattr(request, "otel_trace_id", None) or get_current_trace_id()
 
 
 class APIRenderer(JSONRenderer):
@@ -45,7 +52,7 @@ class APIRenderer(JSONRenderer):
         统一处理返回数据
         """
         response = renderer_context["response"]
-        trace_id = getattr(renderer_context.get("request"), "otel_trace_id", None)
+        trace_id = get_response_trace_id(renderer_context.get("request"))
 
         if is_success(response.status_code):
             response.status_code = status.HTTP_200_OK

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/base.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/base.py
@@ -19,6 +19,7 @@ from rest_framework.viewsets import ViewSetMixin
 
 from aidev_bkplugin.packages.drf.authentication import custom_authentication_classes
 from aidev_bkplugin.packages.drf.decorators import login_exempt
+from aidev_bkplugin.packages.drf.renderers import get_response_trace_id
 from aidev_bkplugin.permissions import AgentPluginPermission
 from aidev_bkplugin.services.agent_builder import LLMOverrideResourceManager
 from aidev_bkplugin.services.agent_helpers import AgentHelper
@@ -141,7 +142,7 @@ class PluginViewSet(ViewSetMixin, APIView):
             return response
         # 目前仅对 Restful Response 进行处理
         if isinstance(response, Response):
-            trace_id = getattr(request, "otel_trace_id", None)
+            trace_id = get_response_trace_id(request)
             if is_success(response.status_code):
                 response.status_code = status.HTTP_200_OK
                 response.data = {

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -15,6 +15,7 @@ from blueapps.core.exceptions import ClientBlueException
 from django.http.response import StreamingHttpResponse
 from rest_framework.views import Response
 
+from aidev_bkplugin.packages.drf.renderers import get_response_trace_id
 from aidev_bkplugin.serializers.chat_completion import ChatCompletionRequestSerializer
 from aidev_bkplugin.services.agent_builder import AgentBuilder
 from aidev_bkplugin.services.agent_execution import AgentExecutor
@@ -527,7 +528,8 @@ class ChatCompletionViewSet(PluginViewSet):
         sr.headers["Cache-Control"] = "no-cache"
         sr.headers["X-Accel-Buffering"] = "no"
         sr.headers["content-type"] = "text/event-stream"
-        sr.headers["Otel-Trace-Id"] = getattr(self.request._request, "otel_trace_id", "") or ""
+        trace_id = get_response_trace_id(self.request._request) or ""
+        sr.headers["Otel-Trace-Id"] = trace_id
         # 注入 session 相关响应标头，便于客户端获取会话信息和跳转链接
         if session_code:
             sr.headers["x-bkaidev-agent-session-code"] = session_code

--- a/src/plugins/aidev_bkplugin/tests/packages/drf/test_renderers_trace.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/drf/test_renderers_trace.py
@@ -1,0 +1,25 @@
+import json
+from types import SimpleNamespace
+
+from aidev_bkplugin.packages.drf.renderers import APIRenderer, get_response_trace_id
+
+
+def test_get_response_trace_id_falls_back_to_current_span(mocker):
+    trace_id = "b" * 32
+    mocker.patch("aidev_bkplugin.packages.drf.renderers.get_current_trace_id", return_value=trace_id)
+
+    assert get_response_trace_id(SimpleNamespace()) == trace_id
+
+
+def test_error_renderer_returns_current_trace_id(mocker):
+    trace_id = "c" * 32
+    mocker.patch("aidev_bkplugin.packages.drf.renderers.get_current_trace_id", return_value=trace_id)
+    data = {"code": "invalid", "message": "bad request", "data": None}
+    context = {
+        "request": SimpleNamespace(),
+        "response": SimpleNamespace(status_code=400, data=data),
+    }
+
+    content = APIRenderer().render(data, renderer_context=context)
+
+    assert json.loads(content)["trace_id"] == trace_id


### PR DESCRIPTION
## 变更
- 为 MCP tools/list 增加 CLIENT Span 与 server、transport、retry、tool count 语义
- 为 MCP 与普通 HTTP 工具的 tool.execution 增加可检索语义属性
- 为 PaaS Sandbox 远程操作增加 CLIENT Span，覆盖重试与底层 HTTP
- 保持 OpenTelemetry extra 可选，未安装时自动 no-op
- SessionContentProperty 增加 trace_id，确保 Session Content 属性可序列化并返回创建链路标识
- template 使用的 bkplugin 统一响应从当前 Span 补齐 trace_id；覆盖普通成功、错误响应和流式响应头

## 验证
- 目标文件 pre-commit（ruff、ruff-format、merge-conflict）通过
- SessionContentProperty trace_id 新增测试 1 passed
- 当前 Trace ID 与 template 响应新增测试 4 passed
- 原有 Trace 新增定向测试 5 passed
- 无 OpenTelemetry extra 环境导入与 no-op 降级通过

## 范围
仅 Trace 相关；不包含 query_param 序列化与 MCP GET/DELETE 兼容修改。
