### PR TITLE
feat: 修复企微后台任务复用失效数据库连接 --story=136129662

### DIFF
--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database.py
@@ -1,0 +1,31 @@
+"""Django 请求周期之外的同步后台任务数据库连接边界。"""
+
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import ParamSpec, TypeVar
+
+from django.db import close_old_connections
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+@contextmanager
+def database_connection_scope() -> Iterator[None]:
+    """在实际 ORM 工作线程清理过期/失效连接，不重试任何业务操作。
+
+    Django 连接按线程隔离，不能在事件循环中替其他线程清理。任务结束即使
+    异常被内部捕获，也要检查连接状态，避免下一次复用同一线程时持续失败。
+    保留 Django 的连接复用策略，不无条件关闭健康连接。
+    """
+    try:
+        close_old_connections()
+        yield
+    finally:
+        close_old_connections()
+
+
+def run_with_database_connections(function: Callable[P, T], /, *args: P.args, **kwargs: P.kwargs) -> T:
+    """供 ``to_thread`` 调用；懒生成器需在 scope 内完成迭代而非仅创建。"""
+    with database_connection_scope():
+        return function(*args, **kwargs)

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -51,6 +51,7 @@ from .constants import (
     WS_INSTANCE_LOCK_CACHE_KEY_PREFIX,
 )
 from .context import THINKING_MSG, ContextGenerator, stream_msg
+from .database import database_connection_scope, run_with_database_connections
 from .direct_stream import DirectStreamFrame, iter_direct_stream_frames
 from .question_cards import bind_question_target, decode_question_key, question_task_id, submitted_question_card
 from .question_resume import prepare_question_submission, submit_question_resume
@@ -477,7 +478,9 @@ class WxAiBotLongConnectionService:
                 return
             if payload.get("msgtype") == "text":
                 with wxbot_span("wxbot.message.prepare"):
-                    response, request = await asyncio.to_thread(self._view.prepare_agent_request, payload)
+                    response, request = await asyncio.to_thread(
+                        run_with_database_connections, self._view.prepare_agent_request, payload
+                    )
                 if response is not None:
                     await self._dispatch_immediate_response(frame, payload, response)
                     return
@@ -491,7 +494,7 @@ class WxAiBotLongConnectionService:
                     await self._send_stream_reply(frame, stream_id, "长连接模式无需轮询流式结果", True)
                 return
 
-            response = await asyncio.to_thread(self._view._reply_wxaibot, payload)
+            response = await asyncio.to_thread(run_with_database_connections, self._view._reply_wxaibot, payload)
             await self._dispatch_immediate_response(frame, payload, response)
 
     async def _handle_approval_card_event(self, frame: dict[str, Any], payload: dict[str, Any]) -> bool:
@@ -518,9 +521,12 @@ class WxAiBotLongConnectionService:
         succeeded = False
         result_card = None
         try:
-            username = await asyncio.to_thread(self._view.resolve_event_username, payload)
+            username = await asyncio.to_thread(
+                run_with_database_connections, self._view.resolve_event_username, payload
+            )
             with wxbot_span("wxbot.approval.cancel", kind=CLIENT) as span:
                 envelope = await asyncio.to_thread(
+                    run_with_database_connections,
                     dispatch_user_operation,
                     "approval_cancel",
                     username,
@@ -623,7 +629,9 @@ class WxAiBotLongConnectionService:
             return True
         delivery = None
         try:
-            username = await asyncio.to_thread(self._view.resolve_event_username, payload)
+            username = await asyncio.to_thread(
+                run_with_database_connections, self._view.resolve_event_username, payload
+            )
             submission = await asyncio.to_thread(
                 prepare_question_submission,
                 action,
@@ -897,6 +905,7 @@ class WxAiBotLongConnectionService:
                 stream_registry.cancel(request.stream_id)
             cancel_event.set()
 
+    @database_connection_scope()
     def _produce_direct_stream(
         self,
         request: WxBotAgentRequest,
@@ -975,6 +984,7 @@ class WxAiBotLongConnectionService:
         self._finish_stream_drain(drain)
         return drain
 
+    @database_connection_scope()
     def _drain_stream_frames(self, frames, drain: StreamDrain) -> None:
         """排空统一流接口，让 Agent 自己完成收尾。
 

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/views.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/views.py
@@ -43,6 +43,7 @@ from .context import (
     stream_msg,
     text_msg,
 )
+from .database import database_connection_scope
 from .decryption import WXBizJsonMsgCrypt
 from .models import AgentSession
 from .strategies import resolve_strategy
@@ -430,6 +431,7 @@ class WxAiBotViewSet(ViewSet):
 
         return stream_msg("已创建新会话，请输入咨询内容", True, stream_id)
 
+    @database_connection_scope()
     def _process_ai_request_async(self, content: str, stream_id: str, username: str, group_id: str):
         """异步处理 AI 请求：根据 agent_type 选择策略，执行并桥接到 RabbitMQ。
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_database.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_database.py
@@ -1,0 +1,189 @@
+"""后台线程的 Django 连接清理必须包围实际执行，且不能重试业务。"""
+
+import asyncio
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aidev_wxbot.wxaibot import database
+from django.db import InterfaceError
+
+from .test_long_connection import StreamDrain, _service
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_cleanup_wraps_worker_call_without_retry(monkeypatch, failed):
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append(("clean", threading.get_ident())))
+
+    def operation():
+        events.append(("call", threading.get_ident()))
+        if failed:
+            raise InterfaceError(0, "")
+        return "result"
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        future = pool.submit(database.run_with_database_connections, operation)
+        if failed:
+            with pytest.raises(InterfaceError):
+                future.result()
+        else:
+            assert future.result() == "result"
+    assert [name for name, _ in events] == ["clean", "call", "clean"]
+    assert len({ident for _, ident in events}) == 1
+    assert events[0][1] != threading.get_ident()
+
+
+async def test_message_prepare_cleanup_stays_in_worker(monkeypatch):
+    service = _service()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append(threading.get_ident()))
+    service._view.prepare_agent_request.side_effect = lambda _payload: (
+        events.append(threading.get_ident()) or {},
+        None,
+    )
+    service._dispatch_immediate_response = AsyncMock()
+    await service._handle_frame({"body": {"msgtype": "text"}})
+    assert len(events) == 3
+    assert len(set(events)) == 1
+    assert events[0] != threading.get_ident()
+
+
+async def test_other_message_cleanup_stays_in_worker(monkeypatch):
+    service = _service()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append(threading.get_ident()))
+    service._view._reply_wxaibot.side_effect = lambda _payload: events.append(threading.get_ident()) or {}
+    service._dispatch_immediate_response = AsyncMock()
+    await service._handle_frame({"body": {"msgtype": "image"}})
+    assert len(events) == 3 and len(set(events)) == 1
+    assert events[0] != threading.get_ident()
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_legacy_callback_worker_is_cleaned_even_when_error_is_caught(monkeypatch, failed):
+    from aidev_wxbot.wxaibot import views
+
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append("clean"))
+    monkeypatch.setattr(views, "LlmChunkMsg", MagicMock())
+    view = object.__new__(views.WxAiBotViewSet)
+    view._get_or_create_thread_id = MagicMock(return_value="thread")
+    execute = MagicMock(side_effect=InterfaceError(0, "") if failed else lambda **_kw: None)
+    monkeypatch.setattr(views, "resolve_strategy", lambda _user: MagicMock(execute=execute))
+    view._process_ai_request_async("test", "test-stream", "test-user", "test-group")
+    assert events == ["clean", "clean"]
+    assert execute.call_count == 1
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_producer_cleanup_covers_agent_iteration(monkeypatch, failed):
+    service = _service()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append("clean"))
+
+    def produce(*_args):
+        events.append("iterate")
+        if failed:
+            raise InterfaceError(0, "")
+
+    service._produce_agent_frames = produce
+    if failed:
+        with pytest.raises(InterfaceError):
+            service._produce_direct_stream(None, None, None, None)
+    else:
+        service._produce_direct_stream(None, None, None, None)
+    assert events == ["clean", "iterate", "clean"]
+
+
+@pytest.mark.parametrize("failed", [False, True])
+def test_drain_cleanup_runs_after_generator_close(monkeypatch, failed):
+    service = _service()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append("clean"))
+
+    def frames():
+        try:
+            events.append("iterate")
+            if failed:
+                raise InterfaceError(0, "")
+            yield "frame"
+        finally:
+            events.append("generator_closed")
+
+    drain = StreamDrain("test-stream")
+    service._drain_stream_frames(frames(), drain)
+    assert drain.completed.is_set()
+    assert events == ["clean", "iterate", "generator_closed", "clean"]
+
+
+async def test_cancel_cleanup_wraps_identity_and_operation(monkeypatch, approval_card_case):
+    from aidev_wxbot.wxaibot import long_connection
+
+    service = _service()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append("clean"))
+    service._view.resolve_event_username.side_effect = lambda _payload: events.append("identity") or "user"
+    dispatch = MagicMock(side_effect=lambda *_args: events.append("cancel") or {})
+    monkeypatch.setattr(long_connection, "dispatch_user_operation", dispatch)
+    await service._handle_frame({"body": approval_card_case.event})
+    assert events == ["clean", "identity", "clean", "clean", "cancel", "clean"]
+    assert dispatch.call_count == 1
+
+
+async def test_question_identity_cleanup_stays_in_worker(monkeypatch, question_case):
+    from aidev_wxbot.wxaibot import long_connection
+    from aidev_wxbot.wxaibot.question_cards import encode_question_key, question_task_id
+
+    service, events = _service(), []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append(("clean", threading.get_ident())))
+    service._view.resolve_event_username.side_effect = (
+        lambda _: events.append(("identity", threading.get_ident())) or "alice"
+    )
+    monkeypatch.setattr(long_connection, "prepare_question_submission", lambda *_: SimpleNamespace())
+    monkeypatch.setattr(long_connection, "submit_question_resume", lambda *_: "busy")
+    service._new_resume_delivery = MagicMock()
+    service._send_resume_message = AsyncMock()
+    action = question_case.action
+    payload = {
+        "from": {"userid": action.target},
+        "event": {
+            "eventtype": "template_card_event",
+            "template_card_event": {
+                "event_key": encode_question_key(action),
+                "task_id": question_task_id(action),
+            },
+        },
+    }
+    assert await service._handle_question_card_event({"body": payload}, payload)
+    assert [name for name, _ in events] == ["clean", "identity", "clean"]
+    assert len({ident for _, ident in events}) == 1 and events[0][1] != threading.get_ident()
+
+
+async def test_cancelling_awaiter_keeps_cleanup_in_worker(monkeypatch):
+    started, release, finished = threading.Event(), threading.Event(), threading.Event()
+    events = []
+    monkeypatch.setattr(database, "close_old_connections", lambda: events.append("clean"))
+
+    def operation():
+        started.set()
+        release.wait(2)
+        events.append("done")
+
+    def worker():
+        try:
+            database.run_with_database_connections(operation)
+        finally:
+            finished.set()
+
+    task = asyncio.create_task(asyncio.to_thread(worker))
+    while not started.is_set():
+        await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    release.set()
+    assert await asyncio.to_thread(finished.wait, 2)
+    assert events == ["clean", "done", "clean"]

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_database_mysql.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_database_mysql.py
@@ -1,0 +1,187 @@
+"""显式 opt-in 的隔离 MySQL 5.7 连接恢复测试，不读取应用数据库配置。
+
+准备仅绑定本机的临时 MySQL 5.7，空密码及数据库 wxbot_recovery_test。
+测试环境需安装 PyMySQL。通过 WXBOT_TEST_MYSQL_PORT 指定临时实例端口后，
+从插件 Makefile 运行；测试入口使用与平台 PatchFeatures 相同的 5.7 版本门槛。
+"""
+
+import asyncio
+import os
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from aidev_wxbot.wxaibot import views
+from aidev_wxbot.wxaibot.database import run_with_database_connections
+from django.db import InterfaceError, connections
+from django.db.utils import ConnectionHandler
+
+pytestmark = pytest.mark.skipif(not os.getenv("WXBOT_TEST_MYSQL_PORT"), reason="requires isolated MySQL 5.7")
+
+
+@pytest.fixture
+def mysql_session_store(monkeypatch, django_db_blocker):
+    import pymysql
+
+    pymysql.install_as_MySQLdb()
+    from django.db.backends.mysql.features import DatabaseFeatures
+
+    # 独立插件测试不加载平台的 PatchFeatures；仅复用其最低版本声明，
+    # 不替换驱动、真实版本查询、SQL 执行或连接状态判断。
+    monkeypatch.setattr(DatabaseFeatures, "minimum_database_version", (5, 7))
+    alias = "wxbot_recovery_test"
+    config = ConnectionHandler(
+        {
+            "default": {
+                "ENGINE": "django.db.backends.mysql",
+                "HOST": "127.0.0.1",
+                "PORT": int(os.environ["WXBOT_TEST_MYSQL_PORT"]),
+                "USER": "root",
+                "PASSWORD": "",
+                "NAME": "wxbot_recovery_test",
+                "CONN_MAX_AGE": None,
+                "OPTIONS": {"connect_timeout": 3, "read_timeout": 3, "write_timeout": 3},
+            }
+        }
+    ).databases["default"]
+    monkeypatch.setitem(connections.databases, alias, config)
+    manager = views.AgentSession.objects.db_manager(alias)
+    monkeypatch.setattr(views.AgentSession, "objects", manager)
+    context = SimpleNamespace(msg_id="test-message", sender_id="test-user", group_id="test-user")
+    monkeypatch.setattr(views.ContextGenerator, "generate", lambda _self: context)
+    view = object.__new__(views.WxAiBotViewSet)
+    with django_db_blocker.unblock():
+        connection = connections[alias]
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT VERSION(), DATABASE()")
+            version, name = cursor.fetchone()
+        assert version.startswith("5.7.") and name == "wxbot_recovery_test"
+        with connection.schema_editor() as editor:
+            editor.create_model(views.AgentSession)
+        try:
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                try:
+                    yield SimpleNamespace(alias=alias, manager=manager, view=view, pool=pool, context=context)
+                finally:
+                    pool.submit(lambda: connections[alias].close()).result()
+        finally:
+            with connection.schema_editor() as editor:
+                editor.delete_model(views.AgentSession)
+            connection.close()
+            del connections[alias]
+
+
+def _close_socket_with_error(alias):
+    connection = connections[alias]
+    connection.ensure_connection()
+    connection.connection._force_close()
+    with pytest.raises(InterfaceError) as raised, connection.cursor() as cursor:
+        cursor.execute("SELECT 1")
+    assert raised.value.args == (0, "")
+    assert connection.errors_occurred
+    return threading.get_ident()
+
+
+def _prepare(view, command):
+    return view.prepare_agent_request({"msgtype": "text", "text": {"content": command}})
+
+
+def _connection_is_reusable(alias):
+    connection = connections[alias]
+    # PyMySQL ping 可原地重连；清理后的结果允许关闭，或已恢复且无错误标记。
+    return connection.connection is None or (not connection.errors_occurred and connection.connection.open)
+
+
+@pytest.mark.parametrize("command", ["/new", "新会话", "会话"])
+def test_stale_connection_repeated_failure_then_recovery(mysql_session_store, command):
+    store = mysql_session_store
+    worker_id = store.pool.submit(_close_socket_with_error, store.alias).result()
+    for _ in range(2):
+        response, request = store.pool.submit(_prepare, store.view, command).result()
+        assert response["stream"]["content"] == "服务暂时不可用" and request is None
+    assert store.manager.count() == 0
+    for _ in range(2):
+        response, request = store.pool.submit(run_with_database_connections, _prepare, store.view, command).result()
+        assert response["stream"]["content"] == "已创建新会话，请输入咨询内容" and request is None
+    assert store.manager.count() == 1
+    assert store.pool.submit(threading.get_ident).result() == worker_id
+    response, request = store.pool.submit(run_with_database_connections, _prepare, store.view, "hello").result()
+    assert response is None and request.content == "hello"
+    thread_id = store.pool.submit(
+        run_with_database_connections, store.view._get_or_create_thread_id, "test-user"
+    ).result()
+    assert thread_id == store.manager.get(group_id="test-user").thread_id
+
+
+def test_in_task_failure_is_cleaned_before_next_request(mysql_session_store):
+    store = mysql_session_store
+
+    def failing_request():
+        _close_socket_with_error(store.alias)
+        return _prepare(store.view, "/new")
+
+    response, _ = store.pool.submit(run_with_database_connections, failing_request).result()
+    assert response["stream"]["content"] == "服务暂时不可用"
+    assert store.pool.submit(_connection_is_reusable, store.alias).result()
+    response, _ = store.pool.submit(run_with_database_connections, _prepare, store.view, "/new").result()
+    assert response["stream"]["content"] == "已创建新会话，请输入咨询内容"
+    assert store.manager.count() == 1
+
+
+def _select_connection_id(alias):
+    with connections[alias].cursor() as cursor:
+        cursor.execute("SELECT CONNECTION_ID()")
+        return cursor.fetchone()[0]
+
+
+@pytest.mark.parametrize("max_age", [None, 0])
+def test_connection_reuse_respects_max_age(mysql_session_store, max_age):
+    store = mysql_session_store
+    connections.databases[store.alias]["CONN_MAX_AGE"] = max_age
+    ids = [
+        store.pool.submit(run_with_database_connections, _select_connection_id, store.alias).result() for _ in range(2)
+    ]
+    assert (ids[0] == ids[1]) == (max_age is None)
+    assert store.pool.submit(lambda: connections[store.alias].connection is None).result() == (max_age == 0)
+
+
+def _long_connection_service(store, monkeypatch, settings, chat_type):
+    from aidev_wxbot.wxaibot import long_connection
+
+    from .test_long_connection import _service
+
+    # The legacy long-connection tests load this subclass with a stub base.
+    class DatabaseView(long_connection._LongConnectionViewSet, views.WxAiBotViewSet):
+        pass
+
+    service = _service()
+    service._view = object.__new__(DatabaseView)
+    service._view._service = service
+    service._dispatch_immediate_response = AsyncMock()
+    settings.WAXIBOT_NAME = "test-bot"
+    store.context.group_id = "test-user" if chat_type == "single" else "test-group"
+    scope = service._view._session_scope(store.context.group_id, store.context.sender_id)
+
+    async def to_worker(function, *args):
+        return await asyncio.get_running_loop().run_in_executor(store.pool, partial(function, *args))
+
+    monkeypatch.setattr(long_connection.asyncio, "to_thread", to_worker)
+    return service, scope
+
+
+@pytest.mark.parametrize("chat_type", ["single", "group"])
+async def test_long_connection_new_recovers_in_actual_worker(mysql_session_store, monkeypatch, settings, chat_type):
+    store = mysql_session_store
+    service, scope = _long_connection_service(store, monkeypatch, settings, chat_type)
+    worker_id = store.pool.submit(_close_socket_with_error, store.alias).result()
+    for _ in range(2):
+        content = "/new" if chat_type == "single" else "@test-bot /new"
+        frame = {"body": {"msgtype": "text", "chattype": chat_type, "text": {"content": content}}}
+        await service._handle_frame(frame)
+        response = service._dispatch_immediate_response.call_args.args[2]
+        assert response["stream"]["content"] == "已创建新会话，请输入咨询内容"
+    assert store.pool.submit(lambda: store.manager.filter(group_id=scope).count()).result() == 1
+    assert store.pool.submit(threading.get_ident).result() == worker_id


### PR DESCRIPTION
## 背景

- 企业微信长连接中的新会话命令可能反复返回服务不可用。

## 原因

- 消息处理在线程池中运行，不经过 Django HTTP 请求的连接清理边界。线程持有的数据库连接失效后，后续命令仍可能复用它。

## 改动内容

- 为同步后台任务增加线程内的数据库连接作用域，任务开始及 finally 退出时调用 close_old_connections。
- 覆盖长连接消息准备、事件身份转换、审批操作、Agent 流生成及排空，以及旧 callback 的后台任务。
- 保留 Django 的健康连接复用策略，不增加业务操作自动重试，不修改数据库结构或连接配置。

## 收益

- 避免失效连接跨消息持续复用；任务内部捕获异常或等待方取消后，工作线程仍执行连接清理。

## 测试验证

- 新增入口回归在修复前失败，修复后通过。
- wxbot make test：425 passed、5 xfailed，包含 13 项新增单元回归和 8 项隔离 MySQL 5.7 回归。
- MySQL 覆盖单线程连续命令、任务内异常后的恢复、单聊/群聊真实消息处理入口，以及 CONN_MAX_AGE 为 0/None 的连接策略。
- 5 项 xfail 为基线已有的 HTTP polling 交互和 runId 问题，本次未修改。
- 完整适用 pre-commit、diff 检查及公开内容脱敏检查通过。
- 未执行真实企业微信收发、共享数据库操作、服务重启或部署。
