### PR TITLE
feat: 将 ChatInput 待发送附件数量上限从 3 调整为 9

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/package.json
+++ b/src/frontend/ai-blueking/packages/chat-x/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueking/chat-x",
-  "version": "0.0.49-beta.16",
+  "version": "0.0.51-beta.1",
   "description": "蓝鲸智云 AI Chat 组件库 —— 遵循 AG-UI，为 AI Agent 和人类开发者共同设计的对话 UI 组件库。",
   "main": "index.js",
   "scripts": {

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
@@ -325,7 +325,7 @@ const handleSendMessage = async (
 
 **个数与大小校验（与 `FileUploadBtn` 分工）**：
 
-- 列表最多保留 **`MAX_UPLOAD_FILES`（3）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
+- 列表最多保留 **`MAX_UPLOAD_FILES`（9）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
 - 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）**、或与已有文件重复的项会被跳过；若本轮有任意文件因此未加入列表，会在处理结束后弹出**同一条文案风格**的错误提示，汇总未成功添加的数量。
 - `FileUploadBtn` 仅在按钮层过滤**空文件与单文件超大**，把合法文件以数组形式 `upload` 上来；**个数上限与重复校验**在 `ChatInput` 的 `handleUpload` 中统一处理，避免与按钮层各弹一条提示。
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
@@ -123,7 +123,7 @@ export const CONST_UPDATE_TOOLS = [
   },
 ] as IToolBtn[];
 
-export const MAX_UPLOAD_FILES = 3; // 最大上传文件数量
+export const MAX_UPLOAD_FILES = 9; // 最大上传文件数量
 
 export const MAX_UPLOAD_FILE_SIZE = 2.4 * 1024 * 1024; // 最大上传文件大小 2.5MB
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -63,7 +63,7 @@ vi.mock('../../../common', async importOriginal => {
     ...actual,
     isEn: false,
     MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
-    MAX_UPLOAD_FILES: 3,
+    MAX_UPLOAD_FILES: 9,
   };
 });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -57,7 +57,7 @@ vi.mock('../../common', async importOriginal => {
     ...actual,
     CHAT_Z_INDEX: 1000,
     isEn: false,
-    MAX_UPLOAD_FILES: 3,
+    MAX_UPLOAD_FILES: 9,
     MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
     commonSVGProps: {
       class: 'mock-svg-icon',

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -489,7 +489,7 @@ const handleSendMessage = async (
 
 **个数与大小校验（与 `FileUploadBtn` 分工）**：
 
-- 列表最多保留 **`MAX_UPLOAD_FILES`（3）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
+- 列表最多保留 **`MAX_UPLOAD_FILES`（9）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
 - 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）**、或与已有文件重复的项会被跳过；若本轮有任意文件因此未加入列表，会在处理结束后弹出**同一条文案风格**的错误提示，汇总未成功添加的数量。
 - `FileUploadBtn` 仅在按钮层过滤**空文件与单文件超大**，把合法文件以数组形式 `upload` 上来；**个数上限与重复校验**在 `ChatInput` 的 `handleUpload` 中统一处理，避免与按钮层各弹一条提示。
 


### PR DESCRIPTION
## 背景
TAPD: 【chat-x】将 ChatInput 待发送附件数量上限从 3 调整为 9
ID: 1070093903137778549

## 改动
- constants.ts: MAX_UPLOAD_FILES 3 → 9
- chat-input / file-upload-btn 单测 mock 同步为 9
- wiki / skill 文档上限说明同步为 9
- package.json: @blueking/chat-x 0.0.49-beta.16 → 0.0.51-beta.1

## 影响面
- ChatInput 待发送附件数量上限变为 9；超限提示逻辑不变
- 发布版本号变更，不影响其它业务逻辑

## 测试
- [ ] 输入区最多可添加 9 个待发送附件
- [ ] 第 10 个文件选择/拖入/粘贴时弹出未加入提示，且不入队
- [ ] 文档与单测中的上限数字与常量一致
- [ ] 包版本为 0.0.51-beta.1

Made with [Cursor](https://cursor.com)