### PR TITLE
fix: 企微调用遵循智能体温度配置 --story=136129662

### DIFF
--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/strategies.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/strategies.py
@@ -53,7 +53,6 @@ WECOM_LONG_CONNECTION_EXECUTION_POLICY = (
     WECOM_AGENT_EXECUTION_POLICY + "\n5. 如果工具把结果保存到文件，必须继续读取文件并把记录写入最终回复；"
     "在明细表格完成前不得只返回概览、文件路径或询问用户是否需要查看详情。"
 )
-WECOM_AGENT_TEMPERATURE = 0.1
 WECOM_AGENT_RETRY_STRATEGY = "sdk"
 
 
@@ -167,7 +166,6 @@ class ChatAgentStrategy:
                 WECOM_LONG_CONNECTION_EXECUTION_POLICY if retry_strategy else WECOM_AGENT_EXECUTION_POLICY
             ),
             enable_query_clarification=False,
-            temperature=WECOM_AGENT_TEMPERATURE,
             retry_strategy=retry_strategy,
         )
         return AgentStream(

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_strategies.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_strategies.py
@@ -24,7 +24,6 @@ from aidev_wxbot.wxaibot.context import LlmChunkMsg
 from aidev_wxbot.wxaibot.formatters import handle_flow_custom_event
 from aidev_wxbot.wxaibot.strategies import (
     WECOM_AGENT_EXECUTION_POLICY,
-    WECOM_AGENT_TEMPERATURE,
     WECOM_LONG_CONNECTION_EXECUTION_POLICY,
     ChatAgentStrategy,
     FlowAgentStrategy,
@@ -192,6 +191,7 @@ class TestChatAgentStrategyExecute:
         call_kwargs = mock_run.call_args.kwargs
         assert call_kwargs["retry_strategy"] == "sdk"
         assert call_kwargs["transient_system_prompt"] == WECOM_LONG_CONNECTION_EXECUTION_POLICY
+        assert "temperature" not in call_kwargs
 
     @patch("aidev_wxbot.wxaibot.strategies.AgentExecutor.run_chat_completion_with_thread_id")
     @patch("aidev_wxbot.wxaibot.strategies.build_execute_kwargs")
@@ -221,7 +221,7 @@ class TestChatAgentStrategyExecute:
         call_kwargs = mock_run.call_args.kwargs
         assert call_kwargs["transient_system_prompt"] == WECOM_AGENT_EXECUTION_POLICY
         assert call_kwargs["enable_query_clarification"] is False
-        assert call_kwargs["temperature"] == WECOM_AGENT_TEMPERATURE
+        assert "temperature" not in call_kwargs
         assert call_kwargs["retry_strategy"] is None
         assert mock_rabbitmq.publish_message.call_count >= 1
 


### PR DESCRIPTION
## 背景

企微 Chat 策略在调用 Agent SDK 时固定传入 `temperature=0.1`，覆盖了智能体发布配置。工具审批恢复路径没有传入这个覆盖值，因此同一次会话的首次执行与恢复执行会使用不同温度。

固定覆盖由 [eb75fbd5](https://github.com/TencentBlueKing/bk-aidev-agent/commit/eb75fbd5db41199f4e42b428718881e319489870) 引入。

## 变更

- 移除企微渠道固定的 temperature 常量和调用级参数。
- 保留企微执行策略、查询澄清开关和 SDK 重试策略不变。
- 更新普通请求与长连接请求测试，验证企微入口不再传入调用级 temperature，由 Agent 配置统一决定。

## 验证

- 企微策略测试：23 passed。
- 企微插件全量测试：472 passed、10 skipped、5 xfailed；一个跨进程时序用例首次超时，单独重跑两种参数均通过。
- 本次改动文件的 ruff、ruff format、merge-conflict hooks 全部通过。
