### PR TITLE
feat: 支持审批恢复结果跨进程交付企微 --story=136129662

### DIFF
--- a/src/agent/aidev_agent/core/nodes/tool/approval_wrapper.py
+++ b/src/agent/aidev_agent/core/nodes/tool/approval_wrapper.py
@@ -11,6 +11,7 @@ from langgraph.prebuilt.tool_node import ToolCallRequest
 from langgraph.types import Command, interrupt
 
 from aidev_agent.api.bk_aidev import BKAidevApi
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span, trace_headers
 
 logger = logging.getLogger(__name__)
 
@@ -292,10 +293,10 @@ def _create_approval_from_target(target: ApprovalTarget, execute_kwargs: Any | N
     }
     logger.info("[ToolApproval] 当前用户: %s, approvers: %s", username, approvers)
     try:
-        result = client.api.create_tool_approval(
-            json=payload,
-            headers={"X-BKAIDEV-USER": username} if username else {},
-        )
+        with recording_span("agent.approval.create", kind=CLIENT_SPAN_KIND, record_exception=False):
+            headers = {"X-BKAIDEV-USER": username} if username else {}
+            headers.update(trace_headers())
+            result = client.api.create_tool_approval(json=payload, headers=headers)
         logger.info("[ToolApproval] 审批工单创建结果: %s", result)
     except Exception as error:
         logger.error("[ToolApproval] 创建审批工单失败: %s: %s", type(error).__name__, error, exc_info=True)

--- a/src/agent/aidev_agent/events.py
+++ b/src/agent/aidev_agent/events.py
@@ -1,4 +1,4 @@
-"""Runtime-independent, process-local integration events (AG-UI envelopes)."""
+"""Runtime-independent integration events (AG-UI envelopes)."""
 
 from collections.abc import Callable
 from threading import RLock
@@ -7,6 +7,8 @@ from typing import Protocol
 from ag_ui.core import BaseEvent, CustomEvent
 
 AIDEV_CHAT_RESUME_READY = "AIDEV_CHAT_RESUME_READY"
+AIDEV_CHAT_RESUME_FINISHED = "AIDEV_CHAT_RESUME_FINISHED"
+AIDEV_CHAT_RESUME_FAILED = "AIDEV_CHAT_RESUME_FAILED"
 EventHandler = Callable[[BaseEvent], None]
 
 

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -20,6 +20,7 @@ from copy import deepcopy
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, List, Optional
 
+from ag_ui.core import BaseEvent
 from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
 
@@ -93,6 +94,12 @@ class BaseResourceManager(abc.ABC):
     def get_agent_code(self, **kwargs: Any) -> str:
         """获取resource manager的agent code。子类可覆写按照其他场景获取agent code"""
         return self.app_code
+
+    def publish_event(self, event: BaseEvent) -> None:
+        """Optional integration boundary; standalone agents have no event backend."""
+
+    def event_publishing_enabled(self) -> bool:
+        return False
 
     def resolve_access_token(self, username: str = None) -> str:
         """获取 access_token，优先级：self.access_token > username 参数 > self.username > 空字符串。

--- a/src/agent/aidev_agent/packages/resource_manager/registry.py
+++ b/src/agent/aidev_agent/packages/resource_manager/registry.py
@@ -19,6 +19,8 @@ from typing_extensions import Protocol
 from aidev_agent.utils.factory import SingletonFactory
 
 if TYPE_CHECKING:
+    from ag_ui.core import BaseEvent
+
     from aidev_agent.api.bk_aidev import Client
     from aidev_agent.pydantic_models import AgentConfig
 
@@ -30,6 +32,14 @@ class ResourceManagerProtocol(Protocol):
     所有方法定义业务契约（含返回结构语义），由 ``AgentResourceManager`` 提供默认实现。
     Plugin / 测试侧若要替换或 Mock，按本协议鸭子类型实现即可（不必继承）。
     """
+
+    def publish_event(self, event: BaseEvent) -> None:
+        """Publish an integration event; acceptance is not channel delivery."""
+        ...
+
+    def event_publishing_enabled(self) -> bool:
+        """Whether this manager has an integration event backend."""
+        ...
 
     def get_client(self, **kwargs) -> "Client":
         """获取已完成认证信息注入的 API Client。"""

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -91,7 +91,7 @@ class SessionContentProperty(BaseModel):
     """会话内容的一些额外属性"""
 
     turn_id: str = Field(default="", description="同一次 user-ai 回复的轮次 ID")
-    trace_id: str = Field(default="", description="chat 入口 Trace ID；未提供时兼容使用内容创建请求的 Trace ID")
+    trace_id: str = Field(default="", description="chat 入口 Trace ID；仅创建时传递，未提供时保持为空，更新时不修改")
     extra: SessionContentExtra | None = None
 
 

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -91,7 +91,7 @@ class SessionContentProperty(BaseModel):
     """会话内容的一些额外属性"""
 
     turn_id: str = Field(default="", description="同一次 user-ai 回复的轮次 ID")
-    trace_id: str = Field(default="", description="创建会话内容时的 Trace ID")
+    trace_id: str = Field(default="", description="chat 入口 Trace ID；未提供时兼容使用内容创建请求的 Trace ID")
     extra: SessionContentExtra | None = None
 
 

--- a/src/agent/aidev_agent/services/agent/approval.py
+++ b/src/agent/aidev_agent/services/agent/approval.py
@@ -97,6 +97,7 @@ class ApprovalStateHandler:
             "interrupts": interrupts,
             "id": latest.get("id"),
             "graph_thread_id": self._extract_graph_thread_id_from_interrupt_record(latest),
+            "approval_trace_context": builtin_property.get("approval_trace_context"),
         }
 
     def query_approval_info(self, session_code: str) -> Optional[dict]:

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1169,6 +1169,8 @@ class ChatCompletionAgent(BaseModel):
         所有事件都由后台 producer 写入消息处理器。producer 会在 RUN_STARTED
         入队后立即 flush，既保持初始化事件顺序，也确保客户端在首帧前断开时
         producer 仍能继续执行并供后续请求 replay。
+
+        恢复事件的 Trace 上下文在入口同步捕获；队列和 producer 仍延迟到消费时启动。
         """
         from aidev_agent.services.resume_events import resume_events_for
 
@@ -1184,32 +1186,37 @@ class ChatCompletionAgent(BaseModel):
             if resume and not attach_only
             else None
         )
-        helper = GeneratorStreamingHelper(
-            thread_id=queue_thread_id or agent_input.thread_id,
-            defer_cleanup_on_complete=background_only,
-            producer_observer=observer,
-        )
-        run_id = agent_input.run_id or self.thread_id
-        cancel_event = helper.prepare_run(run_id)
-        producer = self._build_resume_aware_producer(
-            agui_entry,
-            agent_input,
-            agent_e=agent_e,
-            cfg=cfg,
-            resume=resume,
-            total_timeout=total_timeout,
-            producer_observer=observer,
-        )
-        yield from helper.stream(
-            producer,
-            # replay 模式下由 producer 在 EOD 写入并 flush 成功后更新会话终态；
-            # 消费者中断不会影响最终状态收敛。
-            on_complete=partial(self._on_complete, finalize_session=True),
-            event_handler=self.event_handler,
-            expected_run_id=run_id,
-            cancel_event=cancel_event,
-            attach_only=attach_only,
-        )
+
+        def stream() -> Generator[Any, None, None]:
+            # 不把 observer 放进惰性生成器：HTTP 入口 span 可能在首次消费前已经结束。
+            helper = GeneratorStreamingHelper(
+                thread_id=queue_thread_id or agent_input.thread_id,
+                defer_cleanup_on_complete=background_only,
+                producer_observer=observer,
+            )
+            run_id = agent_input.run_id or self.thread_id
+            cancel_event = helper.prepare_run(run_id)
+            producer = self._build_resume_aware_producer(
+                agui_entry,
+                agent_input,
+                agent_e=agent_e,
+                cfg=cfg,
+                resume=resume,
+                total_timeout=total_timeout,
+                producer_observer=observer,
+            )
+            yield from helper.stream(
+                producer,
+                # replay 模式下由 producer 在 EOD 写入并 flush 成功后更新会话终态；
+                # 消费者中断不会影响最终状态收敛。
+                on_complete=partial(self._on_complete, finalize_session=True),
+                event_handler=self.event_handler,
+                expected_run_id=run_id,
+                cancel_event=cancel_event,
+                attach_only=attach_only,
+            )
+
+        return stream()
 
     def _build_resume_aware_producer(
         self,

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -904,7 +904,45 @@ class ChatCompletionAgent(BaseModel):
                 return self._stream(agent_e, cfg, state, messages, execute_kwargs)
 
         else:
+            from aidev_agent.services.resume_events import uses_resume_event_stream
+
+            if uses_resume_event_stream(self.resource_manager, execute_kwargs):
+                return self._invoke_resume_with_events(agent_e, cfg, state, messages, execute_kwargs)
             return self._invoke(agent_e, cfg, state, messages, execute_kwargs)
+
+    def _invoke_resume_with_events(self, agent_e, cfg, state, messages, execute_kwargs):
+        """Keep a non-stream HTTP response while using the AG-UI resume/persistence path.
+
+        _invoke uses ainvoke(input_state), not Command(resume=...). Opted-in
+        callbacks must not become new input, nor execute the Agent twice.
+        """
+        stream_kwargs = execute_kwargs.model_copy(update={"stream": True})
+        cfg["configurable"]["execute_kwargs"] = stream_kwargs
+        self._execute_kwargs = stream_kwargs
+        text, message_id, outcome = [], "", None
+        for chunk in self._stream(agent_e, cfg, state, messages, stream_kwargs):
+            if not isinstance(chunk, str) or not chunk.startswith("data:"):
+                continue
+            try:
+                event = json.loads(chunk[5:].strip())
+            except ValueError:
+                continue
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") == "TEXT_MESSAGE_CONTENT":
+                text.append(event.get("delta", ""))
+                message_id = event.get("messageId", message_id)
+            elif event.get("type") == "RUN_FINISHED" and not event.get("resume_replay"):
+                outcome = event.get("outcome")
+        result = {
+            "choices": [{"delta": {"role": "assistant", "content": "".join(text)}}],
+            "id": message_id,
+            "model": self.model_name,
+            "reference_doc": [],
+        }
+        if outcome is not None:
+            result["outcome"] = outcome
+        return result
 
     def _invoke(
         self,
@@ -1132,9 +1170,24 @@ class ChatCompletionAgent(BaseModel):
         入队后立即 flush，既保持初始化事件顺序，也确保客户端在首帧前断开时
         producer 仍能继续执行并供后续请求 replay。
         """
+        from aidev_agent.services.resume_events import resume_events_for
+
+        resume_items = (agent_input.forwarded_props or {}).get("command", {}).get("resume") or []
+        observer = (
+            resume_events_for(
+                self.resource_manager,
+                session_code=getattr(self.event_handler, "session_code", "") or "",
+                thread_id=agent_input.thread_id,
+                turn_id=getattr(self.event_handler, "turn_id", "") or "",
+                resume=resume_items if isinstance(resume_items, list) else [resume_items],
+            )
+            if resume and not attach_only
+            else None
+        )
         helper = GeneratorStreamingHelper(
             thread_id=queue_thread_id or agent_input.thread_id,
             defer_cleanup_on_complete=background_only,
+            producer_observer=observer,
         )
         run_id = agent_input.run_id or self.thread_id
         cancel_event = helper.prepare_run(run_id)
@@ -1145,6 +1198,7 @@ class ChatCompletionAgent(BaseModel):
             cfg=cfg,
             resume=resume,
             total_timeout=total_timeout,
+            producer_observer=observer,
         )
         yield from helper.stream(
             producer,
@@ -1165,6 +1219,7 @@ class ChatCompletionAgent(BaseModel):
         cfg: RunnableConfig | None,
         resume: bool,
         total_timeout: int | float | None = None,
+        producer_observer=None,
     ) -> Generator[Any, None, None]:
         """构造「resume 感知」的生产者生成器（方案 B 兜底入口）。
 
@@ -1181,6 +1236,8 @@ class ChatCompletionAgent(BaseModel):
             if resume and agent_e is not None and cfg is not None and agent_input.thread_id:
                 replay = self._build_terminal_resume_replay(agui_entry, agent_input, agent_e, cfg)
                 if replay is not None:
+                    if producer_observer is not None:
+                        producer_observer.enabled = False
                     logger.info(
                         "[ResumeReplay] graph terminal, replay persisted turn from checkpoint "
                         "(scheme B fallback), thread_id=%s",

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -40,6 +40,7 @@ from aidev_agent.core.ag_ui.types import (
 from aidev_agent.core.ag_ui.utils import camel_to_snake, get_interrupt_value, unwrap_interrupt_source
 from aidev_agent.enums import ActivityType, PromptRole
 from aidev_agent.utils.event import RunId
+from aidev_agent.utils.tracing import get_current_trace_id
 
 logger = getLogger(__name__)
 
@@ -114,6 +115,8 @@ class BaseSessionWriter(ABC):
         self.session_code: str = session_code
         self.username: str = username
         self.turn_id: str = turn_id or ""
+        # Writer 在 chat 入口构造；异步回写时的当前 Span 可能已经属于另一条链路。
+        self.trace_id: str = get_current_trace_id() or ""
         self._tools_mapping: dict[str, Any] = {}
         if tools:
             self.set_tools(tools)
@@ -1489,6 +1492,8 @@ class BaseSessionWriter(ABC):
         }
         if self.turn_id:
             payload["property"]["turn_id"] = self.turn_id
+        if self.trace_id:
+            payload["property"]["trace_id"] = self.trace_id
         content_id = self._safe_call(
             self._do_create_content, message_id, "create", payload=payload, headers=self._get_headers()
         )

--- a/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
+++ b/src/agent/aidev_agent/services/messages_handler/streaming_helper.py
@@ -142,12 +142,14 @@ class GeneratorStreamingHelper:
         message_handler: BaseMessageQueueHandler | None = None,
         thread_id: str | None = None,
         defer_cleanup_on_complete: bool = False,
+        producer_observer: Any = None,
     ) -> None:
         self.message_handler = message_handler if message_handler else message_handler_factory.get()
         self.thread_id = thread_id or uuid.uuid4().hex
         # 后台 drain（无 SSE 下游）场景：读到 EOD 时不立即 mark_completed 清队列，
         # 保留缓存历史供前端在清理窗口内接管续流；清理交由 producer 的延迟清理线程兜底。
         self.defer_cleanup_on_complete = defer_cleanup_on_complete
+        self.producer_observer = producer_observer
         self._producer_completion_error: Exception | None = None
         self.run_id: str = ""
         self._cancel_event: threading.Event | None = None
@@ -1299,6 +1301,8 @@ class GeneratorStreamingHelper:
                 if (is_run_finished and cancel_finished_emitted) or (not is_run_finished and cancel_error_emitted):
                     continue
                 self.message_handler.put(self.thread_id, encoded_event)
+                if self.producer_observer is not None:
+                    self.producer_observer.on_chunk(encoded_event)
                 _record_published_sse_event()
                 if event_handler is not None:
                     try:
@@ -1357,6 +1361,8 @@ class GeneratorStreamingHelper:
                     # 初始化帧也由后台 producer 写入。RUN_STARTED 到达后立即提交，
                     # 避免等待批量写入周期，同时保持 MESSAGES_SNAPSHOT 在其之前。
                     self.message_handler.flush(self.thread_id)
+                if self.producer_observer is not None:
+                    self.producer_observer.on_chunk(chunk)
                 logger.debug(f"Produced chunk for thread_id={self.thread_id}")
                 if is_run_finished:
                     _complete_session()
@@ -1383,6 +1389,8 @@ class GeneratorStreamingHelper:
                         if is_run_finished:
                             run_finished_seen = True
                         self.message_handler.put(self.thread_id, event)
+                        if self.producer_observer is not None:
+                            self.producer_observer.on_chunk(event)
                         _record_published_sse_event()
                         if is_run_finished:
                             _complete_session()
@@ -1420,14 +1428,14 @@ class GeneratorStreamingHelper:
                         self.thread_id,
                         expected_run_id,
                     )
-                    self.message_handler.put(
-                        self.thread_id,
-                        emit_run_finished_event(
-                            thread_id=self.thread_id,
-                            run_id=expected_run_id,
-                            event_handler=event_handler,
-                        ),
+                    fallback = emit_run_finished_event(
+                        thread_id=self.thread_id,
+                        run_id=expected_run_id,
+                        event_handler=event_handler,
                     )
+                    self.message_handler.put(self.thread_id, fallback)
+                    if self.producer_observer is not None:
+                        self.producer_observer.on_chunk(fallback)
                     _record_published_sse_event()
                     _complete_session()
 
@@ -1480,6 +1488,8 @@ class GeneratorStreamingHelper:
 
                 if on_complete and self._supports_replay_from_start():
                     _complete_session()
+                if self.producer_observer is not None:
+                    self.producer_observer.on_complete(self._producer_completion_error)
                 if self._producer_completion_error is not None:
                     raise self._producer_completion_error
             finally:

--- a/src/agent/aidev_agent/services/resume_events.py
+++ b/src/agent/aidev_agent/services/resume_events.py
@@ -1,0 +1,135 @@
+"""Producer-owned resume lifecycle, independent of Runtime and channel transports.
+
+The terminal envelope carries only this execution's display events, not prompts,
+state snapshots or the session history. A slow/offline subscriber can render the
+same result without sharing the stream cache or executing the agent again.
+"""
+
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+
+from ag_ui.core import CustomEvent
+
+from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+
+try:
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+except ImportError:
+    TraceContextTextMapPropagator = None
+
+logger = logging.getLogger(__name__)
+DISPLAY_EVENTS = frozenset(
+    {
+        "RUN_STARTED",
+        "RUN_FINISHED",
+        "RUN_ERROR",
+        "TEXT_MESSAGE_START",
+        "TEXT_MESSAGE_CONTENT",
+        "TEXT_MESSAGE_END",
+        "TOOL_CALL_START",
+        "TOOL_CALL_ARGS",
+        "TOOL_CALL_END",
+        "TOOL_CALL_RESULT",
+        "THINKING_TEXT_MESSAGE_START",
+        "THINKING_TEXT_MESSAGE_CONTENT",
+        "THINKING_TEXT_MESSAGE_END",
+    }
+)
+
+
+class ResumeEvents:
+    def __init__(self, resource_manager, *, session_code: str, thread_id: str, turn_id: str, resume: list):
+        self.resource_manager = resource_manager
+        self.enabled = True
+        self._events = []
+        self._ready = None
+        self._ready_published = False
+        self._completed = False
+        self._value = {
+            "schemaVersion": 1,
+            "appCode": resource_manager.get_agent_code(),
+            "sessionCode": session_code,
+            "threadId": thread_id,
+            "turnId": turn_id,
+            "interruptIds": sorted({str(item["interruptId"]) for item in resume if item.get("interruptId")}),
+        }
+        if TraceContextTextMapPropagator is not None:
+            carrier = {}
+            TraceContextTextMapPropagator().inject(carrier)
+            self._value["traceContext"] = carrier
+
+    def on_chunk(self, chunk) -> None:
+        if not self.enabled or not isinstance(chunk, str) or not chunk.startswith("data:"):
+            return
+        try:
+            event = json.loads(chunk[5:].strip())
+        except (ValueError, TypeError):
+            return
+        if not isinstance(event, dict):
+            return
+        event_type = event.get("type")
+        if event_type == "RUN_STARTED" and self._ready is None:
+            self._value["runId"] = event.get("runId") or event.get("run_id")
+            self._ready = self._envelope(AIDEV_CHAT_RESUME_READY)
+            try:
+                self.resource_manager.publish_event(self._ready)
+                self._ready_published = True
+            except Exception as error:
+                # Let the producer finish; retry the identical notification at completion.
+                logger.error("event=resume_ready_publish_failed error_type=%s", type(error).__name__)
+        if self._ready is not None and (
+            event_type in DISPLAY_EVENTS or (event_type == "CUSTOM" and "documents" in event)
+        ):
+            # Coalesce adjacent text deltas in the result snapshot.
+            if (
+                event_type == "TEXT_MESSAGE_CONTENT"
+                and self._events
+                and self._events[-1].get("type") == event_type
+                and self._events[-1].get("messageId") == event.get("messageId")
+            ):
+                self._events[-1]["delta"] += event.get("delta", "")
+            else:
+                self._events.append(event)
+
+    def _envelope(self, name: str, **extra) -> CustomEvent:
+        identity = json.dumps(
+            [self._value[key] for key in ("appCode", "sessionCode", "threadId", "runId", "interruptIds")] + [name],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return CustomEvent(
+            name=name,
+            value={
+                **self._value,
+                "eventId": hashlib.sha256(identity.encode()).hexdigest(),
+                "occurredAt": datetime.now(timezone.utc).isoformat(),
+                **extra,
+            },
+        )
+
+    def on_complete(self, error: Exception | None = None) -> None:
+        if not self.enabled or self._ready is None or self._completed:
+            return
+        if not self._ready_published:
+            self.resource_manager.publish_event(self._ready)
+            self._ready_published = True
+        failed = error is not None or any(e.get("type") == "RUN_ERROR" for e in self._events)
+        name = AIDEV_CHAT_RESUME_FAILED if failed else AIDEV_CHAT_RESUME_FINISHED
+        self.resource_manager.publish_event(self._envelope(name, events=self._events, persisted=error is None))
+        self._completed = True
+
+
+def resume_events_for(resource_manager, **kwargs) -> ResumeEvents | None:
+    enabled = getattr(resource_manager, "event_publishing_enabled", None)
+    if callable(enabled) and enabled() is True and kwargs.get("session_code") and kwargs.get("resume"):
+        return ResumeEvents(resource_manager, **kwargs)
+    return None
+
+
+def uses_resume_event_stream(resource_manager, execute_kwargs) -> bool:
+    enabled = getattr(resource_manager, "event_publishing_enabled", None)
+    return bool(
+        execute_kwargs.resume and not execute_kwargs.legacy_streaming and callable(enabled) and enabled() is True
+    )

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -11,11 +11,13 @@ try:
     from opentelemetry import context as context_api
     from opentelemetry import trace
     from opentelemetry.trace import SpanKind, Tracer
+    from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
 except ImportError:  # OpenTelemetry is an optional Agent SDK extra.
     context_api = None
     trace = None
     SpanKind = None
     Tracer = Any
+    TraceContextTextMapPropagator = None
 
 _agent_tracer: Tracer | None = None
 CLIENT_SPAN_KIND = SpanKind.CLIENT if SpanKind is not None else None
@@ -60,6 +62,29 @@ def get_current_trace_id() -> str | None:
     return format(context.trace_id, "032x") if context.trace_id else None
 
 
+def trace_headers() -> dict[str, str]:
+    """Capture W3C trace context only; do not propagate credentials or baggage."""
+    carrier: dict[str, str] = {}
+    if TraceContextTextMapPropagator is not None:
+        TraceContextTextMapPropagator().inject(carrier)
+    return carrier
+
+
+@contextmanager
+def propagated_trace_context(carrier: Any) -> Iterator[None]:
+    """Restore a durable parent, isolating missing/invalid context from the worker."""
+    if context_api is None or TraceContextTextMapPropagator is None:
+        yield
+        return
+    carrier = carrier if isinstance(carrier, dict) else {}
+    safe = {key: carrier[key] for key in ("traceparent", "tracestate") if isinstance(carrier.get(key), str)}
+    token = context_api.attach(TraceContextTextMapPropagator().extract(safe, context=context_api.Context()))
+    try:
+        yield
+    finally:
+        context_api.detach(token)
+
+
 @contextmanager
 def recording_span(
     name: str,
@@ -67,6 +92,7 @@ def recording_span(
     attributes: dict[str, Any] | None = None,
     kind: Any = None,
     root: bool = False,
+    record_exception: bool = True,
 ) -> Iterator[Any]:
     """Create a span with the Agent tracer, or safely no-op without OTel.
 
@@ -81,6 +107,8 @@ def recording_span(
         return
 
     start_kwargs: dict[str, Any] = {"attributes": attributes or {}}
+    if not record_exception:
+        start_kwargs.update(record_exception=False, set_status_on_exception=False)
     if kind is not None:
         start_kwargs["kind"] = kind
     if root and context_api is not None:

--- a/src/agent/tests/services/event_handlers/test_session_writer_trace.py
+++ b/src/agent/tests/services/event_handlers/test_session_writer_trace.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Session content retains the entry trace after the request context changes."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+
+
+@pytest.mark.parametrize("entry_trace", ["a" * 32, None])
+def test_create_session_content_keeps_entry_trace(entry_trace):
+    client = MagicMock()
+    with patch("aidev_agent.services.event_handlers.base.get_current_trace_id", return_value=entry_trace) as current:
+        writer = AGUISessionWriter("session", client, turn_id="turn")
+        current.return_value = "b" * 32
+        for role in ("user", "assistant"):
+            writer._create_session_content(role, role, "hello", "complete", {})
+        writer._update_session_content(1, "assistant", "updated", {})
+
+    for call in client.api.create_chat_session_content.call_args_list:
+        prop = call.kwargs["json"]["property"]
+        assert prop.get("trace_id") == entry_trace
+        assert prop["turn_id"] == "turn"
+    assert "trace_id" not in client.api.update_chat_session_content.call_args.kwargs["json"]["property"]
+
+
+def test_writers_do_not_share_trace_between_chat_requests():
+    client = MagicMock()
+    with patch("aidev_agent.services.event_handlers.base.get_current_trace_id", side_effect=["a" * 32, "b" * 32]):
+        first = AGUISessionWriter("session", client)
+        second = AGUISessionWriter("session", client)
+
+    first._create_session_content("first", "user", "hello", "complete", {})
+    second._create_session_content("second", "user", "hello again", "complete", {})
+
+    assert [
+        call.kwargs["json"]["property"]["trace_id"] for call in client.api.create_chat_session_content.call_args_list
+    ] == ["a" * 32, "b" * 32]
+
+
+def test_entry_trace_survives_writing_without_request_context():
+    trace = pytest.importorskip("opentelemetry.trace")
+    client = MagicMock()
+    span = trace.NonRecordingSpan(trace.SpanContext(trace_id=int("a" * 32, 16), span_id=1, is_remote=False))
+    with trace.use_span(span):
+        writer = AGUISessionWriter("session", client)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(writer._create_session_content, "message", "assistant", "hello", "complete", {}).result()
+
+    payload = client.api.create_chat_session_content.call_args.kwargs["json"]
+    assert payload["property"]["trace_id"] == "a" * 32

--- a/src/agent/tests/services/test_resume_events.py
+++ b/src/agent/tests/services/test_resume_events.py
@@ -1,0 +1,97 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+from aidev_agent.services.messages_handler import GeneratorStreamingHelper, InMemoryQueueMessageHandler
+from aidev_agent.services.resume_events import ResumeEvents, resume_events_for
+
+
+@pytest.fixture
+def resume_case():
+    published = []
+    manager = SimpleNamespace(get_agent_code=lambda: "app", publish_event=published.append)
+    observer = ResumeEvents(
+        manager, session_code="session", thread_id="graph", turn_id="turn", resume=[{"interruptId": "approval"}]
+    )
+    events = [
+        {"type": "MESSAGES_SNAPSHOT", "messages": [{"content": "private history"}]},
+        {"type": "RUN_STARTED", "runId": "run", "threadId": "graph"},
+        {"type": "TEXT_MESSAGE_CONTENT", "messageId": "answer", "delta": "审批后"},
+        {"type": "TEXT_MESSAGE_CONTENT", "messageId": "answer", "delta": "继续"},
+        {"type": "RUN_FINISHED", "runId": "run", "threadId": "graph"},
+    ]
+    chunks = ["data: " + json.dumps(event, separators=(",", ":")) + "\n\n" for event in events]
+    return SimpleNamespace(observer=observer, manager=manager, events=events, chunks=chunks, published=published)
+
+
+def test_ready_occurs_after_queue_flush_and_terminal_after_persistence(resume_case):
+    case = resume_case
+    handler = InMemoryQueueMessageHandler()
+    original_flush = handler.flush
+    handler.flush = Mock(side_effect=original_flush)
+    completed = []
+
+    def publish(event):
+        assert handler.flush.called
+        assert event.name == AIDEV_CHAT_RESUME_READY or completed
+        case.published.append(event)
+
+    case.manager.publish_event = publish
+    helper = GeneratorStreamingHelper(handler, "graph", producer_observer=case.observer)
+    output = list(helper.stream(iter(case.chunks), on_complete=lambda: completed.append(True), expected_run_id="run"))
+    assert all(chunk in output for chunk in case.chunks)
+    assert [event.name for event in case.published] == [AIDEV_CHAT_RESUME_READY, AIDEV_CHAT_RESUME_FINISHED]
+    assert case.published[-1].value["events"][1]["delta"] == "审批后继续"
+    assert "private history" not in json.dumps(case.published[-1].value)
+
+
+@pytest.mark.parametrize("error", [None, RuntimeError("private exception")])
+def test_completion_is_once_and_preserves_exact_original_identity(resume_case, error):
+    case = resume_case
+    for chunk in case.chunks:
+        case.observer.on_chunk(chunk)
+    case.observer.on_complete(error)
+    case.observer.on_complete(error)
+    assert len(case.published) == 2
+    final = case.published[-1]
+    assert final.name == (AIDEV_CHAT_RESUME_FAILED if error else AIDEV_CHAT_RESUME_FINISHED)
+    assert final.value["sessionCode"] == "session" and final.value["turnId"] == "turn"
+    assert final.value["threadId"] == "graph" and final.value["interruptIds"] == ["approval"]
+    assert "private exception" not in final.model_dump_json()
+
+
+def test_terminal_replay_and_old_interrupt_close_are_not_new_resume(resume_case):
+    case = resume_case
+    case.observer.on_chunk('data: {"type":"RUN_FINISHED","resume_replay":true}')
+    case.observer.on_complete()
+    assert case.published == []
+    case.observer.enabled = False
+    for chunk in case.chunks:
+        case.observer.on_chunk(chunk)
+    case.observer.on_complete()
+    assert case.published == []
+
+
+def test_failed_ready_publish_retries_same_event_after_producer_finishes(resume_case):
+    case = resume_case
+    publish = Mock(side_effect=[RuntimeError("DB unavailable"), None, None])
+    case.manager.publish_event = publish
+    for chunk in case.chunks:
+        case.observer.on_chunk(chunk)
+    case.observer.on_complete()
+    assert publish.call_count == 3
+    assert publish.call_args_list[0].args[0] is publish.call_args_list[1].args[0]
+
+
+@pytest.mark.parametrize("manager", [None, object(), SimpleNamespace(event_publishing_enabled=lambda: False)])
+def test_legacy_resource_manager_is_compatible(manager):
+    assert resume_events_for(manager, session_code="session", resume=[{"interruptId": "i"}]) is None
+
+
+def test_missing_runtime_terminal_is_included_in_durable_result(resume_case):
+    case = resume_case
+    helper = GeneratorStreamingHelper(InMemoryQueueMessageHandler(), "graph", producer_observer=case.observer)
+    list(helper.stream(iter(case.chunks[:-1]), expected_run_id="run"))
+    assert case.published[-1].value["events"][-1]["type"] == "RUN_FINISHED"

--- a/src/agent/tests/services/test_resume_trace_context.py
+++ b/src/agent/tests/services/test_resume_trace_context.py
@@ -1,0 +1,134 @@
+"""Resume envelopes retain the entry context even when stream consumption is deferred."""
+
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from aidev_agent.core.ag_ui.types import AgentInput
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+from opentelemetry import trace
+from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
+
+
+def _span(identity, sampled=True):
+    return trace.NonRecordingSpan(
+        trace.SpanContext(
+            trace_id=identity,
+            span_id=identity,
+            is_remote=False,
+            trace_flags=trace.TraceFlags(int(sampled)),
+            trace_state=trace.TraceState([("vendor", str(identity))]),
+        )
+    )
+
+
+class TestResumeTraceContext:
+    @pytest.fixture
+    def case(self, monkeypatch):
+        from aidev_agent.services.agent import chat
+
+        helper = Mock()
+        helper.stream.side_effect = lambda *a, **kw: iter(())
+        factory = Mock(return_value=helper)
+        monkeypatch.setattr(chat, "GeneratorStreamingHelper", factory)
+        manager = Mock()
+        manager.get_agent_code.return_value = "app"
+        manager.event_publishing_enabled.return_value = True
+        agent = SimpleNamespace(
+            resource_manager=manager,
+            event_handler=SimpleNamespace(session_code="session", turn_id="turn"),
+            _build_resume_aware_producer=Mock(return_value=iter(())),
+            _on_complete=Mock(),
+        )
+        request = AgentInput(
+            thread_id="graph",
+            run_id="run",
+            messages=[],
+            state={},
+            forwarded_props={"command": {"resume": [{"interruptId": "approval"}]}},
+        )
+        return SimpleNamespace(agent=agent, request=request, factory=factory, helper=helper, manager=manager)
+
+    @staticmethod
+    def stream(case, **kwargs):
+        return ChatCompletionAgent._stream_with_queue(case.agent, Mock(), case.request, **kwargs)
+
+    @pytest.mark.parametrize("sampled", [False, True])
+    @pytest.mark.parametrize("in_worker", [False, True])
+    def test_deferred_consumption_keeps_full_entry_context(self, case, sampled, in_worker):
+        expected = {}
+        with trace.use_span(_span(1, sampled)):
+            TraceContextTextMapPropagator().inject(expected)
+            stream = self.stream(case, resume=True)
+        case.factory.assert_not_called()
+        case.manager.publish_event.assert_not_called()
+        with trace.use_span(_span(2)):
+            if in_worker:
+                with ThreadPoolExecutor(max_workers=1) as pool:
+                    pool.submit(list, stream).result()
+            else:
+                list(stream)
+            assert trace.get_current_span().get_span_context().trace_id == 2
+        observer = case.factory.call_args.kwargs["producer_observer"]
+        observer.on_chunk('data: {"type":"RUN_STARTED","runId":"run"}')
+        observer.on_complete()
+        assert case.manager.publish_event.call_count == 2
+        for call in case.manager.publish_event.call_args_list:
+            assert call.args[0].value["traceContext"] == expected
+        case.helper.prepare_run.assert_called_once_with("run")
+        assert case.agent._build_resume_aware_producer.call_args.kwargs["producer_observer"] is observer
+
+    def test_interleaved_requests_do_not_share_context(self, case):
+        streams = []
+        for identity in (1, 2):
+            with trace.use_span(_span(identity)):
+                streams.append(self.stream(case, resume=True))
+        observers = []
+        for stream in reversed(streams):
+            list(stream)
+            observers.append(case.factory.call_args.kwargs["producer_observer"])
+        assert observers[0] is not observers[1]
+        for observer, identity in zip(observers, (2, 1)):
+            carrier = observer._value["traceContext"]
+            parent = TraceContextTextMapPropagator().extract(carrier)
+            assert trace.get_current_span(parent).get_span_context().trace_id == identity
+
+    def test_abandoned_stream_never_starts_queue_or_publishes(self, case):
+        with trace.use_span(_span(1)):
+            stream = self.stream(case, resume=True)
+        stream.close()
+        case.factory.assert_not_called()
+        case.agent._build_resume_aware_producer.assert_not_called()
+        case.manager.publish_event.assert_not_called()
+
+    @pytest.mark.parametrize("otel_available", [False, True])
+    def test_missing_entry_context_does_not_adopt_consumer_context(self, case, monkeypatch, otel_available):
+        from aidev_agent.services import resume_events
+
+        if not otel_available:
+            monkeypatch.setattr(resume_events, "TraceContextTextMapPropagator", None)
+        with trace.use_span(trace.INVALID_SPAN):
+            stream = self.stream(case, resume=True)
+        with trace.use_span(_span(2)):
+            list(stream)
+        observer = case.factory.call_args.kwargs["producer_observer"]
+        assert observer._value.get("traceContext") == ({} if otel_available else None)
+
+    @pytest.mark.parametrize(
+        "resume,attach_only,enabled,session_code",
+        [
+            (False, False, True, "session"),
+            (True, True, True, "session"),
+            (True, False, False, "session"),
+            (True, False, True, ""),
+        ],
+    )
+    def test_non_publishing_paths_remain_lazy(self, case, resume, attach_only, enabled, session_code):
+        case.manager.event_publishing_enabled.return_value = enabled
+        case.agent.event_handler.session_code = session_code
+        stream = self.stream(case, resume=resume, attach_only=attach_only)
+        case.factory.assert_not_called()
+        list(stream)
+        assert case.factory.call_args.kwargs["producer_observer"] is None
+        case.manager.publish_event.assert_not_called()

--- a/src/agent/tests/utils/test_approval_trace.py
+++ b/src/agent/tests/utils/test_approval_trace.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("opentelemetry.sdk")
+
+from aidev_agent.core.nodes.tool.approval_wrapper import ApprovalTarget, _create_approval_from_target
+from aidev_agent.utils import tracing
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture
+def spans(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("test"))
+    yield exporter
+    provider.shutdown()
+
+
+def test_sdk_approval_request_injects_client_parent(spans, monkeypatch):
+    client = MagicMock()
+    monkeypatch.setattr("aidev_agent.core.nodes.tool.approval_wrapper.BKAidevApi.get_client", lambda: client)
+    target = ApprovalTarget("tool", "call", "query", "query", {}, {})
+    with tracing.recording_span("entry") as entry:
+        _create_approval_from_target(target, SimpleNamespace(executor="test-user"))
+    headers = client.api.create_tool_approval.call_args.kwargs["headers"]
+    created = next(span for span in spans.get_finished_spans() if span.name == "agent.approval.create")
+    assert created.parent.span_id == entry.get_span_context().span_id
+    assert headers["traceparent"].split("-")[1:3] == [
+        format(created.context.trace_id, "032x"),
+        format(created.context.span_id, "016x"),
+    ]
+    assert headers["X-BKAIDEV-USER"] == "test-user"
+    assert "baggage" not in headers
+
+
+@pytest.mark.parametrize("carrier", [{}, None, {"traceparent": "invalid"}, {"baggage": "private=value"}])
+def test_invalid_durable_parent_does_not_adopt_worker_trace(spans, carrier):
+    with tracing.recording_span("unrelated-worker") as worker:
+        with tracing.propagated_trace_context(carrier):
+            assert not trace.get_current_span().get_span_context().is_valid
+        assert trace.get_current_span() is worker
+
+
+def test_context_helpers_noop_without_otel(monkeypatch):
+    monkeypatch.setattr(tracing, "TraceContextTextMapPropagator", None)
+    assert tracing.trace_headers() == {}
+    with tracing.propagated_trace_context({"traceparent": "invalid"}):
+        pass

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/migrations/0002_event_delivery.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/migrations/0002_event_delivery.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [("aidev_bkplugin", "0001_initial")]
+
+    operations = [
+        migrations.CreateModel(
+            name="EventSubscription",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("key", models.CharField(max_length=64, unique=True)),
+                ("scope_key", models.CharField(max_length=64, db_index=True)),
+                ("subscriber", models.CharField(max_length=255)),
+                ("event_name", models.CharField(max_length=128)),
+                ("app_code", models.CharField(max_length=255)),
+                ("session_code", models.CharField(max_length=255)),
+                ("enabled", models.BooleanField(default=True)),
+                ("property", models.JSONField(default=dict)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="EventDelivery",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("event_id", models.CharField(max_length=64)),
+                ("envelope", models.JSONField(default=dict)),
+                ("route", models.JSONField(default=dict)),
+                ("status", models.CharField(default="pending", max_length=16)),
+                ("attempts", models.PositiveIntegerField(default=0)),
+                ("available_at", models.DateTimeField()),
+                ("lease_token", models.CharField(default="", max_length=32)),
+                ("lease_until", models.DateTimeField(null=True)),
+                ("progress", models.PositiveIntegerField(default=0)),
+                ("error_type", models.CharField(default="", max_length=128)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("subscription", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="aidev_bkplugin.eventsubscription")),
+            ],
+            options={
+                "indexes": [models.Index(fields=["status", "available_at"], name="event_delivery_ready")],
+                "constraints": [models.UniqueConstraint(fields=("subscription", "event_id"), name="unique_event_delivery")],
+            },
+        ),
+    ]

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/models.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/models.py
@@ -2,7 +2,7 @@
 
 from django.db import models
 
-__all__ = ["Checkpoint", "Write"]
+__all__ = ["Checkpoint", "Write", "EventSubscription", "EventDelivery"]
 
 
 class Checkpoint(models.Model):
@@ -45,3 +45,41 @@ class Write(models.Model):
             models.Index(fields=["created_at"]),
             models.Index(fields=["updated_at"]),  # 清理任务使用此索引
         ]
+
+
+class EventSubscription(models.Model):
+    """Durable, application/session-scoped subscription, installed by trusted code."""
+
+    key = models.CharField(max_length=64, unique=True)
+    scope_key = models.CharField(max_length=64, db_index=True)
+    subscriber = models.CharField(max_length=255)
+    event_name = models.CharField(max_length=128)
+    app_code = models.CharField(max_length=255)
+    session_code = models.CharField(max_length=255)
+    enabled = models.BooleanField(default=True)
+    property = models.JSONField(default=dict)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+
+class EventDelivery(models.Model):
+    """One immutable event per subscriber; the lease/progress belong to delivery."""
+
+    subscription = models.ForeignKey(EventSubscription, on_delete=models.CASCADE)
+    event_id = models.CharField(max_length=64)
+    envelope = models.JSONField(default=dict)
+    route = models.JSONField(default=dict)
+    status = models.CharField(max_length=16, default="pending")
+    attempts = models.PositiveIntegerField(default=0)
+    available_at = models.DateTimeField()
+    lease_token = models.CharField(max_length=32, default="")
+    lease_until = models.DateTimeField(null=True)
+    progress = models.PositiveIntegerField(default=0)
+    error_type = models.CharField(max_length=128, default="")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["subscription", "event_id"], name="unique_event_delivery"),
+        ]
+        indexes = [models.Index(fields=["status", "available_at"], name="event_delivery_ready")]

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_builder.py
@@ -21,6 +21,7 @@ from django.conf import settings
 
 from .agent_helpers import AgentHelper
 from .agent_session import SessionManager
+from .event_resource_manager import with_database_events
 
 logger = getLogger(__name__)
 
@@ -174,9 +175,10 @@ class AgentBuilder:
         elif self.model and isinstance(self.resource_manager, LLMOverrideResourceManager):
             # 注入的 rm 保留用户态认证，仅补上 model 覆盖能力
             self.resource_manager.model = self.model
+        execution_resource_manager = with_database_events(self.resource_manager, self.agent_code)
         event_handler = AGUISessionWriter(
             session_code=session_code,
-            client=AgentHelper.get_client(resource_manager=self.resource_manager),
+            client=AgentHelper.get_client(resource_manager=execution_resource_manager),
             username=self.username,
             turn_id=self.turn_id,
         )
@@ -187,7 +189,7 @@ class AgentBuilder:
             agent_cls=agent_cls,
             checkpointer=AgentHelper.get_checkpointer(),
             event_handler=event_handler,
-            resource_manager=self.resource_manager,
+            resource_manager=execution_resource_manager,
             username=self.username,
             version=version,
             channel_type=channel_type,

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -16,6 +16,7 @@ from aidev_agent.enums import ChatContentStatus, PromptRole, StreamEventType
 from aidev_agent.pydantic_models import ChatPrompt, ExecuteKwargs
 from aidev_agent.services.agent import ChatCompletionAgent
 from aidev_agent.services.event_handlers.base import BaseSessionWriter
+from aidev_agent.services.resume_events import uses_resume_event_stream
 
 # OpenTelemetry 是可选 extras（pip install aidev-bkplugin[opentelemetry]）。
 # 未安装时 trace context 注入降级为 no-op，其余流程不受影响。
@@ -76,6 +77,9 @@ class AgentExecutor:
                 return generator
             return self.wrap_generator(generator, session_code, turn_id=turn_id)
         result = agent_instance.execute(execute_kwargs)
+        if uses_resume_event_stream(getattr(agent_instance, "resource_manager", None), execute_kwargs):
+            # The internal AG-UI producer already persisted/finalized this response.
+            return result
         # 非流式 ainvoke 不经过 AG-UI 事件分发，必须显式写回 assistant
         self.session_manager.save_ai_response(session_code, result, turn_id=turn_id)
         event_handler = getattr(agent_instance, "event_handler", None)

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -17,6 +17,7 @@ from aidev_agent.enums import ChannelType, ChatContentStatus, PromptRole, Sessio
 from aidev_agent.packages.resource_manager import ResourceManagerProtocol
 from aidev_agent.packages.resource_manager.registry import resource_manager as resource_manager_factory
 from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.utils.tracing import get_current_trace_id
 from django.conf import settings
 
 from ..constants import AGUI_PROTOCOL_VERSION
@@ -44,6 +45,7 @@ class SessionManager:
         resource_manager: ResourceManagerProtocol | None = None,
     ):
         self.username = username
+        self.trace_id = get_current_trace_id() or ""
         self.agent_code = agent_code or settings.APP_CODE
         self.resource_manager = resource_manager or resource_manager_factory()
 
@@ -111,6 +113,8 @@ class SessionManager:
             data["extra"] = extra
         if turn_id:
             data["property"] = {"turn_id": turn_id}
+        if self.trace_id:
+            data.setdefault("property", {})["trace_id"] = self.trace_id
         client = self._client()
         result = client.api.create_chat_session_content(json=data, headers=self._user_headers())
         saved = result.get("data", {})

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -16,6 +16,7 @@ from logging import getLogger
 
 from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent.approval import ApprovalStateHandler
+from aidev_agent.utils.tracing import propagated_trace_context, recording_span, trace_headers
 
 from aidev_bkplugin.services.agent_builder import AgentBuilder
 from aidev_bkplugin.services.agent_execution import AgentExecutor
@@ -87,6 +88,16 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
         return
 
     # 3. 审批完成，构建 agent 并续流
+    # 恢复回调落库的父上下文；不要继承轮询线程中可能残留的其他会话 Trace。
+    # 上下文覆盖生成器构造和排空，保证延迟发布的恢复事件也关联到审批回调。
+    with (
+        propagated_trace_context(approve_info.get("approval_trace_context")),
+        recording_span("bkplugin.approval.resume", record_exception=False),
+    ):
+        _resume_approval(session_code, username, graph_thread_id, interrupts, approve_result)
+
+
+def _resume_approval(session_code, username, graph_thread_id, interrupts, approve_result):
     try:
         resume_items = []
         for interrupt in interrupts:
@@ -115,6 +126,7 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
             session_code=session_code,
             thread_id=graph_thread_id,
             resume=resume_items,
+            caller_trace_context=trace_headers(),
             # 后台 drain（无 SSE 下游，下方 for _ in generator 自行排空）：标记 background_only，
             # 使消费者读到 EOD 时不立即清理队列，保留缓存历史供前端在清理窗口内接管续流。
             background_only=True,

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/chat_tracing.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/chat_tracing.py
@@ -1,0 +1,33 @@
+"""Chat entry context must exist before constructing a lazy resume stream."""
+
+from contextlib import nullcontext
+from functools import wraps
+
+from aidev_agent.utils.tracing import propagated_trace_context, recording_span, trace_headers
+
+try:
+    from opentelemetry.trace import SpanKind
+except ImportError:
+    SpanKind = None
+
+
+def chat_request_span(function):
+    @wraps(function)
+    def wrapped(self, request, *args, **kwargs):
+        # Keep an existing HTTP middleware span. When middleware is absent, use
+        # the W3C header rather than allowing the later producer to start a root.
+        headers = getattr(request, "headers", {})
+        parent = nullcontext()
+        if not trace_headers():
+            parent = propagated_trace_context({key: headers.get(key) for key in ("traceparent", "tracestate")})
+        with (
+            parent,
+            recording_span(
+                "bkplugin.chat.request",
+                kind=SpanKind.INTERNAL if SpanKind else None,
+                record_exception=False,
+            ),
+        ):
+            return function(self, request, *args, **kwargs)
+
+    return wrapped

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/database_event_bus.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/database_event_bus.py
@@ -8,6 +8,7 @@ operations run in the publisher. Delivery is at-least-once, not exactly-once.
 import hashlib
 import json
 import logging
+import time
 import uuid
 from datetime import timedelta
 
@@ -18,6 +19,7 @@ from django.db.models import Exists, F, OuterRef, Q
 from django.utils import timezone
 
 from aidev_bkplugin.models import EventDelivery, EventSubscription
+from aidev_bkplugin.services.event_tracing import event_span
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +63,7 @@ class DatabaseEventBus:
             raise ValueError("Invalid event scope or identity")
         event_id = hashlib.sha256(str(value["eventId"]).encode()).hexdigest()
         envelope = event.model_dump(mode="json", by_alias=True)
-        with transaction.atomic():
+        with event_span("database_event.publish", envelope, producer=True), transaction.atomic():
             subscriptions = EventSubscription.objects.filter(
                 scope_key=self._scope_key(value["sessionCode"]),
                 app_code=self.app_code,
@@ -79,6 +81,7 @@ class DatabaseEventBus:
                     raise ValueError("An event identity cannot be reused for different content")
 
     def claim(self, subscriber: str) -> EventDelivery | None:
+        lookup_started = time.perf_counter()
         now = timezone.now()
         eligible = Q(status="pending", available_at__lte=now) | Q(status="processing", lease_until__lte=now)
         earlier = EventDelivery.objects.filter(
@@ -99,17 +102,31 @@ class DatabaseEventBus:
             .order_by("id")[:50]
         )
         for candidate in candidates:
-            # Order all event kinds per session/subscriber; no MySQL-8-only SKIP LOCKED.
-            token = uuid.uuid4().hex
-            count = EventDelivery.objects.filter(eligible, pk=candidate.pk).update(
-                status="processing",
-                lease_token=token,
-                lease_until=now + timedelta(seconds=self.LEASE_SECONDS),
-                attempts=F("attempts") + 1,
-                updated_at=now,
-            )
-            if count:
-                return EventDelivery.objects.get(pk=candidate.pk, lease_token=token)
+            attributes = {
+                "messaging.receive.lookup.duration_ms": (time.perf_counter() - lookup_started) * 1000,
+                "messaging.message.age_ms": max(0, (now - candidate.created_at).total_seconds() * 1000),
+                "messaging.delivery.attempt": candidate.attempts + 1,
+            }
+            # The parent becomes known only after selecting the candidate. Record
+            # lookup time as an attribute, and trace the actual lease acquisition.
+            with event_span("database_event.claim", candidate.envelope, attributes=attributes):
+                claimed = self._claim_candidate(candidate, eligible, now)
+            if claimed is not None:
+                return claimed
+        return None
+
+    def _claim_candidate(self, candidate: EventDelivery, eligible: Q, now) -> EventDelivery | None:
+        # Order all event kinds per session/subscriber; no MySQL-8-only SKIP LOCKED.
+        token = uuid.uuid4().hex
+        count = EventDelivery.objects.filter(eligible, pk=candidate.pk).update(
+            status="processing",
+            lease_token=token,
+            lease_until=now + timedelta(seconds=self.LEASE_SECONDS),
+            attempts=F("attempts") + 1,
+            updated_at=now,
+        )
+        if count:
+            return EventDelivery.objects.get(pk=candidate.pk, lease_token=token)
         return None
 
     def _owned(self, delivery: EventDelivery):

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/database_event_bus.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/database_event_bus.py
@@ -1,0 +1,148 @@
+"""Small durable publisher/consumer boundary, using Django ORM (including MySQL 5.7).
+
+It deliberately does not implement LocalEventBus.subscribe(callback). Subscribers
+are durable identities; channel processes own handlers. No scheduler or network
+operations run in the publisher. Delivery is at-least-once, not exactly-once.
+"""
+
+import hashlib
+import json
+import logging
+import uuid
+from datetime import timedelta
+
+from ag_ui.core import BaseEvent, CustomEvent
+from aidev_agent.events import event_key
+from django.db import transaction
+from django.db.models import Exists, F, OuterRef, Q
+from django.utils import timezone
+
+from aidev_bkplugin.models import EventDelivery, EventSubscription
+
+logger = logging.getLogger(__name__)
+
+
+class DatabaseEventBus:
+    LEASE_SECONDS = 120
+    MAX_ATTEMPTS = 8
+
+    def __init__(self, app_code: str):
+        if not app_code:
+            raise ValueError("Event publisher requires an application scope")
+        self.app_code = app_code
+
+    def subscribe(self, subscriber: str, name: str, session_code: str, *, property: dict) -> EventSubscription:
+        if not subscriber or not name or not session_code:
+            raise ValueError("Incomplete event subscription scope")
+        key = hashlib.sha256(json.dumps([self.app_code, subscriber, name, session_code]).encode()).hexdigest()
+        subscription, _ = EventSubscription.objects.get_or_create(
+            key=key,
+            defaults={
+                "scope_key": self._scope_key(session_code),
+                "subscriber": subscriber,
+                "event_name": name,
+                "app_code": self.app_code,
+                "session_code": session_code,
+                "property": property,
+            },
+        )
+        if subscription.property != property or not subscription.enabled:
+            raise ValueError("Existing subscription binding cannot be silently replaced")
+        return subscription
+
+    def _scope_key(self, session_code: str) -> str:
+        return hashlib.sha256(json.dumps([self.app_code, session_code]).encode()).hexdigest()
+
+    def publish(self, event: BaseEvent) -> None:
+        if not isinstance(event, CustomEvent) or not isinstance(event.value, dict):
+            raise ValueError("Database events require a scoped CUSTOM envelope")
+        value = event.value
+        if value.get("appCode") != self.app_code or not value.get("sessionCode") or not value.get("eventId"):
+            raise ValueError("Invalid event scope or identity")
+        event_id = hashlib.sha256(str(value["eventId"]).encode()).hexdigest()
+        envelope = event.model_dump(mode="json", by_alias=True)
+        with transaction.atomic():
+            subscriptions = EventSubscription.objects.filter(
+                scope_key=self._scope_key(value["sessionCode"]),
+                app_code=self.app_code,
+                session_code=value["sessionCode"],
+                event_name=event_key(event),
+                enabled=True,
+            )
+            for subscription in subscriptions:
+                delivery, created = EventDelivery.objects.get_or_create(
+                    subscription=subscription,
+                    event_id=event_id,
+                    defaults={"envelope": envelope, "route": subscription.property, "available_at": timezone.now()},
+                )
+                if not created and delivery.envelope != envelope:
+                    raise ValueError("An event identity cannot be reused for different content")
+
+    def claim(self, subscriber: str) -> EventDelivery | None:
+        now = timezone.now()
+        eligible = Q(status="pending", available_at__lte=now) | Q(status="processing", lease_until__lte=now)
+        earlier = EventDelivery.objects.filter(
+            subscription__scope_key=OuterRef("subscription__scope_key"),
+            subscription__subscriber=subscriber,
+            subscription__enabled=True,
+            id__lt=OuterRef("id"),
+            status__in=["pending", "processing"],
+        )
+        candidates = (
+            EventDelivery.objects.filter(
+                eligible,
+                subscription__app_code=self.app_code,
+                subscription__subscriber=subscriber,
+                subscription__enabled=True,
+            )
+            .filter(~Exists(earlier))
+            .order_by("id")[:50]
+        )
+        for candidate in candidates:
+            # Order all event kinds per session/subscriber; no MySQL-8-only SKIP LOCKED.
+            token = uuid.uuid4().hex
+            count = EventDelivery.objects.filter(eligible, pk=candidate.pk).update(
+                status="processing",
+                lease_token=token,
+                lease_until=now + timedelta(seconds=self.LEASE_SECONDS),
+                attempts=F("attempts") + 1,
+                updated_at=now,
+            )
+            if count:
+                return EventDelivery.objects.get(pk=candidate.pk, lease_token=token)
+        return None
+
+    def _owned(self, delivery: EventDelivery):
+        return EventDelivery.objects.filter(
+            pk=delivery.pk,
+            subscription__app_code=self.app_code,
+            status="processing",
+            subscription__enabled=True,
+            lease_token=delivery.lease_token,
+            lease_until__gt=timezone.now(),
+        )
+
+    def checkpoint(self, delivery: EventDelivery, progress: int) -> None:
+        if not self._owned(delivery).update(
+            progress=progress,
+            lease_until=timezone.now() + timedelta(seconds=self.LEASE_SECONDS),
+            updated_at=timezone.now(),
+        ):
+            raise RuntimeError("Event delivery lease lost")
+        delivery.progress = progress
+
+    def acknowledge(self, delivery: EventDelivery) -> None:
+        if not self._owned(delivery).update(status="delivered", lease_until=None, updated_at=timezone.now()):
+            raise RuntimeError("Event delivery lease lost")
+
+    def retry(self, delivery: EventDelivery, error: Exception) -> None:
+        status = "failed" if delivery.attempts >= self.MAX_ATTEMPTS else "pending"
+        self._owned(delivery).update(
+            status=status,
+            lease_until=None,
+            lease_token="",
+            error_type=type(error).__name__[:128],
+            available_at=timezone.now() + timedelta(seconds=min(300, 2**delivery.attempts)),
+            updated_at=timezone.now(),
+        )
+        logger.warning("event=database_event_delivery_retry status=%s error_type=%s", status, type(error).__name__)

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
@@ -1,0 +1,32 @@
+"""Per-agent publishing adapter; never replaces the global resource registry."""
+
+from ag_ui.core import BaseEvent
+
+
+class EventResourceManager:
+    def __init__(self, resource_manager, publisher):
+        self._resource_manager = resource_manager
+        self._publisher = publisher
+
+    def __getattr__(self, name):
+        return getattr(self._resource_manager, name)
+
+    def event_publishing_enabled(self) -> bool:
+        return True
+
+    def publish_event(self, event: BaseEvent) -> None:
+        self._publisher.publish(event)
+
+
+def with_database_events(resource_manager, app_code: str):
+    from django.conf import settings
+
+    if getattr(settings, "AIDEV_DATABASE_EVENTS_ENABLED", False) is not True:
+        return resource_manager
+    if isinstance(resource_manager, EventResourceManager):
+        return resource_manager
+    from aidev_agent.packages.resource_manager import resource_manager as factory
+
+    from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
+
+    return EventResourceManager(resource_manager or factory(), DatabaseEventBus(app_code))

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
@@ -1,6 +1,7 @@
 """Per-agent publishing adapter; never replaces the global resource registry."""
 
 from ag_ui.core import BaseEvent
+from django.db import close_old_connections
 
 
 class EventResourceManager:
@@ -15,7 +16,12 @@ class EventResourceManager:
         return True
 
     def publish_event(self, event: BaseEvent) -> None:
-        self._publisher.publish(event)
+        # The Agent producer runs outside Django's request thread/lifecycle.
+        try:
+            close_old_connections()
+            self._publisher.publish(event)
+        finally:
+            close_old_connections()
 
 
 def with_database_events(resource_manager, app_code: str):

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_tracing.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_tracing.py
@@ -1,0 +1,39 @@
+"""Durable event spans without message bodies, recipient identities or baggage."""
+
+from contextlib import contextmanager
+
+from aidev_agent.utils.tracing import get_agent_tracer, propagated_trace_context
+
+try:
+    from opentelemetry.trace import SpanKind, StatusCode
+except ImportError:
+    SpanKind = StatusCode = None
+
+
+@contextmanager
+def event_span(name: str, envelope: dict, *, producer: bool = False, attributes: dict | None = None):
+    value = envelope.get("value") or {}
+    with propagated_trace_context(value.get("traceContext")):
+        tracer = get_agent_tracer(__name__)
+        if tracer is None:
+            yield None
+            return
+        options = {
+            "attributes": {
+                "messaging.system": "database",
+                "event.name": envelope.get("name", ""),
+                **(attributes or {}),
+            },
+            "record_exception": False,
+            "set_status_on_exception": False,
+        }
+        if SpanKind is not None:
+            options["kind"] = SpanKind.PRODUCER if producer else SpanKind.CONSUMER
+        with tracer.start_as_current_span(name, **options) as span:
+            try:
+                yield span
+            except Exception as error:
+                span.set_attribute("error.type", type(error).__name__)
+                if StatusCode is not None:
+                    span.set_status(StatusCode.ERROR)
+                raise

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -11,8 +11,9 @@ AIDEV_AGENT = os.environ.get("AIDEV_AGENT", "aidev_agent.services.common_agent.C
 # ``resource_manager.replace_defaults(...)`` 注入到全局工厂；为空则使用 SDK 默认的
 # ``AgentResourceManager``。
 AIDEV_RESOURCE_MANAGER = os.environ.get("AIDEV_RESOURCE_MANAGER", "")
-# Enable only after migrations; Web and wxbot must share this database and app scope.
-AIDEV_DATABASE_EVENTS_ENABLED = os.environ.get("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", "0") == "1"
+# Enabled by default; migrate before startup and share the database/app scope across Web and wxbot.
+# Set BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=0 to opt out.
+AIDEV_DATABASE_EVENTS_ENABLED = os.environ.get("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", "1") == "1"
 AIDEV_AGENT_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_WORKERS", 16))
 AIDEV_AGENT_MAX_PENDING = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_PENDING", 32))
 AIDEV_AGENT_CLEANUP_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_CLEANUP_MAX_WORKERS", 2))

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -11,6 +11,8 @@ AIDEV_AGENT = os.environ.get("AIDEV_AGENT", "aidev_agent.services.common_agent.C
 # ``resource_manager.replace_defaults(...)`` 注入到全局工厂；为空则使用 SDK 默认的
 # ``AgentResourceManager``。
 AIDEV_RESOURCE_MANAGER = os.environ.get("AIDEV_RESOURCE_MANAGER", "")
+# Enable only after migrations; Web and wxbot must share this database and app scope.
+AIDEV_DATABASE_EVENTS_ENABLED = os.environ.get("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", "0") == "1"
 AIDEV_AGENT_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_WORKERS", 16))
 AIDEV_AGENT_MAX_PENDING = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_PENDING", 32))
 AIDEV_AGENT_CLEANUP_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_CLEANUP_MAX_WORKERS", 2))

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/chat.py
@@ -21,6 +21,7 @@ from aidev_bkplugin.services.agent_builder import AgentBuilder
 from aidev_bkplugin.services.agent_execution import AgentExecutor
 from aidev_bkplugin.services.agent_helpers import AgentHelper
 from aidev_bkplugin.services.agent_session import SessionManager
+from aidev_bkplugin.services.chat_tracing import chat_request_span
 from aidev_bkplugin.views.base import IgnoreClientContentNegotiation, PluginViewSet, logger
 
 
@@ -40,6 +41,7 @@ class ChatCompletionViewSet(PluginViewSet):
             return ChannelType.API.value
         return ChannelType.POPUP.value
 
+    @chat_request_span
     def create(self, request):
         """
         入参校验与解析统一交给 ChatCompletionRequestSerializer：

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -6,8 +6,12 @@ Agent，不创建新会话，也不要求两个进程共用 Redis 或进程内�
 
 ## 启用
 
-默认关闭。启用前需在应用的 Django 环境执行 `migrate aidev_bkplugin`，再为 Web
-和 wxbot **同时**配置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=1`。
+默认开启：未设置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED` 时，Web 发布数据库事件，
+wxbot 注册订阅并消费投递。升级后启动进程前，必须先在应用的 Django 环境执行
+`migrate aidev_bkplugin`，确保事件表已创建。
+
+如需关闭，为 Web 和 wxbot **同时**配置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=0`；
+显式设置 `=1` 可开启。已有 `=0` 配置会继续生效，不会被新默认值覆盖。
 两端必须加载匹配的 SDK / 插件版本，使用同一个应用标识、数据库和会话环境。
 不需要为 wxbot 新增表，通用表由 bkplugin 的迁移维护。
 

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -1,0 +1,105 @@
+# 审批恢复结果交付企业微信
+
+平台调用 Web 进程的 `chat` 接口恢复原会话时，Web 仍返回本次执行的输出；wxbot
+通过数据库订阅收到同一次执行的结果，并在现有长连接上发送新消息。不重新调用
+Agent，不创建新会话，也不要求两个进程共用 Redis 或进程内事件总线。
+
+## 启用
+
+默认关闭。启用前需在应用的 Django 环境执行 `migrate aidev_bkplugin`，再为 Web
+和 wxbot **同时**配置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=1`。
+两端必须加载匹配的 SDK / 插件版本，使用同一个应用标识、数据库和会话环境。
+不需要为 wxbot 新增表，通用表由 bkplugin 的迁移维护。
+
+wxbot 在普通 Chat 请求获取原 session_code 后、消费 Agent 输出前，绑定订阅。
+绑定信息包括应用、机器人、原会话、已校验的用户与原发送目标。后续 `/new` 不
+改变旧会话的绑定。启用前已产生、且没有订阅的历史审批不自动补发；不能根据
+“当前最新会话”猜测原接收方。
+
+## 调用顺序
+
+1. 用户在企微发起会话，wxbot 获取原 session_code 并保存订阅，再发送审批卡片。
+2. 审批平台按原协议调用 Web `chat`，携带原 session_code 及 resume/interruptId。
+3. bkplugin 的 AgentBuilder 用 EventResourceManager 包装原 ResourceManager，
+   委托原有鉴权、模型配置等能力，仅把发布操作交给 DatabaseEventBus。
+4. aidev_agent 的实际恢复生产者在 RUN_STARTED 入队并 flush 后发布
+   AIDEV_CHAT_RESUME_READY。它不代表“审批通过”，不用于更新原审批卡。
+5. 本次执行的 AG-UI 事件照常进入 Web 响应和会话持久化流程。非流式 HTTP
+   回调内部也走同一恢复路径，最终聚合为原有 JSON 响应形态，执行次数仍为一次。
+6. 生产者完成会话写入与队列收尾后，发布 FINISHED 或 FAILED，携带本次执行
+   的展示事件快照；不携带 STATE_SNAPSHOT、MESSAGES_SNAPSHOT 或全量历史。
+7. DatabaseEventBus 为每个匹配订阅持久化独立投递记录。Web 返回给调用方的结果
+   不会“消费掉” wxbot 的投递。
+8. wxbot 的独立消费者领取记录，用现有 AG-UI 渲染器生成文本及下一张
+   Ask-user / 审批卡片，经现有连接的 send_message 发往原用户或群。
+9. 每条消息收到发送成功确认后记录进度，全部完成才确认整条投递。下次原生
+   卡片点击仍走现有身份校验、结构化答案和原会话恢复流程。
+
+本版是**结束或再次中断后的结果交付**，不是逐 token/逐段实时转发。READY 只做
+通知与审计；wxbot 处理 FINISHED/FAILED 才发送结果。HTTP 调用者可以继续流式接收。
+
+## 分层与事件
+
+| 模块 | 职责 |
+| --- | --- |
+| aidev_agent.events | 定义通用事件名称与 AG-UI CUSTOM 外壳 |
+| ResourceManager | publish_event / event_publishing_enabled 扩展点，默认 no-op / False |
+| aidev_agent 恢复生产者 | 发布实际执行的生命周期和展示结果，不依赖 Django 或 wxbot |
+| bkplugin DatabaseEventBus | 持久订阅、事务内生成投递、领取租约、进度、确认及失败重试 |
+| wxbot | 保存可信原路由、消费订阅、复用现有卡片渲染与长连接发送 |
+
+| CUSTOM.name | 触发点 | 用途 |
+| --- | --- | --- |
+| AIDEV_CHAT_RESUME_READY | 实际恢复的 RUN_STARTED 已 flush | 通知执行已开始；不能当作审批结果 |
+| AIDEV_CHAT_RESUME_FINISHED | 本次执行正常收尾并完成持久化 | 交付本次完整结果；可能再次进入人机交互 |
+| AIDEV_CHAT_RESUME_FAILED | 本次执行发生 RUN_ERROR 或收尾失败 | 交付错误结果或恢复失败提示 |
+
+value 使用 schemaVersion=1，包含 eventId、occurredAt、appCode、sessionCode、
+threadId、turnId、runId、interruptIds；终态还包含 events 与 persisted。
+这些 ID 分别描述应用、会话、图线程、会话轮次、运行及中断，不能相互替代。
+终态 checkpoint 重放及队列接管不会再次发布本次业务事件。
+
+开启 OTel 时，仅传递 W3C traceparent/tracestate；wxbot.event.consume 延续生产者
+trace。事件内容、接收者及完整异常不会作为该 span 的属性。
+
+DatabaseEventBus 的 subscribe 注册的是持久订阅身份及路由，不是 Python 回调。
+其他插件可以注册自己的 subscriber/name/session_code，独立领取、确认投递并执行
+自己的处理逻辑；不要求 wxbot 和 Web 在同一进程调用 subscribe(callback)。
+
+## 存储与恢复边界
+
+- EventSubscription：不可被静默覆盖的订阅路由，property 为插件扩展 JSON。
+- EventDelivery：事件快照、原路由副本、状态、租约、重试次数及消息发送进度。
+- 同一应用/会话/订阅者按顺序领取；不同订阅者各自确认，不互相抢走结果。
+- 消费者离线时记录保持 pending；重新上线后补收。租约为 120 秒，单次发送
+  等待上限 45 秒，发送前后续租。过期租约可重新领取，旧消费者不能再确认。
+- 发送失败指数退避，最多 8 次；耗尽后保留 failed 供排查，不自动重跑 Agent。
+- 属于至少一次交付：发送成功但进度尚未写入时进程崩溃，仍可能重复发送。
+  企微没有可用的端到端幂等确认时，不承诺 exactly-once。
+- READY 写入失败会在生产者收尾时重试。数据库持续不可用或生产者在终态事件
+  写入前退出，尚不能保证结果补投；应告警并人工核对原会话，不通过自动重跑
+  已审批工具修复。此实现不是跨平台会话写入与事件表的分布式事务。
+- 记录包含本次回复、工具展示数据和路由，按会话数据保护；不要把 envelope、
+  property 或完整异常写入日志。部署需配置终态记录保留/清理策略，未投递记录
+  不应按普通日志直接清理。当前版本不自动删除事件或修改用户订阅。
+- 不更新后台审批完成前发出的旧卡片，不复用过期 req_id。后续结果使用新消息。
+- 本次只覆盖 AG-UI Chat 的 resume，不补齐 HTTP 轮询卡片能力，不更改 Flow、
+  legacy streaming、跨环境恢复、Web checkpoint 或审批回调鉴权协议。
+
+## 验证
+
+新测试位于 `tests/database_events/`，通过本插件的 `make test` 入口运行。
+测试环境需同时安装/加载当前 aidev-agent 和 aidev-wxbot，以及本插件测试依赖。
+跨进程用例会绑定本机随机端口，使用独立临时 SQLite 文件，不使用真实服务配置。
+
+- Web 流式回调 + 独立 wxbot 消费者：双方获得同次执行内容。
+- Web 非流式回调 + 独立 wxbot 消费者：JSON 返回与企微交付并存。
+- Web 先结束、wxbot 后上线：补收正文和下一张 Ask-user 卡片。
+- 每个跨进程场景断言执行一次、原会话和群目标不变、两条生命周期投递均确认。
+- 覆盖幂等发布、订阅隔离、原路由保护、租约过期、发送进度重试、停机未确认、
+  订阅停用及迁移一致性。
+
+HTTP View、ResourceManager 注入、核心生产者、数据库及企微渲染/消费者使用
+实际代码；鉴权平台、模型执行和企微网络发送使用测试替身。因此这些测试证明
+进程间交付机制，不等同于真实审批平台、LLM、企业微信端到端验收。数据库验证
+基于 SQLite；实现避免 MySQL 8 专用锁语法，MySQL 5.7 的部署验收仍需另行执行。

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -23,7 +23,8 @@ wxbot 在普通 Chat 请求获取原 session_code 后、消费 Agent 输出前�
 3. bkplugin 的 AgentBuilder 用 EventResourceManager 包装原 ResourceManager，
    委托原有鉴权、模型配置等能力，仅把发布操作交给 DatabaseEventBus。
 4. aidev_agent 的实际恢复生产者在 RUN_STARTED 入队并 flush 后发布
-   AIDEV_CHAT_RESUME_READY。它不代表“审批通过”，不用于更新原审批卡。
+   AIDEV_CHAT_RESUME_READY。它不代表“审批通过”；wxbot 按原用户、session_code
+   和 interruptIds 查询平台已落库的原审批结果，确认通过或拒绝后另发结果卡。
 5. 本次执行的 AG-UI 事件照常进入 Web 响应和会话持久化流程。非流式 HTTP
    回调内部也走同一恢复路径，最终聚合为原有 JSON 响应形态，执行次数仍为一次。
 6. 生产者完成会话写入与队列收尾后，发布 FINISHED 或 FAILED，携带本次执行
@@ -35,8 +36,25 @@ wxbot 在普通 Chat 请求获取原 session_code 后、消费 Agent 输出前�
 9. 每条消息收到发送成功确认后记录进度，全部完成才确认整条投递。下次原生
    卡片点击仍走现有身份校验、结构化答案和原会话恢复流程。
 
-本版是**结束或再次中断后的结果交付**，不是逐 token/逐段实时转发。READY 只做
-通知与审计；wxbot 处理 FINISHED/FAILED 才发送结果。HTTP 调用者可以继续流式接收。
+正文是**结束或再次中断后的结果交付**，不是逐 token/逐段实时转发。审批结果卡
+可在 READY 消费时先行发送，正文仍在 FINISHED/FAILED 时交付。HTTP 调用者可以
+继续流式接收。
+
+## 审批结果卡与旧卡点击
+
+- 通过或拒绝后发送新的结果卡，保留原标题、说明、单号、提交时间及跳转链接；
+  底部显示“审批已通过”或“审批已拒绝”，不包含取消按钮。当前平台没有可信
+  实际审批人字段，不使用候选 approvers 或点击用户拼接“由 xx”。
+- 原卡不能通过后台审批回调主动刷新。用户再次点击原卡时仍校验原会话、目标
+  和身份；平台返回 already_finalized 后，使用同一渲染函数替换底部为实际终态，
+  不再次取消或恢复会话。更新需要有效签名及本次点击回调窗口，不复用旧 req_id。
+- 查询精确匹配被恢复的中断，不只读最新一条，避免延迟消费时将下一次审批结果
+  误写到原卡。记录缺失、未终态或相互冲突则重试，不将 READY 当作审批通过。
+- 首次发送前，将结果卡快照保存到本条 EventDelivery.route 的内部 approvalMessages
+  字段，不改变订阅路由。重试或进程重启复用同一内容及消息序号，不新增数据表。
+- Ask-user 不产生审批结果卡；取消已有点击卡片确认，不再额外发送取消通知。
+- 结果查询或发送失败沿用投递重试；同一会话后续事件等待其交付或重试耗尽，
+  不影响 Web 的 HTTP 输出，也不重跑 Agent。历史已确认的 READY 不自动重放。
 
 ## 分层与事件
 
@@ -50,7 +68,7 @@ wxbot 在普通 Chat 请求获取原 session_code 后、消费 Agent 输出前�
 
 | CUSTOM.name | 触发点 | 用途 |
 | --- | --- | --- |
-| AIDEV_CHAT_RESUME_READY | 实际恢复的 RUN_STARTED 已 flush | 通知执行已开始；不能当作审批结果 |
+| AIDEV_CHAT_RESUME_READY | 实际恢复的 RUN_STARTED 已 flush | 通知执行已开始；wxbot 另查可信审批结果后发结果卡 |
 | AIDEV_CHAT_RESUME_FINISHED | 本次执行正常收尾并完成持久化 | 交付本次完整结果；可能再次进入人机交互 |
 | AIDEV_CHAT_RESUME_FAILED | 本次执行发生 RUN_ERROR 或收尾失败 | 交付错误结果或恢复失败提示 |
 
@@ -82,7 +100,7 @@ DatabaseEventBus 的 subscribe 注册的是持久订阅身份及路由，不是 
 - 记录包含本次回复、工具展示数据和路由，按会话数据保护；不要把 envelope、
   property 或完整异常写入日志。部署需配置终态记录保留/清理策略，未投递记录
   不应按普通日志直接清理。当前版本不自动删除事件或修改用户订阅。
-- 不更新后台审批完成前发出的旧卡片，不复用过期 req_id。后续结果使用新消息。
+- 后台不主动更新旧卡，不复用过期 req_id；结果另发新卡，旧卡仅在有效点击后更新。
 - 本次只覆盖 AG-UI Chat 的 resume，不补齐 HTTP 轮询卡片能力，不更改 Flow、
   legacy streaming、跨环境恢复、Web checkpoint 或审批回调鉴权协议。
 
@@ -94,10 +112,12 @@ DatabaseEventBus 的 subscribe 注册的是持久订阅身份及路由，不是 
 
 - Web 流式回调 + 独立 wxbot 消费者：双方获得同次执行内容。
 - Web 非流式回调 + 独立 wxbot 消费者：JSON 返回与企微交付并存。
-- Web 先结束、wxbot 后上线：补收正文和下一张 Ask-user 卡片。
+- Web 先结束、wxbot 后上线：补收审批结果卡、正文和下一张 Ask-user 卡片。
 - 每个跨进程场景断言执行一次、原会话和群目标不变、两条生命周期投递均确认。
 - 覆盖幂等发布、订阅隔离、原路由保护、租约过期、发送进度重试、停机未确认、
   订阅停用及迁移一致性。
+- 审批通过/拒绝文案、延迟读取原中断、结果卡快照重试、无效租约禁止发送；
+  wxbot 卡片测试覆盖重复点击旧卡只更新实际终态、不重复恢复。
 
 HTTP View、ResourceManager 注入、核心生产者、数据库及企微渲染/消费者使用
 实际代码；鉴权平台、模型执行和企微网络发送使用测试替身。因此这些测试证明

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -80,6 +80,12 @@ threadId、turnId、runId、interruptIds；终态还包含 events 与 persisted�
 开启 OTel 时，仅传递 W3C traceparent/tracestate；wxbot.event.consume 延续生产者
 trace。事件内容、接收者及完整异常不会作为该 span 的属性。
 
+恢复事件在 Agent 返回流之前同步捕获入口 Trace 上下文，每次执行独立保存。
+即使入口 span 已结束、流在其他线程或上下文中消费，READY 和终态事件仍使用同一
+入口快照；wxbot 消费和发送 span 由该快照关联。队列初始化、取消标识准备和后台执行
+仍在开始消费流时触发，未消费的流不启动任务、不发布事件。入口没有有效上下文或未安装
+OTel 时不制造 Trace ID，也不借用之后消费者的上下文。
+
 DatabaseEventBus 的 subscribe 注册的是持久订阅身份及路由，不是 Python 回调。
 其他插件可以注册自己的 subscriber/name/session_code，独立领取、确认投递并执行
 自己的处理逻辑；不要求 wxbot 和 Web 在同一进程调用 subscribe(callback)。

--- a/src/plugins/aidev_bkplugin/readme.md
+++ b/src/plugins/aidev_bkplugin/readme.md
@@ -2,6 +2,8 @@
 
 本插件需与智能体模板配合使用，用于开发和管理智能体插件。
 
+审批 Web 回调与企业微信跨进程联动见 [DatabaseEventBus 使用说明](docs/database-events.md)。
+
 ## 本地调试智能体插件
 
 ### 环境准备

--- a/src/plugins/aidev_bkplugin/tests/apps.py
+++ b/src/plugins/aidev_bkplugin/tests/apps.py
@@ -14,3 +14,10 @@ class AidevBkpluginTestConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "aidev_bkplugin"
     label = "aidev_bkplugin"
+
+
+class WxAiBotTestConfig(AppConfig):
+    """Register models only, without starting wxbot services."""
+
+    name = "aidev_wxbot.wxaibot"
+    label = "wxaibot"

--- a/src/plugins/aidev_bkplugin/tests/database_events/conftest.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/conftest.py
@@ -75,3 +75,26 @@ def wx_delivery_case(transactional_db, settings, monkeypatch):
     return SimpleNamespace(
         bus=bus, event=event, send=send, consumer=DatabaseResumeConsumer("app", "bot-original", send)
     )
+
+
+@pytest.fixture
+def approval_delivery_case(wx_delivery_case, monkeypatch):
+    from unittest.mock import MagicMock
+
+    from aidev_agent.events import AIDEV_CHAT_RESUME_READY
+
+    from .process_helpers import approval_record
+
+    case = wx_delivery_case
+    case.event.name = AIDEV_CHAT_RESUME_READY
+    case.event.value.pop("events")
+    case.event.value.pop("persisted")
+    case.bus.subscribe(
+        case.consumer.subscriber,
+        AIDEV_CHAT_RESUME_READY,
+        "session-original",
+        property={"target": "original-group", "username": "author", "sessionCode": "session-original"},
+    )
+    case.history = MagicMock(return_value=[approval_record()])
+    monkeypatch.setattr("aidev_wxbot.wxaibot.approval_notifications.SessionManager.list_session_contents", case.history)
+    return case

--- a/src/plugins/aidev_bkplugin/tests/database_events/conftest.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/conftest.py
@@ -1,0 +1,77 @@
+from types import SimpleNamespace
+
+import pytest
+from ag_ui.core import CustomEvent
+from aidev_agent.events import AIDEV_CHAT_RESUME_FINISHED
+from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
+
+
+@pytest.fixture(scope="session")
+def django_db_modify_db_settings(tmp_path_factory):
+    from django.conf import settings
+
+    settings.DATABASES["default"]["TEST"]["NAME"] = str(tmp_path_factory.mktemp("event-db") / "events.sqlite3")
+
+
+@pytest.fixture
+def event_case(db):
+    bus = DatabaseEventBus("app")
+    subscription = bus.subscribe("wxbot:test", AIDEV_CHAT_RESUME_FINISHED, "session", property={"target": "user"})
+    event = CustomEvent(
+        name=AIDEV_CHAT_RESUME_FINISHED,
+        value={
+            "eventId": "event-1",
+            "appCode": "app",
+            "sessionCode": "session",
+            "events": [],
+        },
+    )
+    return SimpleNamespace(bus=bus, subscription=subscription, event=event)
+
+
+@pytest.fixture
+def wx_delivery_case(transactional_db, settings, monkeypatch):
+    import hashlib
+    from unittest.mock import AsyncMock
+
+    settings.BK_APIGW_MANAGER_URL_TMPL = "https://{api_name}.example.invalid"
+    settings.AIDEV_GATEWAY_NAME, settings.BK_APIGW_STAGE = "test", "test"
+    settings.BKPAAS_APP_CODE, settings.BKPAAS_APP_SECRET = "app", "test-only"
+    from aidev_wxbot.wxaibot.database_delivery import DatabaseResumeConsumer
+
+    from .process_helpers import runtime_events
+
+    monkeypatch.setattr(
+        "aidev_bkplugin.services.agent_helpers.AgentHelper.build_session_detail_url",
+        lambda session: f"https://agent.example.com/?session={session}",
+    )
+    bus = DatabaseEventBus("app")
+    subscriber = "wxbot:" + hashlib.sha256(b"bot-original").hexdigest()
+    bus.subscribe(
+        subscriber,
+        AIDEV_CHAT_RESUME_FINISHED,
+        "session-original",
+        property={
+            "target": "original-group",
+            "username": "author",
+            "sessionCode": "session-original",
+        },
+    )
+    event = CustomEvent(
+        name=AIDEV_CHAT_RESUME_FINISHED,
+        value={
+            "schemaVersion": 1,
+            "eventId": "delivery-1",
+            "appCode": "app",
+            "sessionCode": "session-original",
+            "runId": "run-original",
+            "turnId": "turn-original",
+            "interruptIds": ["approval-original"],
+            "events": runtime_events(),
+            "persisted": True,
+        },
+    )
+    send = AsyncMock()
+    return SimpleNamespace(
+        bus=bus, event=event, send=send, consumer=DatabaseResumeConsumer("app", "bot-original", send)
+    )

--- a/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
@@ -1,0 +1,208 @@
+"""Spawn-safe fixtures: actual HTTP Web process + separate durable wxbot consumer.
+
+Only auth/platform/model execution and the external WeCom socket are fakes.
+The view, AgentBuilder event injection, AgentExecutor, core streaming producer,
+database publisher/leases and wxbot AG-UI renderer/consumer are production code.
+"""
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+import traceback
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def configure_database(path):
+    os.environ["MESSAGE_HANDLER_TYPE"] = "inmemory"
+    import django
+    from django.conf import settings
+
+    from tests import settings as test_settings
+
+    values = {key: getattr(test_settings, key) for key in dir(test_settings) if key.isupper()}
+    values.update(APP_CODE="app", AIDEV_DATABASE_EVENTS_ENABLED=True)
+    values.update(
+        BK_APIGW_MANAGER_URL_TMPL="https://{api_name}.example.invalid",
+        AIDEV_GATEWAY_NAME="test",
+        BK_APIGW_STAGE="test",
+        BKPAAS_APP_CODE="app",
+        BKPAAS_APP_SECRET="test-only",
+    )
+    values["DATABASES"] = {
+        "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": path, "OPTIONS": {"timeout": 15}}
+    }
+    settings.configure(**values)
+    django.setup()
+    logging.disable(logging.CRITICAL)
+    framework = MagicMock()
+    framework.kit.decorators.inject_user_token = lambda func: func
+    sys.modules.setdefault("bk_plugin_framework", framework)
+    sys.modules.setdefault("bk_plugin_framework.kit", framework.kit)
+    sys.modules.setdefault("bk_plugin_framework.kit.decorators", framework.kit.decorators)
+
+
+def runtime_events(question=False):
+    terminal = {"type": "RUN_FINISHED", "runId": "run-original", "threadId": "graph-original"}
+    if question:
+        terminal["outcome"] = {
+            "type": "interrupt",
+            "interrupts": [
+                {
+                    "id": "next-question",
+                    "reason": "aidev:user_question",
+                    "metadata": {
+                        "status": "pending",
+                        "type": "ask_user_question",
+                        "questions": [
+                            {
+                                "question": "请选择查询范围",
+                                "multiSelect": False,
+                                "options": [{"label": "订单"}, {"label": "支付"}],
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+    return [
+        {"type": "RUN_STARTED", "runId": "run-original", "threadId": "graph-original"},
+        {"type": "TEXT_MESSAGE_START", "messageId": "reply-original", "role": "assistant"},
+        {"type": "TEXT_MESSAGE_CONTENT", "messageId": "reply-original", "delta": "审批已完成，继续查询。"},
+        {"type": "TEXT_MESSAGE_END", "messageId": "reply-original"},
+        terminal,
+    ]
+
+
+def build_web_application(events, execution_count):
+    from aidev_agent.core.ag_ui.types import AgentInput
+    from aidev_agent.pydantic_models import ChatPrompt
+    from aidev_agent.services.agent.chat import ChatCompletionAgent
+    from aidev_agent.services.event_handlers.base import BaseSessionWriter
+    from aidev_agent.services.messages_handler import InMemoryQueueMessageHandler
+    from aidev_agent.services.messages_handler.factory import message_handler_factory
+    from aidev_bkplugin.views.chat import ChatCompletionViewSet
+    from rest_framework.parsers import JSONParser
+    from rest_framework.request import Request
+    from rest_framework.test import APIRequestFactory
+
+    message_handler_factory.replace_defaults(InMemoryQueueMessageHandler())
+
+    class Runtime:
+        async def run(self, _input):
+            execution_count.value += 1
+            for event in events:
+                await asyncio.sleep(0.005)
+                yield "data: " + json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n\n"
+
+    class Agent(ChatCompletionAgent):
+        def _stream(self, _agent, _cfg, _state, _messages, execute_kwargs):
+            input = AgentInput(
+                thread_id="graph-original",
+                run_id="run-original",
+                messages=[],
+                state={},
+                forwarded_props={"command": {"resume": execute_kwargs.resume}},
+            )
+            return self._stream_with_queue(Runtime(), input, resume=True)
+
+        def execute(self, execute_kwargs):
+            if execute_kwargs.stream:
+                return self._stream(None, None, {}, [], execute_kwargs)
+            return self._invoke_resume_with_events(None, {"configurable": {}}, {}, [], execute_kwargs)
+
+    def factory(**kwargs):
+        return Agent(
+            thread_id="graph-original",
+            resource_manager=kwargs["resource_manager"],
+            event_handler=kwargs["event_handler"],
+            chat_history=[ChatPrompt(role="user", content="query")],
+        )
+
+    writer = MagicMock(spec=BaseSessionWriter)
+    writer.session_code, writer.turn_id = "session-original", "turn-original"
+    rm = MagicMock()
+    rm.get_agent_code.return_value = "app"
+    rm.event_publishing_enabled.return_value = False
+
+    def application(environ, start_response):
+        raw = environ["wsgi.input"].read(int(environ["CONTENT_LENGTH"]))
+        request = Request(APIRequestFactory().post("/chat/", json.loads(raw), format="json"), parsers=[JSONParser()])
+        request.user = SimpleNamespace(username="author")
+        view = ChatCompletionViewSet()
+        view.request = request
+        with (
+            patch.object(view, "get_username", return_value="author"),
+            patch.object(view, "get_resource_manager", return_value=rm),
+            patch.object(view, "_resolve_chat_turn_id", return_value="turn-original"),
+            patch("aidev_bkplugin.services.agent_builder.AgentInstanceFactory.build_agent", side_effect=factory),
+            patch("aidev_bkplugin.services.agent_builder.AGUISessionWriter", return_value=writer),
+            patch("aidev_bkplugin.services.agent_builder.AgentHelper.get_checkpointer", return_value=None),
+            patch(
+                "aidev_bkplugin.services.agent_config.AgentConfigFetcher.get_info", return_value={"agent_type": "chat"}
+            ),
+        ):
+            response = view.create(request)
+            start_response("200 OK", [("Content-Type", "application/json")])
+            if getattr(response, "streaming", False):
+                yield from response.streaming_content
+            else:
+                yield json.dumps(response.data, ensure_ascii=False).encode()
+
+    return application
+
+
+def web_process(path, events, status, execution_count):
+    from wsgiref.simple_server import WSGIRequestHandler, make_server
+
+    class QuietHandler(WSGIRequestHandler):
+        def log_message(self, *_args):
+            pass
+
+    try:
+        configure_database(path)
+        application = build_web_application(events, execution_count)
+        with make_server("127.0.0.1", 0, application, handler_class=QuietHandler) as server:
+            status.put(("ready", server.server_port, os.getpid()))
+            server.timeout = 20
+            server.handle_request()
+        status.put(("done", os.getpid()))
+    except Exception:
+        status.put(("error", traceback.format_exc()))
+        raise
+
+
+def wxbot_process(path, sent, status, expected_messages):
+    try:
+        configure_database(path)
+        from aidev_wxbot.wxaibot.database_delivery import DatabaseResumeConsumer
+
+        count = 0
+
+        async def send(target, body):
+            nonlocal count
+            sent.put((target, body, os.getpid()))
+            count += 1
+
+        async def consume():
+            consumer = DatabaseResumeConsumer("app", "bot-original", send)
+            deadline = time.monotonic() + 20
+            while time.monotonic() < deadline:
+                await consumer.consume_once()
+                if count >= expected_messages:
+                    return
+                await asyncio.sleep(0.025)
+            raise TimeoutError("wxbot did not receive expected result")
+
+        with patch(
+            "aidev_bkplugin.services.agent_helpers.AgentHelper.build_session_detail_url",
+            side_effect=lambda session: f"https://agent.example.com/?session={session}",
+        ):
+            asyncio.run(consume())
+        status.put(("done", os.getpid()))
+    except Exception:
+        status.put(("error", traceback.format_exc()))
+        raise

--- a/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
@@ -77,6 +77,34 @@ def runtime_events(question=False):
     ]
 
 
+def approval_record(status="approved"):
+    return {
+        "session_code": "session-original",
+        "role": "interrupt",
+        "property": {"builtin_property": {"approve_result": status}},
+        "content": {
+            "outcome": {
+                "type": "success",
+                "interrupts": [
+                    {
+                        "id": "approval-original",
+                        "reason": "aidev:tool_approval",
+                        "metadata": {
+                            "ticket": {
+                                "title": "执行工具需要审批",
+                                "sn": "DE001",
+                                "submit_time": "2026-08-31T00:00:00Z",
+                                "url": "https://approval.example.com/DE001",
+                                "approvers": ["candidate-not-actual-approver"],
+                            }
+                        },
+                    }
+                ],
+            },
+        },
+    }
+
+
 def build_web_application(events, execution_count):
     from aidev_agent.core.ag_ui.types import AgentInput
     from aidev_agent.pydantic_models import ChatPrompt
@@ -197,9 +225,15 @@ def wxbot_process(path, sent, status, expected_messages):
                 await asyncio.sleep(0.025)
             raise TimeoutError("wxbot did not receive expected result")
 
-        with patch(
-            "aidev_bkplugin.services.agent_helpers.AgentHelper.build_session_detail_url",
-            side_effect=lambda session: f"https://agent.example.com/?session={session}",
+        with (
+            patch(
+                "aidev_bkplugin.services.agent_helpers.AgentHelper.build_session_detail_url",
+                side_effect=lambda session: f"https://agent.example.com/?session={session}",
+            ),
+            patch(
+                "aidev_wxbot.wxaibot.approval_notifications.SessionManager.list_session_contents",
+                return_value=[approval_record()],
+            ),
         ):
             asyncio.run(consume())
         status.put(("done", os.getpid()))

--- a/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/process_helpers.py
@@ -25,6 +25,7 @@ def configure_database(path):
 
     values = {key: getattr(test_settings, key) for key in dir(test_settings) if key.isupper()}
     values.update(APP_CODE="app", AIDEV_DATABASE_EVENTS_ENABLED=True)
+    values["INSTALLED_APPS"] = [*values["INSTALLED_APPS"], "tests.apps.WxAiBotTestConfig"]
     values.update(
         BK_APIGW_MANAGER_URL_TMPL="https://{api_name}.example.invalid",
         AIDEV_GATEWAY_NAME="test",
@@ -105,7 +106,7 @@ def approval_record(status="approved"):
     }
 
 
-def build_web_application(events, execution_count):
+def build_web_application(events, execution_count, *, polling_record=None):
     from aidev_agent.core.ag_ui.types import AgentInput
     from aidev_agent.pydantic_models import ChatPrompt
     from aidev_agent.services.agent.chat import ChatCompletionAgent
@@ -156,9 +157,32 @@ def build_web_application(events, execution_count):
     rm.get_agent_code.return_value = "app"
     rm.event_publishing_enabled.return_value = False
 
+    if polling_record is not None:
+
+        def run_polling():
+            from aidev_agent.services.agent.approval import ApprovalStateHandler
+            from aidev_bkplugin.services.approval_resume import _approval_resume_worker
+
+            # Only the platform query/model are faked; use the real polling
+            # worker, approval reader, builder, executor and lazy event producer.
+            with (
+                patch.object(ApprovalStateHandler, "check_resume", return_value=True),
+                patch.object(ApprovalStateHandler, "_get_latest_interrupt_record", return_value=polling_record),
+                patch("aidev_bkplugin.services.agent_builder.LLMOverrideResourceManager", return_value=rm),
+                patch("aidev_bkplugin.services.agent_builder.AgentInstanceFactory.build_agent", side_effect=factory),
+                patch("aidev_bkplugin.services.agent_builder.AGUISessionWriter", return_value=writer),
+                patch("aidev_bkplugin.services.agent_builder.AgentHelper.get_checkpointer", return_value=None),
+            ):
+                _approval_resume_worker("session-original", "author", "graph-original", [{"id": "approval-original"}])
+
+        return run_polling
+
     def application(environ, start_response):
         raw = environ["wsgi.input"].read(int(environ["CONTENT_LENGTH"]))
-        request = Request(APIRequestFactory().post("/chat/", json.loads(raw), format="json"), parsers=[JSONParser()])
+        http_request = APIRequestFactory().post(
+            "/chat/", json.loads(raw), format="json", HTTP_TRACEPARENT=environ.get("HTTP_TRACEPARENT", "")
+        )
+        request = Request(http_request, parsers=[JSONParser()])
         request.user = SimpleNamespace(username="author")
         view = ChatCompletionViewSet()
         view.request = request
@@ -183,7 +207,7 @@ def build_web_application(events, execution_count):
     return application
 
 
-def web_process(path, events, status, execution_count):
+def web_process(path, events, status, execution_count, trace_records=None):
     from wsgiref.simple_server import WSGIRequestHandler, make_server
 
     class QuietHandler(WSGIRequestHandler):
@@ -192,26 +216,53 @@ def web_process(path, events, status, execution_count):
 
     try:
         configure_database(path)
+        published = configure_tracing(trace_records) if trace_records is not None else None
         application = build_web_application(events, execution_count)
         with make_server("127.0.0.1", 0, application, handler_class=QuietHandler) as server:
             status.put(("ready", server.server_port, os.getpid()))
             server.timeout = 20
             server.handle_request()
+        if published is not None and not published.wait(5):
+            raise TimeoutError("Web producer did not finish publishing")
         status.put(("done", os.getpid()))
     except Exception:
         status.put(("error", traceback.format_exc()))
         raise
 
 
-def wxbot_process(path, sent, status, expected_messages):
+def polling_process(path, status, execution_count, trace_records, approved):
+    try:
+        configure_database(path)
+        published = configure_tracing(trace_records)
+        record = approval_record("approved" if approved else "rejected")
+        record["property"]["builtin_property"]["approval_trace_context"] = {
+            "traceparent": "00-" + "1" * 32 + "-" + "2" * 16 + "-01"
+        }
+        build_web_application(runtime_events(), execution_count, polling_record=record)()
+        # EOD can wake the drain before the producer's final publish callback.
+        # A real Web server stays alive; this short-lived fixture must too.
+        if not published.wait(5):
+            raise TimeoutError("Polling producer did not finish publishing")
+        status.put(("done", os.getpid()))
+    except Exception:
+        status.put(("error", traceback.format_exc()))
+        raise
+
+
+def wxbot_process(path, sent, status, expected_messages, trace_records=None, approval="approved"):
     try:
         configure_database(path)
         from aidev_wxbot.wxaibot.database_delivery import DatabaseResumeConsumer
+
+        if trace_records is not None:
+            configure_tracing(trace_records)
 
         count = 0
 
         async def send(target, body):
             nonlocal count
+            if trace_records is not None:
+                await traced_send(target, body)
             sent.put((target, body, os.getpid()))
             count += 1
 
@@ -223,7 +274,13 @@ def wxbot_process(path, sent, status, expected_messages):
                 if count >= expected_messages:
                     return
                 await asyncio.sleep(0.025)
-            raise TimeoutError("wxbot did not receive expected result")
+            from aidev_bkplugin.models import EventDelivery
+            from asgiref.sync import sync_to_async
+
+            states = await sync_to_async(list)(
+                EventDelivery.objects.values("status", "error_type", "progress", "attempts")
+            )
+            raise TimeoutError(f"wxbot sent {count}/{expected_messages}; delivery states={states}")
 
         with (
             patch(
@@ -232,7 +289,7 @@ def wxbot_process(path, sent, status, expected_messages):
             ),
             patch(
                 "aidev_wxbot.wxaibot.approval_notifications.SessionManager.list_session_contents",
-                return_value=[approval_record()],
+                return_value=[approval_record(approval)],
             ),
         ):
             asyncio.run(consume())
@@ -240,3 +297,56 @@ def wxbot_process(path, sent, status, expected_messages):
     except Exception:
         status.put(("error", traceback.format_exc()))
         raise
+
+
+def configure_tracing(records):
+    import threading
+
+    from aidev_agent.utils.tracing import set_agent_tracer
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
+
+    published = threading.Event()
+
+    class QueueExporter(SpanExporter):
+        def export(self, spans):
+            for span in spans:
+                records.put(
+                    {
+                        "name": span.name,
+                        "trace_id": format(span.context.trace_id, "032x"),
+                        "span_id": span.context.span_id,
+                        "parent_id": span.parent.span_id if span.parent else None,
+                    }
+                )
+                if (
+                    span.name == "database_event.publish"
+                    and span.attributes.get("event.name") == "AIDEV_CHAT_RESUME_FINISHED"
+                ):
+                    published.set()
+            return SpanExportResult.SUCCESS
+
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(QueueExporter()))
+    set_agent_tracer(provider.get_tracer("cross-process-test"))
+    return published
+
+
+async def traced_send(target, body):
+    """Use the production send span, with only the external socket/ACK replaced."""
+    from unittest.mock import AsyncMock
+
+    # Polling transport is unrelated to the long-connection sender under test.
+    with patch.dict(sys.modules, {"aidev_wxbot.utils.rabbitmq": MagicMock()}):
+        from aidev_wxbot.wxaibot.long_connection import WxAiBotLongConnectionService
+    from aidev_wxbot.wxaibot.tracing import record_ack
+
+    async def send_with_retry(send, span, _event):
+        record_ack(span, await send())
+
+    service = SimpleNamespace(
+        _shutdown_requested=False,
+        _send_with_retry=send_with_retry,
+        _client=SimpleNamespace(send_message=AsyncMock(return_value={"errcode": 0})),
+    )
+    await WxAiBotLongConnectionService._send_resume_message(service, target, body)

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_approval_delivery.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_approval_delivery.py
@@ -1,0 +1,84 @@
+import asyncio
+from datetime import timedelta
+
+import pytest
+from aidev_bkplugin.models import EventDelivery
+from django.utils import timezone
+
+from .process_helpers import approval_record
+
+
+@pytest.mark.parametrize("status,label", [("approved", "审批已通过"), ("rejected", "审批已拒绝")])
+def test_ready_reads_authoritative_decision_before_notifying(approval_delivery_case, status, label):
+    case = approval_delivery_case
+    case.history.return_value = [approval_record(status)]
+    case.bus.publish(case.event)
+    asyncio.run(case.consumer.consume_once())
+    target, body = case.send.call_args.args
+    assert target == "original-group"
+    assert body["template_card"]["jump_list"] == [{"type": 0, "title": label}]
+    assert EventDelivery.objects.get().status == "delivered"
+    assert EventDelivery.objects.get().progress == 1
+
+
+def test_retry_uses_frozen_notice_without_requerying_platform(approval_delivery_case):
+    from aidev_wxbot.wxaibot.database_delivery import DatabaseResumeConsumer
+
+    case = approval_delivery_case
+    case.bus.publish(case.event)
+    case.send.side_effect = [RuntimeError("send failed"), None]
+    asyncio.run(case.consumer.consume_once())
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == "pending" and delivery.progress == 0
+    assert len(delivery.route["approvalMessages"]) == 1
+    case.history.side_effect = RuntimeError("platform unavailable after restart")
+    EventDelivery.objects.update(available_at=timezone.now() - timedelta(seconds=1))
+    restarted = DatabaseResumeConsumer("app", "bot-original", case.send)
+    asyncio.run(restarted.consume_once())
+    assert case.send.call_args_list[0] == case.send.call_args_list[1]
+    case.history.assert_called_once_with("session-original")
+    assert EventDelivery.objects.get().status == "delivered"
+    assert not asyncio.run(restarted.consume_once())
+
+
+def test_unpersisted_decision_retries_without_claiming_approval(approval_delivery_case):
+    case = approval_delivery_case
+    case.history.return_value = [approval_record("pending")]
+    case.bus.publish(case.event)
+    asyncio.run(case.consumer.consume_once())
+    case.send.assert_not_called()
+    assert EventDelivery.objects.get().status == "pending"
+    assert "approvalMessages" not in EventDelivery.objects.get().route
+    case.history.return_value = [approval_record()]
+    EventDelivery.objects.update(available_at=timezone.now() - timedelta(seconds=1))
+    asyncio.run(case.consumer.consume_once())
+    assert case.send.call_count == 1
+    assert EventDelivery.objects.get().status == "delivered"
+
+
+@pytest.mark.parametrize("status", ["cancelled", "question"])
+def test_no_extra_approval_notice_for_cancel_or_ask_user(approval_delivery_case, status):
+    case = approval_delivery_case
+    record = approval_record("cancelled")
+    if status == "question":
+        record["content"]["outcome"]["interrupts"][0]["reason"] = "aidev:user_question"
+    case.history.return_value = [record]
+    case.bus.publish(case.event)
+    asyncio.run(case.consumer.consume_once())
+    case.send.assert_not_called()
+    assert EventDelivery.objects.get().status == "delivered"
+
+
+def test_expired_lease_cannot_freeze_or_send_notice(approval_delivery_case):
+    case = approval_delivery_case
+    case.bus.publish(case.event)
+
+    def expire_lease(_session):
+        EventDelivery.objects.update(lease_until=timezone.now() - timedelta(seconds=1))
+        return [approval_record()]
+
+    case.history.side_effect = expire_lease
+    asyncio.run(case.consumer.consume_once())
+    case.send.assert_not_called()
+    assert "approvalMessages" not in EventDelivery.objects.get().route
+    assert EventDelivery.objects.get().status != "delivered"

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_bus.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_bus.py
@@ -1,0 +1,143 @@
+from datetime import timedelta
+
+import pytest
+from aidev_bkplugin.models import EventDelivery
+from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
+from django.db import transaction
+from django.utils import timezone
+
+
+def test_publish_is_durable_idempotent_and_not_a_delivery_ack(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    DatabaseEventBus("app").publish(case.event.model_copy(deep=True))
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == "pending" and delivery.attempts == 0
+    assert delivery.route == {"target": "user"}
+    assert delivery.envelope["value"]["sessionCode"] == "session"
+
+
+def test_subscribers_receive_independent_deliveries(event_case):
+    case = event_case
+    case.bus.subscribe("audit", case.event.name, "session", property={})
+    case.bus.publish(case.event)
+    first = case.bus.claim("wxbot:test")
+    case.bus.acknowledge(first)
+    assert case.bus.claim("wxbot:test") is None
+    other = case.bus.claim("audit")
+    assert other and other.pk != first.pk and other.envelope == first.envelope
+
+
+@pytest.mark.parametrize("key,value", [("appCode", "other"), ("sessionCode", ""), ("eventId", "")])
+def test_invalid_scope_cannot_publish(event_case, key, value):
+    event_case.event.value[key] = value
+    with pytest.raises(ValueError):
+        event_case.bus.publish(event_case.event)
+    assert not EventDelivery.objects.exists()
+
+
+def test_unsubscribed_session_is_not_broadcast_and_app_isolation(event_case):
+    case = event_case
+    case.event.value["sessionCode"] = "unrelated"
+    case.bus.publish(case.event)
+    assert not EventDelivery.objects.exists()
+    case.event.value["sessionCode"] = "session"
+    case.bus.publish(case.event)
+    assert DatabaseEventBus("other-app").claim("wxbot:test") is None
+
+
+def test_rollback_does_not_leak_event(event_case):
+    with pytest.raises(RuntimeError), transaction.atomic():
+        event_case.bus.publish(event_case.event)
+        raise RuntimeError("roll back")
+    assert not EventDelivery.objects.exists()
+
+
+def test_existing_route_cannot_be_rebound_on_new_conversation(event_case):
+    case = event_case
+    with pytest.raises(ValueError, match="binding"):
+        case.bus.subscribe("wxbot:test", case.event.name, "session", property={"target": "other"})
+    assert case.subscription.property == {"target": "user"}
+
+
+def test_expired_lease_can_be_reclaimed_but_old_owner_cannot_ack(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    old = case.bus.claim("wxbot:test")
+    assert case.bus.claim("wxbot:test") is None
+    EventDelivery.objects.filter(pk=old.pk).update(lease_until=timezone.now() - timedelta(seconds=1))
+    new = DatabaseEventBus("app").claim("wxbot:test")
+    assert new.pk == old.pk and new.lease_token != old.lease_token
+    with pytest.raises(RuntimeError, match="lease lost"):
+        case.bus.acknowledge(old)
+    case.bus.acknowledge(new)
+
+
+def test_retry_preserves_progress_and_stores_no_exception_body(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    delivery = case.bus.claim("wxbot:test")
+    case.bus.checkpoint(delivery, 1)
+    case.bus.retry(delivery, RuntimeError("private response"))
+    delivery.refresh_from_db()
+    assert delivery.status == "pending" and delivery.progress == 1
+    assert delivery.error_type == "RuntimeError"
+    assert case.bus.claim("wxbot:test") is None
+
+
+def test_same_subscriber_does_not_overtake_retrying_event(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    first = case.bus.claim("wxbot:test")
+    next_event = case.event.model_copy(deep=True)
+    next_event.value["eventId"] = "event-2"
+    case.bus.publish(next_event)
+    case.bus.retry(first, RuntimeError())
+    assert case.bus.claim("wxbot:test") is None
+
+
+def test_exhausted_retry_is_visible_and_not_automatically_reexecuted(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    EventDelivery.objects.update(attempts=case.bus.MAX_ATTEMPTS - 1)
+    delivery = case.bus.claim("wxbot:test")
+    case.bus.retry(delivery, RuntimeError())
+    delivery.refresh_from_db()
+    assert delivery.status == "failed" and case.bus.claim("wxbot:test") is None
+
+
+def test_event_kinds_share_session_order_without_starving_other_sessions(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    first = case.bus.claim("wxbot:test")
+    case.bus.retry(first, RuntimeError())
+    case.bus.subscribe("wxbot:test", "OTHER_EVENT", "session", property={"target": "user"})
+    for number in range(55):
+        event = case.event.model_copy(deep=True)
+        event.name = "OTHER_EVENT"
+        event.value["eventId"] = f"later-{number}"
+        case.bus.publish(event)
+    case.bus.subscribe("wxbot:test", case.event.name, "another-session", property={"target": "user"})
+    event = case.event.model_copy(deep=True)
+    event.value.update(sessionCode="another-session", eventId="other-session-event")
+    case.bus.publish(event)
+    assert case.bus.claim("wxbot:test").envelope["value"]["sessionCode"] == "another-session"
+
+
+def test_disabled_subscription_cannot_send_or_ack_claimed_event(event_case):
+    case = event_case
+    case.bus.publish(case.event)
+    delivery = case.bus.claim("wxbot:test")
+    case.subscription.enabled = False
+    case.subscription.save(update_fields=["enabled"])
+    with pytest.raises(RuntimeError, match="lease lost"):
+        case.bus.checkpoint(delivery, 0)
+    with pytest.raises(RuntimeError, match="lease lost"):
+        case.bus.acknowledge(delivery)
+    assert case.bus.claim("wxbot:test") is None
+
+
+def test_event_migration_matches_models(db):
+    from django.core.management import call_command
+
+    call_command("makemigrations", "aidev_bkplugin", check=True, dry_run=True, verbosity=0)

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
@@ -1,5 +1,6 @@
 import json
 import multiprocessing
+import queue
 from contextlib import contextmanager
 from urllib.request import ProxyHandler, Request, build_opener
 
@@ -9,7 +10,7 @@ from aidev_bkplugin.models import EventDelivery
 from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
 from django.db import connection
 
-from .process_helpers import runtime_events, web_process, wxbot_process
+from .process_helpers import polling_process, runtime_events, web_process, wxbot_process
 
 
 @contextmanager
@@ -89,16 +90,89 @@ def assert_delivered_messages(case, web_pid, question):
         assert case.sent.get(timeout=2)[1]["template_card"]["card_type"] == "vote_interaction"
 
 
-def call_web(port, stream):
+def call_web(port, stream, traceparent="", approved=True):
     data = {
         "session_code": "session-original",
-        "resume": [{"interruptId": "approval-original", "status": "resolved"}],
+        "resume": [{"interruptId": "approval-original", "status": "resolved", "payload": {"approved": approved}}],
         "execute_kwargs": {"stream": stream},
     }
     request = Request(
         f"http://127.0.0.1:{port}/chat/",
         data=json.dumps(data).encode(),
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "traceparent": traceparent},
     )
     with build_opener(ProxyHandler({})).open(request, timeout=20) as response:
         return response.read().decode()
+
+
+@pytest.mark.parametrize("approved", [True, False])
+def test_http_trace_survives_separate_web_and_wxbot_processes(process_case, approved):
+    case = process_case
+    records = case.ctx.Queue()
+    web = case.ctx.Process(
+        target=web_process, args=(case.path, runtime_events(), case.web_status, case.executions, records)
+    )
+    wx = case.ctx.Process(
+        target=wxbot_process,
+        args=(case.path, case.sent, case.wx_status, 2, records, "approved" if approved else "rejected"),
+    )
+    with processes(web, wx):
+        web.start()
+        ready = case.web_status.get(timeout=20)
+        assert ready[0] == "ready", ready
+        wx.start()
+        call_web(ready[1], True, "00-" + "1" * 32 + "-" + "2" * 16 + "-01", approved)
+        assert case.web_status.get(timeout=20)[0] == "done"
+        assert case.wx_status.get(timeout=25)[0] == "done"
+    assert_trace_records(records)
+    assert EventDelivery.objects.filter(status="delivered").count() == 2
+    assert case.executions.value == 1
+    card = case.sent.get(timeout=2)[1]["template_card"]
+    assert card["jump_list"][0]["title"] == ("审批已通过" if approved else "审批已拒绝")
+
+
+@pytest.mark.parametrize("approved", [True, False])
+def test_polling_trace_survives_separate_web_and_wxbot_processes(process_case, approved):
+    case = process_case
+    records = case.ctx.Queue()
+    web = case.ctx.Process(
+        target=polling_process, args=(case.path, case.web_status, case.executions, records, approved)
+    )
+    wx = case.ctx.Process(
+        target=wxbot_process,
+        args=(case.path, case.sent, case.wx_status, 2, records, "approved" if approved else "rejected"),
+    )
+    with processes(web, wx):
+        wx.start()
+        web.start()
+        result = case.web_status.get(timeout=25)
+        assert result[0] == "done", result
+        result = case.wx_status.get(timeout=25)
+        assert result[0] == "done", result
+    assert_trace_records(records, entry_name="bkplugin.approval.resume")
+    assert EventDelivery.objects.filter(status="delivered").count() == 2
+    assert case.executions.value == 1
+    card = case.sent.get(timeout=2)[1]["template_card"]
+    assert card["jump_list"][0]["title"] == ("审批已通过" if approved else "审批已拒绝")
+
+
+def assert_trace_records(records, entry_name="bkplugin.chat.request"):
+    spans = []
+    while True:
+        try:
+            spans.append(records.get(timeout=0.2))
+        except queue.Empty:
+            break
+    expected = {
+        entry_name,
+        "database_event.publish",
+        "database_event.claim",
+        "wxbot.event.consume",
+        "wxbot.resume.send",
+    }
+    assert expected <= {span["name"] for span in spans}
+    assert all(span["trace_id"] == "1" * 32 for span in spans)
+    entry = next(span for span in spans if span["name"] == entry_name)
+    assert entry["parent_id"] == int("2" * 16, 16)
+    consumers = {span["span_id"] for span in spans if span["name"] == "wxbot.event.consume"}
+    assert all(span["parent_id"] in consumers for span in spans if span["name"] == "wxbot.resume.send")

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
@@ -59,7 +59,7 @@ def test_platform_http_callback_and_wxbot_receive_same_resume_once(process_case,
     web = case.ctx.Process(
         target=web_process, args=(case.path, runtime_events(question), case.web_status, case.executions)
     )
-    wx = case.ctx.Process(target=wxbot_process, args=(case.path, case.sent, case.wx_status, 2 if question else 1))
+    wx = case.ctx.Process(target=wxbot_process, args=(case.path, case.sent, case.wx_status, 3 if question else 2))
     with processes(web, wx):
         web.start()
         ready = case.web_status.get(timeout=20)
@@ -73,12 +73,20 @@ def test_platform_http_callback_and_wxbot_receive_same_resume_once(process_case,
             assert EventDelivery.objects.filter(status="pending").count() == 2
             wx.start()
         assert case.wx_status.get(timeout=25)[0] == "done"
-        target, body, wx_pid = case.sent.get(timeout=2)
-        assert target == "original-group" and "审批已完成，继续查询。" in body["markdown"]["content"]
-        assert wx_pid != ready[2] and case.executions.value == 1
-        if question:
-            assert case.sent.get(timeout=2)[1]["template_card"]["card_type"] == "vote_interaction"
+        assert_delivered_messages(case, ready[2], question)
         assert EventDelivery.objects.filter(status="delivered").count() == 2
+
+
+def assert_delivered_messages(case, web_pid, question):
+    target, body, wx_pid = case.sent.get(timeout=2)
+    assert target == "original-group"
+    assert body["template_card"]["jump_list"] == [{"type": 0, "title": "审批已通过"}]
+    assert "button_list" not in body["template_card"] and "task_id" not in body["template_card"]
+    target, body, _ = case.sent.get(timeout=2)
+    assert target == "original-group" and "审批已完成，继续查询。" in body["markdown"]["content"]
+    assert wx_pid != web_pid and case.executions.value == 1
+    if question:
+        assert case.sent.get(timeout=2)[1]["template_card"]["card_type"] == "vote_interaction"
 
 
 def call_web(port, stream):

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_cross_process.py
@@ -1,0 +1,96 @@
+import json
+import multiprocessing
+from contextlib import contextmanager
+from urllib.request import ProxyHandler, Request, build_opener
+
+import pytest
+from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+from aidev_bkplugin.models import EventDelivery
+from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
+from django.db import connection
+
+from .process_helpers import runtime_events, web_process, wxbot_process
+
+
+@contextmanager
+def processes(*workers):
+    try:
+        yield
+    finally:
+        for worker in workers:
+            if worker.pid is not None:
+                worker.join(timeout=25)
+                if worker.is_alive():
+                    worker.terminate()
+                    worker.join(timeout=5)
+
+
+@pytest.fixture
+def process_case(transactional_db):
+    import hashlib
+    from types import SimpleNamespace
+
+    subscriber = "wxbot:" + hashlib.sha256(b"bot-original").hexdigest()
+    for name in (AIDEV_CHAT_RESUME_READY, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_FAILED):
+        DatabaseEventBus("app").subscribe(
+            subscriber,
+            name,
+            "session-original",
+            property={
+                "username": "author",
+                "target": "original-group",
+                "sessionCode": "session-original",
+            },
+        )
+    ctx = multiprocessing.get_context("spawn")
+    return SimpleNamespace(
+        ctx=ctx,
+        path=connection.settings_dict["NAME"],
+        executions=ctx.Value("i", 0),
+        web_status=ctx.Queue(),
+        wx_status=ctx.Queue(),
+        sent=ctx.Queue(),
+    )
+
+
+@pytest.mark.parametrize("stream,question,offline", [(True, False, False), (False, False, False), (True, True, True)])
+def test_platform_http_callback_and_wxbot_receive_same_resume_once(process_case, stream, question, offline):
+    case = process_case
+    web = case.ctx.Process(
+        target=web_process, args=(case.path, runtime_events(question), case.web_status, case.executions)
+    )
+    wx = case.ctx.Process(target=wxbot_process, args=(case.path, case.sent, case.wx_status, 2 if question else 1))
+    with processes(web, wx):
+        web.start()
+        ready = case.web_status.get(timeout=20)
+        assert ready[0] == "ready", ready
+        if not offline:
+            wx.start()
+        response = call_web(ready[1], stream)
+        assert "审批已完成，继续查询。" in response
+        assert case.web_status.get(timeout=20)[0] == "done"
+        if offline:
+            assert EventDelivery.objects.filter(status="pending").count() == 2
+            wx.start()
+        assert case.wx_status.get(timeout=25)[0] == "done"
+        target, body, wx_pid = case.sent.get(timeout=2)
+        assert target == "original-group" and "审批已完成，继续查询。" in body["markdown"]["content"]
+        assert wx_pid != ready[2] and case.executions.value == 1
+        if question:
+            assert case.sent.get(timeout=2)[1]["template_card"]["card_type"] == "vote_interaction"
+        assert EventDelivery.objects.filter(status="delivered").count() == 2
+
+
+def call_web(port, stream):
+    data = {
+        "session_code": "session-original",
+        "resume": [{"interruptId": "approval-original", "status": "resolved"}],
+        "execute_kwargs": {"stream": stream},
+    }
+    request = Request(
+        f"http://127.0.0.1:{port}/chat/",
+        data=json.dumps(data).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+    with build_opener(ProxyHandler({})).open(request, timeout=20) as response:
+        return response.read().decode()

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
@@ -1,0 +1,24 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from aidev_bkplugin.services.event_resource_manager import EventResourceManager, with_database_events
+
+
+@pytest.mark.parametrize("enabled", [False, True])
+def test_injection_is_opt_in_and_preserves_original_resource_manager(settings, enabled):
+    settings.AIDEV_DATABASE_EVENTS_ENABLED = enabled
+    original = SimpleNamespace(username="author", get_agent_config=lambda: "custom-config")
+    wrapped = with_database_events(original, "app")
+    assert wrapped.get_agent_config() == "custom-config" and wrapped.username == "author"
+    assert isinstance(wrapped, EventResourceManager) == enabled
+    assert with_database_events(wrapped, "app") is wrapped
+
+
+def test_publishing_uses_injected_backend():
+    backend = Mock()
+    wrapped = EventResourceManager(object(), backend)
+    event = object()
+    wrapped.publish_event(event)
+    backend.publish.assert_called_once_with(event)
+    assert wrapped.event_publishing_enabled() is True

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
@@ -1,3 +1,4 @@
+import runpy
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -6,13 +7,30 @@ from aidev_bkplugin.services.event_resource_manager import EventResourceManager,
 
 
 @pytest.mark.parametrize("enabled", [False, True])
-def test_injection_is_opt_in_and_preserves_original_resource_manager(settings, enabled):
+def test_injection_respects_setting_and_preserves_original_resource_manager(settings, enabled):
     settings.AIDEV_DATABASE_EVENTS_ENABLED = enabled
     original = SimpleNamespace(username="author", get_agent_config=lambda: "custom-config")
     wrapped = with_database_events(original, "app")
     assert wrapped.get_agent_config() == "custom-config" and wrapped.username == "author"
     assert isinstance(wrapped, EventResourceManager) == enabled
     assert with_database_events(wrapped, "app") is wrapped
+
+
+@pytest.mark.parametrize("value, enabled", [(None, True), ("1", True), ("0", False), ("", False), ("true", False)])
+def test_database_events_environment_default_and_override(settings, monkeypatch, value, enabled):
+    monkeypatch.setenv("BKPAAS_ENGINE_REGION", "ieod")
+    if value is None:
+        monkeypatch.delenv("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", value)
+    config = runpy.run_module("aidev_bkplugin.settings")
+    settings.AIDEV_DATABASE_EVENTS_ENABLED = config["AIDEV_DATABASE_EVENTS_ENABLED"]
+    assert settings.AIDEV_DATABASE_EVENTS_ENABLED is enabled
+    original = object()
+    wrapped = with_database_events(original, "app")
+    assert isinstance(wrapped, EventResourceManager) is enabled
+    if not enabled:
+        assert wrapped is original
 
 
 @pytest.mark.parametrize("failing", [False, True])

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
@@ -15,10 +15,25 @@ def test_injection_is_opt_in_and_preserves_original_resource_manager(settings, e
     assert with_database_events(wrapped, "app") is wrapped
 
 
-def test_publishing_uses_injected_backend():
-    backend = Mock()
+@pytest.mark.parametrize("failing", [False, True])
+def test_publishing_cleans_producer_connections_even_on_error(monkeypatch, failing):
+    calls = []
+    monkeypatch.setattr(
+        "aidev_bkplugin.services.event_resource_manager.close_old_connections",
+        lambda: calls.append("cleanup"),
+    )
+
+    def publish(_event):
+        calls.append("publish")
+        if failing:
+            raise RuntimeError("database unavailable")
+
+    backend = Mock(publish=publish)
     wrapped = EventResourceManager(object(), backend)
-    event = object()
-    wrapped.publish_event(event)
-    backend.publish.assert_called_once_with(event)
+    if failing:
+        with pytest.raises(RuntimeError):
+            wrapped.publish_event(object())
+    else:
+        wrapped.publish_event(object())
+    assert calls == ["cleanup", "publish", "cleanup"]
     assert wrapped.event_publishing_enabled() is True

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_tracing.py
@@ -1,0 +1,59 @@
+import asyncio
+
+import pytest
+from aidev_agent.utils import tracing
+from aidev_bkplugin.models import EventDelivery
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture
+def spans(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("test"))
+    yield exporter
+    provider.shutdown()
+
+
+def test_publish_claim_consume_share_entry_trace(wx_delivery_case, spans):
+    case = wx_delivery_case
+    with tracing.recording_span("web.entry") as entry:
+        case.event.value["traceContext"] = tracing.trace_headers()
+    original = dict(case.event.value["traceContext"])
+    with tracing.recording_span("unrelated-worker"):
+        case.bus.publish(case.event)
+        case.bus.publish(case.event)  # tracing must not break idempotent publishing
+        asyncio.run(case.consumer.consume_once())
+    recorded = [
+        s
+        for s in spans.get_finished_spans()
+        if s.name in ("database_event.publish", "database_event.claim", "wxbot.event.consume")
+    ]
+    assert len(recorded) == 4
+    assert all(s.context.trace_id == entry.get_span_context().trace_id for s in recorded)
+    claim = next(s for s in recorded if s.name == "database_event.claim")
+    assert claim.attributes["messaging.message.age_ms"] >= 0
+    assert claim.attributes["messaging.receive.lookup.duration_ms"] >= 0
+    assert claim.attributes["messaging.delivery.attempt"] == 1
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == "delivered" and delivery.envelope["value"]["traceContext"] == original
+
+
+def test_empty_poll_does_not_create_unbounded_spans(event_case, spans):
+    assert event_case.bus.claim("wxbot:test") is None
+    assert not spans.get_finished_spans()
+
+
+def test_publish_failure_records_type_not_payload(event_case, spans):
+    case = event_case
+    case.bus.publish(case.event)
+    case.event.value["secret"] = "private-value"
+    with pytest.raises(ValueError):
+        case.bus.publish(case.event)
+    failed = spans.get_finished_spans()[-1]
+    assert failed.attributes["error.type"] == "ValueError"
+    assert failed.events == ()
+    assert "private-value" not in str(dict(failed.attributes))

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_wx_delivery.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_wx_delivery.py
@@ -1,0 +1,68 @@
+import asyncio
+from datetime import timedelta
+
+import pytest
+from aidev_bkplugin.models import EventDelivery
+from django.utils import timezone
+
+
+def test_send_failure_retries_from_last_successful_message(wx_delivery_case):
+    case = wx_delivery_case
+    case.event.value["events"][2]["delta"] = "A" * 8001
+    case.bus.publish(case.event)
+    case.send.side_effect = [None, RuntimeError("private failure"), None, None]
+    asyncio.run(case.consumer.consume_once())
+    delivery = EventDelivery.objects.get()
+    assert delivery.status == "pending" and delivery.progress == 1
+    EventDelivery.objects.update(available_at=timezone.now() - timedelta(seconds=1))
+    asyncio.run(case.consumer.consume_once())
+    delivery.refresh_from_db()
+    assert delivery.status == "delivered" and delivery.progress == 3
+    assert case.send.call_count == 4
+    assert all(call.args[0] == "original-group" for call in case.send.call_args_list)
+
+
+def test_rendering_again_yields_question_card_for_the_original_session(wx_delivery_case):
+    from aidev_wxbot.wxaibot.question_cards import decode_question_key
+
+    from .process_helpers import runtime_events
+
+    case = wx_delivery_case
+    case.event.value["events"] = runtime_events(question=True)
+    case.bus.publish(case.event)
+    asyncio.run(case.consumer.consume_once())
+    assert case.send.call_count == 2
+    card = case.send.call_args.args[1]["template_card"]
+    assert card["card_type"] == "vote_interaction"
+    assert decode_question_key(card["submit_button"]["key"]).session_code == "session-original"
+    assert EventDelivery.objects.get().status == "delivered"
+
+
+def test_mismatched_route_is_never_sent(wx_delivery_case):
+    case = wx_delivery_case
+    case.bus.publish(case.event)
+    EventDelivery.objects.update(route={"target": "other", "username": "author", "sessionCode": "other-session"})
+    asyncio.run(case.consumer.consume_once())
+    case.send.assert_not_called()
+    assert EventDelivery.objects.get().status == "pending"
+
+
+def test_restart_after_success_does_not_send_again(wx_delivery_case):
+    from aidev_wxbot.wxaibot.database_delivery import DatabaseResumeConsumer
+
+    case = wx_delivery_case
+    case.bus.publish(case.event)
+    asyncio.run(case.consumer.consume_once())
+    new_consumer = DatabaseResumeConsumer("app", "bot-original", case.send)
+    assert not asyncio.run(new_consumer.consume_once())
+    assert case.send.call_count == 1
+
+
+def test_cancelled_sender_is_not_acknowledged(wx_delivery_case):
+    case = wx_delivery_case
+    case.bus.publish(case.event)
+    case.send.side_effect = asyncio.CancelledError()
+    with pytest.raises(asyncio.CancelledError):
+        asyncio.run(case.consumer.consume_once())
+    assert EventDelivery.objects.get().status == "processing"
+    assert EventDelivery.objects.get().progress == 0

--- a/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
@@ -103,6 +103,20 @@ def test_save_content_generates_turn_id_for_user(session_manager, mock_plugin_rm
     assert saved["property"]["turn_id"] == payload["property"]["turn_id"]
 
 
+def test_save_content_keeps_entry_trace(mock_plugin_rm_client, mocker):
+    from aidev_bkplugin.services.agent_session import SessionManager
+
+    current = mocker.patch("aidev_bkplugin.services.agent_session.get_current_trace_id", return_value="a" * 32)
+    manager = SessionManager("test")
+    current.return_value = "b" * 32
+    mock_plugin_rm_client.api.create_chat_session_content.return_value = {"data": {"id": 1}}
+
+    manager.save_content("sc-1", "user", "hello", turn_id="turn-1")
+
+    payload = mock_plugin_rm_client.api.create_chat_session_content.call_args.kwargs["json"]
+    assert payload["property"] == {"turn_id": "turn-1", "trace_id": "a" * 32}
+
+
 def test_set_flow_resume_pending_preserves_existing_fields(session_manager, mock_plugin_rm_client):
     """read-modify-write：仅叠加 resume_pending，保留 flow_info 其它字段与同级属性。"""
     mock_plugin_rm_client.api.retrieve_chat_session.return_value = {

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume_tracing.py
@@ -1,0 +1,59 @@
+"""Polling resumes use the callback's durable parent, including lazy execution."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.services.agent.approval import ApprovalStateHandler
+from aidev_agent.utils import tracing
+from aidev_bkplugin.services import approval_resume
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+@pytest.fixture
+def resume_case(monkeypatch):
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("test"))
+    monkeypatch.setattr(ApprovalStateHandler, "check_resume", lambda *_: True)
+    monkeypatch.setattr(approval_resume, "AgentBuilder", MagicMock())
+    executor = MagicMock()
+    monkeypatch.setattr(approval_resume, "AgentExecutor", executor)
+    seen = []
+
+    def delayed(*args):
+        seen.extend([tracing.trace_headers(), args[1].caller_trace_context])
+        yield "done"
+
+    executor.return_value.execute_with_save.side_effect = delayed
+    yield exporter, seen
+    provider.shutdown()
+
+
+@pytest.mark.parametrize("result", ["approved", "rejected"])
+@pytest.mark.parametrize("valid", [True, False])
+def test_polling_restores_callback_parent_through_lazy_drain(resume_case, monkeypatch, result, valid):
+    exporter, seen = resume_case
+    carrier = {"traceparent": "00-" + "1" * 32 + "-" + "2" * 16 + "-01"} if valid else {}
+    record = {"property": {"builtin_property": {"approve_result": result, "approval_trace_context": carrier}}}
+    monkeypatch.setattr(ApprovalStateHandler, "_get_latest_interrupt_record", lambda *_: record)
+    with tracing.recording_span("unrelated-worker") as worker:
+        approval_resume._approval_resume_worker("session", "author", "thread", [{"id": "approval"}])
+        assert tracing.get_current_trace_id() == format(worker.get_span_context().trace_id, "032x")
+    resumed = next(s for s in exporter.get_finished_spans() if s.name == "bkplugin.approval.resume")
+    assert resumed.context.trace_id != worker.get_span_context().trace_id
+    assert (resumed.parent.span_id if resumed.parent else None) == (int("2" * 16, 16) if valid else None)
+    assert seen == [{"traceparent": f"00-{resumed.context.trace_id:032x}-{resumed.context.span_id:016x}-01"}] * 2
+
+
+@pytest.mark.parametrize("nested", [True, False])
+def test_approval_reader_keeps_callback_context_from_same_record(monkeypatch, nested):
+    fields = {"approve_result": "approved", "approval_trace_context": {"traceparent": "stored-parent"}}
+    record = {"property": {"builtin_property": fields}} if nested else fields
+    monkeypatch.setattr(ApprovalStateHandler, "_get_latest_interrupt_record", lambda *_: record)
+    assert (
+        ApprovalStateHandler().fetch_approve_result("session")["approval_trace_context"]
+        == fields["approval_trace_context"]
+    )

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_cards.py
@@ -117,6 +117,11 @@ def bind_approval_target(card: dict, target: str) -> dict:
 
 
 def build_cancel_result_card(action: ApprovalCancelAction, task_id: str, *, result: Any) -> dict[str, Any] | None:
+    """Compatibility entry point for cancellation callbacks."""
+    return build_approval_result_card(action, task_id, result=result)
+
+
+def build_approval_result_card(action: ApprovalCancelAction, task_id: str, *, result: Any) -> dict[str, Any] | None:
     """用平台返回的原审批详情更新操作区；信息不完整时保留企微原卡片。
 
     ``ok=False`` 也可能表示审批已经结束，应展示实际结果而非“取消失败”。

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_notifications.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/approval_notifications.py
@@ -1,0 +1,58 @@
+"""Render persisted approval decisions, never infer approval from a resume event."""
+
+from aidev_agent.services.agent.approval import ApprovalStateHandler
+from aidev_bkplugin.services.agent_session import SessionManager
+
+from .approval_cards import ApprovalCancelAction, approval_task_id, build_approval_result_card
+
+
+def approval_result_messages(session_code: str, interrupt_ids: list[str], username: str) -> list[dict]:
+    """Read as the original user and match the exact resumed approvals, including old ones.
+
+    A session can already be waiting for another approval or question by the time
+    this consumer runs. Reading only its latest interrupt would report the wrong
+    decision. No callback tokens, candidate approvers or tool arguments leave here.
+    """
+    if not interrupt_ids:
+        return []
+    records = SessionManager(username=username).list_session_contents(session_code)
+    if not isinstance(records, list):
+        raise ValueError("Invalid approval history response")
+    requested = set(interrupt_ids)
+    found = set()
+    decisions = {}
+    for record in records:
+        if not isinstance(record, dict) or record.get("role") != "interrupt":
+            continue
+        if record.get("session_code", session_code) != session_code:
+            continue
+        interrupts = ApprovalStateHandler._extract_interrupts_from_content(record.get("content"))
+        for interrupt in interrupts:
+            if not isinstance(interrupt, dict) or interrupt.get("id") not in requested:
+                continue
+            found.add(interrupt["id"])
+            if interrupt.get("reason") != "aidev:tool_approval":
+                continue
+            status = ApprovalStateHandler._extract_builtin_property(record).get("approve_result")
+            if status not in ("approved", "rejected", "cancelled"):
+                raise ValueError("Approval decision is not persisted yet")
+            decision = {"approve_result": status, "interrupts": [interrupt]}
+            previous = decisions.setdefault(interrupt["id"], decision)
+            if previous != decision:
+                raise ValueError("Conflicting approval decision records")
+    if requested - found:
+        raise ValueError("Resumed interrupt history is not available yet")
+
+    messages = []
+    for interrupt_id in sorted(decisions):
+        result = decisions[interrupt_id]
+        if result["approve_result"] == "cancelled":
+            continue  # Cancellation is already acknowledged on the clicked card.
+        action = ApprovalCancelAction(session_code, interrupt_id)
+        card = build_approval_result_card(action, approval_task_id(action), result=result)
+        if card is None:
+            raise ValueError("Approval decision has no renderable ticket")
+        # This is a new notice, not a remote replacement of the original card.
+        card.pop("task_id", None)
+        messages.append({"msgtype": "template_card", "template_card": card})
+    return messages

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database.py
@@ -1,13 +1,27 @@
 """Django 请求周期之外的同步后台任务数据库连接边界。"""
 
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import closing, contextmanager
 from typing import ParamSpec, TypeVar
 
-from django.db import close_old_connections
+from django.db import DatabaseError, InterfaceError, close_old_connections, connections
 
 P = ParamSpec("P")
 T = TypeVar("T")
+
+
+def _close_unusable_connections() -> None:
+    """探测当前线程已有连接，覆盖尚未被 Django 标记的断连。"""
+    for connection in connections.all(initialized_only=True):
+        if connection.connection is None or connection.in_atomic_block or not connection.get_autocommit():
+            continue
+        try:
+            # 直接探测旧 socket，不用 PyMySQL ping 的隐式重连，避免跳过
+            # Django 新连接的会话初始化；也不为未使用的数据库建立连接。
+            with connection.wrap_database_errors, closing(connection.connection.cursor()) as cursor:
+                cursor.execute("SELECT 1")
+        except (DatabaseError, InterfaceError):
+            connection.close()
 
 
 @contextmanager
@@ -16,10 +30,12 @@ def database_connection_scope() -> Iterator[None]:
 
     Django 连接按线程隔离，不能在事件循环中替其他线程清理。任务结束即使
     异常被内部捕获，也要检查连接状态，避免下一次复用同一线程时持续失败。
-    保留 Django 的连接复用策略，不无条件关闭健康连接。
+    在请求/任务边界（事务外）使用。入口探测已有连接，保留健康连接的复用；
+    探测成功后仍可能断连，业务异常原样交给调用方，不重放业务。
     """
     try:
         close_old_connections()
+        _close_unusable_connections()
         yield
     finally:
         close_old_connections()

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
@@ -7,8 +7,9 @@ import logging
 
 from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
 from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
-from django.db import close_old_connections, transaction
+from django.db import transaction
 
+from .database import database_connection_scope, run_with_database_connections
 from .direct_stream import AgentStream, iter_direct_stream_frames
 from .resume_delivery import markdown_parts
 from .tracing import CONSUMER, resumed_event_context, wxbot_span
@@ -23,21 +24,18 @@ def subscriber_name(bot_id: str) -> str:
     return "wxbot:" + hashlib.sha256(bot_id.encode()).hexdigest()
 
 
+@database_connection_scope()
 def bind_resume_subscription(app_code: str, bot_id: str, session_code: str, username: str, target: str) -> None:
     if not username or not target:
         raise ValueError("Missing trusted original WeCom recipient")
-    try:
-        close_old_connections()
-        with transaction.atomic():
-            for name in RESUME_EVENTS:
-                DatabaseEventBus(app_code).subscribe(
-                    subscriber_name(bot_id),
-                    name,
-                    session_code,
-                    property={"username": username, "target": target, "sessionCode": session_code},
-                )
-    finally:
-        close_old_connections()
+    with transaction.atomic():
+        for name in RESUME_EVENTS:
+            DatabaseEventBus(app_code).subscribe(
+                subscriber_name(bot_id),
+                name,
+                session_code,
+                property={"username": username, "target": target, "sessionCode": session_code},
+            )
 
 
 def result_messages(envelope: dict) -> list[dict]:
@@ -67,14 +65,6 @@ def result_messages(envelope: dict) -> list[dict]:
     return messages
 
 
-def _database_call(func, *args):
-    try:
-        close_old_connections()
-        return func(*args)
-    finally:
-        close_old_connections()
-
-
 class DatabaseResumeConsumer:
     def __init__(self, app_code: str, bot_id: str, send):
         self.bus = DatabaseEventBus(app_code)
@@ -82,7 +72,7 @@ class DatabaseResumeConsumer:
         self.send = send
 
     async def consume_once(self) -> bool:
-        delivery = await asyncio.to_thread(_database_call, self.bus.claim, self.subscriber)
+        delivery = await asyncio.to_thread(run_with_database_connections, self.bus.claim, self.subscriber)
         if delivery is None:
             return False
         try:
@@ -105,13 +95,13 @@ class DatabaseResumeConsumer:
                     raise ValueError("Invalid event recipient binding")
                 messages = await asyncio.to_thread(result_messages, delivery.envelope)
                 for index in range(delivery.progress, len(messages)):
-                    await asyncio.to_thread(_database_call, self.bus.checkpoint, delivery, index)
+                    await asyncio.to_thread(run_with_database_connections, self.bus.checkpoint, delivery, index)
                     await asyncio.wait_for(self.send(delivery.route["target"], messages[index]), timeout=45)
-                    await asyncio.to_thread(_database_call, self.bus.checkpoint, delivery, index + 1)
-                await asyncio.to_thread(_database_call, self.bus.acknowledge, delivery)
+                    await asyncio.to_thread(run_with_database_connections, self.bus.checkpoint, delivery, index + 1)
+                await asyncio.to_thread(run_with_database_connections, self.bus.acknowledge, delivery)
                 logger.info("event=wxbot_event_delivered event_name=%s", delivery.envelope["name"])
         except Exception as error:
-            await asyncio.to_thread(_database_call, self.bus.retry, delivery, error)
+            await asyncio.to_thread(run_with_database_connections, self.bus.retry, delivery, error)
         # CancelledError leaves the lease unacknowledged for another process after expiry.
         return True
 

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
@@ -1,0 +1,125 @@
+"""Consume producer-owned events; never call chat/Agent to deliver a result."""
+
+import asyncio
+import hashlib
+import json
+import logging
+
+from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
+from django.db import close_old_connections, transaction
+
+from .direct_stream import AgentStream, iter_direct_stream_frames
+from .resume_delivery import markdown_parts
+from .tracing import CONSUMER, resumed_event_context, wxbot_span
+
+logger = logging.getLogger(__name__)
+RESUME_EVENTS = (AIDEV_CHAT_RESUME_READY, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_FAILED)
+
+
+def subscriber_name(bot_id: str) -> str:
+    if not bot_id:
+        raise ValueError("Missing WeCom bot identity")
+    return "wxbot:" + hashlib.sha256(bot_id.encode()).hexdigest()
+
+
+def bind_resume_subscription(app_code: str, bot_id: str, session_code: str, username: str, target: str) -> None:
+    if not username or not target:
+        raise ValueError("Missing trusted original WeCom recipient")
+    try:
+        close_old_connections()
+        with transaction.atomic():
+            for name in RESUME_EVENTS:
+                DatabaseEventBus(app_code).subscribe(
+                    subscriber_name(bot_id),
+                    name,
+                    session_code,
+                    property={"username": username, "target": target, "sessionCode": session_code},
+                )
+    finally:
+        close_old_connections()
+
+
+def result_messages(envelope: dict) -> list[dict]:
+    """Reuse the same AG-UI renderer/card protocol as ordinary long-connection replies."""
+    name, value = envelope["name"], envelope["value"]
+    if name == AIDEV_CHAT_RESUME_READY:
+        return []  # Notification/audit only; never equate READY with approval granted.
+    if name not in RESUME_EVENTS:
+        raise ValueError("Unsupported wxbot event")
+    if not value.get("persisted"):
+        return [{"msgtype": "markdown", "markdown": {"content": "会话恢复未完成，请返回原会话查看。"}}]
+    events = value.get("events") or []
+    if not any(e.get("type") == "RUN_FINISHED" for e in events):
+        raise ValueError("Resume result has no terminal event")
+    chunks = ("data: " + json.dumps(event, ensure_ascii=False) + "\n\n" for event in events)
+    interrupt_id = next(iter(value.get("interruptIds") or []), "")
+    stream = AgentStream("chat", chunks, value["sessionCode"], resume_interrupt_id=interrupt_id)
+    final = None
+    for frame in iter_direct_stream_frames(stream, value["eventId"]):
+        if frame.finish:
+            final = frame
+    if final is None:
+        raise ValueError("Resume result did not render a final frame")
+    messages = [{"msgtype": "markdown", "markdown": {"content": part}} for part in markdown_parts(final.content)]
+    if final.template_card:
+        messages.append({"msgtype": "template_card", "template_card": final.template_card})
+    return messages
+
+
+def _database_call(func, *args):
+    try:
+        close_old_connections()
+        return func(*args)
+    finally:
+        close_old_connections()
+
+
+class DatabaseResumeConsumer:
+    def __init__(self, app_code: str, bot_id: str, send):
+        self.bus = DatabaseEventBus(app_code)
+        self.subscriber = subscriber_name(bot_id)
+        self.send = send
+
+    async def consume_once(self) -> bool:
+        delivery = await asyncio.to_thread(_database_call, self.bus.claim, self.subscriber)
+        if delivery is None:
+            return False
+        try:
+            with (
+                resumed_event_context(delivery.envelope["value"].get("traceContext") or {}),
+                wxbot_span(
+                    "wxbot.event.consume",
+                    kind=CONSUMER,
+                    attributes={"event.name": delivery.envelope["name"]},
+                ),
+            ):
+                value = delivery.envelope["value"]
+                if (
+                    value.get("schemaVersion") != 1
+                    or value.get("appCode") != self.bus.app_code
+                    or value.get("sessionCode") != delivery.route.get("sessionCode")
+                    or not delivery.route.get("target")
+                    or not delivery.route.get("username")
+                ):
+                    raise ValueError("Invalid event recipient binding")
+                messages = await asyncio.to_thread(result_messages, delivery.envelope)
+                for index in range(delivery.progress, len(messages)):
+                    await asyncio.to_thread(_database_call, self.bus.checkpoint, delivery, index)
+                    await asyncio.wait_for(self.send(delivery.route["target"], messages[index]), timeout=45)
+                    await asyncio.to_thread(_database_call, self.bus.checkpoint, delivery, index + 1)
+                await asyncio.to_thread(_database_call, self.bus.acknowledge, delivery)
+                logger.info("event=wxbot_event_delivered event_name=%s", delivery.envelope["name"])
+        except Exception as error:
+            await asyncio.to_thread(_database_call, self.bus.retry, delivery, error)
+        # CancelledError leaves the lease unacknowledged for another process after expiry.
+        return True
+
+    async def run(self, available, stopping) -> None:
+        while not stopping():
+            try:
+                if available() and await self.consume_once():
+                    continue
+            except Exception as error:
+                logger.warning("event=wxbot_event_poll_failed error_type=%s", type(error).__name__)
+            await asyncio.sleep(1)

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/database_delivery.py
@@ -6,9 +6,12 @@ import json
 import logging
 
 from aidev_agent.events import AIDEV_CHAT_RESUME_FAILED, AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+from aidev_bkplugin.models import EventDelivery
 from aidev_bkplugin.services.database_event_bus import DatabaseEventBus
 from django.db import transaction
+from django.utils import timezone
 
+from .approval_notifications import approval_result_messages
 from .database import database_connection_scope, run_with_database_connections
 from .direct_stream import AgentStream, iter_direct_stream_frames
 from .resume_delivery import markdown_parts
@@ -42,7 +45,7 @@ def result_messages(envelope: dict) -> list[dict]:
     """Reuse the same AG-UI renderer/card protocol as ordinary long-connection replies."""
     name, value = envelope["name"], envelope["value"]
     if name == AIDEV_CHAT_RESUME_READY:
-        return []  # Notification/audit only; never equate READY with approval granted.
+        return []  # Approval notices need a separate authoritative history read.
     if name not in RESUME_EVENTS:
         raise ValueError("Unsupported wxbot event")
     if not value.get("persisted"):
@@ -71,6 +74,32 @@ class DatabaseResumeConsumer:
         self.subscriber = subscriber_name(bot_id)
         self.send = send
 
+    @database_connection_scope()
+    def _prepare_messages(self, delivery) -> list[dict]:
+        if delivery.envelope["name"] != AIDEV_CHAT_RESUME_READY:
+            return result_messages(delivery.envelope)
+        if "approvalMessages" in delivery.route:
+            return delivery.route["approvalMessages"]
+        value = delivery.envelope["value"]
+        messages = approval_result_messages(
+            value["sessionCode"], value.get("interruptIds") or [], delivery.route["username"]
+        )
+        # Freeze the rendered notice before the first send. Retrying (or another
+        # process) must not change message indexes if history/config later changes.
+        route = {**delivery.route, "approvalMessages": messages}
+        updated = EventDelivery.objects.filter(
+            pk=delivery.pk,
+            status="processing",
+            lease_token=delivery.lease_token,
+            lease_until__gt=timezone.now(),
+            subscription__enabled=True,
+            subscription__app_code=self.bus.app_code,
+        ).update(route=route)
+        if not updated:
+            raise RuntimeError("Event delivery lease lost")
+        delivery.route = route
+        return messages
+
     async def consume_once(self) -> bool:
         delivery = await asyncio.to_thread(run_with_database_connections, self.bus.claim, self.subscriber)
         if delivery is None:
@@ -93,7 +122,7 @@ class DatabaseResumeConsumer:
                     or not delivery.route.get("username")
                 ):
                     raise ValueError("Invalid event recipient binding")
-                messages = await asyncio.to_thread(result_messages, delivery.envelope)
+                messages = await asyncio.to_thread(self._prepare_messages, delivery)
                 for index in range(delivery.progress, len(messages)):
                     await asyncio.to_thread(run_with_database_connections, self.bus.checkpoint, delivery, index)
                     await asyncio.wait_for(self.send(delivery.route["target"], messages[index]), timeout=45)

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -33,7 +33,7 @@ from django.conf import settings
 from .approval_cards import (
     approval_task_id,
     bind_approval_target,
-    build_cancel_result_card,
+    build_approval_result_card,
     decode_cancel_event_key,
 )
 from .approval_resume import submit_cancelled_approval_resume
@@ -540,7 +540,7 @@ class WxAiBotLongConnectionService:
                     },
                 )
                 succeeded = isinstance(envelope, dict) and envelope.get("ok") is True
-                result_card = build_cancel_result_card(
+                result_card = build_approval_result_card(
                     action, task_id, result=envelope.get("result") if isinstance(envelope, dict) else None
                 )
                 if not succeeded and result_card is None:

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -316,6 +316,7 @@ class WxAiBotLongConnectionService:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._shutdown_task: asyncio.Task[None] | None = None
         self._health_task: asyncio.Task[None] | None = None
+        self._event_consumer_task: asyncio.Task[None] | None = None
         self._authenticated_event: asyncio.Event | None = None
         self._startup_failed_event: asyncio.Event | None = None
         self._startup_error: Exception | None = None
@@ -342,6 +343,7 @@ class WxAiBotLongConnectionService:
             logger.info("[WxAiBot-WS] 长连接认证成功")
             self._set_async_event(self._authenticated_event)
             self._ensure_health_task()
+            self._ensure_event_consumer()
 
         @self._client.on("disconnected")
         def _on_disconnected(reason: str) -> None:
@@ -555,7 +557,10 @@ class WxAiBotLongConnectionService:
             delivery = None
             try:
                 if action.target and target:
-                    delivery = self._new_resume_delivery(frame, "tool_approval")
+                    if self._database_events_enabled():
+                        await asyncio.to_thread(self._bind_resume_route, action.session_code, username, target)
+                    else:
+                        delivery = self._new_resume_delivery(frame, "tool_approval")
                 with wxbot_span("wxbot.approval.resume.submit"):
                     submitted = submit_cancelled_approval_resume(action, username, envelope, delivery)
                 if not submitted and delivery is not None:
@@ -568,6 +573,31 @@ class WxAiBotLongConnectionService:
                     delivery.finish()
                 logger.error("event=wxbot_approval_resume_submit_failed error_type=%s", type(error).__name__)
         return True
+
+    @staticmethod
+    def _database_events_enabled() -> bool:
+        return getattr(settings, "AIDEV_DATABASE_EVENTS_ENABLED", False) is True
+
+    def _bind_resume_route(self, session_code: str, username: str, target: str) -> None:
+        from .database_delivery import bind_resume_subscription
+
+        bind_resume_subscription(settings.APP_CODE, self._config.bot_id, session_code, username, target)
+
+    def _ensure_event_consumer(self) -> None:
+        if not self._database_events_enabled():
+            return
+        task = getattr(self, "_event_consumer_task", None)
+        if task is not None and not task.done():
+            return
+        from .database_delivery import DatabaseResumeConsumer
+
+        consumer = DatabaseResumeConsumer(settings.APP_CODE, self._config.bot_id, self._send_resume_message)
+        self._event_consumer_task = asyncio.create_task(
+            consumer.run(
+                lambda: bool(self._client.is_connected),
+                lambda: self._shutdown_requested,
+            )
+        )
 
     def _new_resume_delivery(self, frame: dict, resume_type: str, *, paused: bool = False) -> ResumeDelivery:
         target = self._resolve_message_target(frame)
@@ -638,9 +668,12 @@ class WxAiBotLongConnectionService:
                 username,
                 card_event.get("selected_items") or {},
             )
-            delivery = self._new_resume_delivery(frame, "ask_user_question", paused=True)
+            if self._database_events_enabled():
+                await asyncio.to_thread(self._bind_resume_route, action.session_code, username, target)
+            else:
+                delivery = self._new_resume_delivery(frame, "ask_user_question", paused=True)
             status = await asyncio.to_thread(submit_question_resume, submission, delivery)
-            if status != "accepted":
+            if status != "accepted" and delivery is not None:
                 delivery.close()
             if status == "busy":
                 await self._send_resume_message(
@@ -663,7 +696,8 @@ class WxAiBotLongConnectionService:
             except Exception as error:
                 logger.warning("event=wxbot_question_card_update_failed error_type=%s", type(error).__name__)
             finally:
-                delivery.activate()
+                if delivery is not None:
+                    delivery.activate()
         except Exception as error:
             if delivery is not None:
                 delivery.close()
@@ -941,6 +975,10 @@ class WxAiBotLongConnectionService:
                 retry_strategy=WECOM_AGENT_RETRY_STRATEGY,
             )
             stream_registry.register(request.stream_id, agent_stream.session_code)
+            if self._database_events_enabled() and agent_stream.kind == "chat":
+                active = self._active_streams.get(request.stream_id)
+                target = self._resolve_message_target(active.frame) if active else ""
+                self._bind_resume_route(agent_stream.session_code, request.username, target)
             frames = iter_direct_stream_frames(
                 agent_stream,
                 request.stream_id,
@@ -1321,6 +1359,10 @@ class WxAiBotLongConnectionService:
                 self._loop.stop()
 
     async def _graceful_shutdown(self) -> None:
+        event_task = getattr(self, "_event_consumer_task", None)
+        if event_task is not None:
+            event_task.cancel()
+            await asyncio.gather(event_task, return_exceptions=True)
         deliveries = tuple(getattr(self, "_resume_deliveries", ()))
         for delivery in deliveries:
             delivery.close()
@@ -1405,6 +1447,7 @@ class WxAiBotLongConnectionService:
         self._group_streams.clear()
         self._shutdown_task = None
         self._health_task = None
+        self._event_consumer_task = None
         self._authenticated_event = None
         self._startup_failed_event = None
 

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/question_resume.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/question_resume.py
@@ -147,19 +147,25 @@ def _question_worker(submission: QuestionSubmission, delivery, key: str) -> None
                 submission.action.session_code,
                 builder.session_manager,
                 turn_id=submission.turn_id,
-                consume_stream=lambda output: delivery.consume(
-                    output,
-                    submission.action.session_code,
-                    submission.action.interrupt_id,
-                    submission.turn_id,
-                    thread_id=submission.graph_thread_id,
-                ),
+                consume_stream=(
+                    lambda output: delivery.consume(
+                        output,
+                        submission.action.session_code,
+                        submission.action.interrupt_id,
+                        submission.turn_id,
+                        thread_id=submission.graph_thread_id,
+                    )
+                )
+                if delivery is not None
+                else None,
             )
             cache.set(key, "completed", timeout=MAX_AGE)
             logger.info("event=wxbot_question_resume_finished")
         except Exception as error:
             logger.error("event=wxbot_question_resume_failed error_type=%s", type(error).__name__)
-            delivery.failed()
+            if delivery is not None:
+                delivery.failed()
         finally:
             close_old_connections()
-            delivery.finish()
+            if delivery is not None:
+                delivery.finish()

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/resume_delivery.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/resume_delivery.py
@@ -8,10 +8,6 @@ This process-local adapter is not an outbox for external approval callbacks.
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Iterator
-from datetime import datetime, timezone
-
-from ag_ui.core import CustomEvent
-from aidev_agent.events import AIDEV_CHAT_RESUME_READY, EventPublisher, LocalEventBus
 
 from .direct_stream import AgentStream, iter_direct_stream_frames
 
@@ -49,12 +45,9 @@ class ResumeDelivery:
         self._sending_allowed = asyncio.Event()
         if not paused:
             self._sending_allowed.set()
-        self._bus = LocalEventBus()
-        self.publisher: EventPublisher = self._bus
-        self._unsubscribe = self._bus.subscribe(AIDEV_CHAT_RESUME_READY, self._on_ready)
         self.task = asyncio.create_task(self._consume_messages())
 
-    def _on_ready(self, event: CustomEvent) -> None:
+    def _on_ready(self) -> None:
         # The updated approval card already confirms cancellation; READY still
         # remains available to other listeners without sending another notice.
         if self._resume_type == "tool_approval":
@@ -86,22 +79,7 @@ class ResumeDelivery:
             if ready or not run_id:
                 return
             ready = True
-            self.publisher.publish(
-                CustomEvent(
-                    name=AIDEV_CHAT_RESUME_READY,
-                    value={
-                        "schemaVersion": 1,
-                        "eventId": f"{run_id}:resume-ready",
-                        "occurredAt": datetime.now(timezone.utc).isoformat(),
-                        "sessionCode": session_code,
-                        "threadId": thread_id,
-                        "runId": run_id,
-                        "turnId": turn_id,
-                        "interruptId": interrupt_id,
-                        "resumeType": self._resume_type,
-                    },
-                )
-            )
+            self._on_ready()
 
         last = None
         try:
@@ -133,7 +111,6 @@ class ResumeDelivery:
 
     def close(self) -> None:
         self._closed = True
-        self._unsubscribe()
         self.task.cancel()
 
     async def _consume_messages(self) -> None:
@@ -152,4 +129,3 @@ class ResumeDelivery:
             logger.error("event=wxbot_resume_delivery_failed error_type=%s", type(error).__name__)
         finally:
             self._closed = True
-            self._unsubscribe()

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/tracing.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/tracing.py
@@ -95,6 +95,20 @@ def wxbot_span(name: str, *, root: bool = False, kind=None, attributes: dict | N
 
 
 @contextmanager
+def resumed_event_context(carrier: dict) -> Iterator[None]:
+    """Continue the producer trace across a durable event; never carry baggage."""
+    if not context or not TraceContextTextMapPropagator:
+        yield
+        return
+    safe = {key: carrier[key] for key in ("traceparent", "tracestate") if isinstance(carrier.get(key), str)}
+    token = context.attach(TraceContextTextMapPropagator().extract(safe))
+    try:
+        yield
+    finally:
+        context.detach(token)
+
+
+@contextmanager
 def received_message_span(frame: dict) -> Iterator[None]:
     payload = frame.get("body") or {}
     msgtype = payload.get("msgtype") if isinstance(payload, dict) else None

--- a/src/plugins/aidev_wxbot/tests/wxaibot/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/conftest.py
@@ -71,6 +71,27 @@ def approval_card_case(monkeypatch):
 
 
 @pytest.fixture
+def approval_notification_case(approval_card_case, monkeypatch):
+    from aidev_wxbot.wxaibot import approval_notifications as module
+
+    case = approval_card_case
+    case.record = {
+        "role": "interrupt",
+        "session_code": case.action.session_code,
+        "property": {"builtin_property": {"approve_result": "approved"}},
+        "content": {"outcome": {"type": "success", "interrupts": case.result["interrupts"]}},
+    }
+    case.history = MagicMock(return_value=[case.record])
+    manager = MagicMock()
+    manager.return_value.list_session_contents = case.history
+    monkeypatch.setattr(module, "SessionManager", manager)
+    case.messages = lambda: module.approval_result_messages(
+        case.action.session_code, [case.action.interrupt_id], "alice"
+    )
+    return case
+
+
+@pytest.fixture
 def approval_resume_case(approval_card_case, monkeypatch):
     from aidev_wxbot.wxaibot import approval_resume as mod
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_notifications.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_approval_notifications.py
@@ -1,0 +1,87 @@
+import copy
+import json
+from unittest.mock import patch
+
+import pytest
+from aidev_wxbot.wxaibot.approval_cards import build_approval_result_card
+
+
+@pytest.mark.parametrize("status,label", [("approved", "审批已通过"), ("rejected", "审批已拒绝")])
+@pytest.mark.parametrize("flattened", [False, True])
+def test_notice_and_old_card_use_identical_result(approval_notification_case, status, label, flattened):
+    case = approval_notification_case
+    case.record["property"]["builtin_property"]["approve_result"] = status
+    if flattened:
+        case.record.update(case.record.pop("property")["builtin_property"])
+    case.result["approve_result"] = status
+    updated = build_approval_result_card(case.action, case.task_id, result=case.result)
+    updated.pop("task_id")
+    assert case.messages() == [{"msgtype": "template_card", "template_card": updated}]
+    assert updated["jump_list"] == [{"type": 0, "title": label}]
+    assert "button_list" not in updated
+    assert "candidate-not-actual-approver" not in json.dumps(updated)
+    assert "must-not-leak" not in json.dumps(updated)
+
+
+def test_delayed_event_uses_original_approval_not_latest_question(approval_notification_case):
+    case = approval_notification_case
+    later = copy.deepcopy(case.record)
+    later["content"]["outcome"]["interrupts"][0]["id"] = "other-interrupt"
+    later["property"]["builtin_property"]["approve_result"] = "rejected"
+    case.history.return_value.append(later)
+    assert case.messages()[0]["template_card"]["jump_list"][0]["title"] == "审批已通过"
+
+
+@pytest.mark.parametrize("skip", ["cancelled", "question"])
+def test_unrelated_or_cancelled_record_sends_no_approval_notice(approval_notification_case, skip):
+    case = approval_notification_case
+    interrupt = case.record["content"]["outcome"]["interrupts"][0]
+    if skip == "cancelled":
+        case.record["property"]["builtin_property"]["approve_result"] = "cancelled"
+    elif skip == "question":
+        interrupt["reason"] = "aidev:user_question"
+    assert case.messages() == []
+
+
+@pytest.mark.parametrize("missing", ["other_session", "other_interrupt", "user", "empty"])
+def test_missing_original_history_is_retried(approval_notification_case, missing):
+    case = approval_notification_case
+    if missing == "other_session":
+        case.record["session_code"] = "other-session"
+    elif missing == "other_interrupt":
+        case.record["content"]["outcome"]["interrupts"][0]["id"] = "other-interrupt"
+    elif missing == "user":
+        case.record["role"] = "user"
+    else:
+        case.history.return_value = []
+    with pytest.raises(ValueError, match="history"):
+        case.messages()
+
+
+@pytest.mark.parametrize("invalid", ["pending", "conflict", "ticket", "history"])
+def test_invalid_decision_is_not_acknowledged_as_approved(approval_notification_case, invalid):
+    case = approval_notification_case
+    if invalid == "pending":
+        case.record["property"]["builtin_property"]["approve_result"] = "pending"
+    elif invalid == "conflict":
+        conflict = copy.deepcopy(case.record)
+        conflict["property"]["builtin_property"]["approve_result"] = "rejected"
+        case.history.return_value.append(conflict)
+    elif invalid == "ticket":
+        case.record["content"]["outcome"]["interrupts"][0]["metadata"].pop("ticket")
+    else:
+        case.history.return_value = {"unexpected": "history"}
+    with pytest.raises(ValueError):
+        case.messages()
+
+
+def test_notice_lookup_forwards_original_user_without_creating_session(approval_notification_case):
+    from aidev_wxbot.wxaibot.approval_notifications import approval_result_messages
+
+    case = approval_notification_case
+    with patch("aidev_wxbot.wxaibot.approval_notifications.SessionManager") as manager:
+        manager.return_value.list_session_contents.return_value = [case.record]
+        assert approval_result_messages("session-1", [case.action.interrupt_id], "alice")
+    manager.assert_called_once_with(username="alice")
+    manager.return_value.list_session_contents.assert_called_once_with("session-1")
+    manager.return_value.get_or_create_by_session_code.assert_not_called()

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_database.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_database.py
@@ -3,14 +3,84 @@
 import asyncio
 import threading
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import nullcontext
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from aidev_wxbot.wxaibot import database
-from django.db import InterfaceError
+from django.db import InterfaceError, OperationalError
 
 from .test_long_connection import StreamDrain, _service
+
+
+@pytest.fixture
+def existing_connection(monkeypatch):
+    connection = MagicMock(in_atomic_block=False)
+    connection.get_autocommit.return_value = True
+    connection.wrap_database_errors = nullcontext()
+    monkeypatch.setattr(database, "close_old_connections", MagicMock())
+    monkeypatch.setattr("django.db.connections.all", MagicMock(return_value=[connection]))
+    return connection
+
+
+@pytest.mark.parametrize("error", [None, InterfaceError(0, ""), OperationalError(2013, "lost connection")])
+def test_scope_checks_existing_socket_before_business(existing_connection, error):
+    connection = existing_connection
+    cursor = connection.connection.cursor.return_value
+    cursor.execute.side_effect = error
+    operation = MagicMock(return_value="result")
+    assert database.run_with_database_connections(operation) == "result"
+    cursor.execute.assert_called_once_with("SELECT 1")
+    assert connection.close.call_count == (error is not None)
+    operation.assert_called_once_with()
+
+
+def test_failed_probe_is_discarded_before_business_runs(existing_connection):
+    connection = existing_connection
+    connection.connection.cursor.return_value.execute.side_effect = InterfaceError(0, "")
+
+    def operation():
+        connection.close.assert_called_once_with()
+
+    database.run_with_database_connections(operation)
+
+
+@pytest.mark.parametrize("disconnect", [False, True])
+def test_sqlite_probe_preserves_or_replaces_existing_connection(monkeypatch, django_db_blocker, tmp_path, disconnect):
+    from django.db.utils import ConnectionHandler
+
+    handler = ConnectionHandler({"default": {"ENGINE": "django.db.backends.sqlite3", "NAME": tmp_path / "probe.db"}})
+    connection = handler["default"]
+    monkeypatch.setattr(database.connections, "all", lambda **_kw: [connection])
+    connection.settings_dict["CONN_MAX_AGE"] = None
+    with django_db_blocker.unblock():
+        connection.ensure_connection()
+        raw = connection.connection
+        if disconnect:
+            raw.close()
+        try:
+            with database.database_connection_scope(), connection.cursor() as cursor:
+                cursor.execute("SELECT 1")
+                assert cursor.fetchone() == (1,)
+                assert (connection.connection is raw) == (not disconnect)
+        finally:
+            connection.close()
+
+
+@pytest.mark.parametrize("state", ["unopened", "atomic", "manual_transaction"])
+def test_scope_does_not_probe_unopened_or_transaction_connections(existing_connection, state):
+    connection = existing_connection
+    raw = connection.connection
+    if state == "unopened":
+        connection.connection = None
+    elif state == "atomic":
+        connection.in_atomic_block = True
+    else:
+        connection.get_autocommit.return_value = False
+    assert database.run_with_database_connections(lambda: "result") == "result"
+    raw.cursor.assert_not_called()
+    connection.close.assert_not_called()
 
 
 @pytest.mark.parametrize("failed", [False, True])

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_database_mysql.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_database_mysql.py
@@ -85,6 +85,37 @@ def _close_socket_with_error(alias):
     return threading.get_ident()
 
 
+def _disconnect_without_error_flag(alias, mode):
+    connection = connections[alias]
+    connection.ensure_connection()
+    old_id = _select_connection_id(alias)
+    if mode == "socket_closed":
+        connection.connection._force_close()
+    else:
+        controller = connection.copy(alias="disconnect_controller")
+        try:
+            with controller.cursor() as cursor:
+                cursor.execute("KILL CONNECTION %s", [old_id])
+        finally:
+            controller.close()
+    assert not connection.errors_occurred
+    assert not connection.health_check_enabled
+    assert connection.close_at is None
+    return threading.get_ident(), old_id
+
+
+@pytest.mark.parametrize("mode", ["socket_closed", "server_closed"])
+def test_first_new_recovers_without_prior_failed_query(mysql_session_store, mode):
+    store = mysql_session_store
+    worker_id, old_id = store.pool.submit(_disconnect_without_error_flag, store.alias, mode).result()
+    response, request = store.pool.submit(run_with_database_connections, _prepare, store.view, "/new").result()
+    assert response["stream"]["content"] == "已创建新会话，请输入咨询内容" and request is None
+    assert store.manager.count() == 1
+    assert store.pool.submit(threading.get_ident).result() == worker_id
+    new_id = store.pool.submit(_select_connection_id, store.alias).result()
+    assert new_id != old_id
+
+
 def _prepare(view, command):
     return view.prepare_agent_request({"msgtype": "text", "text": {"content": command}})
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -168,6 +168,31 @@ async def test_all_text_goes_directly_to_llm_without_question_lookup(content):
     assert service._metrics.completed == 1
 
 
+@pytest.mark.parametrize("kind", ["chat", "flow"])
+async def test_database_route_is_bound_before_chat_output_but_not_for_flow(kind):
+    service = _service()
+    request = SimpleNamespace(content="query", stream_id="bind-original", username="alice", group_id="g1")
+    strategy = MagicMock()
+    with patch.object(service, "_bind_resume_route") as bind:
+
+        def output():
+            assert bind.called == (kind == "chat")
+            yield 'data: {"type":"RUN_FINISHED"}\n'
+
+        strategy.open_stream.return_value = AgentStream(kind, output(), "original-session")
+        with (
+            patch.object(service, "_database_events_enabled", return_value=True),
+            patch.object(long_connection_module, "resolve_strategy", return_value=strategy),
+            patch.object(long_connection_module, "get_agent_executor", return_value=ThreadExecutor()),
+        ):
+            await service._start_direct_stream({"body": {"from": {"userid": "original-user"}}}, request)
+            await service._active_streams[request.stream_id].task
+        if kind == "chat":
+            bind.assert_called_once_with("original-session", "alice", "original-user")
+        else:
+            bind.assert_not_called()
+
+
 @pytest.mark.parametrize("status", ["accepted", "duplicate", "busy"])
 async def test_question_click_updates_only_accepted_card(question_case, question_callback, status):
     service = _service()
@@ -188,6 +213,24 @@ async def test_question_click_updates_only_accepted_card(question_case, question
         delivery.finish()
         await delivery.task
         assert service._client.send_message_calls[-1][0] == "alice-wx"
+
+
+async def test_database_question_click_binds_route_without_local_delivery(question_case, question_callback):
+    service = _service()
+    service._view.resolve_event_username.return_value = "alice"
+    submission = SimpleNamespace(interrupt=question_case.interrupt, answers=[{"answer": [{"label": "华南"}]}])
+    with (
+        patch.object(service, "_database_events_enabled", return_value=True),
+        patch.object(service, "_bind_resume_route") as bind,
+        patch.object(service, "_new_resume_delivery") as local_delivery,
+        patch.object(long_connection_module, "prepare_question_submission", return_value=submission),
+        patch.object(long_connection_module, "submit_question_resume", return_value="accepted") as submit,
+    ):
+        await service._handle_frame({"body": question_callback})
+    bind.assert_called_once_with("session-1", "alice", "alice-wx")
+    assert submit.call_args.args == (submission, None)
+    local_delivery.assert_not_called()
+    assert len(service._client.update_template_card_calls) == 1
 
 
 @pytest.mark.parametrize("failure", ["missing_url", "build_error", "update_error"])

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -834,6 +834,7 @@ class TestLongConnectionStreaming:
             ("cancelled", True, "已取消"),
             ("cancelled", False, "已取消"),
             ("approved", False, "审批已通过"),
+            ("rejected", False, "审批已拒绝"),
         ],
     )
     async def test_approval_cancel_card_event_dispatches_operation_and_updates_card(
@@ -866,6 +867,26 @@ class TestLongConnectionStreaming:
         for delivery in tuple(getattr(service, "_resume_deliveries", ())):
             delivery.finish()
             await delivery.task
+
+    @pytest.mark.parametrize("status,label", [("approved", "审批已通过"), ("rejected", "审批已拒绝")])
+    async def test_repeated_old_card_click_only_updates_actual_terminal_result(self, approval_card_case, status, label):
+        case = approval_card_case
+        service = _service()
+        case.result["approve_result"] = status
+        case.envelope.update(ok=False, already_finalized=True)
+        with (
+            patch.object(long_connection_module, "dispatch_user_operation", return_value=case.envelope),
+            patch.object(long_connection_module, "submit_cancelled_approval_resume") as resume,
+        ):
+            await service._handle_frame({"body": case.event})
+            await service._handle_frame({"body": case.event})
+        resume.assert_not_called()
+        assert service._client.send_message_calls == []
+        cards = service._client.update_template_card_calls
+        assert len(cards) == 2 and cards[0] == cards[1]
+        assert cards[0]["jump_list"] == [{"type": 0, "title": label}]
+        assert cards[0]["task_id"] == case.task_id
+        assert "button_list" not in cards[0]
 
     @pytest.mark.parametrize("envelope", [None, {}, {"ok": True}, {"ok": False}])
     async def test_cancel_missing_result_preserves_card(self, approval_card_case, envelope):

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_question_resume.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_question_resume.py
@@ -42,6 +42,16 @@ def test_user_submission_preserves_original_session_thread_turn(resume_case):
     case.delivery.finish.assert_called_once()
 
 
+def test_database_publisher_mode_runs_once_without_local_delivery(resume_case):
+    case = resume_case
+    submission = mod.prepare_question_submission(case.action, "alice", case.selected)
+    assert mod.submit_question_resume(submission, None) == "accepted"
+    callback, *args = case.executor.submit.call_args.args
+    callback(*args)
+    assert case.run.call_count == 1
+    assert case.run.call_args.kwargs["consume_stream"] is None
+
+
 async def test_native_selection_resumes_and_delivers_agui_output(native_question_case, resume_case):
     from ag_ui.encoder import EventEncoder
     from aidev_agent.core.ag_ui.event_builders import build_tool_result_event

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_resume_delivery.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_resume_delivery.py
@@ -3,7 +3,6 @@ import json
 from unittest.mock import AsyncMock
 
 import pytest
-from aidev_agent.events import AIDEV_CHAT_RESUME_READY
 from aidev_wxbot.wxaibot.resume_delivery import ResumeDelivery, markdown_parts
 
 
@@ -12,11 +11,9 @@ def sse(events):
 
 
 @pytest.mark.parametrize("resume_type, message_count", [("tool_approval", 1), ("ask_user_question", 2)])
-async def test_resume_notice_does_not_change_ready_event_or_final_reply(resume_type, message_count):
+async def test_legacy_resume_notice_and_final_reply_do_not_publish_business_events(resume_type, message_count):
     send = AsyncMock()
     delivery = ResumeDelivery(send, resume_type=resume_type)
-    ready = []
-    delivery._bus.subscribe(AIDEV_CHAT_RESUME_READY, ready.append)
     events = [
         {"type": "RUN_STARTED", "runId": "r1"},
         {"type": "RUN_STARTED", "runId": "r1"},
@@ -28,7 +25,7 @@ async def test_resume_notice_does_not_change_ready_event_or_final_reply(resume_t
     await delivery.task
     bodies = [call.args[0] for call in send.call_args_list]
     assert len(bodies) == message_count
-    assert len(ready) == 1 and ready[0].value["resumeType"] == resume_type
+    assert not hasattr(delivery, "publisher")
     assert "hello" in bodies[-1]["markdown"]["content"]
     if resume_type == "ask_user_question":
         assert "答案已接收" in bodies[0]["markdown"]["content"]
@@ -106,7 +103,7 @@ async def test_close_unregisters_and_does_not_send():
     delivery.finish()
     await asyncio.gather(delivery.task, return_exceptions=True)
     send.assert_not_called()
-    assert not delivery._bus._handlers
+    assert delivery._closed
 
 
 def test_utf8_message_split_is_lossless_and_bounded():

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
@@ -32,6 +32,24 @@ def _spans(exporter, name):
 
 
 class TestWxBotSpan:
+    def test_durable_resume_inherits_producer_trace_without_baggage(self, wxbot_spans):
+        from aidev_agent.services.resume_events import ResumeEvents
+
+        manager = SimpleNamespace(get_agent_code=lambda: "app", publish_event=lambda _: None)
+        with tracing.wxbot_span("producer") as producer:
+            observer = ResumeEvents(manager, session_code="session", thread_id="graph", turn_id="turn", resume=[])
+            observer.on_chunk('data: {"type":"RUN_STARTED","runId":"run"}')
+            carrier = observer._ready.value["traceContext"]
+        with (
+            tracing.resumed_event_context({**carrier, "baggage": "private=value"}),
+            tracing.wxbot_span("wxbot.event.consume"),
+        ):
+            assert get_current_trace_id() == format(producer.get_span_context().trace_id, "032x")
+        consumer = _spans(wxbot_spans, "wxbot.event.consume")[0]
+        assert consumer.parent.span_id == producer.get_span_context().span_id
+        assert "private" not in consumer.to_json()
+        assert get_current_trace_id() is None
+
     @pytest.mark.parametrize("error", [RuntimeError("secret-token"), asyncio.CancelledError("secret-token")])
     def test_exception_is_redacted_and_context_restored(self, wxbot_spans, error):
         with pytest.raises(type(error)), tracing.wxbot_span("operation"):

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
@@ -1,6 +1,8 @@
 """企微消息链路的 span、跨任务上下文与敏感信息边界。"""
 
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -31,7 +33,60 @@ def _spans(exporter, name):
     return [span for span in exporter.get_finished_spans() if span.name == name]
 
 
+def _queued_resume(monkeypatch):
+    from aidev_agent.core.ag_ui.types import AgentInput
+    from aidev_agent.services.agent import chat
+    from aidev_agent.services.messages_handler import GeneratorStreamingHelper, InMemoryQueueMessageHandler
+
+    published = []
+    manager = SimpleNamespace(
+        get_agent_code=lambda: "app", event_publishing_enabled=lambda: True, publish_event=published.append
+    )
+    monkeypatch.setattr(
+        chat, "GeneratorStreamingHelper", partial(GeneratorStreamingHelper, InMemoryQueueMessageHandler())
+    )
+    agent = SimpleNamespace(
+        resource_manager=manager,
+        event_handler=MagicMock(session_code="session", turn_id="turn"),
+        _on_complete=lambda **kwargs: None,
+        _build_resume_aware_producer=lambda *args, **kwargs: iter(
+            ['data: {"type":"RUN_STARTED","runId":"run"}\n\n', 'data: {"type":"RUN_FINISHED","runId":"run"}\n\n']
+        ),
+    )
+    request = AgentInput(
+        thread_id="graph",
+        run_id="run",
+        messages=[],
+        state={},
+        forwarded_props={"command": {"resume": [{"interruptId": "approval"}]}},
+    )
+    return chat.ChatCompletionAgent._stream_with_queue(agent, MagicMock(), request, resume=True), published
+
+
 class TestWxBotSpan:
+    def test_deferred_queue_delivery_links_consumer_and_send_to_entry(self, wxbot_spans, monkeypatch):
+        from aidev_agent.events import AIDEV_CHAT_RESUME_FINISHED, AIDEV_CHAT_RESUME_READY
+
+        with tracing.wxbot_span("chat.entry") as entry:
+            stream, published = _queued_resume(monkeypatch)
+            assert not published
+        with ThreadPoolExecutor(max_workers=1) as pool:
+            list_output = pool.submit(list, stream).result(timeout=10)
+        assert list_output
+        assert [event.name for event in published] == [AIDEV_CHAT_RESUME_READY, AIDEV_CHAT_RESUME_FINISHED]
+        for event in published:
+            with (
+                tracing.resumed_event_context(event.value["traceContext"]),
+                tracing.wxbot_span("wxbot.event.consume") as consumer,
+                tracing.wxbot_span("wxbot.resume.send") as sender,
+            ):
+                assert sender.get_span_context().trace_id == entry.get_span_context().trace_id
+            consumed = _spans(wxbot_spans, "wxbot.event.consume")[-1]
+            sent = _spans(wxbot_spans, "wxbot.resume.send")[-1]
+            assert consumed.parent.span_id == entry.get_span_context().span_id
+            assert sent.parent.span_id == consumer.get_span_context().span_id
+        assert get_current_trace_id() is None
+
     def test_durable_resume_inherits_producer_trace_without_baggage(self, wxbot_spans):
         from aidev_agent.services.resume_events import ResumeEvents
 


### PR DESCRIPTION
## 目标与原因

Web 进程恢复会话时，进程内通知无法交给独立运行的 wxbot。本次提供默认开启、可显式关闭的数据库订阅交付，使 Web 和企微获得同一次恢复结果，不再次运行 Agent。当前 develop 的 ITSM 回调只写审批结果，后续沿用既有后台轮询恢复；本 PR 不新增平台主动 HTTP 回调小鲸的通路。现有 Web chat 恢复接口继续兼容并保留回归测试。

## 改动

- 通用 READY / FINISHED / FAILED 事件在 aidev_agent 定义并由实际恢复生产者发布；ResourceManager 提供发布扩展点。
- bkplugin 提供 DatabaseEventBus 和 ResourceManager 包装器；新增通用订阅、投递表，支持领取租约、原路由快照、逐消息确认、退避重试和订阅隔离。
- wxbot 在原会话建立可信路由，独立消费数据库记录，复用 AG-UI 渲染器及现有长连接发送正文、后续审批或 Ask-user 卡片。
- 保留 HTTP 流式返回；非流式 resume 回调内部使用同一 AG-UI 恢复路径再聚合响应，避免新输入或重复落库。
- 终态重放和缓存接管不重复发布；普通文字、现有卡片鉴权及关闭开关时的交互保持原路径。
- 跨进程传播 W3C trace context，增加 wxbot.event.consume span，不将消息正文、接收者或完整异常加入 span。

## 验证

- Agent 相关回归：228 passed、1 skipped、4 deselected。
- bkplugin 订阅、投递、迁移及执行链回归：42 passed。
- wxbot 全量回归：422 passed、8 skipped、5 xfailed（已包含最新 develop 的数据库连接回归）。
- 3 个真实本地 HTTP / 独立消费者进程测试：流式回调、非流式回调、wxbot 离线后补收正文及下一张问题卡。断言同一执行只运行一次，原会话与发送目标不变。
- 完整配置的 pre-commit 和 diff 检查通过。

已 rebase develop，包含后台任务失效数据库连接修复，并复用其 database_connection_scope / run_with_database_connections。
Web 恢复生产者线程的数据库发布同样在调用前后清理失效连接，异常时也执行清理。

进程测试使用实际 HTTP View、发布注入、生产者、数据库及消费渲染代码；鉴权平台、模型和企微网络发送为测试替身，不代表真实审批平台和企微端到端验收。数据库用临时 SQLite，MySQL 5.7 部署验收待执行。

## 启用与范围

升级启动前先在应用环境执行 migrate aidev_bkplugin，Web 和 wxbot 使用同一应用、数据库及匹配插件版本。BKAPP_AIDEV_DATABASE_EVENTS_ENABLED 未配置时默认开启，显式 =1 开启、=0 关闭；已有 =0 配置继续生效。关闭时两端同时配置，不自动迁移、部署或启动真实服务。

本版在恢复结束或再次中断后发送完整正文，不是逐段实时转发；READY 不等于审批通过，wxbot 需另查已落库的原审批结果后才发送结果卡。旧的未订阅会话不自动补发，不用旧卡片回调标识进行后台刷新。

至少一次交付，发送成功到进度确认之间崩溃仍可能重复。数据库持续故障或生产者在终态事件落库前退出的补投、数据保留策略，需要部署侧处理；不自动重跑审批工具。HTTP 轮询卡片、Flow、legacy streaming 和跨环境恢复不在本次范围。

详细调用顺序、故障边界及配置见 src/plugins/aidev_bkplugin/docs/database-events.md。


## 本轮补充：后台任务连接健康检查

- 在现有 wxbot 任务边界加入已打开连接的只读探测，识别未过期、没有异常标记但 socket 已失效的连接；健康连接继续复用，不重试业务操作。
- 不主动打开未使用的数据库；探测跳过事务中的连接，scope 仍限定为事务外后台任务边界。
- 修复提交 `dc8f5866`；沿用本 PR，不另建数据库修复 PR。
- 数据库修复在 develop 基线上完成全量验证：436 passed、5 xfailed，含 10 项隔离 MySQL 5.7 测试及 SQLite 真实连接测试。
- 合入本 PR 后重跑 wxbot 全量：431 passed、10 skipped、5 xfailed（本次未再次启动 MySQL，10 项 MySQL 测试已在同一修复提交上通过）。
- 合入后 bkplugin 数据库事件测试：27 passed，含 3 个 HTTP / 独立消费者进程用例。
- 完整适用 pre-commit、diff 与公开输出安全检查通过。真实企微审批回调端到端验收待用户触发，不将测试替身或启动成功视为真实交付成功。


## 本轮补充：审批结果卡与旧卡终态

- wxbot 消费 READY 后，按原用户、session_code 和 interruptIds 查询已持久化的审批记录，通过或拒绝后另发结果卡。不会把恢复开始当作审批通过，也不会用下一次审批覆盖原审批。
- 新结果卡保留标题、说明、单号、提交时间和原跳转；旧卡再次点击时复用同一渲染逻辑，按平台实际终态替换底部操作区，不重复取消或恢复。
- 当前平台未提供实际审批人，先显示“审批已通过/审批已拒绝”，不使用候选处理人或点击用户冒充实际处理人。
- 首次发送前保存卡片快照到已有投递 JSON；重试或重启复用原内容及消息进度。取消及 Ask-user 不额外发送审批结果卡。未新增表或改动 Agent 事件协议。
- wxbot 全量：450 passed、10 skipped（隔离 MySQL 测试本轮未启用）、5 xfailed；数据库事件测试：34 passed，包含 3 个真实本地 HTTP 与独立消费者进程测试。
- 验证流式/非流式 Web 回调、离线补投递、结果卡加后续正文/问题卡、旧卡重复点击不重跑、平台历史暂未可读重试、快照重试及失效租约禁止发送。
- 完整适用 pre-commit 及 diff 检查通过。本轮未重启、部署或操作真实企微；平台/LLM/企微发送仍是测试替身，真实端到端效果待手工验收。
- 原卡只在有效签名和当前点击回调窗口内更新，不复用过期回调标识；已确认的历史 READY 不自动重放。会话列表分类与实际审批人协议不在本轮实现范围。



## Trace PR integration and review

- Merged #856 into this branch, preserving commit history (merge commit `566ebdc4`). This does not merge either PR into develop or deploy services.
- Companion platform change: TencentBlueKing/bk-aidev#2026. The platform must preserve the explicit content trace ID; the Agent change alone cannot prevent an older platform from overwriting it.
- Combined local regression: 450 wxbot tests, 63 bkplugin tests and 24 Agent writer/event tests passed (537 total); 10 MySQL-environment skips and 5 existing polling xfails remain. Full pre-commit checks passed.
- Review found an existing P2 in the combined delivery path: `_stream_with_queue` constructs ResumeEvents lazily. If the entry context has ended before stream iteration, the writer retains the entry trace ID but the event traceContext is empty. An isolated diagnostic reproduced this (1 failing expectation). Capture and explicitly carry the entry W3C context before deferred iteration; this was not implemented in the integration commit and is addressed by the follow-up below.
- This observability gap is not evidence of the cause of missing approval messages. No live approval replay, service startup or production validation was performed. Prior CI failures still require checking against the new head; local tests are not a substitute for CI.


## Follow-up: preserve entry Trace across deferred resume consumption

- Fixed the reviewed P2 in `cdfef5ec`: construct the per-execution resume observer synchronously before returning the stream, preserving entry traceparent/tracestate and sampling flags. Queue preparation and producer execution remain lazy.
- READY and terminal events retain the entry context after the entry span ends, across worker threads or another active trace. Requests do not share observers; unconsumed streams do not prepare queues or publish events. Missing OTel/context does not fabricate or borrow an unrelated Trace.
- Added 12 Agent regression cases and a queue-to-wxbot span-parent test. The original isolated failing diagnostic now passes unchanged.
- Regression: Agent chat/writer/events 148 passed, 1 skipped, 4 deselected; wxbot 451 passed, 10 MySQL-environment skips, 5 existing polling xfails; bkplugin events/session/builder 63 passed including three local HTTP / independent consumer process cases. Total 662 passed, plus the original diagnostic. Full pre-commit and public-output checks passed.
- Companion platform PR TencentBlueKing/bk-aidev#2026 is now merged, with four checks successful; deployment is not verified. This Agent PR is not merged or deployed. Live approval non-delivery still requires the documented environment and event-delivery checks; Trace repair alone is not evidence that delivery is fixed.


## 本轮补充：原审批轮询的 Trace 传递

- 提交 `e16f1fb6`：SDK 创建审批时透传 W3C traceparent/tracestate；原后台轮询读取审批记录中的上下文，覆盖 Agent 构造、执行和惰性流排空，不新增第二条 HTTP 恢复路径。
- 现有 Web chat 入口补充 span/context 兜底；增加 database_event.publish / database_event.claim span，记录候选查询耗时、消息年龄与领取次数。空轮询不产 span，持久化 envelope 保持不变，保留幂等和租约语义。
- 不采集事件正文、接收者、审批凭据、baggage 或异常正文；缺失/非法上下文不会继承其他会话 Trace。
- 配套平台 PR：TencentBlueKing/bk-aidev#2036，负责 ITSM callback URL 的 W3C 上下文传递、审批结果记录与平台原 worker 的上下文恢复。完整审批 Trace 需要两端版本以及网关 header 透传、OTel/采样配置共同满足。
- 本轮已完成：Agent 21 passed，Bkplugin 85 passed，wxbot 451 passed / 10 skipped / 5 xfailed；独立轮询进程专项另连续 5 轮各 2 passed。完整适用 pre-commit 与公开新增行检查通过。
- 本地 HTTP 与原轮询测试使用独立 Web/wxbot 进程，断言通过/拒绝只执行一次、2 条投递 delivered、原 Trace ID 与消费/发送父关系。平台查询、模型与外部企微 socket 使用测试替身，不代表真实平台→ITSM→企微端到端验收。
- 组合测试曾出现消费者超时；最终组合和重复专项已通过，旧超时未取得完整错误类型，不宣称已证明根因或排除所有并发风险。
- 提交时 develop 新增 Flow task_id 变更 #857，本次保留 #855 的现有历史直接快进追加，不宣称已 rebase 最新 develop。未部署、重启服务或重放真实审批。


## 本轮补充：数据库事件默认开启

- 提交 `cf870398`：未设置 BKAPP_AIDEV_DATABASE_EVENTS_ENABLED 时默认启用；保留显式关闭与现有严格布尔解析，不改变事件协议或发送时机。
- 补充未配置、显式开启/关闭、空值和非约定值的配置及 ResourceManager 注入回归。
- 数据库事件测试通过插件 `make test path=tests/database_events` 入口执行：46 passed、15 warnings，含 7 个独立进程 HTTP/轮询及 Trace 交付用例；完整适用 pre-commit 和 diff 检查通过。
- 初次跨进程运行受本机沙箱端口绑定限制，获得本地端口权限后整套通过。使用临时 SQLite 及外部依赖替身，不代表线上端到端验证。
- 升级前必须迁移事件表；原来显式配置 =0 的环境需要移除或改为 =1。缺少可信订阅的历史会话不自动补发。
- 沿用本 PR 历史快进追加，未 rebase 最新 develop、未部署或重启。上一版 CI 有失败检查，新提交 CI 状态需单独确认。

