### PR TITLE
feat: 规范数据库事件配置 --story=136129662

### DIFF
--- a/src/agent/aidev_agent/config.py
+++ b/src/agent/aidev_agent/config.py
@@ -108,6 +108,17 @@ def update_django_settings(django_settings=None):
 
 env = environs.Env()
 env.read_env()
+
+
+def _read_bool_env(name: str, legacy_name: str, default: bool) -> bool:
+    """Read a boolean setting while preserving the legacy ``1`` semantics."""
+    if name in os.environ:
+        return env.bool(name)
+    if legacy_name in os.environ:
+        return os.environ[legacy_name] == "1"
+    return default
+
+
 existed_keys = list(locals().keys())
 existed_keys.append("existed_keys")
 
@@ -160,6 +171,12 @@ LLM_RETRY_STRATEGY = env.str("LLM_RETRY_STRATEGY", "llm_gw")
 BKAI_FAST_LLM = env.str("BKAI_FAST_LLM", None)
 # 是否启用任务完成度评估（None 表示不覆盖平台配置）
 BKAI_ENABLE_JUDGE_RESPONSE = env.bool("BKAI_ENABLE_JUDGE_RESPONSE", None)
+
+# Agent 事件配置
+# BKAPP_AIDEV_DATABASE_EVENTS_ENABLED 仅作为迁移期兼容项；新配置优先。
+BKAI_DATABASE_EVENTS_ENABLED = _read_bool_env(
+    "BKAI_DATABASE_EVENTS_ENABLED", "BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", True
+)
 
 # Agent 指标与异步任务配置
 # None 表示未通过环境变量显式覆盖，允许平台下发的 otel_info.metrics.enabled 生效。

--- a/src/agent/aidev_agent/config.py
+++ b/src/agent/aidev_agent/config.py
@@ -110,15 +110,6 @@ env = environs.Env()
 env.read_env()
 
 
-def _read_bool_env(name: str, legacy_name: str, default: bool) -> bool:
-    """Read a boolean setting while preserving the legacy ``1`` semantics."""
-    if name in os.environ:
-        return env.bool(name)
-    if legacy_name in os.environ:
-        return os.environ[legacy_name] == "1"
-    return default
-
-
 existed_keys = list(locals().keys())
 existed_keys.append("existed_keys")
 
@@ -173,10 +164,7 @@ BKAI_FAST_LLM = env.str("BKAI_FAST_LLM", None)
 BKAI_ENABLE_JUDGE_RESPONSE = env.bool("BKAI_ENABLE_JUDGE_RESPONSE", None)
 
 # Agent 事件配置
-# BKAPP_AIDEV_DATABASE_EVENTS_ENABLED 仅作为迁移期兼容项；新配置优先。
-BKAI_DATABASE_EVENTS_ENABLED = _read_bool_env(
-    "BKAI_DATABASE_EVENTS_ENABLED", "BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", True
-)
+BKAI_EVENT_DATABASE_ENABLED = env.bool("BKAI_EVENT_DATABASE_ENABLED", True)
 
 # Agent 指标与异步任务配置
 # None 表示未通过环境变量显式覆盖，允许平台下发的 otel_info.metrics.enabled 生效。

--- a/src/agent/tests/test_config.py
+++ b/src/agent/tests/test_config.py
@@ -1,0 +1,34 @@
+import pytest
+from aidev_agent.config import BKAI_DATABASE_EVENTS_ENABLED, _read_bool_env, settings
+
+
+def test_database_events_setting_is_registered_in_agent_config():
+    assert settings.BKAI_DATABASE_EVENTS_ENABLED is BKAI_DATABASE_EVENTS_ENABLED
+
+
+@pytest.mark.parametrize(
+    "canonical, legacy, expected",
+    [
+        (None, None, True),
+        ("1", None, True),
+        ("0", None, False),
+        ("true", None, True),
+        (None, "1", True),
+        (None, "0", False),
+        (None, "true", False),
+        (None, "", False),
+        ("1", "0", True),
+        ("0", "1", False),
+    ],
+)
+def test_read_bool_env_prefers_canonical_name(monkeypatch, canonical, legacy, expected):
+    canonical_name = "BKAI_DATABASE_EVENTS_ENABLED"
+    legacy_name = "BKAPP_AIDEV_DATABASE_EVENTS_ENABLED"
+    monkeypatch.delenv(canonical_name, raising=False)
+    monkeypatch.delenv(legacy_name, raising=False)
+    if canonical is not None:
+        monkeypatch.setenv(canonical_name, canonical)
+    if legacy is not None:
+        monkeypatch.setenv(legacy_name, legacy)
+
+    assert _read_bool_env(canonical_name, legacy_name, True) is expected

--- a/src/agent/tests/test_config.py
+++ b/src/agent/tests/test_config.py
@@ -1,34 +1,29 @@
+import runpy
+
 import pytest
-from aidev_agent.config import BKAI_DATABASE_EVENTS_ENABLED, _read_bool_env, settings
+from aidev_agent import config
+from aidev_agent.config import BKAI_EVENT_DATABASE_ENABLED, settings
 
 
 def test_database_events_setting_is_registered_in_agent_config():
-    assert settings.BKAI_DATABASE_EVENTS_ENABLED is BKAI_DATABASE_EVENTS_ENABLED
+    assert settings.BKAI_EVENT_DATABASE_ENABLED is BKAI_EVENT_DATABASE_ENABLED
 
 
 @pytest.mark.parametrize(
-    "canonical, legacy, expected",
+    "value, expected",
     [
-        (None, None, True),
-        ("1", None, True),
-        ("0", None, False),
-        ("true", None, True),
-        (None, "1", True),
-        (None, "0", False),
-        (None, "true", False),
-        (None, "", False),
-        ("1", "0", True),
-        ("0", "1", False),
+        (None, True),
+        ("1", True),
+        ("0", False),
+        ("true", True),
+        ("false", False),
     ],
 )
-def test_read_bool_env_prefers_canonical_name(monkeypatch, canonical, legacy, expected):
-    canonical_name = "BKAI_DATABASE_EVENTS_ENABLED"
-    legacy_name = "BKAPP_AIDEV_DATABASE_EVENTS_ENABLED"
-    monkeypatch.delenv(canonical_name, raising=False)
-    monkeypatch.delenv(legacy_name, raising=False)
-    if canonical is not None:
-        monkeypatch.setenv(canonical_name, canonical)
-    if legacy is not None:
-        monkeypatch.setenv(legacy_name, legacy)
+def test_database_events_environment_default_and_override(monkeypatch, value, expected):
+    name = "BKAI_EVENT_DATABASE_ENABLED"
+    monkeypatch.delenv(name, raising=False)
+    if value is not None:
+        monkeypatch.setenv(name, value)
 
-    assert _read_bool_env(canonical_name, legacy_name, True) is expected
+    module = runpy.run_path(config.__file__)
+    assert module[name] is expected

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
@@ -26,7 +26,7 @@ class EventResourceManager:
 
 
 def with_database_events(resource_manager, app_code: str):
-    if agent_settings.BKAI_DATABASE_EVENTS_ENABLED is not True:
+    if agent_settings.BKAI_EVENT_DATABASE_ENABLED is not True:
         return resource_manager
     if isinstance(resource_manager, EventResourceManager):
         return resource_manager

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_resource_manager.py
@@ -1,6 +1,7 @@
 """Per-agent publishing adapter; never replaces the global resource registry."""
 
 from ag_ui.core import BaseEvent
+from aidev_agent.config import settings as agent_settings
 from django.db import close_old_connections
 
 
@@ -25,9 +26,7 @@ class EventResourceManager:
 
 
 def with_database_events(resource_manager, app_code: str):
-    from django.conf import settings
-
-    if getattr(settings, "AIDEV_DATABASE_EVENTS_ENABLED", False) is not True:
+    if agent_settings.BKAI_DATABASE_EVENTS_ENABLED is not True:
         return resource_manager
     if isinstance(resource_manager, EventResourceManager):
         return resource_manager

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -11,9 +11,6 @@ AIDEV_AGENT = os.environ.get("AIDEV_AGENT", "aidev_agent.services.common_agent.C
 # ``resource_manager.replace_defaults(...)`` 注入到全局工厂；为空则使用 SDK 默认的
 # ``AgentResourceManager``。
 AIDEV_RESOURCE_MANAGER = os.environ.get("AIDEV_RESOURCE_MANAGER", "")
-# Enabled by default; migrate before startup and share the database/app scope across Web and wxbot.
-# Set BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=0 to opt out.
-AIDEV_DATABASE_EVENTS_ENABLED = os.environ.get("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", "1") == "1"
 AIDEV_AGENT_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_WORKERS", 16))
 AIDEV_AGENT_MAX_PENDING = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_PENDING", 32))
 AIDEV_AGENT_CLEANUP_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_CLEANUP_MAX_WORKERS", 2))

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -6,12 +6,15 @@ Agent，不创建新会话，也不要求两个进程共用 Redis 或进程内�
 
 ## 启用
 
-默认开启：未设置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED` 时，Web 发布数据库事件，
+默认开启：未设置 `BKAI_DATABASE_EVENTS_ENABLED` 时，Web 发布数据库事件，
 wxbot 注册订阅并消费投递。升级后启动进程前，必须先在应用的 Django 环境执行
 `migrate aidev_bkplugin`，确保事件表已创建。
 
-如需关闭，为 Web 和 wxbot **同时**配置 `BKAPP_AIDEV_DATABASE_EVENTS_ENABLED=0`；
-显式设置 `=1` 可开启。已有 `=0` 配置会继续生效，不会被新默认值覆盖。
+如需关闭，为 Web 和 wxbot **同时**配置 `BKAI_DATABASE_EVENTS_ENABLED=0`；
+显式设置 `=1` 可开启。迁移期仍兼容旧变量
+`BKAPP_AIDEV_DATABASE_EVENTS_ENABLED`，但新变量优先；已有旧变量 `=0` 配置会继续
+生效，不会被新默认值覆盖。后续新增的 Agent 配置统一使用 `BKAI_` 前缀，并在
+`aidev_agent/config.py` 定义。
 两端必须加载匹配的 SDK / 插件版本，使用同一个应用标识、数据库和会话环境。
 不需要为 wxbot 新增表，通用表由 bkplugin 的迁移维护。
 

--- a/src/plugins/aidev_bkplugin/docs/database-events.md
+++ b/src/plugins/aidev_bkplugin/docs/database-events.md
@@ -6,14 +6,12 @@ Agent，不创建新会话，也不要求两个进程共用 Redis 或进程内�
 
 ## 启用
 
-默认开启：未设置 `BKAI_DATABASE_EVENTS_ENABLED` 时，Web 发布数据库事件，
+默认开启：未设置 `BKAI_EVENT_DATABASE_ENABLED` 时，Web 发布数据库事件，
 wxbot 注册订阅并消费投递。升级后启动进程前，必须先在应用的 Django 环境执行
 `migrate aidev_bkplugin`，确保事件表已创建。
 
-如需关闭，为 Web 和 wxbot **同时**配置 `BKAI_DATABASE_EVENTS_ENABLED=0`；
-显式设置 `=1` 可开启。迁移期仍兼容旧变量
-`BKAPP_AIDEV_DATABASE_EVENTS_ENABLED`，但新变量优先；已有旧变量 `=0` 配置会继续
-生效，不会被新默认值覆盖。后续新增的 Agent 配置统一使用 `BKAI_` 前缀，并在
+如需关闭，为 Web 和 wxbot **同时**配置 `BKAI_EVENT_DATABASE_ENABLED=0`；
+显式设置 `=1` 可开启。后续新增的 Agent 配置统一使用 `BKAI_` 前缀，并在
 `aidev_agent/config.py` 定义。
 两端必须加载匹配的 SDK / 插件版本，使用同一个应用标识、数据库和会话环境。
 不需要为 wxbot 新增表，通用表由 bkplugin 的迁移维护。

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
@@ -8,7 +8,7 @@ from aidev_bkplugin.services.event_resource_manager import EventResourceManager,
 
 @pytest.mark.parametrize("enabled", [False, True])
 def test_injection_respects_setting_and_preserves_original_resource_manager(monkeypatch, enabled):
-    monkeypatch.setattr(agent_settings, "BKAI_DATABASE_EVENTS_ENABLED", enabled, raising=False)
+    monkeypatch.setattr(agent_settings, "BKAI_EVENT_DATABASE_ENABLED", enabled, raising=False)
     original = SimpleNamespace(username="author", get_agent_config=lambda: "custom-config")
     wrapped = with_database_events(original, "app")
     assert wrapped.get_agent_config() == "custom-config" and wrapped.username == "author"

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_resource_manager.py
@@ -1,36 +1,19 @@
-import runpy
 from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
+from aidev_agent.config import settings as agent_settings
 from aidev_bkplugin.services.event_resource_manager import EventResourceManager, with_database_events
 
 
 @pytest.mark.parametrize("enabled", [False, True])
-def test_injection_respects_setting_and_preserves_original_resource_manager(settings, enabled):
-    settings.AIDEV_DATABASE_EVENTS_ENABLED = enabled
+def test_injection_respects_setting_and_preserves_original_resource_manager(monkeypatch, enabled):
+    monkeypatch.setattr(agent_settings, "BKAI_DATABASE_EVENTS_ENABLED", enabled, raising=False)
     original = SimpleNamespace(username="author", get_agent_config=lambda: "custom-config")
     wrapped = with_database_events(original, "app")
     assert wrapped.get_agent_config() == "custom-config" and wrapped.username == "author"
     assert isinstance(wrapped, EventResourceManager) == enabled
     assert with_database_events(wrapped, "app") is wrapped
-
-
-@pytest.mark.parametrize("value, enabled", [(None, True), ("1", True), ("0", False), ("", False), ("true", False)])
-def test_database_events_environment_default_and_override(settings, monkeypatch, value, enabled):
-    monkeypatch.setenv("BKPAAS_ENGINE_REGION", "ieod")
-    if value is None:
-        monkeypatch.delenv("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", raising=False)
-    else:
-        monkeypatch.setenv("BKAPP_AIDEV_DATABASE_EVENTS_ENABLED", value)
-    config = runpy.run_module("aidev_bkplugin.settings")
-    settings.AIDEV_DATABASE_EVENTS_ENABLED = config["AIDEV_DATABASE_EVENTS_ENABLED"]
-    assert settings.AIDEV_DATABASE_EVENTS_ENABLED is enabled
-    original = object()
-    wrapped = with_database_events(original, "app")
-    assert isinstance(wrapped, EventResourceManager) is enabled
-    if not enabled:
-        assert wrapped is original
 
 
 @pytest.mark.parametrize("failing", [False, True])

--- a/src/plugins/aidev_bkplugin/tests/services/agent/test_builder.py
+++ b/src/plugins/aidev_bkplugin/tests/services/agent/test_builder.py
@@ -94,9 +94,10 @@ def test_by_thread_id_skips_save_when_save_content_false():
     sm.save_content.assert_not_called()
 
 
-def test_by_session_code_passes_user_resource_manager():
+def test_by_session_code_wraps_user_resource_manager_for_events():
     from aidev_agent.packages.resource_manager.agent import AgentResourceManager
     from aidev_bkplugin.services.agent_builder import AgentBuilder
+    from aidev_bkplugin.services.event_resource_manager import EventResourceManager
 
     build_p, factory_p, client_p, checkpointer_p = _patch_factories()
     with build_p as mock_build, factory_p as mock_factory, client_p, checkpointer_p:
@@ -105,7 +106,8 @@ def test_by_session_code_passes_user_resource_manager():
         AgentBuilder(username="alice").by_session_code("sc-1")
 
     rm = mock_build.call_args.kwargs["resource_manager"]
-    assert isinstance(rm, AgentResourceManager)
+    assert isinstance(rm, EventResourceManager)
+    assert isinstance(rm._resource_manager, AgentResourceManager)
     assert rm.username == "alice"
 
 

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -577,7 +577,7 @@ class WxAiBotLongConnectionService:
 
     @staticmethod
     def _database_events_enabled() -> bool:
-        return agent_settings.BKAI_DATABASE_EVENTS_ENABLED is True
+        return agent_settings.BKAI_EVENT_DATABASE_ENABLED is True
 
     def _bind_resume_route(self, session_code: str, username: str, target: str) -> None:
         from .database_delivery import bind_resume_subscription

--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -21,6 +21,7 @@ from tempfile import gettempdir
 from typing import Any
 
 from aibot import WSClient, WSClientOptions
+from aidev_agent.config import settings as agent_settings
 from aidev_agent.utils.tracing import get_current_trace_id
 from aidev_bkplugin.services.execution import (
     get_agent_cleanup_executor,
@@ -576,7 +577,7 @@ class WxAiBotLongConnectionService:
 
     @staticmethod
     def _database_events_enabled() -> bool:
-        return getattr(settings, "AIDEV_DATABASE_EVENTS_ENABLED", False) is True
+        return agent_settings.BKAI_DATABASE_EVENTS_ENABLED is True
 
     def _bind_resume_route(self, session_code: str, username: str, target: str) -> None:
         from .database_delivery import bind_resume_subscription

--- a/src/plugins/aidev_wxbot/tests/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/conftest.py
@@ -36,7 +36,7 @@ def pytest_configure():
     from aidev_agent.config import settings as agent_settings
     from django.conf import settings
 
-    agent_settings.set("BKAI_DATABASE_EVENTS_ENABLED", False)
+    agent_settings.set("BKAI_EVENT_DATABASE_ENABLED", False)
     if settings.configured:
         return
     from aidev_wxbot import settings as wxbot_settings

--- a/src/plugins/aidev_wxbot/tests/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/conftest.py
@@ -33,8 +33,10 @@ sys.modules.setdefault(TEST_APP_CONFIG_MODULE, sys.modules[__name__])
 @pytest.hookimpl(tryfirst=True)
 def pytest_configure():
     """Configure Django before pytest-django initializes the app registry."""
+    from aidev_agent.config import settings as agent_settings
     from django.conf import settings
 
+    agent_settings.set("BKAI_DATABASE_EVENTS_ENABLED", False)
     if settings.configured:
         return
     from aidev_wxbot import settings as wxbot_settings
@@ -67,7 +69,6 @@ def pytest_configure():
         USER_TOKEN_KEY_NAME="access_token",
         ENABLE_OTEL_TRACE=False,
         AIDEV_AGENT="aidev_agent.services.common_agent.CommonQAAgent",
-        AIDEV_DATABASE_EVENTS_ENABLED=False,
     )
     settings.configure(**values)
 

--- a/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
@@ -33,9 +33,11 @@ class AidevWxbotTestConfig(AppConfig):
 def configure_database(path):
     os.environ["MESSAGE_HANDLER_TYPE"] = "inmemory"
     import django
+    from aidev_agent.config import settings as agent_settings
     from aidev_wxbot import settings as wxbot_settings
     from django.conf import settings
 
+    agent_settings.set("BKAI_DATABASE_EVENTS_ENABLED", True)
     app_config_module = "aidev_wxbot_test_app_configs"
     sys.modules.setdefault(app_config_module, sys.modules[__name__])
     values = {key: getattr(wxbot_settings, key) for key in dir(wxbot_settings) if key.isupper()}
@@ -51,7 +53,6 @@ def configure_database(path):
         MIDDLEWARE=[],
         ROOT_URLCONF="aidev_bkplugin.urls",
         APP_CODE="app",
-        AIDEV_DATABASE_EVENTS_ENABLED=True,
     )
     values.update(
         BK_APIGW_MANAGER_URL_TMPL="https://{api_name}.example.invalid",

--- a/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
@@ -37,7 +37,7 @@ def configure_database(path):
     from aidev_wxbot import settings as wxbot_settings
     from django.conf import settings
 
-    agent_settings.set("BKAI_DATABASE_EVENTS_ENABLED", True)
+    agent_settings.set("BKAI_EVENT_DATABASE_ENABLED", True)
     app_config_module = "aidev_wxbot_test_app_configs"
     sys.modules.setdefault(app_config_module, sys.modules[__name__])
     values = {key: getattr(wxbot_settings, key) for key in dir(wxbot_settings) if key.isupper()}

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -297,7 +297,7 @@ async def test_expired_card_callback_is_not_retried():
 
 @pytest.mark.parametrize("enabled", [False, True])
 def test_database_events_use_agent_config(monkeypatch, enabled):
-    monkeypatch.setattr(long_connection_module.agent_settings, "BKAI_DATABASE_EVENTS_ENABLED", enabled, raising=False)
+    monkeypatch.setattr(long_connection_module.agent_settings, "BKAI_EVENT_DATABASE_ENABLED", enabled, raising=False)
     assert WxAiBotLongConnectionService._database_events_enabled() is enabled
 
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -295,6 +295,12 @@ async def test_expired_card_callback_is_not_retried():
     assert not service._client.update_template_card_calls
 
 
+@pytest.mark.parametrize("enabled", [False, True])
+def test_database_events_use_agent_config(monkeypatch, enabled):
+    monkeypatch.setattr(long_connection_module.agent_settings, "BKAI_DATABASE_EVENTS_ENABLED", enabled, raising=False)
+    assert WxAiBotLongConnectionService._database_events_enabled() is enabled
+
+
 class TestAgentStreamDrain:
     """收尾只排空 Agent 统一流接口，不由长连接操作消息缓存。"""
 


### PR DESCRIPTION
## 背景

数据库事件开关同时由 Web 发布端和企业微信消费端使用，需要统一命名和配置来源。

## 原因

原开关使用应用部署层前缀，并在插件的 Django settings 中单独解析，导致 Agent 公共配置存在重复来源。

## 改动内容

- 新增 `BKAI_EVENT_DATABASE_ENABLED`，集中由 Agent 配置模块解析
- Web 发布端与企业微信消费端读取同一 Agent 配置
- 更新配置文档，并覆盖默认值和显式开关测试

## 收益

- 统一 Agent 配置命名和读取入口
- 避免 Web 与企业微信加载不同配置副本

## 测试验证

- Agent 配置测试：11 passed
- Web 数据库事件测试：21 passed
- 企业微信配置读取测试：2 passed
- PR 目标文件 pre-commit：passed

## 已知基线情况

- 全仓库 pre-commit 会命中 develop 中与本次变更无关的存量 lint；本 PR 目标文件门禁通过
