### PR TITLE
feat: 新增宿主接入 trace 的工具并把 trace_id 随会话内容入库 --story=136129662

### DIFF
--- a/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/instrumentor.py
@@ -23,6 +23,7 @@ import orjson
 from langchain_core.messages import BaseMessage
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.sdk.trace import TracerProvider
 from wrapt import wrap_function_wrapper
 
 from aidev_agent.pydantic_models import ExecuteKwargs
@@ -36,6 +37,22 @@ from .utils import dont_throw
 logger = logging.getLogger(__name__)
 
 _instruments = ("langchain-core > 0.1.0",)
+
+
+def get_agent_tracer_provider() -> Optional[TracerProvider]:
+    """返回已启动的 Agent TracerProvider；未 instrument 时为 None。
+
+    供宿主（如企微长连接）复用同一套 exporter 与 resource。本插桩器刻意不把 provider
+    注册为全局（见 ``BkAidevAgentInstrumentor`` 说明），宿主若自建一个，它产出的 span
+    会落在另一棵树上且无处上报。
+
+    直接读单例属性而不是构造 ``BkAidevAgentInstrumentor()``：``BaseInstrumentor.__new__``
+    返回单例，但 ``__init__`` 仍会重跑并把 ``_otel_service`` 抹回 None。
+    """
+    instance = BkAidevAgentInstrumentor._instance
+    if instance is None or instance._otel_service is None:
+        return None
+    return instance._otel_service.tracer_provider
 
 
 class BkAidevAgentInstrumentor(BaseInstrumentor):

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -40,6 +40,7 @@ from aidev_agent.core.ag_ui.types import (
 from aidev_agent.core.ag_ui.utils import camel_to_snake, get_interrupt_value, unwrap_interrupt_source
 from aidev_agent.enums import ActivityType, PromptRole
 from aidev_agent.utils.event import RunId
+from aidev_agent.utils.tracing import current_trace_id
 
 logger = getLogger(__name__)
 
@@ -274,16 +275,18 @@ class BaseSessionWriter(ABC):
             message_id = extract_message_id(upgraded)
             db_item_adapter = {"property": {"builtin_property": bp}}
             updated_builtin = build_updated_builtin_property(db_item_adapter, message_id, status)
+            payload = {
+                "content": upgraded,
+                "status": "complete",
+                "property": {
+                    "builtin_property": updated_builtin,
+                    "turn_id": value.get("turn_id") or "",
+                },
+            }
+            self._stamp_trace_id(payload)
             self._do_update_content(
                 content_id=content_id,
-                payload={
-                    "content": upgraded,
-                    "status": "complete",
-                    "property": {
-                        "builtin_property": updated_builtin,
-                        "turn_id": value.get("turn_id") or "",
-                    },
-                },
+                payload=payload,
                 headers=self._get_headers(),
             )
             logger.info(
@@ -300,14 +303,16 @@ class BaseSessionWriter(ABC):
         """处理 user 输入落库事件（所有带 input 路径）：直调 _do_create_content 写 user 记录。"""
         value = event.value if isinstance(event.value, dict) else {}
         try:
+            payload = {
+                "session_code": self.session_code,
+                "role": PromptRole.USER.value,
+                "content": value.get("content") or "",
+                "status": "success",
+                "property": {"turn_id": value.get("turn_id") or ""},
+            }
+            self._stamp_trace_id(payload)
             self._do_create_content(
-                payload={
-                    "session_code": self.session_code,
-                    "role": PromptRole.USER.value,
-                    "content": value.get("content") or "",
-                    "status": "success",
-                    "property": {"turn_id": value.get("turn_id") or ""},
-                },
+                payload=payload,
                 headers=self._get_headers(),
             )
         except Exception:
@@ -1456,6 +1461,16 @@ class BaseSessionWriter(ABC):
             logger.exception(f"Failed to {action} session content: message_id={message_id}, error={e}", exc_info=True)
             return None
 
+    @staticmethod
+    def _stamp_trace_id(payload: dict[str, Any]) -> None:
+        """把当前 trace id 盖进 payload.property，原地修改。
+
+        与 turn_id 并列：turn_id 标识一轮 user-ai 对话，trace_id 标识这轮实际执行的
+        调用链，两者一起才能从一条会话记录直接跳到 APM。无有效 span 时不写空值。
+        """
+        if trace_id := current_trace_id():
+            payload.setdefault("property", {})["trace_id"] = trace_id
+
     def _create_session_content(
         self,
         message_id: str,
@@ -1489,6 +1504,7 @@ class BaseSessionWriter(ABC):
         }
         if self.turn_id:
             payload["property"]["turn_id"] = self.turn_id
+        self._stamp_trace_id(payload)
         content_id = self._safe_call(
             self._do_create_content, message_id, "create", payload=payload, headers=self._get_headers()
         )
@@ -1519,6 +1535,7 @@ class BaseSessionWriter(ABC):
         }
         if self.turn_id:
             payload["property"]["turn_id"] = self.turn_id
+        self._stamp_trace_id(payload)
         self._safe_call(
             self._do_update_content,
             message_id,

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+"""
+TencentBlueKing is pleased to support the open source community by making
+蓝鲸智云 - AIDev (BlueKing - AIDev) available.
+Copyright (C) 2025 THL A29 Limited,
+a Tencent company. All rights reserved.
+Licensed under the MIT License (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at http://opensource.org/licenses/MIT
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the
+specific language governing permissions and limitations under the License.
+We undertake not to change the open source license (MIT license) applicable
+to the current version of the project delivered to anyone in the future.
+
+宿主进程接入 Agent trace 的工具：读当前 trace id、开请求级 root span、装全局 provider。
+
+面向的是「自己起进程驱动 Agent」的宿主（企微长连接是第一个，Celery worker、
+常驻消费者同理）。走 HTTP 的宿主由 blueapps + ``BkAidevAgentInstrumentor`` 兜住，
+用不上这里。
+
+独立于 ``packages.opentelemetry``：那个包的 __init__ 会连带导入 exporter，未装
+otel extras 的部署会直接 ImportError。本模块整体降级为空操作——宿主不该因为缺一个
+观测依赖就起不来，落库这类核心链路更不能被拖垮。
+"""
+
+import contextlib
+from collections.abc import Iterator
+from logging import getLogger
+from typing import Any, Optional
+
+logger = getLogger(__name__)
+
+try:
+    from opentelemetry import trace
+    from opentelemetry.context import Context
+except ImportError:  # pragma: no cover - 取决于部署时是否安装 otel
+    trace = None
+    Context = None
+
+try:
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import ConsoleSpanExporter, SimpleSpanProcessor
+except ImportError:  # pragma: no cover - SDK 与 instrumentation 同样是可选 extras
+    RequestsInstrumentor = None
+    TracerProvider = None
+    ConsoleSpanExporter = None
+    SimpleSpanProcessor = None
+
+_tracer = trace.get_tracer(__name__) if trace is not None else None
+
+
+def current_trace_id() -> str:
+    """当前 span 的 32 位 hex trace id；无有效 span 时返回空串。
+
+    不像 turn_id 那样逐层透传，是因为 OTel context 本来就跟着执行走：producer 线程
+    显式 copy_context，跨进程有 ExecuteKwargs.caller_trace_context。再铺一条平行的
+    参数链只会多出漏传的可能。
+    """
+    if trace is None:
+        return ""
+    span_context = trace.get_current_span().get_span_context()
+    return format(span_context.trace_id, "032x") if span_context.is_valid else ""
+
+
+@contextlib.contextmanager
+def start_request_span(name: str, **attributes: Any) -> Iterator[str]:
+    """为一次请求开一条独立 trace，yield 其 trace id（不可用时为空串）。
+
+    ``agent.execution`` 会自动挂到它下面：``BkAidevAgentInjector.on_bk_agent_start``
+    在没有上游 caller_trace_context 时传 ``context=None``，也就是取当前 context。
+
+    显式传空 Context 强制成为 root span。常驻 worker 线程上可能残留上一次执行未
+    detach 的 OTel context（LangChain 回调在生成器被中途丢弃时不保证走到
+    on_chain_end），继承过去会让不同请求共用同一个 trace id。
+    """
+    if _tracer is None:
+        yield ""
+        return
+    with _tracer.start_as_current_span(name, context=Context()) as span:
+        for key, value in attributes.items():
+            if value:
+                span.set_attribute(key, value)
+        yield current_trace_id()
+
+
+def setup_tracing(*, console: bool = False) -> bool:
+    """装上全局 TracerProvider 并让出站 requests 自动带 traceparent，返回是否装上。
+
+    两件事都是必须的，缺一条 trace 就断在半路：
+
+    1. ``BkAidevAgentInstrumentor`` 自建 provider 且刻意不注册为全局（见其 docstring
+       「默认使用由 BkAidevAgentInstrumentor 提供的 tracer_provider 而不是全局的」），
+       所以全局这里始终是 NoOp，本模块起的 span 拿不到有效 trace id。
+    2. 平台侧接口有的走宿主自己的 client、有的走 aidev_bkplugin 的 bkapi client，
+       手工注入总会漏；只能在 requests 这一层统一注入。
+
+    日志里的 provider 标明 span 去了哪：``agent_sdk`` 复用了 Agent 的 exporter，能在
+    APM 上看到；``standalone`` 是 Agent 侧 OTel 未启用时的兜底，trace id 有效且会透传
+    给平台，但本地不上报——平台侧仍能把一轮对话聚成一条 trace，只是缺了宿主这一段。
+
+    Args:
+        console: 把 span 摘要打到终端，见 :func:`_attach_console_exporter`。
+    """
+    if trace is None or TracerProvider is None or RequestsInstrumentor is None:
+        logger.info("event=agent_tracing_setup enabled=false reason=extras_missing")
+        return False
+
+    agent_provider = _agent_tracer_provider()
+    if isinstance(trace.get_tracer_provider(), TracerProvider):
+        # 已经有人设过全局（重复调用或宿主自行初始化），再设会被 OTel 拒绝并告警
+        source = "existing"
+    elif agent_provider is not None:
+        trace.set_tracer_provider(agent_provider)
+        source = "agent_sdk"
+    else:
+        trace.set_tracer_provider(TracerProvider())
+        source = "standalone"
+
+    RequestsInstrumentor().instrument()
+    attached = _attach_console_exporter() if console else False
+    logger.info("event=agent_tracing_setup enabled=true provider=%s console=%s", source, attached)
+    return True
+
+
+def _agent_tracer_provider() -> Optional[Any]:
+    """取 ``BkAidevAgentInstrumentor`` 已启动的 provider；取不到时为 None。
+
+    延迟导入：``packages.opentelemetry`` 的 __init__ 会连带导入 exporter，模块级
+    导入会让未装 extras 的部署连 current_trace_id 都用不上。
+    """
+    try:
+        from aidev_agent.packages.opentelemetry.instrumentor import get_agent_tracer_provider
+    except ImportError:  # pragma: no cover - 未装 otel extras
+        return None
+    return get_agent_tracer_provider()
+
+
+def _format_span_line(span) -> str:
+    """一行一个 span：靠 span/parent 两列就能把树拼出来，不必读整段 JSON。"""
+    span_context = span.get_span_context()
+    duration_ms = (span.end_time - span.start_time) / 1_000_000 if span.end_time else 0
+    parent = format(span.parent.span_id, "016x") if span.parent else "root"
+    return (
+        f"[span] trace={format(span_context.trace_id, '032x')} "
+        f"span={format(span_context.span_id, '016x')} parent={parent} "
+        f"{duration_ms:>8.0f}ms {span.name}\n"
+    )
+
+
+def _attach_console_exporter() -> bool:
+    """把 span 摘要打到终端，返回是否挂上。
+
+    本地排查用：APM 上看不到 span 时，先在这里确认它到底有没有产出，免得在
+    「没埋点」和「没上报」之间来回猜。挂到当前生效的 provider 上而不是新建一个，
+    否则打印出来的是另一棵树。用 Simple 而非 Batch，退出前不刷新就白打了。
+    """
+    provider = trace.get_tracer_provider()
+    if not hasattr(provider, "add_span_processor"):
+        return False
+    provider.add_span_processor(SimpleSpanProcessor(ConsoleSpanExporter(formatter=_format_span_line)))
+    return True

--- a/src/agent/pyproject.toml
+++ b/src/agent/pyproject.toml
@@ -59,6 +59,7 @@ opentelemetry = [
     "opentelemetry-exporter-otlp-proto-http==1.33.1",
     "opentelemetry-instrumentation==0.54b1",
     "opentelemetry-instrumentation-httpx==0.54b1",
+    "opentelemetry-instrumentation-requests==0.54b1",
     "opentelemetry-instrumentation-threading==0.54b1",
     "opentelemetry-instrumentation-langchain==0.38.10",
     "opentelemetry-semantic-conventions==0.54b1",
@@ -80,6 +81,8 @@ dev = [
     "pytest-xdist<4.0.0,>=3.5.0",
     "responses<1.0.0,>=0.25.0",
     "loguru>=0.7.3",
+    "opentelemetry-sdk==1.33.1",
+    "opentelemetry-instrumentation-requests==0.54b1",
 ]
 
 [tool.pdm.build]

--- a/src/agent/tests/services/event_handlers/test_session_content_trace_id.py
+++ b/src/agent/tests/services/event_handlers/test_session_content_trace_id.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""会话内容落库时给 property.trace_id 盖章。
+
+trace_id 与 turn_id 并列：turn_id 标识一轮 user-ai 对话，trace_id 标识这轮实际执行的
+调用链，两者一起才能从一条会话记录直接跳到 APM。
+
+trace_id 不像 turn_id 那样逐层透传，而是在写入时读当前 span——OTel context 本来就跟着
+执行走（producer 线程显式 copy_context，跨进程有 caller_trace_context）。因此这里的
+用例都围绕「有没有活跃 span」来组织。
+"""
+
+import pytest
+from ag_ui.core import CustomEvent, EventType
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+
+from aidev_agent.core.ag_ui.types import SessionPersistenceEventNames
+from aidev_agent.enums import PromptRole
+from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+from aidev_agent.utils.tracing import current_trace_id
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _tracer_provider():
+    """全局 provider 只能设一次；不挂 exporter，用例只关心 trace id 是否有效。"""
+    if not isinstance(trace.get_tracer_provider(), TracerProvider):
+        trace.set_tracer_provider(TracerProvider())
+
+
+class _MockApi:
+    def __init__(self):
+        self.created: list[dict] = []
+        self.updated: list[dict] = []
+
+    def create_chat_session_content(self, json, headers):
+        self.created.append(json)
+        return {"data": {"id": len(self.created)}}
+
+    def update_chat_session_content(self, path_params, json, headers):
+        self.updated.append(json)
+        return {"data": {"id": path_params["id"]}}
+
+
+class _MockClient:
+    def __init__(self):
+        self.api = _MockApi()
+
+
+def _writer(turn_id: str = "turn-1") -> AGUISessionWriter:
+    return AGUISessionWriter(
+        session_code="s-trace-1",
+        client=_MockClient(),
+        username="test",
+        tools=[],
+        turn_id=turn_id,
+    )
+
+
+class TestAssistantContent:
+    def test_trace_id_is_stamped_alongside_turn_id(self):
+        writer = _writer()
+
+        with trace.get_tracer(__name__).start_as_current_span("agent.execution"):
+            expected = current_trace_id()
+            writer._create_session_content(
+                message_id="m-1",
+                role=PromptRole.ASSISTANT.value,
+                content="hi",
+                status="complete",
+                builtin_property={"message_id": "m-1"},
+            )
+
+        prop = writer.client.api.created[0]["property"]
+        assert prop["trace_id"] == expected
+        assert prop["turn_id"] == "turn-1"
+
+    def test_no_active_span_leaves_the_key_out_entirely(self):
+        """宁可没有这个 key，也不要写个空串——查 APM 时空串比缺失更容易误导。"""
+        writer = _writer()
+
+        writer._create_session_content(
+            message_id="m-1",
+            role=PromptRole.ASSISTANT.value,
+            content="hi",
+            status="complete",
+            builtin_property={"message_id": "m-1"},
+        )
+
+        assert "trace_id" not in writer.client.api.created[0]["property"]
+
+    def test_updates_carry_the_trace_id_too(self):
+        """流式回复先建后更，只盖 create 的话最终落库记录反而丢了 trace_id。"""
+        writer = _writer()
+
+        with trace.get_tracer(__name__).start_as_current_span("agent.execution"):
+            expected = current_trace_id()
+            writer._update_session_content(
+                content_id=1,
+                message_id="m-1",
+                content="hi there",
+                builtin_property={"message_id": "m-1"},
+            )
+
+        assert writer.client.api.updated[0]["property"]["trace_id"] == expected
+
+
+class TestUserContent:
+    def test_user_record_shares_the_trace_id_with_the_reply(self):
+        """一轮对话的 user 与 assistant 必须同 trace，否则只能查到半截链路。"""
+        writer = _writer()
+        event = CustomEvent(
+            type=EventType.CUSTOM,
+            name=SessionPersistenceEventNames.UserInputSaved,
+            value={"content": "我要回家", "turn_id": "turn-1"},
+        )
+
+        with trace.get_tracer(__name__).start_as_current_span("agent.execution"):
+            expected = current_trace_id()
+            writer.handle_user_input_saved(event)
+            writer._create_session_content(
+                message_id="m-1",
+                role=PromptRole.ASSISTANT.value,
+                content="hi",
+                status="complete",
+                builtin_property={"message_id": "m-1"},
+            )
+
+        user_prop, assistant_prop = (record["property"] for record in writer.client.api.created)
+        assert user_prop["trace_id"] == assistant_prop["trace_id"] == expected
+
+
+class TestCurrentTraceId:
+    def test_returns_a_32_hex_id_inside_a_span(self):
+        with trace.get_tracer(__name__).start_as_current_span("agent.execution"):
+            assert len(current_trace_id()) == 32
+
+    def test_returns_empty_outside_any_span(self):
+        assert current_trace_id() == ""

--- a/src/agent/tests/utils/test_tracing.py
+++ b/src/agent/tests/utils/test_tracing.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""宿主进程接入 Agent trace：每个请求一条独立 trace，并让出站请求把它带给平台。
+
+面向自己起进程驱动 Agent 的宿主（企微长连接是第一个）。走 HTTP 的宿主由 blueapps +
+BkAidevAgentInstrumentor 兜住，用不上这里。
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from unittest.mock import patch
+
+import pytest
+import requests
+from opentelemetry import context as context_api
+from opentelemetry import trace
+from opentelemetry.instrumentation.requests import RequestsInstrumentor
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.util._once import Once
+
+from aidev_agent.utils import tracing
+from aidev_agent.utils.tracing import setup_tracing, start_request_span
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _tracer_provider() -> Iterator[None]:
+    """全局 TracerProvider 只能设一次，用内存 exporter 承接本模块产出的 span。
+
+    tracing.py 在 import 时拿到的是 ProxyTracer，会在首次使用时才解析 provider，
+    因此这里在 import 之后设置仍然生效。
+    """
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(InMemorySpanExporter()))
+    trace.set_tracer_provider(provider)
+    yield
+    # instrument 是进程级的，留着会影响同一轮里其它用例发出的请求
+    RequestsInstrumentor().uninstrument()
+
+
+@contextlib.contextmanager
+def _capture_outbound_headers() -> Iterator[dict]:
+    """拦在 adapter 层：instrument 的注入发生在这之前，看到的就是最终请求头。"""
+    captured: dict = {}
+
+    def fake_send(_adapter, request, **_kwargs):
+        captured.update(request.headers)
+        response = requests.Response()
+        response.status_code = 200
+        response.request = request
+        return response
+
+    with patch.object(requests.adapters.HTTPAdapter, "send", fake_send):
+        yield captured
+
+
+@contextlib.contextmanager
+def _forget_the_global_provider() -> Iterator[None]:
+    """让全局 provider 回到「没人设过」的状态。
+
+    OTel 用 Once 守住 set_tracer_provider，只设第一次；不复位就测不到选 provider 的分支。
+    """
+    with patch.object(trace, "_TRACER_PROVIDER", None), patch.object(trace, "_TRACER_PROVIDER_SET_ONCE", Once()):
+        yield
+
+
+def _trace_id_of(headers: dict) -> str:
+    """traceparent 格式为 00-<trace_id>-<span_id>-<flags>。"""
+    return headers["traceparent"].split("-")[1]
+
+
+class TestRequestSpan:
+    def test_each_request_gets_a_new_trace_id(self):
+        """同一进程内连续两次请求必须是两条 trace，否则排障时无法区分。"""
+        with start_request_span("wxbot.agent_request") as first:
+            pass
+        with start_request_span("wxbot.agent_request") as second:
+            pass
+
+        assert first and second
+        assert len(first) == 32
+        assert first != second
+
+    def test_span_is_root_even_when_thread_context_is_polluted(self):
+        """常驻 worker 线程可能残留上一次未 detach 的 span，新请求不能继承它的 trace。
+
+        LangChain 回调在生成器被 /stop、超时中途丢弃时不保证走到 on_chain_end，
+        attach 的 context 就留在了线程上；继承过去会让后续请求共用同一个 trace id。
+        """
+        leaked = trace.get_tracer("leak").start_span("leaked")
+        leaked_trace_id = format(leaked.get_span_context().trace_id, "032x")
+        token = context_api.attach(trace.set_span_in_context(leaked))
+
+        try:
+            with start_request_span("wxbot.agent_request") as trace_id:
+                assert trace_id != leaked_trace_id
+                assert trace.get_current_span().parent is None
+        finally:
+            context_api.detach(token)
+            leaked.end()
+
+    def test_attributes_are_written_to_the_span(self):
+        with start_request_span(
+            "wxbot.agent_request",
+            **{"wxbot.stream_id": "s-1", "wxbot.group_id": "g-1", "wxbot.username": ""},
+        ):
+            span = trace.get_current_span()
+            assert span.attributes["wxbot.stream_id"] == "s-1"
+            assert span.attributes["wxbot.group_id"] == "g-1"
+            # 空值不写入，避免 APM 上出现一堆空属性
+            assert "wxbot.username" not in span.attributes
+
+
+class TestProviderChoice:
+    def test_agent_sdk_provider_is_reused_so_spans_can_reach_apm(self):
+        """必须复用 Agent 的 provider：自建的那个没有 exporter，span 建了也上报不出去。"""
+        agent_provider = TracerProvider()
+
+        with (
+            _forget_the_global_provider(),
+            patch.object(tracing, "_agent_tracer_provider", lambda: agent_provider),
+        ):
+            assert setup_tracing() is True
+            assert trace.get_tracer_provider() is agent_provider
+
+    def test_standalone_provider_still_yields_a_usable_trace_id(self):
+        """Agent 侧没开 OTel 时也得兜住：本地不上报，但 trace id 仍要能透传给平台。"""
+        with _forget_the_global_provider(), patch.object(tracing, "_agent_tracer_provider", lambda: None):
+            assert setup_tracing() is True
+
+            with start_request_span("wxbot.agent_request") as trace_id:
+                assert len(trace_id) == 32
+
+
+class TestOutboundPropagation:
+    def test_one_request_span_binds_every_outbound_call_into_one_trace(self):
+        """一轮对话里发给平台的所有调用必须落在同一条 trace 上。
+
+        断言真实发出的请求头而不是 propagator 本身：平台侧接口有的走宿主自己的
+        client、有的走 aidev_bkplugin 的 bkapi client，手工注入总会漏，只有 requests
+        这一层的自动注入管得住全部出站调用。
+        """
+        assert setup_tracing() is True
+
+        with start_request_span("wxbot.agent_request") as trace_id:
+            with _capture_outbound_headers() as first:
+                requests.get("http://platform.invalid/session")
+            with _capture_outbound_headers() as second:
+                requests.get("http://platform.invalid/content")
+
+        assert _trace_id_of(first) == trace_id
+        assert _trace_id_of(second) == trace_id
+
+    def test_outbound_calls_without_a_request_span_are_unrelated_traces(self):
+        """没有 root span 时每次调用自成一条 trace——这正是排障时对不上号的原因。
+
+        instrument 本身会给每个请求开 client span，所以 traceparent 一直都在；
+        缺的是把它们收拢到一起的父 span。
+        """
+        assert setup_tracing() is True
+
+        with _capture_outbound_headers() as first:
+            requests.get("http://platform.invalid/session")
+        with _capture_outbound_headers() as second:
+            requests.get("http://platform.invalid/content")
+
+        assert _trace_id_of(first) != _trace_id_of(second)
+
+
+class TestConsoleExporter:
+    """本地把 span 摘要打到终端，用来区分「没埋点」和「没上报」。"""
+
+    def test_stays_off_unless_asked(self):
+        """线上不能被这堆输出淹掉，默认必须是关的。"""
+        with patch.object(tracing, "_attach_console_exporter") as attach:
+            assert setup_tracing() is True
+
+        attach.assert_not_called()
+
+    def test_the_flag_actually_reaches_the_exporter(self):
+        with patch.object(tracing, "_attach_console_exporter", return_value=True) as attach:
+            assert setup_tracing(console=True) is True
+
+        attach.assert_called_once()
+
+    def test_attaches_to_the_live_provider_rather_than_a_fresh_one(self):
+        """挂错 provider 会打印出另一棵树，看着有 span、要查的那条却还是空的。"""
+        provider = TracerProvider()
+
+        with (
+            patch.object(trace, "get_tracer_provider", lambda: provider),
+            patch.object(provider, "add_span_processor") as add_processor,
+        ):
+            assert tracing._attach_console_exporter() is True
+
+        assert add_processor.call_count == 1
+
+    def test_a_span_line_carries_its_parent_link(self):
+        """靠 span / parent 两列拼树，缺一列就只剩一堆孤立的名字。"""
+        tracer = TracerProvider().get_tracer(__name__)
+        with (
+            tracer.start_as_current_span("agent.execution") as parent,
+            tracer.start_as_current_span("tool.execution") as child,
+        ):
+            pass
+
+        line = tracing._format_span_line(child)
+
+        assert "tool.execution" in line
+        assert f"parent={format(parent.get_span_context().span_id, '016x')}" in line
+        assert "parent=root" in tracing._format_span_line(parent)

--- a/src/agent/uv.lock
+++ b/src/agent/uv.lock
@@ -94,6 +94,7 @@ opentelemetry = [
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-httpx" },
     { name = "opentelemetry-instrumentation-langchain" },
+    { name = "opentelemetry-instrumentation-requests" },
     { name = "opentelemetry-instrumentation-threading" },
     { name = "opentelemetry-sdk" },
     { name = "opentelemetry-semantic-conventions" },
@@ -105,6 +106,8 @@ dev = [
     { name = "faker" },
     { name = "ipdb" },
     { name = "loguru" },
+    { name = "opentelemetry-instrumentation-requests" },
+    { name = "opentelemetry-sdk" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -147,6 +150,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation", marker = "extra == 'opentelemetry'", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-httpx", marker = "extra == 'opentelemetry'", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-langchain", marker = "extra == 'opentelemetry'", specifier = "==0.38.10" },
+    { name = "opentelemetry-instrumentation-requests", marker = "extra == 'opentelemetry'", specifier = "==0.54b1" },
     { name = "opentelemetry-instrumentation-threading", marker = "extra == 'opentelemetry'", specifier = "==0.54b1" },
     { name = "opentelemetry-sdk", marker = "extra == 'opentelemetry'", specifier = "==1.33.1" },
     { name = "opentelemetry-semantic-conventions", marker = "extra == 'opentelemetry'", specifier = "==0.54b1" },
@@ -169,6 +173,8 @@ dev = [
     { name = "faker", specifier = ">=37.0.0,<38.0.0" },
     { name = "ipdb", specifier = ">=0.13.13,<0.14.0" },
     { name = "loguru", specifier = ">=0.7.3" },
+    { name = "opentelemetry-instrumentation-requests", specifier = "==0.54b1" },
+    { name = "opentelemetry-sdk", specifier = "==1.33.1" },
     { name = "pre-commit", specifier = "==4.0.1" },
     { name = "pytest", specifier = ">=7.4.4,<7.5.0" },
     { name = "pytest-asyncio", specifier = ">=0.23.3,<0.24.0" },
@@ -1366,6 +1372,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2d/fb/499334b03a7f9a274da5f7b9b8674479800f402bf1792cafc944c87b00bd/opentelemetry_instrumentation_langchain-0.38.10.tar.gz", hash = "sha256:d63ebba00d6741d69d7ee68b186fa353364b94d781827b848d32fdc21e60286c", size = 8838, upload-time = "2025-03-05T14:22:26.834Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0f/46/dfa63ef4e0bfba712f7395aeba592a6f7214b7190c5a276a99503a9a268d/opentelemetry_instrumentation_langchain-0.38.10-py3-none-any.whl", hash = "sha256:d3f71da783a6771a15bc282e09f58e6155a7d8e537bd10f8d5a899f0072dc60b", size = 10277, upload-time = "2025-03-05T14:21:44.42Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.54b1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/45/116da84930d3dc2f5cdd876283ca96e9b96547bccee7eaa0bd01ce6bf046/opentelemetry_instrumentation_requests-0.54b1.tar.gz", hash = "sha256:3eca5d697c5564af04c6a1dd23b6a3ffbaf11e64887c6051655cee03998f4654", size = 15148, upload-time = "2025-05-16T19:04:00.488Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/b1/6e33d2c3d3cc9e3ae20a9a77625ec81a509a0e5d7fa87e09e7f879468990/opentelemetry_instrumentation_requests-0.54b1-py3-none-any.whl", hash = "sha256:a0c4cd5d946224f336d6bd73cdabdecc6f80d5c39208f84eb96eb15f16cd41a0", size = 12968, upload-time = "2025-05-16T19:03:03.131Z" },
 ]
 
 [[package]]

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -17,6 +17,7 @@ from aidev_agent.enums import ChatContentStatus, PromptRole, SessionsStatus
 from aidev_agent.packages.resource_manager import ResourceManagerProtocol
 from aidev_agent.packages.resource_manager.registry import resource_manager as resource_manager_factory
 from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.utils.tracing import current_trace_id
 from django.conf import settings
 
 from ..constants import AGUI_PROTOCOL_VERSION
@@ -101,6 +102,9 @@ class SessionManager:
             data["extra"] = extra
         if turn_id:
             data["property"] = {"turn_id": turn_id}
+        # 与 turn_id 并列：turn_id 标识一轮对话，trace_id 标识这轮实际执行的调用链
+        if trace_id := current_trace_id():
+            data.setdefault("property", {})["trace_id"] = trace_id
         client = self._client()
         result = client.api.create_chat_session_content(json=data, headers=self._user_headers())
         saved = result.get("data", {})


### PR DESCRIPTION
## 背景

TAPD [#136129662](https://tapd.woa.com/tapd_fe/70093903/story/detail/1070093903136129662)：会话记录里没有任何指向实际执行链路的线索，排障只能靠时间戳和 `session_code` 去 APM 上翻。

根因 / 现状：

- `ChatSessionContent` 只有 `turn_id`（标识一轮 user-ai 对话），缺一个标识这轮实际调用链的 id，从一条会话记录跳不到 APM。
- `BkAidevAgentInstrumentor` 刻意不把自己的 `TracerProvider` 注册为全局（见其 docstring），宿主若自建一个，产出的 span 会落在另一棵树上且无处上报。
- 自己起进程驱动 Agent 的宿主（企微长连接是第一个，Celery worker、常驻消费者同理）没有统一接入点，只能各写各的。

## 改动

**改动一：新增 `aidev_agent/utils/tracing.py`**

- `current_trace_id()`：读当前 span 的 32 位 hex trace id，无有效 span 返回空串。不像 `turn_id` 那样逐层透传参数，因为 OTel context 本来就跟着执行走，再铺一条平行参数链只会多出漏传的可能。
- `start_request_span()`：为一次请求开 root span 并 yield 其 trace id。显式传空 `Context()` 强制成为 root —— 常驻 worker 线程上可能残留上一次未 detach 的 OTel context（LangChain 回调在生成器被中途丢弃时不保证走到 `on_chain_end`），继承过去会让不同请求共用同一个 trace id。
- `setup_tracing()`：装上全局 `TracerProvider`（优先复用 Agent SDK 的 provider，取不到则 standalone 兜底）并 instrument `requests`，让出站调用自动带 `traceparent`。日志里的 `provider=agent_sdk|standalone|existing` 标明 span 去了哪。
- 整个模块在 otel extras 缺失时降级为空操作：宿主不该因为缺一个观测依赖就起不来，落库这类核心链路更不能被拖垮。

**改动二：`trace_id` 随会话内容入库**

- 新增 `BaseSessionWriter._stamp_trace_id()`，把当前 trace id 盖进 `payload.property`，与 `turn_id` 并列；user 输入落库、assistant 内容创建 / 更新、ask-user-question 收尾四条写入路径统一走它。无有效 span 时不写空值。
- `aidev_bkplugin` 的 `SessionManager.create_chat_session_content` 同样补上 `trace_id`。

**改动三：新增 `get_agent_tracer_provider()`**

- 暴露 `BkAidevAgentInstrumentor` 已启动的 provider，供宿主复用同一套 exporter 与 resource。直接读单例属性而不是构造 `BkAidevAgentInstrumentor()`：`BaseInstrumentor.__new__` 返回单例，但 `__init__` 仍会重跑并把 `_otel_service` 抹回 `None`。

**改动四：依赖**

- `opentelemetry-instrumentation-requests==0.54b1` 加入 `opentelemetry` extras；它与 `opentelemetry-sdk` 一并加入 dev 组供单测使用。

## 测试

- `src/agent/tests/utils/test_tracing.py`（新增）：请求级 trace 隔离、线程 context 污染下仍为 root、provider 选择、出站 `traceparent` 注入、console exporter。
- `src/agent/tests/services/event_handlers/test_session_content_trace_id.py`（新增）：创建 / 更新 / user 记录三条路径的 `trace_id` 落库，以及无 span 时不写 key。
- 回归：`src/agent/tests/services/event_handlers` 17 passed；`src/plugins/aidev_bkplugin/tests/services` 87 passed, 1 skipped。

## 兼容性

- 无 breaking：`trace_id` 是 `property` 下的新增 key，无有效 span 时整个 key 不写入，老数据与老调用方不受影响。
- `setup_tracing()` 是宿主显式调用的可选入口，不调用则现有行为完全不变。
- 前端若要做「从会话记录跳 APM」，后续对接 `property.trace_id` 即可。

## 关联

tapd: #136129662

发起人：
- cursoragent
- @Vellun7

Made with [Cursor](https://cursor.com)