### PR TITLE
feat: 调整企微审批卡片跳转并在取消后续流 --story=136129662

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -80,6 +80,12 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
         return
     approve_result = approve_info["approve_result"]
 
+    # 主动取消由调用方根据 user_operation.next 续流（Web 或企微）。
+    # 与平台后台 worker 保持一致，避免两个消费者同时恢复同一个中断。
+    if approve_result == "cancelled":
+        logger.info("[ApprovalResume] 审批已取消，由操作发起方续流: session_code=%s", session_code)
+        return
+
     # 3. 审批完成，构建 agent 并续流
     try:
         resume_items = []

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
@@ -1,0 +1,25 @@
+"""取消由操作发起方续流；审批通过和拒绝保留后台自动续流。"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_bkplugin.services import approval_resume as mod
+
+
+@pytest.mark.parametrize("status", ["cancelled", "approved", "rejected"])
+def test_polling_does_not_duplicate_explicit_cancellation(monkeypatch, status):
+    handler = MagicMock()
+    handler.check_resume.return_value = True
+    handler.fetch_approve_result.return_value = {"approve_result": status}
+    monkeypatch.setattr(mod, "ApprovalStateHandler", MagicMock(return_value=handler))
+    builder = MagicMock()
+    executor = MagicMock()
+    executor.return_value.execute_with_save.return_value = iter([])
+    monkeypatch.setattr(mod, "AgentBuilder", builder)
+    monkeypatch.setattr(mod, "AgentExecutor", executor)
+    monkeypatch.setattr(mod, "SessionManager", MagicMock())
+    mod._approval_resume_worker(
+        "session-1", "alice", "graph-1", [{"id": "approval-1", "reason": "aidev:tool_approval"}]
+    )
+    assert builder.call_count == (0 if status == "cancelled" else 1)
+    assert executor.return_value.execute_with_save.call_count == (0 if status == "cancelled" else 1)

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
@@ -150,8 +150,6 @@ def _build_pending_card(interrupt: dict, session_code: str) -> dict[str, Any]:
         horizontal_content_list.append(ticket_row)
     if submit_time:
         horizontal_content_list.append({"keyname": "提交时间", "value": submit_time})
-    if session_url:
-        horizontal_content_list.append({"keyname": "会话", "value": "查看会话", "type": 1, "url": session_url})
     if horizontal_content_list:
         card["horizontal_content_list"] = horizontal_content_list
 

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
@@ -138,13 +138,16 @@ def _build_pending_card(interrupt: dict, session_code: str) -> dict[str, Any]:
         "card_type": "button_interaction",
         "main_title": {
             "title": title,
-            "desc": "点击卡片查看单据详情" if approval_url else "请在审批系统中处理",
+            "desc": "点击卡片查看会话" if session_url else "请点击单据编号查看审批详情",
         },
         "sub_title_text": "审批完成后系统将继续执行。",
     }
     horizontal_content_list = []
     if ticket_sn:
-        horizontal_content_list.append({"keyname": "单据编号", "value": ticket_sn})
+        ticket_row = {"keyname": "单据编号", "value": ticket_sn}
+        if approval_url:
+            ticket_row.update(type=1, url=approval_url)
+        horizontal_content_list.append(ticket_row)
     if submit_time:
         horizontal_content_list.append({"keyname": "提交时间", "value": submit_time})
     if session_url:
@@ -152,9 +155,7 @@ def _build_pending_card(interrupt: dict, session_code: str) -> dict[str, Any]:
     if horizontal_content_list:
         card["horizontal_content_list"] = horizontal_content_list
 
-    detail_url = approval_url or session_url
-    if detail_url:
-        card["card_action"] = {"type": 1, "url": detail_url}
+    card["card_action"] = {"type": 1, "url": session_url} if session_url else {"type": 0}
 
     interrupt_id = str(interrupt.get("id") or "")
     if session_code and interrupt_id:

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_resume.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_resume.py
@@ -1,0 +1,118 @@
+"""取消成功后在原会话续流，结果由 Agent 写回 Web，不发送额外企微消息。"""
+
+import threading
+from contextvars import copy_context
+from logging import getLogger
+
+from aidev_agent.enums import ChannelType
+from aidev_agent.services.agent.approval import ApprovalStateHandler
+from aidev_agent.utils.tracing import get_current_trace_id
+from aidev_bkplugin.services.agent_builder import AgentBuilder
+from aidev_bkplugin.services.agent_execution import AgentExecutor, build_execute_kwargs
+from aidev_bkplugin.services.agent_session import SessionManager
+from aidev_bkplugin.services.execution import get_agent_executor
+from django.db import close_old_connections
+
+from .approval_cards import ApprovalCancelAction
+from .tracing import record_failure, wxbot_span
+
+logger = getLogger(__name__)
+_pending: set[ApprovalCancelAction] = set()
+_pending_lock = threading.Lock()
+
+
+def submit_cancelled_approval_resume(action: ApprovalCancelAction, username: str, envelope: dict) -> bool:
+    """仅接受本次撤销成功的原会话指令；不信任回调携带的 URL 或执行参数。"""
+    if not _can_resume(action, envelope):
+        return False
+    with _pending_lock:
+        if action in _pending:
+            return True
+        _pending.add(action)
+    submitted = False
+    try:
+        submitted = get_agent_executor().submit(copy_context().run, _resume_worker, action, username)
+        logger.info("event=wxbot_approval_resume_submitted accepted=%s trace_id=%s", submitted, get_current_trace_id())
+        return submitted
+    finally:
+        if not submitted:
+            with _pending_lock:
+                _pending.discard(action)
+
+
+def _can_resume(action: ApprovalCancelAction, envelope: dict) -> bool:
+    if not isinstance(envelope, dict) or envelope.get("ok") is not True:
+        return False
+    result = envelope.get("result")
+    next_action = envelope.get("next")
+    if not isinstance(result, dict) or not isinstance(next_action, dict):
+        return False
+    payload = next_action.get("payload")
+    return (
+        result.get("approve_result") == "cancelled"
+        and not result.get("already_finalized")
+        and next_action.get("endpoint") == "chat_completion"
+        and isinstance(payload, dict)
+        and payload.get("session_code") == action.session_code
+    )
+
+
+def _resume_worker(action: ApprovalCancelAction, username: str) -> None:
+    with wxbot_span("wxbot.approval.resume") as span:
+        try:
+            close_old_connections()
+            _resume_cancelled_approval(action, username)
+        except Exception as error:
+            record_failure(span, error)
+            logger.error(
+                "event=wxbot_approval_resume_failed error_type=%s trace_id=%s",
+                type(error).__name__,
+                get_current_trace_id(),
+            )
+        finally:
+            try:
+                close_old_connections()
+            finally:
+                with _pending_lock:
+                    _pending.discard(action)
+
+
+def _contains_interrupt(interrupts, interrupt_id: str) -> bool:
+    return isinstance(interrupts, list) and any(
+        isinstance(item, dict)
+        and (item.get("id") or item.get("interruptId")) == interrupt_id
+        and item.get("reason") == "aidev:tool_approval"
+        for item in interrupts
+    )
+
+
+def _resume_cancelled_approval(action: ApprovalCancelAction, username: str) -> None:
+    handler = ApprovalStateHandler(username=username)
+    pending = handler.get_pending_interrupt_context(action.session_code)
+    info = handler.fetch_approve_result(action.session_code)
+    # 排队期间可能已由 Web 恢复或进入下一轮审批，不对旧卡片重放 Agent。
+    if (
+        not pending.get("graph_thread_id")
+        or not _contains_interrupt(pending.get("interrupts"), action.interrupt_id)
+        or not info
+        or info.get("approve_result") != "cancelled"
+        or not _contains_interrupt(info.get("interrupts"), action.interrupt_id)
+    ):
+        logger.info("event=wxbot_approval_resume_skipped reason=interrupt_changed trace_id=%s", get_current_trace_id())
+        return
+    resume = [{"interruptId": action.interrupt_id}]
+    handler.hydrate_resume_payload(resume, "cancelled")
+    execute_kwargs = build_execute_kwargs(
+        {
+            "stream": True,
+            "session_code": action.session_code,
+            "thread_id": pending["graph_thread_id"],
+            "resume": resume,
+        },
+        username,
+    )
+    builder = AgentBuilder(username=username)
+    agent = builder.by_session_code(action.session_code, channel_type=ChannelType.RTX.value)
+    manager = SessionManager(username=username, resource_manager=builder.resource_manager)
+    AgentExecutor.run_agent_to_completion(agent, execute_kwargs, action.session_code, manager)
+    logger.info("event=wxbot_approval_resume_finished trace_id=%s", get_current_trace_id())

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -35,6 +35,7 @@ from .approval_cards import (
     build_cancel_result_card,
     decode_cancel_event_key,
 )
+from .approval_resume import submit_cancelled_approval_resume
 from .constants import (
     AGENT_STREAM_DRAIN_TIMEOUT,
     BUSY_BY_OTHERS_REPLY,
@@ -529,6 +530,17 @@ class WxAiBotLongConnectionService:
                     record_failure(span, RuntimeError("approval_cancel_failed"))
         except Exception:
             logger.exception("event=wxbot_approval_cancel_failed task_id=%s", task_id)
+
+        if succeeded:
+            try:
+                with wxbot_span("wxbot.approval.resume.submit"):
+                    submitted = submit_cancelled_approval_resume(action, username, envelope)
+                if not submitted and result_card is not None:
+                    result_card["sub_title_text"] = "审批已取消，请点击卡片返回会话继续。"
+            except Exception:
+                logger.exception("event=wxbot_approval_resume_submit_failed task_id=%s", task_id)
+                if result_card is not None:
+                    result_card["sub_title_text"] = "审批已取消，请点击卡片返回会话继续。"
 
         if result_card is None:
             # 请求失败或旧平台未返回原详情时，不用精简失败卡片覆盖用户已有的信息。

--- a/src/plugins/aidev_wxbot/tests/wxaibot/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/conftest.py
@@ -1,6 +1,7 @@
 """企微审批卡片测试使用的脱敏平台响应与回调。"""
 
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 from aidev_wxbot.wxaibot.approval_cards import (
@@ -48,4 +49,44 @@ def approval_card_case(monkeypatch):
         },
     }
     result = {"approve_result": "cancelled", "interrupts": [interrupt]}
-    return SimpleNamespace(action=action, task_id=task_id, result=result, card=card, event=event)
+    envelope = {
+        "ok": True,
+        "result": result,
+        "next": {
+            "endpoint": "chat_completion",
+            "payload": {"session_code": action.session_code, "execute_kwargs": {"stream": True}},
+        },
+    }
+    return SimpleNamespace(action=action, task_id=task_id, result=result, card=card, event=event, envelope=envelope)
+
+
+@pytest.fixture
+def approval_resume_case(approval_card_case, monkeypatch):
+    from aidev_wxbot.wxaibot import approval_resume as mod
+
+    case = approval_card_case
+    real_hydrate = mod.ApprovalStateHandler.hydrate_resume_payload
+    handler_type = MagicMock()
+    handler = handler_type.return_value
+    handler.hydrate_resume_payload.side_effect = real_hydrate
+    handler.get_pending_interrupt_context.return_value = {
+        "graph_thread_id": "graph-1",
+        "interrupts": case.result["interrupts"],
+    }
+    handler.fetch_approve_result.return_value = case.result
+    monkeypatch.setattr(mod, "ApprovalStateHandler", handler_type)
+    case.builder = MagicMock()
+    monkeypatch.setattr(mod, "AgentBuilder", case.builder)
+    case.manager = MagicMock()
+    monkeypatch.setattr(mod, "SessionManager", case.manager)
+    case.real_run = mod.AgentExecutor.run_agent_to_completion
+    case.run = MagicMock()
+    monkeypatch.setattr(mod.AgentExecutor, "run_agent_to_completion", case.run)
+    case.executor = MagicMock()
+    case.executor.submit.return_value = True
+    monkeypatch.setattr(mod, "get_agent_executor", lambda: case.executor)
+    case.cleanup = MagicMock()
+    monkeypatch.setattr(mod, "close_old_connections", case.cleanup)
+    monkeypatch.setattr(mod, "_pending", set())
+    case.module, case.handler = mod, handler
+    return case

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_cards.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_cards.py
@@ -25,10 +25,11 @@ def test_pending_card_has_separate_safe_web_session_link(approval_card_case, mon
     card = build_pending_approval_card(
         {"outcome": {"type": "interrupt", "interrupts": case.result["interrupts"]}}, case.action.session_code
     )
-    links = [row for row in card["horizontal_content_list"] if row.get("type") == 1]
+    links = [row for row in card["horizontal_content_list"] if row["keyname"] == "会话"]
     expected = [{"keyname": "会话", "value": "查看会话", "type": 1, "url": session_url}]
     assert links == (expected if session_url.startswith(("https://", "http://")) else [])
-    assert card["card_action"] == case.card["card_action"]
+    assert card["card_action"] == ({"type": 1, "url": session_url} if links else {"type": 0})
+    assert card["horizontal_content_list"][0] == case.card["horizontal_content_list"][0]
     assert card["button_list"] == case.card["button_list"]
 
 
@@ -52,6 +53,21 @@ def test_result_only_replaces_action_area(approval_card_case, status, label):
     assert case.result == original
     assert "must-not-leak" not in json.dumps(card)
     assert "candidate-not-actual-approver" not in json.dumps(card)
+
+
+@pytest.mark.parametrize(
+    "ticket_url", ["https://approval.example.com/#/ticket?type=ticket&id=1", "", "javascript:alert(1)"]
+)
+def test_ticket_number_link_is_separate_from_default_action(approval_card_case, ticket_url):
+    case = approval_card_case
+    case.result["interrupts"][0]["metadata"]["ticket"]["url"] = ticket_url
+    card = build_cancel_result_card(case.action, case.task_id, result=case.result)
+    assert card["card_action"] == {"type": 1, "url": "https://agent.example.com/session-1"}
+    row = {"keyname": "单据编号", "value": "DE001"}
+    if ticket_url.startswith("https://"):
+        row.update(type=1, url=ticket_url)
+    assert card["horizontal_content_list"][0] == row
+    assert card["main_title"]["desc"] == "点击卡片查看会话"
 
 
 @pytest.mark.parametrize("result", [None, [], {}, {"approve_result": []}, {"approve_result": "pending"}])

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_cards.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_cards.py
@@ -17,7 +17,7 @@ from aidev_wxbot.wxaibot.approval_cards import build_cancel_result_card, build_p
         "javascript:void(0)",
     ],
 )
-def test_pending_card_has_separate_safe_web_session_link(approval_card_case, monkeypatch, session_url):
+def test_pending_card_opens_safe_session_without_session_row(approval_card_case, monkeypatch, session_url):
     case = approval_card_case
     monkeypatch.setattr(
         "aidev_wxbot.wxaibot.approval_cards.AgentHelper.build_session_detail_url", lambda _session: session_url
@@ -25,10 +25,11 @@ def test_pending_card_has_separate_safe_web_session_link(approval_card_case, mon
     card = build_pending_approval_card(
         {"outcome": {"type": "interrupt", "interrupts": case.result["interrupts"]}}, case.action.session_code
     )
-    links = [row for row in card["horizontal_content_list"] if row["keyname"] == "会话"]
-    expected = [{"keyname": "会话", "value": "查看会话", "type": 1, "url": session_url}]
-    assert links == (expected if session_url.startswith(("https://", "http://")) else [])
-    assert card["card_action"] == ({"type": 1, "url": session_url} if links else {"type": 0})
+    assert [row["keyname"] for row in card["horizontal_content_list"]] == ["单据编号", "提交时间"]
+    expected_action = (
+        {"type": 1, "url": session_url} if session_url.startswith(("https://", "http://")) else {"type": 0}
+    )
+    assert card["card_action"] == expected_action
     assert card["horizontal_content_list"][0] == case.card["horizontal_content_list"][0]
     assert card["button_list"] == case.card["button_list"]
 
@@ -44,12 +45,8 @@ def test_result_only_replaces_action_area(approval_card_case, status, label):
     expected = {key: value for key, value in case.card.items() if key != "button_list"}
     expected.update(card_type="text_notice", jump_list=[{"type": 0, "title": label}])
     assert card == expected
-    assert card["horizontal_content_list"][-1] == {
-        "keyname": "会话",
-        "value": "查看会话",
-        "type": 1,
-        "url": "https://agent.example.com/session-1",
-    }
+    assert [row["keyname"] for row in card["horizontal_content_list"]] == ["单据编号", "提交时间"]
+    assert card["card_action"] == {"type": 1, "url": "https://agent.example.com/session-1"}
     assert case.result == original
     assert "must-not-leak" not in json.dumps(card)
     assert "candidate-not-actual-approver" not in json.dumps(card)

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_resume.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_resume.py
@@ -1,0 +1,143 @@
+"""取消审批后续流：只执行一次、沿用原会话、后台写回，不重复执行工具。"""
+
+from contextvars import ContextVar
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "invalid", ["failed", "approved", "already_finalized", "endpoint", "session", "next", "result"]
+)
+def test_only_successful_cancel_can_schedule(approval_resume_case, invalid):
+    case = approval_resume_case
+    if invalid == "failed":
+        case.envelope["ok"] = False
+    elif invalid == "approved":
+        case.result["approve_result"] = "approved"
+    elif invalid == "already_finalized":
+        case.result["already_finalized"] = True
+    elif invalid == "endpoint":
+        case.envelope["next"]["endpoint"] = "https://untrusted.example.com"
+    elif invalid == "session":
+        case.envelope["next"]["payload"]["session_code"] = "other-session"
+    else:
+        case.envelope[invalid] = None
+    assert not case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    case.executor.submit.assert_not_called()
+
+
+def test_repeated_callback_is_deduplicated_until_worker_finishes(approval_resume_case):
+    case = approval_resume_case
+    for _ in range(2):
+        assert case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    case.executor.submit.assert_called_once()
+    callback, *args = case.executor.submit.call_args.args
+    callback(*args)
+    case.run.assert_called_once()
+    assert not case.module._pending
+    assert case.cleanup.call_count == 2
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_failed_submission_releases_dedup_entry(approval_resume_case, raises):
+    case = approval_resume_case
+    case.executor.submit.return_value = False
+    if raises:
+        case.executor.submit.side_effect = RuntimeError("executor unavailable")
+        with pytest.raises(RuntimeError):
+            case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    else:
+        assert not case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    assert not case.module._pending
+
+
+def test_resume_uses_original_session_and_denies_cancelled_tool(approval_resume_case):
+    case = approval_resume_case
+    case.module._resume_worker(case.action, "alice")
+    case.builder.assert_called_once_with(username="alice")
+    case.builder.return_value.by_session_code.assert_called_once_with("session-1", channel_type="rtx")
+    _, kwargs, session_code, _ = case.run.call_args.args
+    assert session_code == kwargs.session_code == "session-1"
+    assert kwargs.thread_id == "graph-1"
+    assert kwargs.stream and not kwargs.input
+    assert kwargs.executor == "alice"
+    assert kwargs.resume == [
+        {"interruptId": case.action.interrupt_id, "status": "cancelled", "payload": {"approved": False}}
+    ]
+
+
+def test_background_execution_consumes_stream_and_saves_reply(approval_resume_case):
+    case = approval_resume_case
+    agent = case.builder.return_value.by_session_code.return_value
+    agent.event_handler = None
+    agent.execute.return_value = iter(['data: {"event":"text","content":"已跳过取消的工具，继续处理。"}\n'])
+    case.run.side_effect = case.real_run
+    case.module._resume_worker(case.action, "alice")
+    assert agent.execute.call_args.args[0].background_only
+    case.manager.return_value.save_content.assert_called_once()
+    saved = case.manager.return_value.save_content.call_args.kwargs
+    assert saved["session_code"] == "session-1"
+    assert saved["content"] == "已跳过取消的工具，继续处理。"
+
+
+@pytest.mark.parametrize("changed", ["pending", "thread", "interrupt", "approved", "result"])
+def test_worker_does_not_replay_old_approval(approval_resume_case, changed):
+    case = approval_resume_case
+    pending = case.handler.get_pending_interrupt_context.return_value
+    if changed == "pending":
+        pending.clear()
+    elif changed == "thread":
+        pending["graph_thread_id"] = ""
+    elif changed == "interrupt":
+        pending["interrupts"] = [{"id": "another", "reason": "aidev:tool_approval"}]
+    elif changed == "approved":
+        case.result["approve_result"] = "approved"
+    else:
+        case.handler.fetch_approve_result.return_value = None
+    case.module._resume_worker(case.action, "alice")
+    case.builder.assert_not_called()
+    assert case.cleanup.call_count == 2
+
+
+def test_resume_failure_is_sanitized_and_releases_worker_state(approval_resume_case, caplog):
+    case = approval_resume_case
+    case.run.side_effect = RuntimeError("secret-in-upstream-error")
+    case.module._pending.add(case.action)
+    case.module._resume_worker(case.action, "alice")
+    assert "secret-in-upstream-error" not in caplog.text
+    assert "wxbot_approval_resume_failed" in caplog.text
+    assert not case.module._pending
+    assert case.cleanup.call_count == 2
+
+
+def test_submission_propagates_context_to_worker(approval_resume_case, monkeypatch):
+    case = approval_resume_case
+    trace = ContextVar("test_approval_trace", default="")
+    observed = []
+    monkeypatch.setattr(case.module, "_resume_cancelled_approval", lambda *_: observed.append(trace.get()))
+    token = trace.set("callback-trace")
+    try:
+        case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    finally:
+        trace.reset(token)
+    callback, *args = case.executor.submit.call_args.args
+    callback(*args)
+    assert observed == ["callback-trace"]
+
+
+def test_resume_span_and_agent_traceparent_follow_callback(approval_resume_case, wxbot_spans):
+    from aidev_wxbot.wxaibot.tracing import received_message_span
+
+    case = approval_resume_case
+    with received_message_span({"body": {"msgtype": "event"}}):
+        case.module.submit_cancelled_approval_resume(case.action, "alice", case.envelope)
+    callback, *args = case.executor.submit.call_args.args
+    callback(*args)
+    spans = {span.name: span for span in wxbot_spans.get_finished_spans()}
+    parent = spans["wxbot.message.receive"]
+    resumed = spans["wxbot.approval.resume"]
+    assert resumed.parent.span_id == parent.context.span_id
+    assert resumed.context.trace_id == parent.context.trace_id
+    kwargs = case.run.call_args.args[1]
+    assert kwargs.caller_trace_context["traceparent"].split("-")[1] == f"{parent.context.trace_id:032x}"
+    assert "alice" not in resumed.to_json()

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_direct_stream.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_direct_stream.py
@@ -271,7 +271,7 @@ def test_pending_tool_approval_is_pushed_as_interactive_card(mock_detail_url, ti
     assert card["card_type"] == "button_interaction"
     assert card["main_title"]["title"] == "执行「retrieve_private_v1_skills」需要审批"
     assert card["horizontal_content_list"] == [
-        {"keyname": "单据编号", "value": "DE001"},
+        {"keyname": "单据编号", "value": "DE001", "type": 1, "url": expected_url},
         {"keyname": "提交时间", "value": "2026-08-28T16:30:15.245792+00:00"},
         {
             "keyname": "会话",
@@ -280,7 +280,7 @@ def test_pending_tool_approval_is_pushed_as_interactive_card(mock_detail_url, ti
             "url": "https://agent.example.com/chat-window/?session=session-1",
         },
     ]
-    assert card["card_action"] == {"type": 1, "url": expected_url}
+    assert card["card_action"] == {"type": 1, "url": "https://agent.example.com/chat-window/?session=session-1"}
     assert "source" not in card  # 不展示“已通过”等状态徽标
     assert card["button_list"][0]["text"] == "取消审批"
     action = decode_cancel_event_key(card["button_list"][0]["key"])
@@ -311,7 +311,7 @@ def test_pending_tool_approval_drops_non_http_ticket_url(_mock_detail_url):
 
     card = frames[-1].template_card
     assert card["horizontal_content_list"] == [{"keyname": "单据编号", "value": "DE002"}]
-    assert "card_action" not in card
+    assert card["card_action"] == {"type": 0}
     assert "javascript" not in json.dumps(card, ensure_ascii=False)
 
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_direct_stream.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_direct_stream.py
@@ -273,12 +273,6 @@ def test_pending_tool_approval_is_pushed_as_interactive_card(mock_detail_url, ti
     assert card["horizontal_content_list"] == [
         {"keyname": "单据编号", "value": "DE001", "type": 1, "url": expected_url},
         {"keyname": "提交时间", "value": "2026-08-28T16:30:15.245792+00:00"},
-        {
-            "keyname": "会话",
-            "value": "查看会话",
-            "type": 1,
-            "url": "https://agent.example.com/chat-window/?session=session-1",
-        },
     ]
     assert card["card_action"] == {"type": 1, "url": "https://agent.example.com/chat-window/?session=session-1"}
     assert "source" not in card  # 不展示“已通过”等状态徽标

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -674,9 +674,13 @@ class TestLongConnectionStreaming:
         service = _service()
         service._view.resolve_event_username.return_value = "alice"
         case.result["approve_result"] = status
-        envelope = {"ok": ok, "result": case.result}
-        with patch.object(long_connection_module, "dispatch_user_operation", return_value=envelope) as dispatch:
+        case.envelope["ok"] = ok
+        with (
+            patch.object(long_connection_module, "dispatch_user_operation", return_value=case.envelope) as dispatch,
+            patch.object(long_connection_module, "submit_cancelled_approval_resume", return_value=True) as resume,
+        ):
             await service._handle_frame({"body": case.event})
+        assert resume.call_count == int(ok)
         dispatch.assert_called_once_with(
             "approval_cancel",
             "alice",
@@ -703,6 +707,36 @@ class TestLongConnectionStreaming:
         with patch.object(long_connection_module, "dispatch_user_operation", side_effect=RuntimeError("failed")):
             await service._handle_frame({"body": approval_card_case.event})
         assert service._client.update_template_card_calls == []
+
+    @pytest.mark.parametrize("update_fails", [False, True])
+    async def test_cancel_resumes_even_when_card_update_fails(self, approval_card_case, update_fails):
+        case = approval_card_case
+        service = _service()
+        service._view.resolve_event_username.return_value = "alice"
+        if update_fails:
+            service._client.update_template_card = AsyncMock(side_effect=RuntimeError("failed"))
+        with (
+            patch.object(long_connection_module, "dispatch_user_operation", return_value=case.envelope),
+            patch.object(long_connection_module, "submit_cancelled_approval_resume", return_value=True) as resume,
+        ):
+            await service._handle_frame({"body": case.event})
+        resume.assert_called_once_with(case.action, "alice", case.envelope)
+
+    @pytest.mark.parametrize("raises", [False, True])
+    async def test_resume_capacity_failure_keeps_cancelled_state_and_web_link(self, approval_card_case, raises):
+        case = approval_card_case
+        service = _service()
+        with (
+            patch.object(long_connection_module, "dispatch_user_operation", return_value=case.envelope),
+            patch.object(long_connection_module, "submit_cancelled_approval_resume", return_value=False) as resume,
+        ):
+            if raises:
+                resume.side_effect = RuntimeError("executor unavailable")
+            await service._handle_frame({"body": case.event})
+        card = service._client.update_template_card_calls[0]
+        assert card["jump_list"] == [{"type": 0, "title": "已取消"}]
+        assert card["card_action"] == case.card["card_action"]
+        assert card["sub_title_text"] == "审批已取消，请点击卡片返回会话继续。"
 
     async def test_slow_wecom_sender_applies_bounded_backpressure(self, monkeypatch):
         class SlowClient(FakeClient):


### PR DESCRIPTION
## 背景

调整企微审批卡片的跳转入口，并在用户成功撤销审批后继续原会话。

## 原因

原卡片默认打开审批单，单据编号不提供独立跳转；取消回调仅更新卡片，没有显式消费平台返回的续流指令。

## 改动内容

- 整卡默认点击进入对应 Web 会话，点击单据编号进入审批单；结果卡片保留原详情和两类入口，缺失或不安全的链接不可点击。
- 仅在平台本次取消成功、结果为 cancelled 且 next 指向原会话时，通过 Bkplugin 有界执行器后台续流。复用原 session 和 graph thread，按取消结果生成 resume，禁止执行被取消的工具，不新增用户输入。
- 排队任务按 session 和 interrupt 去重；执行前核对当前中断及已落库的取消结果，避免旧卡片重放。续流事件由 Agent 写回 Web 会话，不新增企微后续消息。
- SDK 轮询与平台保持一致：主动取消由操作发起方续流，审批通过和拒绝仍自动续流，避免重复消费者。
- 卡片更新失败不阻断已提交的续流；执行器拒绝任务时保留取消状态，提示返回 Web 继续。新增后台任务的工作线程数据库清理、脱敏日志与续流 span，并透传 trace context。

## 收益

明确区分会话入口与审批单入口；工单撤销成功后不再只更新卡片，而是继续会话。取消失败、已结束或过期的审批不会误触发恢复。

## 测试验证

- 新分支从最新 develop 的 `e409bc21` 创建，无旧 PR 的未提交数据库修复。
- wxbot 全量：203 项通过；Bkplugin 取消/透传/执行器：13 项通过；AG-UI 中断协议：17 项通过，共 233 项。
- 覆盖 URL 跳转与编码、卡片字段保留、取消状态、异常与容量拒绝、重复回调、过期中断、后台 SSE 消费写回及 trace 透传。
- 完整适用 pre-commit 和 diff 检查通过；本地自审未发现必须修复的问题。
- 未修改平台代码，未调用真实工单撤销、未部署或重启服务。原生企微显示和真实审批链路仍需部署后人工验收。
