### PR TITLE
feat: 传递 Sandbox 与 MCP Trace Context --story=1070093903137679449

### DIFF
--- a/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
@@ -41,7 +41,7 @@ from langchain_core.runnables import RunnableConfig
 from requests.exceptions import HTTPError
 
 from aidev_agent.config import settings
-from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span, trace_headers
 
 from .types import (
     EditResult,
@@ -177,6 +177,13 @@ def _trace_sandbox_operation(operation: str):
         return wrapper
 
     return decorator
+
+
+def _trace_request_kwargs() -> dict[str, dict[str, str]]:
+    """Build optional W3C trace headers for one sandbox HTTP request."""
+
+    headers = trace_headers()
+    return {"headers": headers} if headers else {}
 
 
 # ---------------------------------------------------------------------------
@@ -349,7 +356,11 @@ class PaasSandboxBackend(RuntimeBackend):
         # volume_mounts: 无实例默认值，仅使用方法参数
         if volume_mounts is not None:
             payload["volume_mounts"] = volume_mounts
-        response = self.client.create_sandbox.request(json=payload, path_params={"app_code": self._app_code})
+        response = self.client.create_sandbox.request(
+            json=payload,
+            path_params={"app_code": self._app_code},
+            **_trace_request_kwargs(),
+        )
         response.raise_for_status()
         data = response.json()
         if isinstance(data, dict) and data.get("uuid"):
@@ -365,7 +376,11 @@ class PaasSandboxBackend(RuntimeBackend):
             sandbox_id: 沙箱 UUID。
             timeout: HTTP 请求超时秒数，默认 10 秒。防止进程退出时 HTTP 调用无限期挂起。
         """
-        response = self.client.delete_sandbox.request(path_params={"sandbox_id": sandbox_id}, timeout=timeout)
+        response = self.client.delete_sandbox.request(
+            path_params={"sandbox_id": sandbox_id},
+            timeout=timeout,
+            **_trace_request_kwargs(),
+        )
         response.raise_for_status()
 
     @_trace_sandbox_operation("execute")
@@ -393,6 +408,7 @@ class PaasSandboxBackend(RuntimeBackend):
         response = self.client.exec_command.request(
             json={"cmd": cmd},
             path_params={"sandbox_id": sandbox_id},
+            **_trace_request_kwargs(),
         )
         response.raise_for_status()
         data = response.json()
@@ -424,6 +440,7 @@ class PaasSandboxBackend(RuntimeBackend):
         response = self.client.upload_file.request(
             files={"file": (filename, content), "path": (None, path)},
             path_params={"sandbox_id": sandbox_id},
+            **_trace_request_kwargs(),
         )
         response.raise_for_status()
 
@@ -442,6 +459,7 @@ class PaasSandboxBackend(RuntimeBackend):
         response = self.client.download_file.request(
             params={"path": path},
             path_params={"sandbox_id": sandbox_id},
+            **_trace_request_kwargs(),
         )
         response.raise_for_status()
         return response.content

--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -16,6 +16,7 @@ import abc
 import asyncio
 import json
 import time
+from collections.abc import Awaitable, Callable
 from copy import deepcopy
 from logging import getLogger
 from typing import TYPE_CHECKING, Any, List, Optional
@@ -23,6 +24,7 @@ from typing import TYPE_CHECKING, Any, List, Optional
 from ag_ui.core import BaseEvent
 from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
+from langchain_mcp_adapters.interceptors import MCPToolCallRequest, MCPToolCallResult
 
 from aidev_agent.api.paas_client import BkPaaSSandboxApi
 from aidev_agent.config import settings
@@ -36,7 +38,7 @@ from aidev_agent.packages.langchain_core.tools.base import (
 )
 from aidev_agent.pydantic_models import AgentConfig
 from aidev_agent.utils.loop import run_coro_sync
-from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span, trace_headers
 
 try:
     import bkoauth
@@ -47,6 +49,35 @@ if TYPE_CHECKING:
     from aidev_agent.api.bk_aidev import Client
 
 _logger = getLogger(__name__)
+
+
+def _inject_mcp_trace_headers(server_config: dict[str, dict[str, Any]]) -> None:
+    """Inject active W3C context into MCP discovery and initialization calls."""
+
+    current_headers = trace_headers()
+    if not current_headers:
+        return
+    for connection in server_config.values():
+        if not connection.get("url"):
+            continue
+        headers = connection.get("headers")
+        if not isinstance(headers, dict):
+            headers = {}
+            connection["headers"] = headers
+        headers.update(current_headers)
+
+
+async def _mcp_trace_context_interceptor(
+    request: MCPToolCallRequest,
+    handler: Callable[[MCPToolCallRequest], Awaitable[MCPToolCallResult]],
+) -> MCPToolCallResult:
+    """Refresh W3C trace headers when an MCP tool creates its HTTP session."""
+
+    current_headers = trace_headers()
+    if not current_headers:
+        return await handler(request)
+    headers = {**(request.headers or {}), **current_headers}
+    return await handler(request.override(headers=headers))
 
 
 def _get_access_token_by_user(username: str) -> str | None:
@@ -556,7 +587,6 @@ class BaseResourceManager(abc.ABC):
             server_config = new_server_config[server_name]
             transport = str(server_config.get("transport") or "unknown")
             for _i in range(2):
-                client = MultiServerMCPClient(new_server_config)
                 try:
                     with recording_span(
                         "mcp.tools.list",
@@ -569,6 +599,12 @@ class BaseResourceManager(abc.ABC):
                             "mcp.retry.count": _i,
                         },
                     ) as span:
+                        client_config = deepcopy(new_server_config)
+                        _inject_mcp_trace_headers(client_config)
+                        client = MultiServerMCPClient(
+                            client_config,
+                            tool_interceptors=[_mcp_trace_context_interceptor],
+                        )
                         tools: list[StructuredTool] = await client.get_tools(server_name=server_name)
                         span.set_attribute("mcp.tool.count", len(tools))
                     total_count = len(tools)

--- a/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
@@ -769,6 +769,17 @@ class TestPaasSandboxBackendHTTPMethods:
         assert span.attributes["sandbox.operation.name"] == "execute"
         assert "echo hello" not in str(span.attributes)
 
+    def test_exec_command_propagates_current_trace_context(self, http_backend, monkeypatch):
+        traceparent = "00-992eea94222b572e883ab78b23e73d64-99e019654b49749a-01"
+        monkeypatch.setattr(f"{_PAAS_BACKEND_MOD}.trace_headers", lambda: {"traceparent": traceparent})
+        http_backend.client.exec_command.request.return_value = _make_http_response(
+            json_data={"stdout": "ok", "stderr": "", "exit_code": 0}
+        )
+
+        http_backend.exec_command("sb-123", "echo hello")
+
+        assert http_backend.client.exec_command.request.call_args.kwargs["headers"] == {"traceparent": traceparent}
+
     @pytest.fixture()
     def http_backend(self):
         b = _make_backend()

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -542,6 +542,58 @@ def test_make_mcp_tools_with_blueapps_auth(mock_mcp_client_class, sample_mcp_con
     assert len(result.tools) == 1
 
 
+@patch(
+    "aidev_agent.packages.resource_manager.base.trace_headers",
+    return_value={"traceparent": "00-992eea94222b572e883ab78b23e73d64-99e019654b49749a-01"},
+)
+@patch("aidev_agent.packages.resource_manager.base.MultiServerMCPClient")
+def test_make_mcp_tools_propagates_trace_context_to_all_remote_servers(mock_mcp_client_class, _mock_trace_headers):
+    config = {
+        "apigw": {
+            "url": "https://example.com/apigw/mcp",
+            "transport": "streamable_http",
+            "credential_type": "blueapps",
+        },
+        "external": {"url": "https://example.net/mcp", "transport": "sse", "headers": {"X-Custom": "kept"}},
+        "local": {"transport": "stdio", "command": "python", "args": ["server.py"]},
+    }
+    mock_mcp_client_class.return_value.get_tools = AsyncMock(return_value=[])
+
+    make_mcp_tools(config)
+
+    client_config = mock_mcp_client_class.call_args_list[0].args[0]
+    assert client_config["apigw"]["headers"]["traceparent"].split("-")[1] == "992eea94222b572e883ab78b23e73d64"
+    assert client_config["external"]["headers"]["traceparent"].split("-")[1] == "992eea94222b572e883ab78b23e73d64"
+    assert client_config["external"]["headers"]["X-Custom"] == "kept"
+    assert "headers" not in client_config["local"]
+    assert callable(mock_mcp_client_class.call_args_list[0].kwargs["tool_interceptors"][0])
+
+
+@pytest.mark.asyncio
+@patch(
+    "aidev_agent.packages.resource_manager.base.trace_headers",
+    return_value={"traceparent": "00-992eea94222b572e883ab78b23e73d64-99e019654b49749a-01"},
+)
+async def test_mcp_tool_call_refreshes_trace_context(_mock_trace_headers):
+    from aidev_agent.packages.resource_manager.base import _mcp_trace_context_interceptor
+
+    request = MagicMock()
+    request.headers = {"X-Custom": "kept"}
+    updated_request = request.override.return_value
+    handler = AsyncMock(return_value="ok")
+
+    result = await _mcp_trace_context_interceptor(request, handler)
+
+    assert result == "ok"
+    request.override.assert_called_once_with(
+        headers={
+            "X-Custom": "kept",
+            "traceparent": "00-992eea94222b572e883ab78b23e73d64-99e019654b49749a-01",
+        }
+    )
+    handler.assert_awaited_once_with(updated_request)
+
+
 @patch("aidev_agent.packages.resource_manager.base.MultiServerMCPClient")
 def test_make_mcp_tools_error_handling(mock_mcp_client_class, sample_mcp_config, caplog):
     """测试 MCP 工具获取失败时跳过并记录 warning"""


### PR DESCRIPTION
## 背景

Agent 调用 Sandbox 和远程 MCP 时，当前 W3C Trace Context 未传递到下游，跨服务链路无法完整关联。

## 原因

现有实现仅创建了 CLIENT Span，但底层 Sandbox HTTP 请求及 MCP 客户端会话没有注入当前 trace headers。

## 改动内容

- 为 PaaS Sandbox 的创建、销毁、命令执行、文件上传和下载请求注入当前 W3C trace headers。
- 为所有远程 MCP 的初始化、工具发现及每次工具调用注入当前 trace headers，不区分 APIGW 或外部 MCP。
- 保留 MCP 已有鉴权和自定义请求头；stdio transport 因不存在 HTTP Header 通道而保持原行为。
- 补充 Sandbox 与 MCP trace context 传播测试。

## 收益

Sandbox 与远程 MCP 下游可以继续使用同一 trace，便于跨服务检索和定位调用链路。

## 测试验证

- SDK 完整测试：2217 passed, 62 skipped, 61 deselected, 6 xfailed。
- 本次四个目标文件的 Ruff、格式化和冲突检查通过。
- 全仓 pre-commit 已执行；被改动范围外的 11 个既有 Ruff 问题阻塞，本次文件无新增检查问题。
