### PR TITLE
fix: 清洗会话 PV 非法文件名并隔离 download_url 失败 --story=136417903

### DIFF
--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -18,14 +18,17 @@ from __future__ import annotations
 
 import logging
 import posixpath
+import re
 import threading
 import time
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
 from typing import NotRequired, Optional, TypedDict
+from urllib.parse import quote, urlencode
 from uuid import uuid4
 
 from bkapi_client_core.exceptions import HTTPResponseError
+from requests import HTTPError as RequestsHTTPError
 
 from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
 from aidev_agent.packages.resource_manager.registry import ResourceManagerProtocol
@@ -133,6 +136,12 @@ SESSION_UPLOAD_FILE_EXTENSIONS = (
     )
     | SESSION_UPLOAD_IMAGE_EXTENSIONS
 )
+# PaaS download_url 等接口解码后校验 path：空格、`&`、括号等会 VALIDATION_ERROR。
+# 只改落盘文件名，展示仍用原始 name。
+# 正则保留 \w（含 Unicode 字母，如中文已验证通过）与 . - ，只把空格、`&`、括号等 ASCII 标点替换为 `_`；
+# PaaS 接受 Unicode 字母（中文已验证），仅拒绝字典/路径中的非法字符，故中文文件名原样保留。
+_UNSAFE_FILE_NAME_RE = re.compile(r"[^\w.\-]+", flags=re.UNICODE)
+_REPEAT_UNDERSCORE_RE = re.compile(r"_+")
 
 # PaaS 沙箱文件接口错误码 → 语义分组
 PV_PAAS_ERROR_NOT_FOUND_CODES = frozenset({"AGENT_SANDBOX_FILE_NOT_FOUND", "VOLUME_NOT_FOUND"})
@@ -219,6 +228,15 @@ class SandboxUploadFile(TypedDict):
     name: str
     content: bytes
     mime_type: NotRequired[str]
+
+
+def encode_paas_query_params(params: dict) -> str:
+    """把 query 编成 RFC 3986 形式，空格为 `%20` 而不是 form 的 `+`。
+
+    bkapi / requests 默认 `quote_plus`，PaaS agent-sandbox 的 path 校验不认 `+`。
+    预编码成字符串再传给 client，避免 dict params 被二次 `quote_plus`。
+    """
+    return urlencode(params, doseq=True, safe="", quote_via=quote)
 
 
 def validate_session_upload_files(files: list[SandboxUploadFile]) -> None:
@@ -411,17 +429,24 @@ class SandboxPvFileService:
     # ------------------------------------------------------------------
 
     @staticmethod
-    def _parse_paas_code(exc: HTTPResponseError) -> str:
+    def _parse_paas_body(exc: Exception) -> dict:
         response = getattr(exc, "response", None)
         if response is None:
-            return ""
+            return {}
         try:
             body = response.json()
         except Exception:  # noqa: BLE001 - 响应体可能不是 JSON
-            return ""
-        if not isinstance(body, dict):
-            return ""
-        return str(body.get("code") or "")
+            return {}
+        return body if isinstance(body, dict) else {}
+
+    @classmethod
+    def _parse_paas_code(cls, exc: Exception) -> str:
+        return str(cls._parse_paas_body(exc).get("code") or "")
+
+    @classmethod
+    def _parse_paas_message(cls, exc: Exception) -> str:
+        body = cls._parse_paas_body(exc)
+        return str(body.get("message") or body.get("detail") or "")
 
     @classmethod
     def _is_sandbox_gone(cls, exc: HTTPResponseError) -> bool:
@@ -435,7 +460,7 @@ class SandboxPvFileService:
         return cls._parse_paas_code(exc) in PV_PAAS_SANDBOX_GONE_CODES
 
     @classmethod
-    def _map_paas_error(cls, exc: HTTPResponseError) -> SandboxFileError:
+    def _map_paas_error(cls, exc: Exception) -> SandboxFileError:
         """PaaS HTTP 错误 → 沙箱文件业务异常（表驱动）。
 
         规则：(match_status_code, matched_paas_codes, exception_cls)
@@ -446,6 +471,9 @@ class SandboxPvFileService:
         status_code = getattr(getattr(exc, "response", None), "status_code", 0) or 0
         paas_code = cls._parse_paas_code(exc)
         message = f"PaaS 沙箱文件接口调用失败: status={status_code} code={paas_code or '-'}"
+        extra = cls._parse_paas_message(exc)
+        if extra:
+            message = f"{message}; {extra}"
 
         rules: tuple[tuple[Optional[int], frozenset[str], type[SandboxFileError]], ...] = (
             (404, PV_PAAS_ERROR_NOT_FOUND_CODES, SandboxFileNotFoundError),
@@ -459,7 +487,7 @@ class SandboxPvFileService:
         return SandboxFileServerError(message)
 
     @classmethod
-    def _raise_mapped_paas_error(cls, action: str, exc: HTTPResponseError) -> None:
+    def _raise_mapped_paas_error(cls, action: str, exc: Exception) -> None:
         mapped = cls._map_paas_error(exc)
         logger.warning("call paas sandbox file api failed: action=%s error=%s", action, mapped, exc_info=True)
         raise mapped from exc
@@ -481,21 +509,23 @@ class SandboxPvFileService:
             raise SandboxFileInvalidArgumentError("since/until 必须是 tz-aware datetime（含时区信息）")
         return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def _call_single(self, action: str, session_code: str, params: dict):
+    def _call_single(self, action: str, session_code: str, params: dict, *, volume_id=None, client=None):
         """调用 PaaS 单个操作（非分页），返回原始 Response。
 
         `action` 同时用作 Client 属性名与错误日志 tag（当前所有单请求方法都对齐）。
+        `volume_id` / `client` 可选：调用方已算好的可传入，避免分页等循环场景重复
+        `_get_volume_id`（一次会话 HTTP 查询）与 `_get_client` 构造。
         """
-        volume_id = self._get_volume_id(session_code)
-        client = self._get_client()
+        volume_id = volume_id or self._get_volume_id(session_code)
+        client = client or self._get_client()
         try:
             resp = getattr(client, action).request(
                 path_params=self._build_path_params(volume_id),
-                params=params,
+                params=encode_paas_query_params(params),
             )
             resp.raise_for_status()
             return resp
-        except HTTPResponseError as exc:
+        except (HTTPResponseError, RequestsHTTPError) as exc:
             self._raise_mapped_paas_error(action, exc)
 
     # ------------------------------------------------------------------
@@ -507,7 +537,13 @@ class SandboxPvFileService:
         file_name = PurePosixPath(name.replace("\\", "/")).name
         if not file_name or file_name in {".", ".."}:
             raise SandboxFileInvalidArgumentError("文件名不能为空")
-        return file_name
+        stem, suffix = posixpath.splitext(file_name)
+        # 只剥尾部点/下划线：前导点文件（如 .gitignore）与「...png」这类多点名要保留，
+        # 否则会吃掉扩展名（...png -> png）或把隐藏文件改成普通文件。
+        safe_stem = _REPEAT_UNDERSCORE_RE.sub("_", _UNSAFE_FILE_NAME_RE.sub("_", stem)).strip("_").rstrip(".")
+        if not safe_stem:
+            safe_stem = "file"
+        return f"{safe_stem}{suffix}"
 
     def _resolve_upload_snapshot(self) -> str:
         """读取平台注入的 snapshot；未注入则报错。"""
@@ -697,8 +733,8 @@ class SandboxPvFileService:
                 created_at=sandbox_created_at,
             )
 
-        succeeded = sum(item["status"] == "success" for item in results)
         self._attach_image_download_urls(session_code, results)
+        succeeded = sum(item["status"] == "success" for item in results)
         return {
             "count": len(results),
             "succeeded": succeeded,
@@ -707,7 +743,10 @@ class SandboxPvFileService:
         }
 
     def _attach_image_download_urls(self, session_code: str, results: list[dict]) -> None:
-        """给成功上传的图片签发 download_url，供输入框和首条 user 消息展示。"""
+        """给成功上传的图片签发 download_url，供输入框和首条 user 消息展示。
+
+        签发失败不得打垮整批：该文件改为 failed 并写入原因，其它已成功文件不受影响。
+        """
         for item in results:
             if item.get("status") != "success":
                 continue
@@ -720,8 +759,16 @@ class SandboxPvFileService:
                 url_data = self.get_download_url(
                     session_code, path, expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN
                 )
-            except SandboxFileError:
-                logger.exception("签发上传图片 URL 失败: session=%s path=%s", session_code, path)
+            except (SandboxFileError, HTTPResponseError, RequestsHTTPError) as exc:
+                # 文件已成功写入 PV，失败的只是「签发展示用临时 URL」；保留 status=success，
+                # 仅记 download_url_error，避免前端把「已落盘但缺 URL」误判为上传失败。
+                logger.warning(
+                    "签发上传图片 URL 失败（文件已落 PV，仅缺可访问 URL）: session=%s path=%s",
+                    session_code,
+                    path,
+                    exc_info=True,
+                )
+                item["download_url_error"] = str(exc)
                 continue
             url = url_data.get("download_url")
             if url:
@@ -750,7 +797,6 @@ class SandboxPvFileService:
         """
         volume_id = self._get_volume_id(session_code)
         client = self._get_client()
-        path_params = self._build_path_params(volume_id)
 
         base_params: dict = {
             "path": path or "",
@@ -771,12 +817,10 @@ class SandboxPvFileService:
                 time.sleep(PV_LIST_PAGE_SLEEP_SECONDS)
 
             params = dict(base_params, page=page)
-            try:
-                resp = client.list_files.request(path_params=path_params, params=params)
-                resp.raise_for_status()
-                data = resp.json() or {}
-            except HTTPResponseError as exc:
-                self._raise_mapped_paas_error("list_files", exc)
+            # 走 _call_single：统一接住 HTTPResponseError 与 requests.HTTPError，
+            # 避免 PaaS 返回 4xx/5xx 时 raise_for_status 抛出的 requests.HTTPError 冒泡成整次 500。
+            resp = self._call_single("list_files", session_code, params, volume_id=volume_id, client=client)
+            data = resp.json() or {}
 
             page_items = data.get("results") or []
             all_results.extend(page_items)

--- a/src/agent/tests/services/test_sandbox_pv_files.py
+++ b/src/agent/tests/services/test_sandbox_pv_files.py
@@ -6,8 +6,12 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qsl
 
 import pytest
+from bkapi_client_core.exceptions import HTTPResponseError
+from requests import HTTPError as RequestsHTTPError
+
 from aidev_agent.services import sandbox_pv_files as module
 from aidev_agent.services.sandbox_pv_files import (
     MAX_SESSION_UPLOAD_FILE_SIZE,
@@ -20,24 +24,52 @@ from aidev_agent.services.sandbox_pv_files import (
     SandboxFileNotFoundError,
     SandboxFileServerError,
     SandboxPvFileService,
+    encode_paas_query_params,
     fill_user_image_urls,
     validate_session_upload_files,
 )
-from bkapi_client_core.exceptions import HTTPResponseError
 
 # ---------------------------------------------------------------------------
 # 工具函数 & fixture
 # ---------------------------------------------------------------------------
 
 
-def _mock_http_error(status_code: int, code: str = "") -> HTTPResponseError:
+def _query_params(raw) -> dict[str, str]:
+    """解析 client.request 的 params（预编码字符串或 dict）。"""
+    if isinstance(raw, str):
+        return dict(parse_qsl(raw, keep_blank_values=True))
+    return {str(key): str(value) for key, value in raw.items()}
+
+
+def _mock_http_error(status_code: int, code: str = "", message: str = "") -> HTTPResponseError:
     """构造 PaaS HTTPResponseError（携带 status_code + JSON body 里的 code）。"""
     mock_response = MagicMock()
     mock_response.status_code = status_code
-    mock_response.json.return_value = {"code": code} if code else {}
+    body: dict = {}
+    if code:
+        body["code"] = code
+    if message:
+        body["message"] = message
+    mock_response.json.return_value = body
     exc = HTTPResponseError()
     exc.response = mock_response
     return exc
+
+
+def _mock_raise_for_status_error(status_code: int = 400, code: str = "", message: str = ""):
+    """模拟线上路径：request() 返回 4xx Response，raise_for_status 抛 requests.HTTPError。"""
+    resp = MagicMock()
+    resp.ok = False
+    resp.status_code = status_code
+    body: dict = {}
+    if code:
+        body["code"] = code
+    if message:
+        body["message"] = message
+    resp.json.return_value = body
+    http_error = RequestsHTTPError(f"{status_code} Client Error", response=resp)
+    resp.raise_for_status.side_effect = http_error
+    return resp
 
 
 def _mock_paas_response(json_data=None, headers=None, content: bytes = b""):
@@ -436,8 +468,8 @@ class TestUploadFiles:
 
         assert "download_url" not in result["results"][0]
         assert result["results"][1]["download_url"] == "https://cdn/image.png"
-        params = mock_client.get_download_url.request.call_args.kwargs["params"]
-        assert params == {"path": "files/image.png", "expires_in": 3600}
+        params = _query_params(mock_client.get_download_url.request.call_args.kwargs["params"])
+        assert params == {"path": "files/image.png", "expires_in": "3600"}
 
     @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
     def test_does_not_fallback_to_preview_url(self, mock_backend_cls, service, mock_client):
@@ -460,15 +492,45 @@ class TestUploadFiles:
         backend = mock_backend_cls.return_value
         backend.create_sandbox.return_value = "sandbox-upload"
         backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
-        mock_client.get_download_url.request.side_effect = _mock_http_error(500, "UNKNOWN_XYZ")
+        mock_client.get_download_url.request.side_effect = _mock_http_error(
+            400, "AGENT_SANDBOX_FILE_OPERATION_FAILED", "路径不合法"
+        )
+
+        result = service.upload_files(
+            "s1",
+            [
+                {"name": "note.txt", "content": b"txt", "mime_type": "text/plain"},
+                {"name": "image.png", "content": b"png", "mime_type": "image/png"},
+            ],
+        )
+
+        # 两张都成功落 PV：note.txt 非图片本就 success，image.png 写盘成功仅缺可访问 URL。
+        assert result["succeeded"] == 2
+        assert result["failed"] == 0
+        assert result["results"][0]["status"] == "success"
+        image = result["results"][1]
+        assert image["status"] == "success"
+        assert "路径不合法" in image["download_url_error"]
+        assert "download_url" not in image
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_image_url_http_error_records_download_url_error(self, mock_backend_cls, service, mock_client):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        mock_client.get_download_url.request.return_value = _mock_raise_for_status_error(
+            400, message="路径不合法"
+        )
 
         result = service.upload_files(
             "s1",
             [{"name": "image.png", "content": b"png", "mime_type": "image/png"}],
         )
 
-        assert result["succeeded"] == 1
-        assert "download_url" not in result["results"][0]
+        # 文件已落 PV：status 仍为 success，仅记录 download_url_error，failed 不计。
+        assert result["failed"] == 0
+        assert result["results"][0]["status"] == "success"
+        assert "路径不合法" in result["results"][0]["download_url_error"]
 
     @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
     def test_uses_executor_info_snapshot(self, mock_backend_cls, resource_manager, _no_sleep):
@@ -531,10 +593,10 @@ class TestListFiles:
         # 调 PaaS 参数：硬编码 is_recursive=True + page_size + page=1
         req_kwargs = mock_client.list_files.request.call_args.kwargs
         assert req_kwargs["path_params"] == {"app_code": "test-app", "volume_id": "vol-abc"}
-        params = req_kwargs["params"]
-        assert params["is_recursive"] is True
-        assert params["page_size"] == PV_LIST_PAGE_SIZE
-        assert params["page"] == 1
+        params = _query_params(req_kwargs["params"])
+        assert params["is_recursive"] == "True"
+        assert params["page_size"] == str(PV_LIST_PAGE_SIZE)
+        assert params["page"] == "1"
         assert "since" not in params
         assert "until" not in params
 
@@ -545,14 +607,14 @@ class TestListFiles:
 
         service.list_files(session_code="s1", since=since, until=until)
 
-        params = mock_client.list_files.request.call_args.kwargs["params"]
+        params = _query_params(mock_client.list_files.request.call_args.kwargs["params"])
         assert params["since"] == "2026-06-24T10:23:11Z"
         assert params["until"] == "2026-06-25T10:23:11Z"
 
     def test_path_forwarded(self, service, mock_client):
         mock_client.list_files.request.return_value = _mock_paas_response({"count": 0, "results": []})
         service.list_files(session_code="s1", path="sub/dir")
-        assert mock_client.list_files.request.call_args.kwargs["params"]["path"] == "sub/dir"
+        assert _query_params(mock_client.list_files.request.call_args.kwargs["params"])["path"] == "sub/dir"
 
     def test_multi_page_accumulates_and_sleeps(self, service, mock_client, _no_sleep):
         page1 = {
@@ -598,6 +660,16 @@ class TestListFiles:
         with pytest.raises(SandboxFileNotFoundError):
             service.list_files(session_code="s1")
 
+    def test_raise_for_status_http_error_maps(self, service, mock_client):
+        """线上真实路径：request 返回 4xx Response，raise_for_status 抛 requests.HTTPError，
+        list_files 必须接住并映射为 SandboxFileError，而非冒泡成整次 500。"""
+        mock_client.list_files.request.return_value = _mock_raise_for_status_error(
+            400, code="AGENT_SANDBOX_FILE_OPERATION_FAILED", message="路径不合法"
+        )
+        with pytest.raises(SandboxFileError) as exc_info:
+            service.list_files(session_code="s1")
+        assert "路径不合法" in str(exc_info.value)
+
 
 # ---------------------------------------------------------------------------
 # delete_file / stat_file / preview_file / get_download_url
@@ -609,7 +681,7 @@ class TestOtherServiceMethods:
         mock_client.delete_file.request.return_value = _mock_paas_response()
         service.delete_file(session_code="s1", path="x.txt")
         kwargs = mock_client.delete_file.request.call_args.kwargs
-        assert kwargs["params"] == {"path": "x.txt"}
+        assert _query_params(kwargs["params"]) == {"path": "x.txt"}
         assert kwargs["path_params"]["volume_id"] == "vol-abc"
 
     def test_delete_file_maps_404(self, service, mock_client):
@@ -642,7 +714,7 @@ class TestOtherServiceMethods:
     def test_preview_file_max_bytes_forwarded(self, service, mock_client):
         mock_client.preview_file.request.return_value = _mock_paas_response(content=b"")
         service.preview_file(session_code="s1", path="x.txt", max_bytes=1024)
-        assert mock_client.preview_file.request.call_args.kwargs["params"]["max_bytes"] == 1024
+        assert _query_params(mock_client.preview_file.request.call_args.kwargs["params"])["max_bytes"] == "1024"
 
     def test_preview_file_maps_415(self, service, mock_client):
         mock_client.preview_file.request.side_effect = _mock_http_error(415, "AGENT_SANDBOX_FILE_NOT_PREVIEWABLE")
@@ -655,8 +727,64 @@ class TestOtherServiceMethods:
         )
         result = service.get_download_url(session_code="s1", path="x.txt", expires_in=300)
         assert result == {"download_url": "https://cdn/x", "preview_url": "https://cdn/x"}
-        params = mock_client.get_download_url.request.call_args.kwargs["params"]
-        assert params["expires_in"] == 300
+        params = _query_params(mock_client.get_download_url.request.call_args.kwargs["params"])
+        assert params["expires_in"] == "300"
+
+
+class TestEncodePaasQueryParams:
+    def test_space_is_percent20_not_plus(self):
+        encoded = encode_paas_query_params({"path": "files/保存 & 归档的会话 (1).png"})
+        assert "+" not in encoded
+        assert "%20" in encoded
+        assert "%26" in encoded
+
+    def test_roundtrip_keeps_filename(self):
+        path = "files/保存 & 归档的会话 (1).png"
+        encoded = encode_paas_query_params({"path": path, "expires_in": 3600})
+        assert dict(parse_qsl(encoded, keep_blank_values=True))["path"] == path
+
+    def test_download_url_passes_preencoded_query(self, service, mock_client):
+        mock_client.get_download_url.request.return_value = _mock_paas_response({})
+        path = "files/保存 & 归档的会话 (1).png"
+        service.get_download_url(session_code="s1", path=path)
+        raw = mock_client.get_download_url.request.call_args.kwargs["params"]
+        assert isinstance(raw, str)
+        assert "+" not in raw
+        assert dict(parse_qsl(raw, keep_blank_values=True))["path"] == path
+
+
+class TestSafeFileName:
+    def test_strips_ampersand_and_spaces(self):
+        assert SandboxPvFileService._safe_file_name("保存 & 归档的会话.png") == "保存_归档的会话.png"
+
+    def test_keeps_plain_chinese_name(self):
+        assert SandboxPvFileService._safe_file_name("报告.pdf") == "报告.pdf"
+
+    def test_preserves_leading_dots_and_extension(self):
+        # 前导多点名保留扩展名：...png -> ...png（不再被 .strip 吃掉成 png）
+        assert SandboxPvFileService._safe_file_name("...png") == "...png"
+        # 隐藏文件（无扩展名）保留前导点：.gitignore -> .gitignore
+        assert SandboxPvFileService._safe_file_name(".gitignore") == ".gitignore"
+
+    def test_upload_uses_sanitized_path_for_download_url(self, service, mock_client):
+        mock_client.get_download_url.request.return_value = _mock_paas_response(
+            {"download_url": "https://cdn/x.png"}
+        )
+        with patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend") as mock_backend_cls:
+            backend = mock_backend_cls.return_value
+            backend.create_sandbox.return_value = "sandbox-upload"
+            backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+            result = service.upload_files(
+                "s1",
+                [{"name": "保存 & 归档的会话.png", "content": b"png", "mime_type": "image/png"}],
+            )
+        item = result["results"][0]
+        assert item["name"] == "保存 & 归档的会话.png"
+        assert item["path"] == "files/保存_归档的会话.png"
+        assert item["status"] == "success"
+        assert _query_params(mock_client.get_download_url.request.call_args.kwargs["params"])["path"] == (
+            "files/保存_归档的会话.png"
+        )
 
 
 class TestValidateSessionUploadFiles:


### PR DESCRIPTION
## 背景

TAPD [#136417903](https://tapd.woa.com/tapd_fe/70093903/story/detail/136417903)：会话 PV 上传含空格、`&` 等字符的图片时，整次接口 500。

根因 / 现状：

- 文件已写入 PV，随后签发 `download_url` 被 PaaS 以 `VALIDATION_ERROR`（路径不合法）拒绝
- `_call_single` 只接 `HTTPResponseError`，`raise_for_status()` 抛出的 `requests.HTTPError` 冒泡成整次 upload 500
- 仅改 query 空格编码（`+` → `%20`）不够：PaaS 校验的是解码后的 path，`&` / 空格本身仍不合法

## 改动

- `_safe_file_name` 清洗落盘文件名（空格、`&`、括号等改为 `_`）；`name` 仍保留原始展示名，`path` / `id` 使用清洗后路径
- `encode_paas_query_params` 预编码 query，空格使用 `%20`，避免 bkapi / requests 默认 `quote_plus`
- `_call_single` 同时接住 `HTTPResponseError` 与 `requests.HTTPError`，并把 PaaS `message` / `detail` 写入错误文案
- `_attach_image_download_urls` 签发失败时只将该条标为 `failed` 并写入 `error`，整次 upload 仍 200；`succeeded` / `failed` 在签发后计数

## 测试

- `src/agent/tests/services/test_sandbox_pv_files.py`：70 passed

## 兼容性

- 含非法字符的新上传，`path` / `id` 不再等于原始文件名；前端签发 URL、引用文件须用返回的 `path`，不要用 `name`
- 本次之前已落到 PV 的旧路径（仍含 `&` / 空格）不会自动改名，再次 `download_url` 仍可能 400

## 关联

tapd: #136417903

发起人：
- @Vellun7