### PR TITLE
feat: 增强模型重试与超时指标 --story=1070093903136959970

### DIFF
--- a/dev/otel/grafana/components/aidev-agent-metrics-bkmonitor.json
+++ b/dev/otel/grafana/components/aidev-agent-metrics-bkmonitor.json
@@ -2605,6 +2605,332 @@
       ],
       "title": "错误速率（指标来源与 error.type）",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：模型限流以及 SDK 重试生命周期事件的每秒速率。scheduled 表示已决定等待，started 表示等待结束并开始下一次尝试，exhausted 表示超过 max_model_retries，cancelled 表示等待期间被总时限或取消信号中断。计算：分别对 rate_limit.count 与 retry.count Counter 按 model_role、retry_strategy、outcome、error.type 求 rate；一次重试会依次贡献 scheduled 和 started，请勿把全部 outcome 相加当作重试次数。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "限流 · $tag_model_role · $tag_retry_strategy · $tag_error_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (model_role, retry_strategy, error_type) (rate({__name__=~\"gen_ai_client_rate_limit_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))",
+          "step": "",
+          "type": "range"
+        },
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "重试 · $tag_outcome · $tag_model_role · $tag_retry_strategy · $tag_error_type",
+          "query_configs": [],
+          "refId": "B",
+          "showLastPoint": false,
+          "source": "sum by (model_role, retry_strategy, outcome, error_type) (rate({__name__=~\"gen_ai_client_retry_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "模型限流与重试事件速率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内主模型切换到备选模型及其结果。started 表示发生切换，succeeded/failed 表示备选模型最终成功/失败；一次完整成功 fallback 会分别贡献 started 与 succeeded。计算：对 fallback.count Counter 按 outcome 与 error.type 求 increase，并按值降序展示。请求模型、实际响应模型与触发原因的明细保留在 gen_ai.fallback.switch/result Span Event 中，不作为指标标签。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 112,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_outcome · $tag_error_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sort_desc(sum by (outcome, error_type) (increase({__name__=~\"gen_ai_client_fallback_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "备选模型切换与结果（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：已计划模型重试的等待时长 P95，当前 SDK 限流策略固定为 60 秒，因此正常情况下曲线应接近 60 秒。计算：对 gen_ai.client.retry.wait.duration Histogram bucket 按 model_role、retry_strategy 求 rate，再使用 histogram_quantile(0.95, …) 估算；只在 scheduled 时记录一次，started/exhausted 不重复进入等待分布。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "P95 · $tag_model_role · $tag_retry_strategy",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "histogram_quantile(0.95, sum by (le, model_role, retry_strategy) (rate(gen_ai_client_retry_wait_duration_seconds_bucket{agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "模型重试等待时长 P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：所选时段内各类超时事件。timeout.scope=session 表示整次 Agent/session 总时限耗尽并取消图执行；tool 表示单个工具调用超时；external 表示检索或外部依赖调用超时，三者互不混用。计算：对 aidev.operation.timeout.count Counter 按 timeout.scope、outcome、error.type 求 increase。session_code、run_id、trace_id 仅在关联 Span/Event 中定位，不作为指标标签。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 114,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_timeout_scope · $tag_outcome · $tag_error_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sort_desc(sum by (timeout_scope, outcome, error_type) (increase({__name__=~\"aidev_operation_timeout_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window])))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "总时限与 Tool/外部超时（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "bkmonitor-timeseries-datasource",
+        "uid": "cfjy28njb6ghsd"
+      },
+      "description": "含义：工具或外部调用重试生命周期事件速率，与模型重试和 session 总时限分开。scheduled 表示准备再次调用，exhausted 表示达到 max_retries 或 max_seconds；当前通用重试器不主动等待，因此无等待时长分布。计算：对 aidev.operation.retry.count Counter 按 operation.scope、outcome、error.type 求 rate。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 124
+      },
+      "id": 115,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "cluster": [],
+          "datasource": {
+            "type": "bkmonitor-timeseries-datasource",
+            "uid": "cfjy28njb6ghsd"
+          },
+          "enableDownSampling": true,
+          "expressionList": [],
+          "format": "time_series",
+          "host": [],
+          "mode": "code",
+          "module": [],
+          "promqlAlias": "$tag_operation_scope · $tag_outcome · $tag_error_type",
+          "query_configs": [],
+          "refId": "A",
+          "showLastPoint": false,
+          "source": "sum by (operation_scope, outcome, error_type) (rate({__name__=~\"aidev_operation_retry_count.*_total\",agent_info_code=~\"$agent_code\",agent_info_sdk_version=~\"$agent_version\"}[$window]))",
+          "step": "",
+          "type": "range"
+        }
+      ],
+      "title": "Tool/外部调用重试事件速率",
+      "type": "timeseries"
     }
   ],
   "refresh": "1m",

--- a/dev/otel/grafana/dashboards/aidev-agent-metrics.json
+++ b/dev/otel/grafana/dashboards/aidev-agent-metrics.json
@@ -2256,6 +2256,280 @@
       ],
       "title": "错误速率（指标来源与 error.type）",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：模型限流以及 SDK 重试生命周期事件的每秒速率。scheduled 表示已决定等待，started 表示等待结束并开始下一次尝试，exhausted 表示超过 max_model_retries，cancelled 表示等待期间被总时限或取消信号中断。计算：分别对 rate_limit.count 与 retry.count Counter 按 model_role、retry_strategy、outcome、error.type 求 rate；一次重试会依次贡献 scheduled 和 started，请勿把全部 outcome 相加当作重试次数。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 108
+      },
+      "id": 111,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model_role, retry_strategy, error_type) (rate({__name__=~\"gen_ai_client_rate_limit_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))",
+          "legendFormat": "限流 · {{model_role}} · {{retry_strategy}} · {{error_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (model_role, retry_strategy, outcome, error_type) (rate({__name__=~\"gen_ai_client_retry_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))",
+          "legendFormat": "重试 · {{outcome}} · {{model_role}} · {{retry_strategy}} · {{error_type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "模型限流与重试事件速率",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：所选时段内主模型切换到备选模型及其结果。started 表示发生切换，succeeded/failed 表示备选模型最终成功/失败；一次完整成功 fallback 会分别贡献 started 与 succeeded。计算：对 fallback.count Counter 按 outcome 与 error.type 求 increase，并按值降序展示。请求模型、实际响应模型与触发原因的明细保留在 gen_ai.fallback.switch/result Span Event 中，不作为指标标签。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 108
+      },
+      "id": 112,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(sum by (outcome, error_type) (increase({__name__=~\"gen_ai_client_fallback_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])))",
+          "instant": true,
+          "legendFormat": "{{outcome}} · {{error_type}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "备选模型切换与结果（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：已计划模型重试的等待时长 P95，当前 SDK 限流策略固定为 60 秒，因此正常情况下曲线应接近 60 秒。计算：对 gen_ai.client.retry.wait.duration Histogram bucket 按 model_role、retry_strategy 求 rate，再使用 histogram_quantile(0.95, …) 估算；只在 scheduled 时记录一次，started/exhausted 不重复进入等待分布。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 116
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, model_role, retry_strategy) (rate(gen_ai_client_retry_wait_duration_seconds_bucket{agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval])))",
+          "legendFormat": "P95 · {{model_role}} · {{retry_strategy}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "模型重试等待时长 P95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：所选时段内各类超时事件。timeout.scope=session 表示整次 Agent/session 总时限耗尽并取消图执行；tool 表示单个工具调用超时；external 表示检索或外部依赖调用超时，三者互不混用。计算：对 aidev.operation.timeout.count Counter 按 timeout.scope、outcome、error.type 求 increase。session_code、run_id、trace_id 仅在关联 Span/Event 中定位，不作为指标标签。",
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 0,
+          "min": 0,
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 116
+      },
+      "id": 114,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sort_desc(sum by (timeout_scope, outcome, error_type) (increase({__name__=~\"aidev_operation_timeout_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__range])))",
+          "instant": true,
+          "legendFormat": "{{timeout_scope}} · {{outcome}} · {{error_type}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "总时限与 Tool/外部超时（所选时段）",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "含义：工具或外部调用重试生命周期事件速率，与模型重试和 session 总时限分开。scheduled 表示准备再次调用，exhausted 表示达到 max_retries 或 max_seconds；当前通用重试器不主动等待，因此无等待时长分布。计算：对 aidev.operation.retry.count Counter 按 operation.scope、outcome、error.type 求 rate。",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "unit": "ops"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 124
+      },
+      "id": 115,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum by (operation_scope, outcome, error_type) (rate({__name__=~\"aidev_operation_retry_count.*_total\",agent_info_code=~\"${agent_code:regex}\",agent_info_sdk_version=~\"${agent_version:regex}\"}[$__rate_interval]))",
+          "legendFormat": "{{operation_scope}} · {{outcome}} · {{error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tool/外部调用重试事件速率",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/dev/otel/mock_agent_metrics.py
+++ b/dev/otel/mock_agent_metrics.py
@@ -408,6 +408,34 @@ def _record_initial_error_samples(
         },
         error=MockToolInvocationError("mock tool invocation failed"),
     )
+    retry_attributes = {
+        "model_role": "primary",
+        "retry_strategy": "sdk",
+        "error.type": "RateLimitError",
+        "outcome": "encountered",
+    }
+    recorder.record_llm_rate_limit(retry_attributes)
+    recorder.record_llm_retry({**retry_attributes, "outcome": "scheduled"}, wait_seconds=60)
+    recorder.record_llm_retry({**retry_attributes, "outcome": "started"})
+    recorder.record_llm_retry({**retry_attributes, "outcome": "exhausted"})
+    fallback_attributes = {
+        "model_role": "fallback",
+        "error.type": "RateLimitError",
+    }
+    recorder.record_llm_fallback({**fallback_attributes, "outcome": "started"})
+    recorder.record_llm_fallback({**fallback_attributes, "outcome": "succeeded"})
+    recorder.record_llm_fallback({**fallback_attributes, "outcome": "failed"})
+    recorder.record_operation_timeout(
+        {"timeout.scope": "session", "error.type": "AgentDeadlineExceededError", "outcome": "cancelled"}
+    )
+    recorder.record_operation_timeout({"timeout.scope": "tool", "error.type": "TimeoutError", "outcome": "failed"})
+    recorder.record_operation_timeout(
+        {"timeout.scope": "external", "error.type": "ReadTimeout", "outcome": "scheduled"}
+    )
+    recorder.record_operation_retry({"operation.scope": "tool", "error.type": "TimeoutError", "outcome": "scheduled"})
+    recorder.record_operation_retry(
+        {"operation.scope": "external", "error.type": "ReadTimeout", "outcome": "exhausted"}
+    )
     for handler_type in handlers:
         recorder.record_message_publish(
             handler_type=handler_type,

--- a/dev/otel/tests/test_local_observability.py
+++ b/dev/otel/tests/test_local_observability.py
@@ -41,7 +41,7 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
     assert "grafana/grafana:10.4.19" in compose
     assert dashboard["schemaVersion"] == 39
     assert dashboard["graphTooltip"] == 1
-    assert len(dashboard["panels"]) == 37
+    assert len(dashboard["panels"]) == 42
 
     for panel in dashboard["panels"]:
         if panel.get("type") == "row":
@@ -171,6 +171,17 @@ def test_local_dashboard_covers_required_filters_and_metric_groups():
         "Handler · {{error_type}}",
     ]
     assert all('error_type!=""' in target["expr"] for target in panels_by_id[28]["targets"])
+    assert panels_by_id[111]["title"] == "模型限流与重试事件速率"
+    assert "gen_ai_client_rate_limit_count" in panels_by_id[111]["targets"][0]["expr"]
+    assert "gen_ai_client_retry_count" in panels_by_id[111]["targets"][1]["expr"]
+    assert panels_by_id[112]["title"] == "备选模型切换与结果（所选时段）"
+    assert "gen_ai_client_fallback_count" in panels_by_id[112]["targets"][0]["expr"]
+    assert panels_by_id[113]["title"] == "模型重试等待时长 P95"
+    assert "histogram_quantile(0.95" in panels_by_id[113]["targets"][0]["expr"]
+    assert panels_by_id[114]["title"] == "总时限与 Tool/外部超时（所选时段）"
+    assert "aidev_operation_timeout_count" in panels_by_id[114]["targets"][0]["expr"]
+    assert panels_by_id[115]["title"] == "Tool/外部调用重试事件速率"
+    assert "aidev_operation_retry_count" in panels_by_id[115]["targets"][0]["expr"]
     assert 26 not in panels_by_id
     assert panels_by_id[25]["title"] == "SSE 事件与物理消息数量"
     assert panels_by_id[25]["gridPos"]["y"] == panels_by_id[31]["gridPos"]["y"] == 74
@@ -212,7 +223,7 @@ def test_bkmonitor_dashboard_is_a_separate_importable_component():
     assert dashboard["uid"] == "aidev-agent-metrics-bkmonitor"
     assert dashboard["title"] == "AIDev Agent Metrics (BK Monitor)"
     assert dashboard["schemaVersion"] == 39
-    assert len(dashboard["panels"]) == len(local["panels"]) == 37
+    assert len(dashboard["panels"]) == len(local["panels"]) == 42
     assert "__inputs" not in dashboard
     assert dashboard["__requires"][0]["id"] == "bkmonitor-timeseries-datasource"
     rows = [panel for panel in dashboard["panels"] if panel["type"] == "row"]

--- a/src/agent/aidev_agent/core/nodes/model/model_chain.py
+++ b/src/agent/aidev_agent/core/nodes/model/model_chain.py
@@ -33,6 +33,12 @@ from tenacity import RetryError
 from aidev_agent.config import settings
 from aidev_agent.packages.langchain_core.output_parsers import StructuredOutputToToolMessageParser
 
+try:
+    from aidev_agent.packages.opentelemetry.resilience import record_model_rate_limit, record_model_retry
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    record_model_rate_limit = None
+    record_model_retry = None
+
 from .pydantic_models import (
     RETRYABLE_EXCEPTIONS,
     ProcessorContext,
@@ -72,9 +78,9 @@ def _extract_query_text_and_images(query: Any) -> tuple[Any, list[dict[str, Any]
             text = item.get("text")
             if isinstance(text, str):
                 text_parts.append(text)
-        elif item_type == "image_url":
-            image_contents.append(item)
-        elif item_type == "binary" and str(item.get("mime_type") or "").startswith("image/"):
+        elif (
+            item_type == "image_url" or item_type == "binary" and str(item.get("mime_type") or "").startswith("image/")
+        ):
             image_contents.append(item)
 
     return "\n".join(text_parts), image_contents
@@ -223,18 +229,50 @@ def _build_model_chain(
             invoke_kwargs["max_tokens"] = ctx.model_chain_state.max_tokens_override
         try:
             response = llm_with_tools.invoke(ctx.messages, config=ctx.config, **invoke_kwargs)
-        except RateLimitError:
-            if settings.LLM_RETRY_STRATEGY != "sdk":
+        except RateLimitError as error:
+            retry_strategy = settings.LLM_RETRY_STRATEGY
+            if record_model_rate_limit is not None:
+                record_model_rate_limit(retry_strategy=retry_strategy, error=error)
+            if retry_strategy != "sdk":
                 raise
             ctx.model_chain_state.empty_content_retries += 1
+            attempt = ctx.model_chain_state.empty_content_retries
+            max_attempts = ctx.model_chain_state.max_retries
             logger.warning(
                 "Rate limit error, waiting 60s before retry (%d/%d)",
-                ctx.model_chain_state.empty_content_retries,
-                ctx.model_chain_state.max_retries,
+                attempt,
+                max_attempts,
             )
-            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_retries:
+            if attempt > max_attempts:
+                if record_model_retry is not None:
+                    record_model_retry(
+                        outcome="exhausted",
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        wait_seconds=60,
+                        retry_strategy=retry_strategy,
+                        error=error,
+                    )
                 raise
+            if record_model_retry is not None:
+                record_model_retry(
+                    outcome="scheduled",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    wait_seconds=60,
+                    retry_strategy=retry_strategy,
+                    error=error,
+                )
             time.sleep(60)
+            if record_model_retry is not None:
+                record_model_retry(
+                    outcome="started",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    wait_seconds=60,
+                    retry_strategy=retry_strategy,
+                    error=error,
+                )
             raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
         ctx.response = response
         return ctx
@@ -256,18 +294,62 @@ def _build_model_chain(
             invoke_kwargs["max_tokens"] = ctx.model_chain_state.max_tokens_override
         try:
             response = await llm_with_tools.ainvoke(ctx.messages, config=ctx.config, **invoke_kwargs)
-        except RateLimitError:
-            if settings.LLM_RETRY_STRATEGY != "sdk":
+        except RateLimitError as error:
+            retry_strategy = settings.LLM_RETRY_STRATEGY
+            if record_model_rate_limit is not None:
+                record_model_rate_limit(retry_strategy=retry_strategy, error=error)
+            if retry_strategy != "sdk":
                 raise
             ctx.model_chain_state.empty_content_retries += 1
+            attempt = ctx.model_chain_state.empty_content_retries
+            max_attempts = ctx.model_chain_state.max_retries
             logger.warning(
                 "Rate limit error, waiting 60s before retry (%d/%d)",
-                ctx.model_chain_state.empty_content_retries,
-                ctx.model_chain_state.max_retries,
+                attempt,
+                max_attempts,
             )
-            if ctx.model_chain_state.empty_content_retries > ctx.model_chain_state.max_retries:
+            if attempt > max_attempts:
+                if record_model_retry is not None:
+                    record_model_retry(
+                        outcome="exhausted",
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        wait_seconds=60,
+                        retry_strategy=retry_strategy,
+                        error=error,
+                    )
                 raise
-            await asyncio.sleep(60)
+            if record_model_retry is not None:
+                record_model_retry(
+                    outcome="scheduled",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    wait_seconds=60,
+                    retry_strategy=retry_strategy,
+                    error=error,
+                )
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                if record_model_retry is not None:
+                    record_model_retry(
+                        outcome="cancelled",
+                        attempt=attempt,
+                        max_attempts=max_attempts,
+                        wait_seconds=60,
+                        retry_strategy=retry_strategy,
+                        error=error,
+                    )
+                raise
+            if record_model_retry is not None:
+                record_model_retry(
+                    outcome="started",
+                    attempt=attempt,
+                    max_attempts=max_attempts,
+                    wait_seconds=60,
+                    retry_strategy=retry_strategy,
+                    error=error,
+                )
             raise RetryableRateLimitError(ctx.response or AIMessage(content=""))
         ctx.response = response
         return ctx

--- a/src/agent/aidev_agent/exceptions.py
+++ b/src/agent/aidev_agent/exceptions.py
@@ -26,6 +26,10 @@ class AgentException(AIDevException):
     MESSAGE = "Agent异常"
 
 
+class AgentDeadlineExceededError(TimeoutError):
+    """The configured total Agent/session runtime limit was exhausted."""
+
+
 def find_mcp_errors(exc):
     if isinstance(exc, McpError):
         _logger.exception(f"MCP error: {exc}")

--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -18,13 +18,21 @@ to the current version of the project delivered to anyone in the future.
 
 import json
 import os
-from typing import AsyncIterator, Iterator, Optional, Type, Union
+from typing import Any, AsyncIterator, Iterator, Optional, Type, Union
 
 import openai
 import requests
+from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessageChunk, BaseMessage
-from langchain_core.outputs import ChatGenerationChunk, ChatResult
+from langchain_core.outputs import ChatGenerationChunk, ChatResult, LLMResult
+from langchain_core.runnables import RunnableConfig
+from langchain_core.runnables.config import (
+    ensure_config,
+    get_async_callback_manager_for_config,
+    get_callback_manager_for_config,
+    patch_config,
+)
 from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
 from langchain_openai.chat_models.base import _convert_message_to_dict
@@ -35,6 +43,170 @@ from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
 from aidev_agent.exceptions import AIDevException
 from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
+
+try:
+    from aidev_agent.packages.opentelemetry.resilience import (
+        begin_model_attempt,
+        finish_model_attempt_error,
+        finish_model_attempt_success,
+        propagate_model_failure,
+        record_model_fallback_result,
+        record_model_fallback_switch,
+    )
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    begin_model_attempt = None
+    finish_model_attempt_error = None
+    finish_model_attempt_success = None
+    propagate_model_failure = None
+    record_model_fallback_result = None
+    record_model_fallback_switch = None
+
+
+def _runnable_model_name(runnable: Any) -> str:
+    current = runnable
+    visited: set[int] = set()
+    while current is not None and id(current) not in visited:
+        visited.add(id(current))
+        model_name = getattr(current, "model_name", None)
+        if model_name:
+            return str(model_name)
+        current = getattr(current, "bound", None) or getattr(current, "runnable", None)
+    return "unknown"
+
+
+class _FallbackObservationHandler(BaseCallbackHandler):
+    """Observe one RunnableWithFallbacks invocation without sharing state across runs."""
+
+    run_inline = True
+
+    def __init__(self, primary_model: str, fallback_models: list[str]):
+        self.primary_model = primary_model
+        self.fallback_models = fallback_models
+        self._roles_by_run_id: dict[Any, tuple[str, str]] = {}
+        self._primary_error: BaseException | None = None
+        self._fallback_index = 0
+
+    @property
+    def primary_error(self) -> BaseException | None:
+        return self._primary_error
+
+    @staticmethod
+    def _request_model(kwargs: dict[str, Any]) -> str | None:
+        invocation_params = kwargs.get("invocation_params") or {}
+        return invocation_params.get("model") or invocation_params.get("model_name")
+
+    @staticmethod
+    def _response_model(response: LLMResult) -> str | None:
+        output = response.llm_output or {}
+        return output.get("model_name") or output.get("model_id") or output.get("model")
+
+    def on_chat_model_start(self, serialized, messages, *, run_id, **kwargs) -> None:
+        del serialized, messages
+        request_model = self._request_model(kwargs)
+        if self._primary_error is None:
+            self._roles_by_run_id[run_id] = ("primary", request_model or self.primary_model)
+            return
+
+        fallback_model = request_model or self.fallback_models[min(self._fallback_index, len(self.fallback_models) - 1)]
+        self._roles_by_run_id[run_id] = ("fallback", fallback_model)
+        self._fallback_index += 1
+        if record_model_fallback_switch is not None:
+            record_model_fallback_switch(
+                trigger_error=self._primary_error,
+                primary_model=self.primary_model,
+                fallback_model=fallback_model,
+            )
+
+    def on_llm_end(self, response: LLMResult, *, run_id, **kwargs) -> None:
+        del kwargs
+        role, request_model = self._roles_by_run_id.pop(run_id, ("primary", self.primary_model))
+        if role == "fallback" and self._primary_error is not None and record_model_fallback_result is not None:
+            record_model_fallback_result(
+                outcome="succeeded",
+                trigger_error=self._primary_error,
+                primary_model=self.primary_model,
+                fallback_model=request_model,
+                response_model=self._response_model(response) or request_model,
+            )
+
+    def on_llm_error(self, error: BaseException, *, run_id, **kwargs) -> None:
+        del kwargs
+        role, request_model = self._roles_by_run_id.pop(run_id, ("primary", self.primary_model))
+        if role == "primary":
+            self._primary_error = error
+            return
+        if self._primary_error is not None and record_model_fallback_result is not None:
+            record_model_fallback_result(
+                outcome="failed",
+                trigger_error=self._primary_error,
+                primary_model=self.primary_model,
+                fallback_model=request_model,
+                fallback_error=error,
+            )
+
+
+class ObservableRunnableWithFallbacks(RunnableWithFallbacks):
+    """Add per-invocation fallback observations while preserving LangChain behavior."""
+
+    def _observed_config(
+        self,
+        config: RunnableConfig | None,
+        *,
+        is_async: bool,
+    ) -> tuple[RunnableConfig, _FallbackObservationHandler]:
+        normalized = ensure_config(config)
+        observer = _FallbackObservationHandler(
+            primary_model=_runnable_model_name(self.runnable),
+            fallback_models=[_runnable_model_name(item) for item in self.fallbacks],
+        )
+        manager = (
+            get_async_callback_manager_for_config(normalized)
+            if is_async
+            else get_callback_manager_for_config(normalized)
+        )
+        manager.add_handler(observer, inherit=True)
+        return patch_config(normalized, callbacks=manager), observer
+
+    def _propagate_primary_failure(self, observer: _FallbackObservationHandler) -> None:
+        if observer.primary_error is not None and propagate_model_failure is not None:
+            propagate_model_failure(
+                model_role="primary",
+                request_model=_runnable_model_name(self.runnable),
+                error=observer.primary_error,
+            )
+
+    def invoke(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> Any:
+        observed_config, observer = self._observed_config(config, is_async=False)
+        try:
+            return super().invoke(input, observed_config, **kwargs)
+        except Exception:
+            self._propagate_primary_failure(observer)
+            raise
+
+    async def ainvoke(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> Any:
+        observed_config, observer = self._observed_config(config, is_async=True)
+        try:
+            return await super().ainvoke(input, observed_config, **kwargs)
+        except Exception:
+            self._propagate_primary_failure(observer)
+            raise
+
+    def stream(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> Iterator[Any]:
+        observed_config, observer = self._observed_config(config, is_async=False)
+        try:
+            yield from super().stream(input, observed_config, **kwargs)
+        except Exception:
+            self._propagate_primary_failure(observer)
+            raise
+
+    async def astream(self, input: Any, config: RunnableConfig | None = None, **kwargs: Any) -> AsyncIterator[Any]:
+        observed_config, observer = self._observed_config(config, is_async=True)
+        try:
+            async for item in super().astream(input, observed_config, **kwargs):
+                yield item
+        except Exception:
+            self._propagate_primary_failure(observer)
+            raise
 
 
 class ApiGwMixin(BaseModel):
@@ -66,6 +238,7 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     max_content_length: Optional[int] = None
     fallback_model: str | None = None
     _owns_http_async_client: bool = PrivateAttr(default=False)
+    _model_role: str = PrivateAttr(default="primary")
 
     @classmethod
     def get_setup_instance(cls, **kwargs) -> "ChatModel | RunnableWithFallbacks":
@@ -80,7 +253,7 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         fallback = model._get_fallback_model()
         if fallback is None:
             return model
-        return model.with_fallbacks([fallback])
+        return ObservableRunnableWithFallbacks(runnable=model, fallbacks=[fallback])
 
     @model_validator(mode="before")
     @classmethod
@@ -171,7 +344,45 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
     def _get_fallback_model(self) -> "ChatModel | None":
         if not self.fallback_model or self.fallback_model == self.model_name:
             return None
-        return self.model_copy(update={"model_name": self.fallback_model, "fallback_model": None})
+        fallback = self.model_copy(update={"model_name": self.fallback_model, "fallback_model": None})
+        fallback._model_role = "fallback"
+        return fallback
+
+    def _begin_model_observation(self):
+        if begin_model_attempt is None:
+            return None
+        return begin_model_attempt(
+            model_role=self._model_role,
+            request_model=self.model_name or "unknown",
+        )
+
+    def _finish_model_observation_success(self, handle) -> None:
+        if handle is not None and finish_model_attempt_success is not None:
+            finish_model_attempt_success(handle)
+
+    def _finish_model_observation_error(self, handle, error: BaseException) -> None:
+        if handle is not None and finish_model_attempt_error is not None:
+            finish_model_attempt_error(handle, error, retry_strategy=settings.LLM_RETRY_STRATEGY)
+
+    def _generate(self, *args, **kwargs) -> ChatResult:
+        handle = self._begin_model_observation()
+        try:
+            result = super()._generate(*args, **kwargs)
+        except Exception as error:
+            self._finish_model_observation_error(handle, error)
+            raise
+        self._finish_model_observation_success(handle)
+        return result
+
+    async def _agenerate(self, *args, **kwargs) -> ChatResult:
+        handle = self._begin_model_observation()
+        try:
+            result = await super()._agenerate(*args, **kwargs)
+        except Exception as error:
+            self._finish_model_observation_error(handle, error)
+            raise
+        self._finish_model_observation_success(handle)
+        return result
 
     def _convert_chunk_to_generation_chunk(
         self,
@@ -222,23 +433,35 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
 
     def _stream(self, *args, **kwargs) -> Iterator[ChatGenerationChunk]:
         """对reasoning_content字段进行时间统计"""
+        handle = self._begin_model_observation()
         reasoning_start_time = 0
         last_reasoning_content = ""
-        for chunk in super()._stream(*args, **kwargs):
-            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                chunk, reasoning_start_time, last_reasoning_content
-            )
-            yield chunk
+        try:
+            for chunk in super()._stream(*args, **kwargs):
+                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                    chunk, reasoning_start_time, last_reasoning_content
+                )
+                yield chunk
+        except Exception as error:
+            self._finish_model_observation_error(handle, error)
+            raise
+        self._finish_model_observation_success(handle)
 
     async def _astream(self, *args, **kwargs) -> AsyncIterator[ChatGenerationChunk]:
         """对reasoning_content字段进行时间统计"""
+        handle = self._begin_model_observation()
         reasoning_start_time = 0
         last_reasoning_content = ""
-        async for chunk in super()._astream(*args, **kwargs):
-            chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
-                chunk, reasoning_start_time, last_reasoning_content
-            )
-            yield chunk
+        try:
+            async for chunk in super()._astream(*args, **kwargs):
+                chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
+                    chunk, reasoning_start_time, last_reasoning_content
+                )
+                yield chunk
+        except Exception as error:
+            self._finish_model_observation_error(handle, error)
+            raise
+        self._finish_model_observation_success(handle)
 
 
 ChatModelRunnable = RunnableWithFallbacks | BaseChatModel

--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -41,6 +41,12 @@ from aidev_agent.pydantic_models import ExecuteKwargs
 
 from .metrics import AgentMetrics, get_agent_metrics
 from .metrics import extract_token_usage as extract_metric_token_usage
+from .resilience import (
+    is_timeout_error,
+    record_operation_timeout,
+    reset_operation_scope,
+    set_operation_scope,
+)
 from .span_utils import (
     SpanHolder,
     set_chat_request,
@@ -332,6 +338,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
         self._llm_first_chunk_seen: set[UUID] = set()
         self._tool_started_at: Dict[UUID, float] = {}
         self._tool_metric_attributes: Dict[UUID, Dict[str, str]] = {}
+        self._tool_operation_scope_tokens: Dict[UUID, Any] = {}
         self._active_llm_operation_count = 0
         self._active_tool_operation_count = 0
         self._agent_phase: str | None = None
@@ -449,6 +456,9 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             self._metrics.record_active_tool(-1, attributes)
         self._llm_active_attributes.clear()
         self._tool_metric_attributes.clear()
+        for token in self._tool_operation_scope_tokens.values():
+            reset_operation_scope(token)
+        self._tool_operation_scope_tokens.clear()
         self._llm_started_at.clear()
         self._tool_started_at.clear()
         self._llm_first_chunk_seen.clear()
@@ -1137,6 +1147,7 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
             kind=SpanKind.INTERNAL,
             attributes=attributes,
         )
+        self._tool_operation_scope_tokens[run_id] = set_operation_scope("tool")
         if self._metrics is not None:
             self._tool_started_at[run_id] = time.monotonic()
             metric_attributes = {
@@ -1175,6 +1186,9 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
                 self._metrics.record_active_tool(-1, metric_attributes)
                 self._active_tool_operation_count = max(0, self._active_tool_operation_count - 1)
                 self._transition_agent_phase(self._operation_phase())
+        operation_scope_token = self._tool_operation_scope_tokens.pop(run_id, None)
+        if operation_scope_token is not None:
+            reset_operation_scope(operation_scope_token)
         span.set_status(Status(StatusCode.OK))
         self._end_span(span, run_id)
 
@@ -1204,6 +1218,11 @@ class BkAidevAgentCallbackHandler(AsyncCallbackHandler):
                 self._metrics.record_active_tool(-1, metric_attributes)
                 self._active_tool_operation_count = max(0, self._active_tool_operation_count - 1)
                 self._transition_agent_phase(self._operation_phase())
+        operation_scope_token = self._tool_operation_scope_tokens.pop(run_id, None)
+        if operation_scope_token is not None:
+            reset_operation_scope(operation_scope_token)
+        if is_timeout_error(error):
+            record_operation_timeout(scope="tool", outcome="failed", error=error)
         # 使用统一的错误处理
         self._handle_error(error, run_id, parent_run_id, **kwargs)
 

--- a/src/agent/aidev_agent/packages/opentelemetry/metrics.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/metrics.py
@@ -143,6 +143,26 @@ class AgentMetrics:
         self.llm_time_to_first_chunk = meter.create_histogram(
             "gen_ai.client.operation.time_to_first_chunk", unit="s", description="LLM time to first stream chunk"
         )
+        self.llm_rate_limit_count = meter.create_counter(
+            "gen_ai.client.rate_limit.count",
+            unit="{event}",
+            description="LLM rate-limit events",
+        )
+        self.llm_retry_count = meter.create_counter(
+            "gen_ai.client.retry.count",
+            unit="{event}",
+            description="LLM retry lifecycle events",
+        )
+        self.llm_retry_wait_duration = meter.create_histogram(
+            "gen_ai.client.retry.wait.duration",
+            unit="s",
+            description="LLM retry wait duration",
+        )
+        self.llm_fallback_count = meter.create_counter(
+            "gen_ai.client.fallback.count",
+            unit="{event}",
+            description="LLM fallback lifecycle events",
+        )
         self.tool_duration = meter.create_histogram(
             "gen_ai.execute_tool.duration", unit="s", description="Tool execution duration"
         )
@@ -167,6 +187,16 @@ class AgentMetrics:
         )
         self.message_publish_duration = meter.create_histogram(
             "aidev.message.publish.duration", unit="s", description="Handler publish batch duration"
+        )
+        self.operation_retry_count = meter.create_counter(
+            "aidev.operation.retry.count",
+            unit="{event}",
+            description="Tool or external operation retry lifecycle events",
+        )
+        self.operation_timeout_count = meter.create_counter(
+            "aidev.operation.timeout.count",
+            unit="{event}",
+            description="Agent deadline and tool or external operation timeout events",
         )
 
     @staticmethod
@@ -232,6 +262,17 @@ class AgentMetrics:
     def record_first_llm_chunk(self, duration: float, attributes: dict[str, str]) -> None:
         self.llm_time_to_first_chunk.record(duration, attributes)
 
+    def record_llm_rate_limit(self, attributes: dict[str, str]) -> None:
+        self.llm_rate_limit_count.add(1, attributes)
+
+    def record_llm_retry(self, attributes: dict[str, str], *, wait_seconds: float | None = None) -> None:
+        self.llm_retry_count.add(1, attributes)
+        if wait_seconds is not None:
+            self.llm_retry_wait_duration.record(wait_seconds, attributes)
+
+    def record_llm_fallback(self, attributes: dict[str, str]) -> None:
+        self.llm_fallback_count.add(1, attributes)
+
     def record_tool(
         self,
         duration: float,
@@ -242,6 +283,12 @@ class AgentMetrics:
         if error is not None:
             attrs["error.type"] = type(error).__name__
         self.tool_duration.record(duration, attrs)
+
+    def record_operation_retry(self, attributes: dict[str, str]) -> None:
+        self.operation_retry_count.add(1, attributes)
+
+    def record_operation_timeout(self, attributes: dict[str, str]) -> None:
+        self.operation_timeout_count.add(1, attributes)
 
     def record_sse_event(self, message_attributes: dict[str, str] | None = None) -> None:
         self.sse_event_count.add(1, {**_metric_identity, **(message_attributes or {})})

--- a/src/agent/aidev_agent/packages/opentelemetry/resilience.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/resilience.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+"""Low-cardinality resilience metrics and correlated OTel span events."""
+
+from __future__ import annotations
+
+from contextvars import ContextVar, Token
+from dataclasses import dataclass, replace
+from typing import Any
+
+from opentelemetry import trace
+
+from .metrics import get_enabled_agent_metrics
+
+
+@dataclass(frozen=True)
+class ModelAttempt:
+    model_role: str
+    request_model: str
+    active: bool = True
+    error_type: str = ""
+
+
+@dataclass(frozen=True)
+class ModelAttemptHandle:
+    nested: bool
+
+
+_model_attempt: ContextVar[ModelAttempt | None] = ContextVar("aidev_model_attempt", default=None)
+_operation_scope: ContextVar[str] = ContextVar("aidev_operation_scope", default="external")
+
+
+def _error_type(error: BaseException | type[BaseException] | str) -> str:
+    if isinstance(error, str):
+        return error or "unknown"
+    if isinstance(error, type):
+        return error.__name__
+    return type(error).__name__
+
+
+def is_timeout_error(error: BaseException) -> bool:
+    """Recognize timeout classes without importing every optional HTTP client."""
+    return isinstance(error, TimeoutError) or "timeout" in type(error).__name__.lower()
+
+
+def _event(name: str, attributes: dict[str, Any]) -> None:
+    span = trace.get_current_span()
+    if not span.is_recording():
+        return
+    safe_attributes = {
+        key: value
+        for key, value in attributes.items()
+        if value is not None and isinstance(value, (bool, int, float, str))
+    }
+    span.add_event(name, attributes=safe_attributes)
+
+
+def begin_model_attempt(*, model_role: str, request_model: str) -> ModelAttemptHandle:
+    previous = _model_attempt.get()
+    if (
+        previous is not None
+        and previous.active
+        and previous.model_role == model_role
+        and previous.request_model == request_model
+    ):
+        return ModelAttemptHandle(nested=True)
+
+    _model_attempt.set(
+        ModelAttempt(
+            model_role=model_role,
+            request_model=request_model or "unknown",
+        )
+    )
+    return ModelAttemptHandle(nested=False)
+
+
+def finish_model_attempt_success(handle: ModelAttemptHandle) -> None:
+    if handle.nested:
+        return
+    attempt = _model_attempt.get()
+    if attempt is None:
+        return
+    _model_attempt.set(None)
+
+
+def finish_model_attempt_error(handle: ModelAttemptHandle, error: BaseException, *, retry_strategy: str) -> None:
+    if handle.nested:
+        return
+    attempt = _model_attempt.get()
+    if attempt is None:
+        return
+    error_type = _error_type(error)
+    _model_attempt.set(replace(attempt, active=False, error_type=error_type))
+    recorder = get_enabled_agent_metrics()
+    if error_type == "RateLimitError":
+        attributes = {
+            "model_role": attempt.model_role,
+            "retry_strategy": retry_strategy or "unknown",
+            "error.type": error_type,
+            "outcome": "encountered",
+        }
+        if recorder is not None:
+            recorder.record_llm_rate_limit(attributes)
+        _event(
+            "gen_ai.rate_limit",
+            {
+                **attributes,
+                "gen_ai.request.model": attempt.request_model,
+            },
+        )
+
+
+def propagate_model_failure(*, model_role: str, request_model: str, error: BaseException) -> None:
+    """Restore a failed attempt in the caller context after LangChain copied it."""
+    _model_attempt.set(
+        ModelAttempt(
+            model_role=model_role,
+            request_model=request_model or "unknown",
+            active=False,
+            error_type=_error_type(error),
+        )
+    )
+
+
+def record_model_fallback_switch(
+    *,
+    trigger_error: BaseException,
+    primary_model: str,
+    fallback_model: str,
+) -> None:
+    error_type = _error_type(trigger_error)
+    attributes = {
+        "model_role": "fallback",
+        "error.type": error_type,
+        "outcome": "started",
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_llm_fallback(attributes)
+    _event(
+        "gen_ai.fallback.switch",
+        {
+            **attributes,
+            "gen_ai.request.model": primary_model or "unknown",
+            "gen_ai.fallback.trigger.error.type": error_type,
+            "gen_ai.model.primary": primary_model or "unknown",
+            "gen_ai.model.fallback": fallback_model or "unknown",
+        },
+    )
+
+
+def record_model_fallback_result(
+    *,
+    outcome: str,
+    trigger_error: BaseException,
+    primary_model: str,
+    fallback_model: str,
+    response_model: str | None = None,
+    fallback_error: BaseException | None = None,
+) -> None:
+    trigger_error_type = _error_type(trigger_error)
+    attributes = {
+        "model_role": "fallback",
+        "error.type": trigger_error_type,
+        "outcome": outcome,
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_llm_fallback(attributes)
+    event_attributes: dict[str, Any] = {
+        **attributes,
+        "gen_ai.request.model": primary_model or "unknown",
+        "gen_ai.fallback.model": fallback_model or "unknown",
+        "gen_ai.fallback.trigger.error.type": trigger_error_type,
+    }
+    if response_model is not None:
+        event_attributes["gen_ai.response.model"] = response_model
+    if fallback_error is not None:
+        event_attributes["gen_ai.fallback.error.type"] = _error_type(fallback_error)
+    _event("gen_ai.fallback.result", event_attributes)
+
+
+def failed_model_attempt() -> ModelAttempt | None:
+    attempt = _model_attempt.get()
+    return attempt if attempt is not None and not attempt.active else None
+
+
+def record_model_rate_limit(*, retry_strategy: str, error: BaseException) -> None:
+    """Record a rate limit when the concrete model wrapper did not already do so."""
+    model_attempt = failed_model_attempt()
+    # ChatModel records the same failure at the concrete request boundary.
+    if model_attempt is not None and model_attempt.error_type == _error_type(error):
+        return
+    attributes = {
+        "model_role": model_attempt.model_role if model_attempt is not None else "primary",
+        "retry_strategy": retry_strategy or "unknown",
+        "error.type": _error_type(error),
+        "outcome": "encountered",
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_llm_rate_limit(attributes)
+    _event(
+        "gen_ai.rate_limit",
+        {
+            **attributes,
+            "gen_ai.request.model": model_attempt.request_model if model_attempt is not None else "unknown",
+        },
+    )
+
+
+def record_model_retry(
+    *,
+    outcome: str,
+    attempt: int,
+    max_attempts: int,
+    wait_seconds: float,
+    retry_strategy: str,
+    error: BaseException | str,
+) -> None:
+    model_attempt = failed_model_attempt()
+    attributes = {
+        "model_role": model_attempt.model_role if model_attempt is not None else "primary",
+        "retry_strategy": retry_strategy or "unknown",
+        "error.type": _error_type(error),
+        "outcome": outcome,
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_llm_retry(attributes, wait_seconds=wait_seconds if outcome == "scheduled" else None)
+    event_attributes: dict[str, Any] = {
+        **attributes,
+        "retry.attempt": attempt,
+        "retry.max_attempts": max_attempts,
+        "retry.wait_seconds": wait_seconds,
+    }
+    if model_attempt is not None:
+        event_attributes["gen_ai.request.model"] = model_attempt.request_model
+    _event(f"gen_ai.retry.{outcome}", event_attributes)
+
+
+def record_operation_retry(
+    *,
+    outcome: str,
+    attempt: int,
+    max_attempts: int,
+    error: BaseException,
+) -> None:
+    scope = _operation_scope.get()
+    attributes = {
+        "operation.scope": scope,
+        "error.type": _error_type(error),
+        "outcome": outcome,
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_operation_retry(attributes)
+    _event(
+        "aidev.operation.retry",
+        {
+            **attributes,
+            "retry.attempt": attempt,
+            "retry.max_attempts": max_attempts,
+        },
+    )
+
+
+def record_operation_timeout(
+    *,
+    scope: str,
+    outcome: str,
+    error: BaseException | str,
+    timeout_seconds: float | None = None,
+) -> None:
+    attributes = {
+        "timeout.scope": scope,
+        "error.type": _error_type(error),
+        "outcome": outcome,
+    }
+    recorder = get_enabled_agent_metrics()
+    if recorder is not None:
+        recorder.record_operation_timeout(attributes)
+    _event(
+        "aidev.deadline.exceeded" if scope in {"agent", "session"} else "aidev.operation.timeout",
+        {**attributes, "timeout.seconds": timeout_seconds},
+    )
+
+
+def set_operation_scope(scope: str) -> Token[str]:
+    return _operation_scope.set(scope)
+
+
+def current_operation_scope() -> str:
+    return _operation_scope.get()
+
+
+def reset_operation_scope(token: Token[str]) -> None:
+    try:
+        _operation_scope.reset(token)
+    except ValueError:
+        # Some LangChain callbacks may finish in a copied async context.
+        _operation_scope.set("external")

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -50,7 +51,7 @@ from aidev_agent.core.ag_ui.utils import (
 from aidev_agent.core.tools.a2a_tools.types import AgentBackendType, AgentSpec
 from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
 from aidev_agent.enums import AgentType, PromptRole
-from aidev_agent.exceptions import AgentException
+from aidev_agent.exceptions import AgentDeadlineExceededError, AgentException
 from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel, ChatModelRunnable
 from aidev_agent.packages.langgraph.streaming.streaming_protocol import AgentStreamAdapter
 from aidev_agent.packages.resource_manager.registry import resource_manager
@@ -75,6 +76,11 @@ from aidev_agent.utils.migrations import (
     migration_knowledge_query_options_from_agent_options_v1,
     migration_model_context_options_from_agent_options_v1,
 )
+
+try:
+    from aidev_agent.packages.opentelemetry.resilience import record_operation_timeout
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    record_operation_timeout = None
 
 logger = getLogger(__name__)
 
@@ -925,7 +931,21 @@ class ChatCompletionAgent(BaseModel):
                 finally:
                     await self._aclose_chat_models()
 
-            result = run_coro_sync(_ainvoke_with_cleanup, timeout=execute_kwargs.invoke_timeout)
+            async def _ainvoke_with_deadline():
+                if execute_kwargs.invoke_timeout is None:
+                    return await _ainvoke_with_cleanup()
+                deadline = asyncio.timeout(execute_kwargs.invoke_timeout)
+                try:
+                    async with deadline:
+                        return await _ainvoke_with_cleanup()
+                except TimeoutError:
+                    if not deadline.expired():
+                        raise
+                    raise AgentDeadlineExceededError(
+                        f"Agent/session deadline exceeded after {float(execute_kwargs.invoke_timeout):g}s"
+                    ) from None
+
+            result = run_coro_sync(_ainvoke_with_deadline)
             result_output = result.get("messages")[-1]
             return_data = {
                 "choices": [{"delta": {"role": "assistant", "content": result_output.content}}],
@@ -934,6 +954,16 @@ class ChatCompletionAgent(BaseModel):
                 "reference_doc": result.get("reference_doc", []),
             }
             return return_data
+        except AgentDeadlineExceededError as deadline_error:
+            if record_operation_timeout is not None:
+                record_operation_timeout(
+                    scope="session",
+                    outcome="cancelled",
+                    error=deadline_error,
+                    timeout_seconds=execute_kwargs.invoke_timeout,
+                )
+            logger.exception("Agent/session deadline exceeded")
+            raise AgentException(message=str(deadline_error)) from deadline_error
         except Exception as e:
             logger.exception(f"Error executing agent: {e}")
             raise AgentException(message=f"Error executing agent: {e}")
@@ -1080,6 +1110,7 @@ class ChatCompletionAgent(BaseModel):
             cfg=merged_cfg,
             resume=bool(execute_kwargs.resume),
             attach_only=execute_kwargs.stream_mode == "attach",
+            total_timeout=execute_kwargs.invoke_timeout,
         )
 
     def _stream_with_queue(
@@ -1092,6 +1123,7 @@ class ChatCompletionAgent(BaseModel):
         cfg: RunnableConfig | None = None,
         resume: bool = False,
         attach_only: bool = False,
+        total_timeout: int | float | None = None,
     ) -> Generator[Any, None, None]:
         """使用队列处理器缓存流式请求，支持断点续传。
 
@@ -1105,7 +1137,14 @@ class ChatCompletionAgent(BaseModel):
         )
         run_id = agent_input.run_id or self.thread_id
         cancel_event = helper.prepare_run(run_id)
-        producer = self._build_resume_aware_producer(agui_entry, agent_input, agent_e=agent_e, cfg=cfg, resume=resume)
+        producer = self._build_resume_aware_producer(
+            agui_entry,
+            agent_input,
+            agent_e=agent_e,
+            cfg=cfg,
+            resume=resume,
+            total_timeout=total_timeout,
+        )
         yield from helper.stream(
             producer,
             # replay 模式下由 producer 在 EOD 写入并 flush 成功后更新会话终态；
@@ -1124,6 +1163,7 @@ class ChatCompletionAgent(BaseModel):
         agent_e: Runnable | None,
         cfg: RunnableConfig | None,
         resume: bool,
+        total_timeout: int | float | None = None,
     ) -> Generator[Any, None, None]:
         """构造「resume 感知」的生产者生成器（方案 B 兜底入口）。
 
@@ -1153,6 +1193,7 @@ class ChatCompletionAgent(BaseModel):
             yield from async_to_sync_generator(
                 agui_entry.run(agent_input),
                 async_finalizer=self._aclose_chat_models,
+                total_timeout=total_timeout,
             )
 
         return _gen()

--- a/src/agent/aidev_agent/utils/async_utils.py
+++ b/src/agent/aidev_agent/utils/async_utils.py
@@ -17,7 +17,13 @@ from contextvars import copy_context
 from logging import getLogger
 from typing import AsyncGenerator, Awaitable, Callable
 
+from aidev_agent.exceptions import AgentDeadlineExceededError
 from aidev_agent.utils import Empty
+
+try:
+    from aidev_agent.packages.opentelemetry.resilience import record_operation_timeout
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    record_operation_timeout = None
 
 logger = getLogger(__name__)
 
@@ -46,8 +52,14 @@ async def async_generator_with_timeout(
 def async_to_sync_generator(
     async_gen: AsyncGenerator,
     async_finalizer: Callable[[], Awaitable[None]] | None = None,
+    total_timeout: int | float | None = None,
 ):
-    """在独立 loop 中消费异步生成器，并在同一 loop 执行 finalizer。"""
+    """在独立 loop 中消费异步生成器，并在同一 loop 执行 finalizer。
+
+    ``total_timeout`` is a total Agent/session deadline, not a per-chunk or
+    tool timeout.  Expiry cancels the async graph before surfacing a typed
+    error to the producer so it can emit RUN_ERROR and RUN_FINISHED.
+    """
     data_queue = queue.Queue()
     end = object()
     error = None
@@ -59,9 +71,35 @@ def async_to_sync_generator(
 
     async def consume_async():
         nonlocal error
-        try:
+
+        async def _consume_items() -> None:
             async for item in async_gen:
                 data_queue.put(item)
+
+        try:
+            if total_timeout is None:
+                await _consume_items()
+            else:
+                deadline = asyncio.timeout(total_timeout)
+                try:
+                    async with deadline:
+                        await _consume_items()
+                except TimeoutError:
+                    if not deadline.expired():
+                        raise
+                    raise AgentDeadlineExceededError(
+                        f"Agent/session deadline exceeded after {float(total_timeout):g}s"
+                    ) from None
+        except AgentDeadlineExceededError as deadline_error:
+            if record_operation_timeout is not None:
+                record_operation_timeout(
+                    scope="session",
+                    outcome="cancelled",
+                    error=deadline_error,
+                    timeout_seconds=float(total_timeout),
+                )
+            logger.warning("[ASYNC] Agent/session deadline exceeded")
+            error = deadline_error
         except Exception as e:
             logger.warning(f"[ASYNC] consume_async error: {e}", exc_info=True)
             error = e

--- a/src/agent/aidev_agent/utils/decorator.py
+++ b/src/agent/aidev_agent/utils/decorator.py
@@ -23,6 +23,19 @@ from functools import wraps
 
 logger = logging.getLogger(__name__)
 
+try:
+    from aidev_agent.packages.opentelemetry.resilience import (
+        current_operation_scope,
+        is_timeout_error,
+        record_operation_retry,
+        record_operation_timeout,
+    )
+except ImportError:  # OpenTelemetry is an optional SDK extra.
+    current_operation_scope = None
+    is_timeout_error = None
+    record_operation_retry = None
+    record_operation_timeout = None
+
 
 def timeit(message=""):
     """
@@ -58,12 +71,31 @@ def retry(max_retries=5, max_seconds=1800):
                 try:
                     try_cnt += 1
                     return func(*args, **kwargs)
-                except Exception:  # noqa: PERF203
+                except Exception as error:  # noqa: PERF203
+                    exhausted = try_cnt >= max_retries or (time.time() - start_time) >= max_seconds
+                    outcome = "exhausted" if exhausted else "scheduled"
+                    if record_operation_retry is not None:
+                        record_operation_retry(
+                            outcome=outcome,
+                            attempt=try_cnt,
+                            max_attempts=max_retries,
+                            error=error,
+                        )
+                    if (
+                        is_timeout_error is not None
+                        and is_timeout_error(error)
+                        and record_operation_timeout is not None
+                    ):
+                        record_operation_timeout(
+                            scope=current_operation_scope() if current_operation_scope is not None else "external",
+                            outcome=outcome,
+                            error=error,
+                        )
                     logger.info(
                         f"\n\n=====\n>>>>> 执行出错，重试中。当前尝试次数: {try_cnt}。"
                         f"详细错误情况：\n{traceback.format_exc()}\n=====\n\n"
                     )
-                    if try_cnt >= max_retries or (time.time() - start_time) >= max_seconds:
+                    if exhausted:
                         # 如果达到最大重试次数或者超过最大时间限制，最后一次重试的异常将被抛出。
                         # 这样可以确保在所有重试都失败的情况下，异常会被正确地抛出并处理。
                         raise

--- a/src/agent/tests/core/nodes/model/test_model_chain.py
+++ b/src/agent/tests/core/nodes/model/test_model_chain.py
@@ -214,6 +214,8 @@ class TestModelChain:
         with (
             patch("aidev_agent.core.nodes.model.model_chain.settings.LLM_RETRY_STRATEGY", "sdk"),
             patch("time.sleep", return_value=None),
+            patch("aidev_agent.core.nodes.model.model_chain.record_model_rate_limit") as rate_limit_metric,
+            patch("aidev_agent.core.nodes.model.model_chain.record_model_retry") as retry_metric,
         ):
             chain = _build_model_chain(
                 llm=mock_llm,
@@ -237,6 +239,47 @@ class TestModelChain:
             result = chain.invoke(initial_ctx)
             assert result.response.content == "限流后重试成功"
             assert invoke_counter[0] == 2
+            rate_limit_metric.assert_called_once()
+            assert [call.kwargs["outcome"] for call in retry_metric.call_args_list] == ["scheduled", "started"]
+            assert retry_metric.call_args_list[0].kwargs["wait_seconds"] == 60
+            assert retry_metric.call_args_list[0].kwargs["attempt"] == 1
+            assert retry_metric.call_args_list[0].kwargs["max_attempts"] == 3
+
+    def test_rate_limit_retry_exhaustion_is_observed(self, mock_context_assembly):
+        mock_llm = RunnableLambda(lambda *_args, **_kwargs: (_ for _ in ()).throw(_make_rate_limit_error()))
+        mock_llm.bind_tools = Mock(return_value=mock_llm)
+        self._set_rendered_messages(mock_context_assembly, [HumanMessage(content="test")])
+
+        with (
+            patch("aidev_agent.core.nodes.model.model_chain.settings.LLM_RETRY_STRATEGY", "sdk"),
+            patch("aidev_agent.core.nodes.model.model_chain.record_model_rate_limit"),
+            patch("aidev_agent.core.nodes.model.model_chain.record_model_retry") as retry_metric,
+        ):
+            chain = _build_model_chain(
+                llm=mock_llm,
+                context_assembly=mock_context_assembly,
+                max_retries=0,
+                quality_gate=QualityGate(enable_judge_response=False),
+                use_structured_response=False,
+                enable_parallel_tool_calls=False,
+                use_tool_call_promotion=False,
+            )
+            initial_ctx = ProcessorContext(
+                state={"messages": []},
+                config=RunnableConfig(),
+                store=Mock(),
+                messages=[],
+                model_chain_state=ModelChainState(max_retries=0),
+                response=None,
+            )
+
+            with pytest.raises(RateLimitError):
+                chain.invoke(initial_ctx)
+
+        retry_metric.assert_called_once()
+        assert retry_metric.call_args.kwargs["outcome"] == "exhausted"
+        assert retry_metric.call_args.kwargs["attempt"] == 1
+        assert retry_metric.call_args.kwargs["max_attempts"] == 0
 
     def test_tool_calls_passthrough(self, mock_context_assembly):
         """测试工具调用：返回 TOOL_EXECUTION → 不重试，原样返回"""
@@ -766,9 +809,7 @@ class TestExtractQueryTextAndImages:
             "type": "binary",
             "url": "https://example.com/a.jpeg",
         }
-        text, images = _extract_query_text_and_images(
-            [binary, {"type": "text", "text": "图片内容是啥呀"}]
-        )
+        text, images = _extract_query_text_and_images([binary, {"type": "text", "text": "图片内容是啥呀"}])
         assert text == "图片内容是啥呀"
         assert images == [binary]
 

--- a/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
+++ b/src/agent/tests/packages/langchain_core/models/test_session_id_header.py
@@ -16,6 +16,7 @@ from aidev_agent.pydantic_models import AgentConfig, AgentOptions
 from aidev_agent.services.agent import AgentBuildContext, ChatBuildExtras
 from aidev_agent.services.agent.chat import ChatAgentBuilder
 from aidev_agent.services.common_agent import CommonQAAgent
+from langchain_core.runnables.fallbacks import RunnableWithFallbacks
 from langgraph.checkpoint.memory import MemorySaver
 
 # ============================== ApiGwMixin.get_setup_instance ==============================
@@ -69,6 +70,13 @@ class TestApiGwMixinSessionIdHeader:
         instance = ChatModel.get_setup_instance(model="mock-model", session_code="abc")
         # ChatOpenAI / pydantic 不应有 ``session_code`` 字段
         assert not hasattr(instance, "session_code")
+
+    def test_fallback_model_has_explicit_observability_role(self):
+        instance = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+        assert isinstance(instance, RunnableWithFallbacks)
+        assert instance.runnable._model_role == "primary"
+        assert instance.fallbacks[0]._model_role == "fallback"
 
 
 # ============================== ChatAgentBuilder.build_chat_model ==============================

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -358,6 +358,19 @@ class TestBkAidevAgentCallbackHandler:
         recorder.record_tool.assert_called_once()
         assert recorder.record_tool.call_args.kwargs["error"] is error
 
+    def test_tool_timeout_is_classified_separately_from_session_deadline(self, tracer_and_exporter, mocker):
+        tracer, _ = tracer_and_exporter
+        timeout_metric = mocker.patch("aidev_agent.packages.opentelemetry.callback_handler.record_operation_timeout")
+        handler = BkAidevAgentCallbackHandler(tracer=tracer, metric_recorder=MagicMock())
+        run_id = uuid4()
+
+        asyncio.run(handler.on_tool_start(serialized={"name": "demo-tool"}, input_str="input", run_id=run_id))
+        asyncio.run(handler.on_tool_error(TimeoutError("upstream timed out"), run_id=run_id))
+
+        timeout_metric.assert_called_once()
+        assert timeout_metric.call_args.kwargs["scope"] == "tool"
+        assert timeout_metric.call_args.kwargs["outcome"] == "failed"
+
     def test_llm_metric_keeps_request_model_when_traces_are_disabled(self):
         recorder = MagicMock()
         handler = BkAidevAgentCallbackHandler(

--- a/src/agent/tests/packages/opentelemetry/test_metrics.py
+++ b/src/agent/tests/packages/opentelemetry/test_metrics.py
@@ -54,12 +54,18 @@ def test_agent_metrics_only_create_instruments_used_by_the_dashboard():
         "gen_ai.client.operation.active",
         "gen_ai.client.operation.duration",
         "gen_ai.client.operation.time_to_first_chunk",
+        "gen_ai.client.fallback.count",
+        "gen_ai.client.rate_limit.count",
+        "gen_ai.client.retry.count",
+        "gen_ai.client.retry.wait.duration",
         "gen_ai.execute_tool.active",
         "gen_ai.execute_tool.duration",
         "gen_ai.invoke_agent.duration",
         "gen_ai.invoke_agent.iteration_count",
         "gen_ai.invoke_agent.started",
         "gen_ai.invoke_agent.time_to_first_token",
+        "aidev.operation.retry.count",
+        "aidev.operation.timeout.count",
     }
 
 
@@ -229,3 +235,34 @@ def test_failed_message_publish_is_not_counted_as_successful_broker_writes():
     assert meter.instruments["aidev.message.publish.event_count"].calls == []
     assert meter.instruments["aidev.message.publish.size"].calls == []
     assert meter.instruments["aidev.message.publish.duration"].calls[0][1]["error.type"] == "TimeoutError"
+
+
+def test_resilience_metrics_keep_model_names_and_run_ids_out_of_dimensions():
+    meter = FakeMeter()
+    recorder = AgentMetrics(meter)
+    attributes = {
+        "model_role": "fallback",
+        "retry_strategy": "sdk",
+        "error.type": "RateLimitError",
+        "outcome": "scheduled",
+    }
+
+    recorder.record_llm_rate_limit(attributes)
+    recorder.record_llm_retry(attributes, wait_seconds=60)
+    recorder.record_llm_fallback({**attributes, "outcome": "succeeded"})
+    recorder.record_operation_timeout(
+        {"timeout.scope": "session", "error.type": "AgentDeadlineExceededError", "outcome": "cancelled"}
+    )
+
+    for instrument_name in (
+        "gen_ai.client.rate_limit.count",
+        "gen_ai.client.retry.count",
+        "gen_ai.client.retry.wait.duration",
+        "gen_ai.client.fallback.count",
+        "aidev.operation.timeout.count",
+    ):
+        _, metric_attributes = meter.instruments[instrument_name].calls[0]
+        assert "gen_ai.request.model" not in metric_attributes
+        assert "gen_ai.response.model" not in metric_attributes
+        assert "agent.session.session_code" not in metric_attributes
+        assert "run_id" not in metric_attributes

--- a/src/agent/tests/packages/opentelemetry/test_resilience.py
+++ b/src/agent/tests/packages/opentelemetry/test_resilience.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
+from aidev_agent.packages.opentelemetry import resilience
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_openai.chat_models import ChatOpenAI as RawChatOpenAI
+
+
+class RateLimitError(Exception):
+    pass
+
+
+def test_fallback_events_include_models_but_metric_dimensions_do_not(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    trigger_error = RateLimitError()
+    resilience.record_model_fallback_switch(
+        trigger_error=trigger_error,
+        primary_model="primary-model",
+        fallback_model="fallback-model",
+    )
+    resilience.record_model_fallback_result(
+        outcome="succeeded",
+        trigger_error=trigger_error,
+        primary_model="primary-model",
+        fallback_model="fallback-model",
+        response_model="routed-fallback-model",
+    )
+
+    metric_attributes = [call.args[0] for call in recorder.record_llm_fallback.call_args_list]
+    assert [attrs["outcome"] for attrs in metric_attributes] == ["started", "succeeded"]
+    assert all("gen_ai.request.model" not in attrs for attrs in metric_attributes)
+    switch_event = next(call for call in span.add_event.call_args_list if call.args[0] == "gen_ai.fallback.switch")
+    assert switch_event.kwargs["attributes"]["gen_ai.request.model"] == "primary-model"
+    assert switch_event.kwargs["attributes"]["gen_ai.model.fallback"] == "fallback-model"
+    result_event = next(call for call in span.add_event.call_args_list if call.args[0] == "gen_ai.fallback.result")
+    assert result_event.kwargs["attributes"]["gen_ai.response.model"] == "routed-fallback-model"
+
+
+def test_retry_wait_and_deadline_are_separate_low_cardinality_metrics(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    resilience.record_model_retry(
+        outcome="scheduled",
+        attempt=2,
+        max_attempts=10,
+        wait_seconds=60,
+        retry_strategy="sdk",
+        error="RateLimitError",
+    )
+    resilience.record_operation_timeout(
+        scope="session",
+        outcome="cancelled",
+        error="AgentDeadlineExceededError",
+        timeout_seconds=600,
+    )
+    resilience.record_operation_timeout(
+        scope="tool",
+        outcome="failed",
+        error="TimeoutError",
+        timeout_seconds=30,
+    )
+
+    retry_attributes = recorder.record_llm_retry.call_args.args[0]
+    assert retry_attributes == {
+        "model_role": "primary",
+        "retry_strategy": "sdk",
+        "error.type": "RateLimitError",
+        "outcome": "scheduled",
+    }
+    assert recorder.record_llm_retry.call_args.kwargs["wait_seconds"] == 60
+    timeout_scopes = [call.args[0]["timeout.scope"] for call in recorder.record_operation_timeout.call_args_list]
+    assert timeout_scopes == ["session", "tool"]
+
+
+def test_real_runnable_fallback_records_started_and_success(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    def _generate(model, *_args, **_kwargs):
+        if model.model_name == "primary-model":
+            raise RuntimeError("sanitized primary failure")
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="fallback response"))],
+            llm_output={"model_name": "routed-fallback-model"},
+        )
+
+    monkeypatch.setattr(RawChatOpenAI, "_generate", _generate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    response = model.invoke([HumanMessage(content="hello")])
+
+    assert response.content == "fallback response"
+    attributes = [call.args[0] for call in recorder.record_llm_fallback.call_args_list]
+    outcomes = [item["outcome"] for item in attributes]
+    assert outcomes == ["started", "succeeded"]
+    assert {item["error.type"] for item in attributes} == {"RuntimeError"}
+
+
+def test_fallback_failure_keeps_trigger_error_in_metric_and_own_error_in_event(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    trigger_error = RateLimitError()
+    resilience.record_model_fallback_switch(
+        trigger_error=trigger_error,
+        primary_model="primary-model",
+        fallback_model="fallback-model",
+    )
+    resilience.record_model_fallback_result(
+        outcome="failed",
+        trigger_error=trigger_error,
+        primary_model="primary-model",
+        fallback_model="fallback-model",
+        fallback_error=TimeoutError("sanitized"),
+    )
+
+    failed_attributes = recorder.record_llm_fallback.call_args.args[0]
+    assert failed_attributes == {
+        "model_role": "fallback",
+        "error.type": "RateLimitError",
+        "outcome": "failed",
+    }
+    result_event = [call for call in span.add_event.call_args_list if call.args[0] == "gen_ai.fallback.result"][-1]
+    assert result_event.kwargs["attributes"]["gen_ai.fallback.error.type"] == "TimeoutError"
+
+
+async def test_real_async_runnable_fallback_records_trigger_error(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    async def _agenerate(model, *_args, **_kwargs):
+        if model.model_name == "primary-model":
+            raise RateLimitError()
+        return ChatResult(
+            generations=[ChatGeneration(message=AIMessage(content="fallback response"))],
+            llm_output={"model_name": "routed-fallback-model"},
+        )
+
+    monkeypatch.setattr(RawChatOpenAI, "_agenerate", _agenerate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    response = await model.ainvoke([HumanMessage(content="hello")])
+
+    assert response.content == "fallback response"
+    attributes = [call.args[0] for call in recorder.record_llm_fallback.call_args_list]
+    assert [item["outcome"] for item in attributes] == ["started", "succeeded"]
+    assert {item["error.type"] for item in attributes} == {"RateLimitError"}
+
+
+def test_real_runnable_fallback_failure_records_both_error_categories(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    def _generate(model, *_args, **_kwargs):
+        if model.model_name == "primary-model":
+            raise RateLimitError()
+        raise TimeoutError("sanitized fallback timeout")
+
+    monkeypatch.setattr(RawChatOpenAI, "_generate", _generate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    with pytest.raises(RateLimitError):
+        model.invoke([HumanMessage(content="hello")])
+
+    attributes = [call.args[0] for call in recorder.record_llm_fallback.call_args_list]
+    assert [item["outcome"] for item in attributes] == ["started", "failed"]
+    assert {item["error.type"] for item in attributes} == {"RateLimitError"}
+    result_event = [call for call in span.add_event.call_args_list if call.args[0] == "gen_ai.fallback.result"][-1]
+    assert result_event.kwargs["attributes"]["gen_ai.fallback.error.type"] == "TimeoutError"
+
+
+def test_fallback_failure_propagates_primary_rate_limit_for_outer_deduplication(monkeypatch):
+    recorder = MagicMock()
+    span = MagicMock()
+    span.is_recording.return_value = True
+    monkeypatch.setattr(resilience, "get_enabled_agent_metrics", lambda: recorder)
+    monkeypatch.setattr(resilience.trace, "get_current_span", lambda: span)
+
+    def _generate(model, *_args, **_kwargs):
+        if model.model_name == "primary-model":
+            raise RateLimitError()
+        raise TimeoutError("sanitized fallback timeout")
+
+    monkeypatch.setattr(RawChatOpenAI, "_generate", _generate)
+    model = ChatModel.get_setup_instance(model="primary-model", fallback_model="fallback-model")
+
+    with pytest.raises(RateLimitError) as error_info:
+        model.invoke([HumanMessage(content="hello")])
+    resilience.record_model_rate_limit(retry_strategy="sdk", error=error_info.value)
+
+    recorder.record_llm_rate_limit.assert_called_once()

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -2398,14 +2398,22 @@ class TestTerminalResumeReplay:
 
         with (
             patch.object(agent, "_build_terminal_resume_replay") as mock_replay,
-            patch(f"{_CHAT_MODULE}.async_to_sync_generator", return_value=iter(["X"])),
+            patch(f"{_CHAT_MODULE}.async_to_sync_generator", return_value=iter(["X"])) as mock_astream,
         ):
-            producer = agent._build_resume_aware_producer(agui_entry, agent_input, agent_e=None, cfg=None, resume=False)
+            producer = agent._build_resume_aware_producer(
+                agui_entry,
+                agent_input,
+                agent_e=None,
+                cfg=None,
+                resume=False,
+                total_timeout=600,
+            )
             out = list(producer)
 
         assert out == ["X"]
         mock_replay.assert_not_called()
         agui_entry.run.assert_called_once_with(agent_input)
+        assert mock_astream.call_args.kwargs["total_timeout"] == 600
 
     def test_producer_resume_missing_context_uses_astream(self):
         """resume=True 但缺少 agent_e/cfg → 不查 checkpoint，直接 astream"""
@@ -2768,11 +2776,11 @@ class TestBuildKnowledgeQueryOptions:
     @pytest.mark.parametrize(
         "env_val, resources, expected_ekn",
         [
-            (None, [{"type": "knowledgebase", "id": 58}], True),   # env 未设 + 含 kb → resources 覆盖为 True
-            (None, [{"type": "mcp", "code": "x"}], False),         # env 未设 + 不含 kb → 保持默认 False
-            (None, [], False),                                     # env 未设 + 无 resources → 默认 False
+            (None, [{"type": "knowledgebase", "id": 58}], True),  # env 未设 + 含 kb → resources 覆盖为 True
+            (None, [{"type": "mcp", "code": "x"}], False),  # env 未设 + 不含 kb → 保持默认 False
+            (None, [], False),  # env 未设 + 无 resources → 默认 False
             ("false", [{"type": "knowledgebase", "id": 58}], False),  # env 已设 false → 取 env，忽略 resources
-            ("true", [], True),                                    # env 已设 true → 取 env True
+            ("true", [], True),  # env 已设 true → 取 env True
         ],
     )
     def test_enable_knowledge_node_env_and_resources_priority(self, monkeypatch, env_val, resources, expected_ekn):
@@ -2796,7 +2804,7 @@ class TestBuildKnowledgeQueryOptions:
     @pytest.mark.parametrize(
         "env_val, expected",
         [
-            (None, True),    # env 未设 → 保持字段默认 True
+            (None, True),  # env 未设 → 保持字段默认 True
             ("true", True),  # env=true → True
             ("false", False),  # env=false → False
             ("abc", False),  # 非法值 → False（严格 .lower()=="true" 匹配）

--- a/src/agent/tests/utils/test_async_utils.py
+++ b/src/agent/tests/utils/test_async_utils.py
@@ -19,6 +19,7 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from aidev_agent.exceptions import AgentDeadlineExceededError
 from aidev_agent.utils import (
     Empty,
 )
@@ -86,6 +87,34 @@ def test_async_to_sync_generator_finalizes_when_consumer_closes():
     generator.close()
 
     assert finalized is True
+
+
+def test_async_to_sync_generator_enforces_total_agent_deadline(mocker):
+    timeout_metric = mocker.patch("aidev_agent.utils.async_utils.record_operation_timeout")
+
+    async def _blocked_gen():
+        await asyncio.Event().wait()
+        yield "unreachable"
+
+    with pytest.raises(AgentDeadlineExceededError, match="deadline exceeded"):
+        list(async_to_sync_generator(_blocked_gen(), total_timeout=0.01))
+
+    timeout_metric.assert_called_once()
+    assert timeout_metric.call_args.kwargs["scope"] == "session"
+    assert timeout_metric.call_args.kwargs["outcome"] == "cancelled"
+
+
+def test_async_to_sync_generator_does_not_misclassify_inner_timeout(mocker):
+    timeout_metric = mocker.patch("aidev_agent.utils.async_utils.record_operation_timeout")
+
+    async def _inner_timeout():
+        raise TimeoutError("tool timed out")
+        yield "unreachable"
+
+    with pytest.raises(TimeoutError, match="tool timed out"):
+        list(async_to_sync_generator(_inner_timeout(), total_timeout=10))
+
+    timeout_metric.assert_not_called()
 
 
 async def test_async_gen_with_timeout():

--- a/src/agent/tests/utils/test_decorator_observability.py
+++ b/src/agent/tests/utils/test_decorator_observability.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+from aidev_agent.utils import decorator as decorator_module
+
+
+def test_external_retry_records_scheduled_and_exhausted(mocker):
+    retry_metric = mocker.patch.object(decorator_module, "record_operation_retry")
+    timeout_metric = mocker.patch.object(decorator_module, "record_operation_timeout")
+    mocker.patch.object(decorator_module, "is_timeout_error", return_value=True)
+    mocker.patch.object(decorator_module, "current_operation_scope", return_value="external")
+    calls = 0
+
+    @decorator_module.retry(max_retries=2, max_seconds=30)
+    def _always_times_out():
+        nonlocal calls
+        calls += 1
+        raise TimeoutError("sanitized external timeout")
+
+    with pytest.raises(TimeoutError):
+        _always_times_out()
+
+    assert calls == 2
+    assert [call.kwargs["outcome"] for call in retry_metric.call_args_list] == ["scheduled", "exhausted"]
+    assert all(call.kwargs["error"].__class__ is TimeoutError for call in retry_metric.call_args_list)
+    assert [call.kwargs["scope"] for call in timeout_metric.call_args_list] == ["external", "external"]


### PR DESCRIPTION
## 背景

真实并发评测中，部分 Agent Run 在模型限流重试期间达到约 600 秒会话总时限，但缺少明确的限流、重试、fallback 与 deadline 可观测信号。

## 改动

- 新增模型限流、重试生命周期、等待时长、fallback 切换/结果指标及关联 Span Event
- fallback 在 LangChain 复制上下文和并发调用下保持调用级隔离，并避免限流重复计数
- 为流式与非流式 Agent Run 增加总时限，超时取消图执行并由生产者补齐 RUN_ERROR/RUN_FINISHED
- 区分 session、tool、external 超时与重试，模型名和会话标识仅进入 Event/Span，不作为指标标签
- Grafana 与 BK Monitor 仪表盘新增 5 个面板，并补充脱敏 mock 数据

## 验证

- Agent 受影响套件：392 passed, 22 skipped, 3 xfailed
- bkplugin/exporter/仪表盘：43 passed
- pre-commit：全部通过
- 本地 OTel Collector → Prometheus → Grafana 10.4.19：新增 6 组指标均有原始数据，5 个面板成功加载