### PR TITLE
feat: 一次性管理命令同时关闭指标和 Trace --story=1070093903137732556

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
@@ -94,6 +94,15 @@ def init_bk_aidev_agent_otel() -> None:
         set_metric_service(None)
         return
 
+    if _is_one_off_management_command():
+        # 一次性命令不采集指标或 Trace，避免退出时等待上报；无需获取远程 OT 配置。
+        otel_config.enable_metrics = False
+        otel_config.enable_traces = False
+        set_metric_service(None)
+        BkAidevAgentInstrumentor(config=otel_config).instrument()
+        logger.info("[aidev_bkplugin] metrics and traces disabled for one-off management command")
+        return
+
     if getattr(otel_config, "trace_exporter", "otlp") == "logging":
         # 本地评测只需要 trace/span，禁用远程 endpoint 探测和指标上报，
         # 由 Agent SDK 的 LoggingSpanExporter 写入应用日志。
@@ -122,14 +131,6 @@ def init_bk_aidev_agent_otel() -> None:
     endpoints.extend(get_otel_endpoint_by_env())
 
     otel_config.otel_endpoints = endpoints
-    if _is_one_off_management_command():
-        # 一次性命令不启动指标采集线程，避免退出时等待最后一次上报；Trace 保持原配置。
-        # 在两种指标上报路径之前统一关闭，平台配置也不能重新开启。
-        otel_config.enable_metrics = False
-        set_metric_service(None)
-        BkAidevAgentInstrumentor(config=otel_config).instrument()
-        logger.info("[aidev_bkplugin] metric export skipped for one-off management command")
-        return
     if configure_metric_identity is None or BkPluginMetricService is None or MetricExportSettings is None:
         logger.info("[aidev_bkplugin] metric OpenTelemetry extras unavailable; metric export skipped")
         otel_config.enable_metrics = False

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/apps.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 
 import logging
+import sys
+from pathlib import Path
 
 from aidev_agent.utils.module_loading import import_string
 from django.apps import AppConfig
@@ -60,6 +62,12 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _is_one_off_management_command() -> bool:
+    if not sys.argv or Path(sys.argv[0]).name not in {"manage.py", "django-admin", "django-admin.py"}:
+        return False
+    return sys.argv[1:2] not in (["runserver"], ["celery"], ["run_wxaibot_ws"])
+
+
 def init_bk_aidev_agent_otel() -> None:
     """
     初始化 BK AIDEV Agent OpenTelemetry。
@@ -114,6 +122,14 @@ def init_bk_aidev_agent_otel() -> None:
     endpoints.extend(get_otel_endpoint_by_env())
 
     otel_config.otel_endpoints = endpoints
+    if _is_one_off_management_command():
+        # 一次性命令不启动指标采集线程，避免退出时等待最后一次上报；Trace 保持原配置。
+        # 在两种指标上报路径之前统一关闭，平台配置也不能重新开启。
+        otel_config.enable_metrics = False
+        set_metric_service(None)
+        BkAidevAgentInstrumentor(config=otel_config).instrument()
+        logger.info("[aidev_bkplugin] metric export skipped for one-off management command")
+        return
     if configure_metric_identity is None or BkPluginMetricService is None or MetricExportSettings is None:
         logger.info("[aidev_bkplugin] metric OpenTelemetry extras unavailable; metric export skipped")
         otel_config.enable_metrics = False

--- a/src/plugins/aidev_bkplugin/readme.md
+++ b/src/plugins/aidev_bkplugin/readme.md
@@ -2,6 +2,16 @@
 
 本插件需与智能体模板配合使用，用于开发和管理智能体插件。
 
+## 管理命令的指标采集
+
+通过 `manage.py` 或 `django-admin` 运行一次性管理命令（如 `migrate`、
+`collectstatic`、`shell`）时，插件不会启动指标采集线程，避免进程退出时等待最后一次上报。
+该策略同时覆盖直连 OTLP 和经 Celery 上报，即使环境或平台配置启用了指标也不会启动。
+
+`runserver`、`celery`（含 worker/beat）、`run_wxaibot_ws` 保留原有指标配置；
+直接启动的 Gunicorn、Celery 不受影响。Trace 和日志上报配置不变。
+策略位于插件初始化入口，已有模板升级插件即可生效，无需修改 `bin/manage.py`。
+
 ## 本地调试智能体插件
 
 ### 环境准备

--- a/src/plugins/aidev_bkplugin/readme.md
+++ b/src/plugins/aidev_bkplugin/readme.md
@@ -2,14 +2,15 @@
 
 本插件需与智能体模板配合使用，用于开发和管理智能体插件。
 
-## 管理命令的指标采集
+## 管理命令的指标和 Trace 采集
 
 通过 `manage.py` 或 `django-admin` 运行一次性管理命令（如 `migrate`、
-`collectstatic`、`shell`）时，插件不会启动指标采集线程，避免进程退出时等待最后一次上报。
+`collectstatic`、`shell`）时，插件同时关闭指标和 Trace，避免进程退出时等待上报，
+也不会为初始化 OT 获取远程配置。
 该策略同时覆盖直连 OTLP 和经 Celery 上报，即使环境或平台配置启用了指标也不会启动。
 
-`runserver`、`celery`（含 worker/beat）、`run_wxaibot_ws` 保留原有指标配置；
-直接启动的 Gunicorn、Celery 不受影响。Trace 和日志上报配置不变。
+`runserver`、`celery`（含 worker/beat）、`run_wxaibot_ws` 保留原有指标和 Trace 配置；
+直接启动的 Gunicorn、Celery 不受影响。常规应用日志不变。
 策略位于插件初始化入口，已有模板升级插件即可生效，无需修改 `bin/manage.py`。
 
 ## 本地调试智能体插件

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import aidev_agent.packages as aidev_agent_packages
 import pytest
 from aidev_bkplugin import apps
+from aidev_bkplugin.services.agent_config import AgentConfigFetcher
 
 
 def test_init_otel_disabled_skips_remote_initialization(mocker):
@@ -78,17 +79,22 @@ def _mock_otel_inputs(mocker, agent_info, metric_settings):
         ["django-admin.py", "migrate"],
     ],
 )
-def test_management_commands_skip_both_metric_export_paths(mocker, monkeypatch, argv):
+@pytest.mark.parametrize("trace_exporter", ["otlp", "logging"])
+def test_management_commands_disable_metrics_and_traces_before_remote_config(mocker, monkeypatch, argv, trace_exporter):
     monkeypatch.setattr(apps.sys, "argv", argv)
     config, instrumentor = _mock_otel_inputs(mocker, {"otel_info": {"enable_metrics": True}}, None)
     config.enable_traces = True
+    config.trace_exporter = trace_exporter
     metric_service = mocker.patch.object(apps, "BkPluginMetricService")
     set_metric_service = mocker.patch.object(apps, "set_metric_service")
 
     apps.init_bk_aidev_agent_otel()
 
     assert config.enable_metrics is False
-    assert config.enable_traces is True
+    assert config.enable_traces is False
+    AgentConfigFetcher.get_info.assert_not_called()
+    apps.get_otel_endpoint_by_json_str.assert_not_called()
+    apps.get_otel_endpoint_by_env.assert_not_called()
     apps.MetricExportSettings.from_agent_info.assert_not_called()
     metric_service.assert_not_called()
     set_metric_service.assert_called_once_with(None)
@@ -115,6 +121,7 @@ def test_service_entries_preserve_metric_configuration(mocker, monkeypatch, argv
         enabled=enabled, export_via_celery=via_celery, export_interval_millis=1500, export_timeout_millis=7000
     )
     config, instrumentor = _mock_otel_inputs(mocker, {}, metric_settings)
+    config.enable_traces = not enabled
     metric_service = mocker.patch.object(apps, "BkPluginMetricService")
     metric_service.return_value.start.return_value = enabled
     mocker.patch.object(apps, "configure_metric_identity")
@@ -123,6 +130,7 @@ def test_service_entries_preserve_metric_configuration(mocker, monkeypatch, argv
     apps.init_bk_aidev_agent_otel()
 
     assert config.enable_metrics is enabled
+    assert config.enable_traces is (not enabled)
     assert config.metric_provider_managed_externally is (enabled and via_celery)
     assert metric_service.called is via_celery
     apps.MetricExportSettings.from_agent_info.assert_called_once()

--- a/src/plugins/aidev_bkplugin/tests/test_apps.py
+++ b/src/plugins/aidev_bkplugin/tests/test_apps.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import aidev_agent.packages as aidev_agent_packages
+import pytest
 from aidev_bkplugin import apps
 
 
@@ -62,6 +63,70 @@ def _mock_otel_inputs(mocker, agent_info, metric_settings):
     metric_export_settings.from_agent_info.return_value = metric_settings
     instrumentor = mocker.patch.object(apps, "BkAidevAgentInstrumentor").return_value
     return otel_config, instrumentor
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["bin/manage.py", "migrate", "--noinput"],
+        ["manage.py", "collectstatic"],
+        ["manage.py", "shell", "-c", "pass"],
+        ["manage.py", "upgrade_sessions"],
+        ["manage.py", "new_management_command"],
+        ["manage.py", "--help"],
+        ["/usr/bin/django-admin", "check"],
+        ["django-admin.py", "migrate"],
+    ],
+)
+def test_management_commands_skip_both_metric_export_paths(mocker, monkeypatch, argv):
+    monkeypatch.setattr(apps.sys, "argv", argv)
+    config, instrumentor = _mock_otel_inputs(mocker, {"otel_info": {"enable_metrics": True}}, None)
+    config.enable_traces = True
+    metric_service = mocker.patch.object(apps, "BkPluginMetricService")
+    set_metric_service = mocker.patch.object(apps, "set_metric_service")
+
+    apps.init_bk_aidev_agent_otel()
+
+    assert config.enable_metrics is False
+    assert config.enable_traces is True
+    apps.MetricExportSettings.from_agent_info.assert_not_called()
+    metric_service.assert_not_called()
+    set_metric_service.assert_called_once_with(None)
+    instrumentor.instrument.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["bin/manage.py", "runserver", "--noreload"],
+        ["manage.py", "celery", "worker", "-B"],
+        ["manage.py", "celery", "beat", "-l", "info"],
+        ["manage.py", "celery", "-A", "test_app", "worker"],
+        ["manage.py", "run_wxaibot_ws"],
+        ["gunicorn", "wsgi:application"],
+        ["celery", "-A", "test_app", "worker"],
+    ],
+)
+@pytest.mark.parametrize("enabled", [False, True])
+@pytest.mark.parametrize("via_celery", [False, True])
+def test_service_entries_preserve_metric_configuration(mocker, monkeypatch, argv, enabled, via_celery):
+    monkeypatch.setattr(apps.sys, "argv", argv)
+    metric_settings = SimpleNamespace(
+        enabled=enabled, export_via_celery=via_celery, export_interval_millis=1500, export_timeout_millis=7000
+    )
+    config, instrumentor = _mock_otel_inputs(mocker, {}, metric_settings)
+    metric_service = mocker.patch.object(apps, "BkPluginMetricService")
+    metric_service.return_value.start.return_value = enabled
+    mocker.patch.object(apps, "configure_metric_identity")
+    mocker.patch.object(apps, "set_metric_service")
+
+    apps.init_bk_aidev_agent_otel()
+
+    assert config.enable_metrics is enabled
+    assert config.metric_provider_managed_externally is (enabled and via_celery)
+    assert metric_service.called is via_celery
+    apps.MetricExportSettings.from_agent_info.assert_called_once()
+    instrumentor.instrument.assert_called_once_with()
 
 
 def test_init_otel_keeps_direct_metric_export_in_agent_sdk(mocker, monkeypatch):

--- a/src/plugins/aidev_bkplugin/tests/test_management_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/test_management_metrics.py
@@ -10,7 +10,7 @@ PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 AGENT_ROOT = PLUGIN_ROOT.parents[1] / "agent"
 
 # Exercise the actual plugin initializer and SDK shutdown without a database,
-# collector or broker. A regression delays exit during the final metric export.
+# collector or broker. A regression delays exit during metric/trace shutdown.
 EXIT_PROBE = dedent("""
     import sys
     import threading
@@ -23,8 +23,9 @@ EXIT_PROBE = dedent("""
     from aidev_bkplugin.services.otel_metrics import BkPluginMetricService
     from aidev_agent.packages.opentelemetry.otel_service import BkAgentOTelService
     from aidev_agent.packages.opentelemetry.utils import ExporterType
-    from opentelemetry import metrics
+    from opentelemetry import metrics, trace
     from opentelemetry.sdk.metrics.export import MetricExporter, MetricExportResult
+    from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
     class SlowExporter(MetricExporter):
         def export(self, metrics_data, timeout_millis=10000, **kwargs):
@@ -36,6 +37,14 @@ EXIT_PROBE = dedent("""
 
         def shutdown(self, timeout_millis=30000, **kwargs):
             pass
+
+    class SlowSpanExporter(SpanExporter):
+        def export(self, spans):
+            threading.Event().wait(20)
+            return SpanExportResult.SUCCESS
+
+        def shutdown(self):
+            threading.Event().wait(20)
 
     def instrumentor(config):
         # Keep the real SDK provider lifecycle; avoid unrelated agent wrappers.
@@ -57,24 +66,27 @@ EXIT_PROBE = dedent("""
         patch.object(apps, "BkAidevAgentInstrumentor", side_effect=instrumentor),
         patch.object(apps, "push_bkm_metrics_task", SimpleNamespace(delay=lambda *args: None)),
         patch.object(BkAgentOTelService, "_create_metric_exporter", side_effect=lambda *args: SlowExporter()),
+        patch.object(BkAgentOTelService, "_create_trace_exporter", side_effect=lambda *args: SlowSpanExporter()),
         patch.object(BkPluginMetricService, "_create_celery_exporter", side_effect=lambda: SlowExporter()),
     ):
         apps.init_bk_aidev_agent_otel()
         metrics.get_meter("exit-probe").create_counter("probe.count").add(1)
+        with trace.get_tracer("exit-probe").start_as_current_span("probe"):
+            pass
         print("command returned", flush=True)
 """)
 
 
 @pytest.mark.parametrize("transport", ["direct", "celery"])
 @pytest.mark.parametrize("command", ["migrate", "upgrade_sessions"])
-def test_management_initialization_exits_without_final_metric_export(transport, command):
+def test_management_initialization_exits_without_metric_or_trace_export(transport, command):
     env = {
         **os.environ,
         "DJANGO_SETTINGS_MODULE": "tests.settings",
         "PYTHONPATH": os.pathsep.join([str(PLUGIN_ROOT), str(AGENT_ROOT)]),
         "BKAI_AGENT_OTEL_ENABLED": "true",
         "BKAI_AGENT_ENABLE_METRICS": "true",
-        "BKAI_AGENT_ENABLE_TRACES": "false",
+        "BKAI_AGENT_ENABLE_TRACES": "true",
         "BKAI_AGENT_ENABLE_LOGS": "false",
         "BKAI_AGENT_TRACE_EXPORTER": "otlp",
     }

--- a/src/plugins/aidev_bkplugin/tests/test_management_metrics.py
+++ b/src/plugins/aidev_bkplugin/tests/test_management_metrics.py
@@ -1,0 +1,90 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+from textwrap import dedent
+
+import pytest
+
+PLUGIN_ROOT = Path(__file__).resolve().parents[1]
+AGENT_ROOT = PLUGIN_ROOT.parents[1] / "agent"
+
+# Exercise the actual plugin initializer and SDK shutdown without a database,
+# collector or broker. A regression delays exit during the final metric export.
+EXIT_PROBE = dedent("""
+    import sys
+    import threading
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    import django
+    django.setup()
+    from aidev_bkplugin import apps
+    from aidev_bkplugin.services.otel_metrics import BkPluginMetricService
+    from aidev_agent.packages.opentelemetry.otel_service import BkAgentOTelService
+    from aidev_agent.packages.opentelemetry.utils import ExporterType
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics.export import MetricExporter, MetricExportResult
+
+    class SlowExporter(MetricExporter):
+        def export(self, metrics_data, timeout_millis=10000, **kwargs):
+            threading.Event().wait(20)
+            return MetricExportResult.SUCCESS
+
+        def force_flush(self, timeout_millis=10000):
+            return True
+
+        def shutdown(self, timeout_millis=30000, **kwargs):
+            pass
+
+    def instrumentor(config):
+        # Keep the real SDK provider lifecycle; avoid unrelated agent wrappers.
+        return SimpleNamespace(instrument=BkAgentOTelService(config).start)
+
+    via_celery = sys.argv[1] == "celery"
+    sys.argv = ["bin/manage.py", sys.argv[2]]
+    agent_info = {"otel_info": {"metrics": {
+        "enabled": True, "export_via_celery": via_celery,
+        "agent_data_id": 1, "agent_access_token": "test-token",
+        "agent_push_url": "http://collector.example.com/v2/push/",
+    }}}
+    endpoint = {"url": "http://collector.example.com", "token": "", "exporter_type": ExporterType.HTTP}
+    with (
+        patch.object(apps, "get_otel_endpoint_by_json_str", return_value=[endpoint]),
+        patch.object(apps, "get_otel_endpoint_by_agent_info", return_value=[]),
+        patch.object(apps, "get_otel_endpoint_by_env", return_value=[]),
+        patch("aidev_bkplugin.services.agent_config.AgentConfigFetcher.get_info", return_value=agent_info),
+        patch.object(apps, "BkAidevAgentInstrumentor", side_effect=instrumentor),
+        patch.object(apps, "push_bkm_metrics_task", SimpleNamespace(delay=lambda *args: None)),
+        patch.object(BkAgentOTelService, "_create_metric_exporter", side_effect=lambda *args: SlowExporter()),
+        patch.object(BkPluginMetricService, "_create_celery_exporter", side_effect=lambda: SlowExporter()),
+    ):
+        apps.init_bk_aidev_agent_otel()
+        metrics.get_meter("exit-probe").create_counter("probe.count").add(1)
+        print("command returned", flush=True)
+""")
+
+
+@pytest.mark.parametrize("transport", ["direct", "celery"])
+@pytest.mark.parametrize("command", ["migrate", "upgrade_sessions"])
+def test_management_initialization_exits_without_final_metric_export(transport, command):
+    env = {
+        **os.environ,
+        "DJANGO_SETTINGS_MODULE": "tests.settings",
+        "PYTHONPATH": os.pathsep.join([str(PLUGIN_ROOT), str(AGENT_ROOT)]),
+        "BKAI_AGENT_OTEL_ENABLED": "true",
+        "BKAI_AGENT_ENABLE_METRICS": "true",
+        "BKAI_AGENT_ENABLE_TRACES": "false",
+        "BKAI_AGENT_ENABLE_LOGS": "false",
+        "BKAI_AGENT_TRACE_EXPORTER": "otlp",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", EXIT_PROBE, transport, command],
+        cwd=PLUGIN_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "command returned" in result.stdout


### PR DESCRIPTION
## 背景

Django 管理命令会执行插件的启动钩子。启用指标或 Trace 时，一次性命令也会创建上报线程，命令结束后仍可能等待上报或资源关闭。

## 改动内容

- 在插件的 OpenTelemetry 初始化入口同时关闭一次性管理命令的指标和 Trace，并在远程 OT 配置获取之前返回，覆盖 `manage.py`、`django-admin` 和 `django-admin.py`。
- 直连 OTLP 和经 Celery 上报两条路径采用相同策略，环境或平台配置不能为一次性命令重新开启指标或 Trace。
- `runserver`、`celery`（含 worker/beat）、`run_wxaibot_ws` 保留原有指标和 Trace 配置；直接启动的 Gunicorn、Celery 不受影响。
- 策略随插件升级生效，已有模板无需修改 `bin/manage.py`。

## 影响范围

调整 Agent 插件的指标与 Trace 初始化，不更改常规应用日志、授权或数据库操作；不关闭其他组件独立配置的追踪。未来新增常驻管理命令时需要加入保留列表。未调整 SDK 包版本，也未发布或部署。

## 测试验证

- 84 项定向测试通过，覆盖管理命令同时关闭指标和 Trace、跳过远程配置、常驻服务保留配置，以及现有指标转换与上报逻辑。
- 使用真实插件初始化和 OTel SDK，模拟慢 exporter：基线代码在两条上报路径均已打印完成但 3 秒内未退出；修复后均约 0.65 秒正常退出。
- 子进程同时开启 Metrics/Trace 环境开关，模拟慢指标和 Trace exporter，验证正常退出；使用测试 Django 设置，不执行实际管理命令，也不连接真实数据库、采集器或消息队列。
- 通过项目 Makefile 运行，复用与 Agent 依赖声明一致的 OTel 1.33.1 环境；完整 pre-commit 检查通过。
