### PR TITLE
fix: 保留发布 Agent 角色模板与变量 --bug=163219427

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/agent.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/agent.py
@@ -42,8 +42,6 @@ class AgentInfoViewSet(PluginViewSet):
             "username": request.user.username,
         }
         prompt_setting = agent_info.get("prompt_setting", {})
-        prompt_setting["collection_content"] = []
-        prompt_setting["collection_variables"] = []
         prompt_setting["content"] = [
             content for content in prompt_setting["content"] if content.get("role") == PromptRole.PAUSE.value
         ]

--- a/src/plugins/aidev_bkplugin/tests/views/test_agent_view.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_agent_view.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+base_mod = types.ModuleType("aidev_bkplugin.views.base")
+base_mod.PluginViewSet = object
+sys.modules["aidev_bkplugin.views.base"] = base_mod
+
+agent_config_mod = types.ModuleType("aidev_bkplugin.services.agent_config")
+agent_config_mod.AgentConfigFetcher = MagicMock()
+sys.modules["aidev_bkplugin.services.agent_config"] = agent_config_mod
+
+agent_helpers_mod = types.ModuleType("aidev_bkplugin.services.agent_helpers")
+agent_helpers_mod.AgentHelper = MagicMock()
+sys.modules["aidev_bkplugin.services.agent_helpers"] = agent_helpers_mod
+
+utils_mod = types.ModuleType("aidev_bkplugin.utils")
+utils_mod.is_local_dev = lambda: False
+utils_mod.set_user_access_token = MagicMock()
+sys.modules["aidev_bkplugin.utils"] = utils_mod
+
+from aidev_bkplugin.views import agent as agent_mod  # noqa: E402
+
+
+def test_agent_info_keeps_role_template_and_variables(mocker):
+    role_template = [{"role": "hidden-system", "content": "你是测试助手"}]
+    role_variables = [{"field_name": "language", "field_value": "中文"}]
+    agent_info = {
+        "prompt_setting": {
+            "collection_id": 1,
+            "collection_content": role_template,
+            "collection_variables": role_variables,
+            "content": [
+                {"role": "hidden-system", "content": "渲染后的系统提示词"},
+                {"role": "pause", "content": "请问我可以帮你做什么？"},
+            ],
+        },
+        "otel_info": "sensitive-otel-config",
+    }
+    get_info = mocker.patch.object(
+        agent_mod.AgentConfigFetcher,
+        "get_info",
+        return_value=agent_info,
+    )
+    request = SimpleNamespace(query_params={}, user=SimpleNamespace(username="alice"))
+
+    response = agent_mod.AgentInfoViewSet().info(request)
+
+    assert response.data["prompt_setting"]["collection_id"] == 1
+    assert response.data["prompt_setting"]["collection_content"] == role_template
+    assert response.data["prompt_setting"]["collection_variables"] == role_variables
+    assert response.data["prompt_setting"]["content"] == [{"role": "pause", "content": "请问我可以帮你做什么？"}]
+    assert "otel_info" not in response.data
+    get_info.assert_called_once_with(username="alice", app_code=None)


### PR DESCRIPTION
## 背景

TAPD [#163219427](https://tapd.woa.com/tapd_fe/70093903/bug/detail/1070093903163219427)：已发布智能体 `agent/info` 会清空角色模板和变量，导致接口与平台配置不一致。

根因 / 现状：

- 发布模板 `agent/info` 对 `prompt_setting.collection_content` 与 `collection_variables` 进行了强制清空。

## 改动

- 保留 `collection_content` 与 `collection_variables`，让已发布应用接口返回已保存的角色模板与变量。
- 保持 `prompt_setting.content` 仅返回 `pause` 项，不暴露渲染后的 system prompt。
- 新增发布模板 Agent info 回归测试。

## 测试

- `./.venv/bin/pytest -c pyproject.toml tests/views/test_agent_view.py -q`
- `uvx ruff check aidev_bkplugin/views/agent.py tests/views/test_agent_view.py`
- `uvx ruff format --check aidev_bkplugin/views/agent.py tests/views/test_agent_view.py`

## 关联

tapd: #163219427

发起人：
- cursoragent
- @Vellun7
