### PR TITLE
feat: Chat 长连接首包前发送准备中占位 --story=137821628

### DIFF
--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/long_connection.py
@@ -74,7 +74,7 @@ from .once import BoundedOnceRegistry
 from .question_cards import bind_question_target, decode_question_key, question_task_id, submitted_question_card
 from .question_resume import prepare_question_submission, submit_question_resume
 from .resume_delivery import ResumeDelivery
-from .strategies import WECOM_AGENT_RETRY_STRATEGY, resolve_strategy
+from .strategies import ChatAgentStrategy, WECOM_AGENT_RETRY_STRATEGY, resolve_strategy
 from .stream_registry import stream_registry
 from .tracing import (
     CLIENT,
@@ -917,7 +917,14 @@ class WxAiBotLongConnectionService:
             await self._send_stream_reply(frame, request.stream_id, notice, True)
             return
 
+        send_placeholder = isinstance(resolve_strategy(request.username), ChatAgentStrategy)
+        if send_placeholder:
+            # Chat 首包前先占位，避免用户发完消息后长时间看不到气泡。
+            await self._send_stream_reply(frame, request.stream_id, PREPARING_REPLY, False)
+
         self._launch_direct_stream(frame, request)
+        if send_placeholder and (active := self._active_streams.get(request.stream_id)):
+            active.last_content = PREPARING_REPLY
 
     def _launch_direct_stream(self, frame: dict[str, Any], request: WxBotAgentRequest) -> None:
         cancel_event = threading.Event()

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -73,6 +73,7 @@ pytestmark = pytest.mark.skipif(not _wxbot_available, reason="Django and aidev_w
 
 if _wxbot_available:
     from aidev_wxbot.wxaibot.direct_stream import AgentStream
+    from aidev_wxbot.wxaibot.strategies import ChatAgentStrategy, FlowAgentStrategy
 
 
 class FakeClient:
@@ -729,6 +730,63 @@ class TestLongConnectionConfig:
 
 @pytest.mark.asyncio
 class TestLongConnectionStreaming:
+    async def test_chat_sends_preparing_placeholder_before_first_agent_frame(self):
+        service = _service()
+        service._view._get_or_create_thread_id.return_value = "thread-1"
+        started = threading.Event()
+        release = threading.Event()
+
+        def generator():
+            started.set()
+            release.wait(timeout=2)
+            yield f'data: {{"type":"TEXT_MESSAGE_CONTENT","delta":"{"a" * 50}"}}\n'
+            yield 'data: {"type":"RUN_FINISHED"}\n'
+
+        strategy = ChatAgentStrategy()
+        strategy.open_stream = MagicMock(
+            return_value=AgentStream("chat", generator(), "session-1")
+        )
+        request = SimpleNamespace(content="q", stream_id="chat-placeholder", username="u", group_id="g1")
+
+        with (
+            patch.object(long_connection_module, "resolve_strategy", return_value=strategy),
+            patch.object(long_connection_module, "get_agent_executor", return_value=ThreadExecutor()),
+        ):
+            await service._start_direct_stream({}, request)
+            assert service._client.reply_stream_calls == [(PREPARING_REPLY, False)]
+            assert service._active_streams[request.stream_id].last_content == PREPARING_REPLY
+            for _ in range(200):
+                if started.is_set():
+                    break
+                await asyncio.sleep(0.01)
+            assert started.is_set()
+            release.set()
+            await service._active_streams[request.stream_id].task
+
+        assert service._client.reply_stream_calls == [
+            (PREPARING_REPLY, False),
+            ("a" * 50, False),
+            ("a" * 50, True),
+        ]
+
+    async def test_flow_does_not_send_preparing_placeholder(self):
+        service = _service()
+        service._view._get_or_create_thread_id.return_value = "thread-1"
+        strategy = FlowAgentStrategy()
+        strategy.open_stream = MagicMock(
+            return_value=AgentStream("flow", iter(['data: {"type":"RUN_FINISHED"}\n']), "session-1")
+        )
+        request = SimpleNamespace(content="q", stream_id="flow-no-placeholder", username="u", group_id="g1")
+
+        with (
+            patch.object(long_connection_module, "resolve_strategy", return_value=strategy),
+            patch.object(long_connection_module, "get_agent_executor", return_value=ThreadExecutor()),
+        ):
+            await service._start_direct_stream({}, request)
+            await service._active_streams[request.stream_id].task
+
+        assert all(content != PREPARING_REPLY for content, _finish in service._client.reply_stream_calls)
+
     async def test_stream_timeout_gets_explicit_terminal_reply(self, monkeypatch):
         service = _service()
         request = SimpleNamespace(content="q", stream_id="stream-timeout", username="u", group_id="g")
@@ -741,6 +799,7 @@ class TestLongConnectionStreaming:
         monkeypatch.setattr(settings, "WXAIBOT_WS_STREAM_TIMEOUT_SEC", 1)
 
         with (
+            patch.object(long_connection_module, "resolve_strategy", return_value=MagicMock()),
             patch.object(long_connection_module, "get_agent_executor", return_value=ThreadExecutor()),
             patch.object(long_connection_module.stream_registry, "cancel", return_value=True) as cancel,
         ):


### PR DESCRIPTION
## 背景

TAPD [#137821628](https://tapd.woa.com/tapd_fe/70093903/story/detail/1070093903137821628)：企微 Chat 长连接在 Agent 首包到达前没有气泡，用户发完消息会空白一段时间。

根因 / 现状：

- HTTP 回调已立刻返回「正在思考中...」
- 长连接要等第一帧 `reply_stream` 才出内容；Flow 已有节点进度，本次只补 Chat

## 改动

- `_start_direct_stream` 在繁忙检查通过后，若 `resolve_strategy` 为 `ChatAgentStrategy`，立刻 `reply_stream` 发送已有文案 `PREPARING_REPLY`（正在准备回复中...），`finish=False`
- 同步写入 `ActiveStream.last_content`，占位阶段 `/stop` 文案与用户已看到的内容一致
- 首包正文仍覆盖同一 `stream_id`；`/new`、`/help`、繁忙拒绝等命令路径不发占位

## 测试

- `src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py`
  - Chat 先出占位再出正文
  - Flow 不发占位
  - 超时 / 直推 / `/stop` 中途截断相关用例

## 关联

tapd: #137821628

发起人：
- @Vellun7

Made with [Cursor](https://cursor.com)