### PR TITLE
feat: 会话内容传递 chat 入口 Trace ID --story=1070093903137679449

### DIFF
--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -91,7 +91,7 @@ class SessionContentProperty(BaseModel):
     """会话内容的一些额外属性"""
 
     turn_id: str = Field(default="", description="同一次 user-ai 回复的轮次 ID")
-    trace_id: str = Field(default="", description="创建会话内容时的 Trace ID")
+    trace_id: str = Field(default="", description="chat 入口 Trace ID；未提供时兼容使用内容创建请求的 Trace ID")
     extra: SessionContentExtra | None = None
 
 

--- a/src/agent/aidev_agent/services/event_handlers/base.py
+++ b/src/agent/aidev_agent/services/event_handlers/base.py
@@ -40,6 +40,7 @@ from aidev_agent.core.ag_ui.types import (
 from aidev_agent.core.ag_ui.utils import camel_to_snake, get_interrupt_value, unwrap_interrupt_source
 from aidev_agent.enums import ActivityType, PromptRole
 from aidev_agent.utils.event import RunId
+from aidev_agent.utils.tracing import get_current_trace_id
 
 logger = getLogger(__name__)
 
@@ -114,6 +115,8 @@ class BaseSessionWriter(ABC):
         self.session_code: str = session_code
         self.username: str = username
         self.turn_id: str = turn_id or ""
+        # Writer 在 chat 入口构造；异步回写时的当前 Span 可能已经属于另一条链路。
+        self.trace_id: str = get_current_trace_id() or ""
         self._tools_mapping: dict[str, Any] = {}
         if tools:
             self.set_tools(tools)
@@ -1489,6 +1492,8 @@ class BaseSessionWriter(ABC):
         }
         if self.turn_id:
             payload["property"]["turn_id"] = self.turn_id
+        if self.trace_id:
+            payload["property"]["trace_id"] = self.trace_id
         content_id = self._safe_call(
             self._do_create_content, message_id, "create", payload=payload, headers=self._get_headers()
         )

--- a/src/agent/tests/services/event_handlers/test_session_writer_trace.py
+++ b/src/agent/tests/services/event_handlers/test_session_writer_trace.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+"""Session content retains the entry trace after the request context changes."""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+import pytest
+from aidev_agent.services.event_handlers.agui_writer import AGUISessionWriter
+
+
+@pytest.mark.parametrize("entry_trace", ["a" * 32, None])
+def test_create_session_content_keeps_entry_trace(entry_trace):
+    client = MagicMock()
+    with patch("aidev_agent.services.event_handlers.base.get_current_trace_id", return_value=entry_trace) as current:
+        writer = AGUISessionWriter("session", client, turn_id="turn")
+        current.return_value = "b" * 32
+        for role in ("user", "assistant"):
+            writer._create_session_content(role, role, "hello", "complete", {})
+        writer._update_session_content(1, "assistant", "updated", {})
+
+    for call in client.api.create_chat_session_content.call_args_list:
+        prop = call.kwargs["json"]["property"]
+        assert prop.get("trace_id") == entry_trace
+        assert prop["turn_id"] == "turn"
+    assert "trace_id" not in client.api.update_chat_session_content.call_args.kwargs["json"]["property"]
+
+
+def test_writers_do_not_share_trace_between_chat_requests():
+    client = MagicMock()
+    with patch("aidev_agent.services.event_handlers.base.get_current_trace_id", side_effect=["a" * 32, "b" * 32]):
+        first = AGUISessionWriter("session", client)
+        second = AGUISessionWriter("session", client)
+
+    first._create_session_content("first", "user", "hello", "complete", {})
+    second._create_session_content("second", "user", "hello again", "complete", {})
+
+    assert [
+        call.kwargs["json"]["property"]["trace_id"] for call in client.api.create_chat_session_content.call_args_list
+    ] == ["a" * 32, "b" * 32]
+
+
+def test_entry_trace_survives_writing_without_request_context():
+    trace = pytest.importorskip("opentelemetry.trace")
+    client = MagicMock()
+    span = trace.NonRecordingSpan(trace.SpanContext(trace_id=int("a" * 32, 16), span_id=1, is_remote=False))
+    with trace.use_span(span):
+        writer = AGUISessionWriter("session", client)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        executor.submit(writer._create_session_content, "message", "assistant", "hello", "complete", {}).result()
+
+    payload = client.api.create_chat_session_content.call_args.kwargs["json"]
+    assert payload["property"]["trace_id"] == "a" * 32

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_session.py
@@ -17,6 +17,7 @@ from aidev_agent.enums import ChannelType, ChatContentStatus, PromptRole, Sessio
 from aidev_agent.packages.resource_manager import ResourceManagerProtocol
 from aidev_agent.packages.resource_manager.registry import resource_manager as resource_manager_factory
 from aidev_agent.pydantic_models import ChatPrompt
+from aidev_agent.utils.tracing import get_current_trace_id
 from django.conf import settings
 
 from ..constants import AGUI_PROTOCOL_VERSION
@@ -44,6 +45,7 @@ class SessionManager:
         resource_manager: ResourceManagerProtocol | None = None,
     ):
         self.username = username
+        self.trace_id = get_current_trace_id() or ""
         self.agent_code = agent_code or settings.APP_CODE
         self.resource_manager = resource_manager or resource_manager_factory()
 
@@ -111,6 +113,8 @@ class SessionManager:
             data["extra"] = extra
         if turn_id:
             data["property"] = {"turn_id": turn_id}
+        if self.trace_id:
+            data.setdefault("property", {})["trace_id"] = self.trace_id
         client = self._client()
         result = client.api.create_chat_session_content(json=data, headers=self._user_headers())
         saved = result.get("data", {})

--- a/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/services/agent/test_session_manager.py
@@ -103,6 +103,20 @@ def test_save_content_generates_turn_id_for_user(session_manager, mock_plugin_rm
     assert saved["property"]["turn_id"] == payload["property"]["turn_id"]
 
 
+def test_save_content_keeps_entry_trace(mock_plugin_rm_client, mocker):
+    from aidev_bkplugin.services.agent_session import SessionManager
+
+    current = mocker.patch("aidev_bkplugin.services.agent_session.get_current_trace_id", return_value="a" * 32)
+    manager = SessionManager("test")
+    current.return_value = "b" * 32
+    mock_plugin_rm_client.api.create_chat_session_content.return_value = {"data": {"id": 1}}
+
+    manager.save_content("sc-1", "user", "hello", turn_id="turn-1")
+
+    payload = mock_plugin_rm_client.api.create_chat_session_content.call_args.kwargs["json"]
+    assert payload["property"] == {"turn_id": "turn-1", "trace_id": "a" * 32}
+
+
 def test_set_flow_resume_pending_preserves_existing_fields(session_manager, mock_plugin_rm_client):
     """read-modify-write：仅叠加 resume_pending，保留 flow_info 其它字段与同级属性。"""
     mock_plugin_rm_client.api.retrieve_chat_session.return_value = {


### PR DESCRIPTION
## 背景

会话内容经独立 API 请求回写时，保存请求可能具有不同于 chat 入口的 Trace ID，导致会话记录不能关联到发起本轮对话的链路。

## 原因

内容回写载荷没有显式携带入口 Trace ID，异步写入时仅依赖当前请求上下文无法保证稳定关联。

## 改动内容

- 会话回写器在构造时保存入口 Trace ID，并在创建内容时通过 property.trace_id 传递。
- SessionManager 的直接保存路径采用相同行为，覆盖用户消息和 Flow 调用。
- 后续内容更新不重新采集 Trace ID；无 OpenTelemetry 时保持可选依赖兼容。

## 收益

同一次 chat 创建的内容保持相同入口 Trace ID，跨线程写入和后续请求不会改变已捕获的值。

## 测试验证

- Agent 回写、ask_user_question 与 tracing 定向检查：18 passed。
- bkplugin SessionManager 回归：22 passed。
- 变更文件的完整 pre-commit 检查通过。
- 包含真实 OpenTelemetry 上下文退出后的线程池写入检查。

## 依赖与边界

需配合[平台侧修复](https://github.com/TencentBlueKing/bk-aidev/pull/2026)。未修改 HTTP 追踪传播、未回填历史数据；尚未进行部署后端到端复验。
