### PR TITLE
feat: 将 stopped queue 不存在视为未停止 --story=1070093903137894271

### DIFF
--- a/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
+++ b/src/agent/aidev_agent/services/messages_handler/rabbitmq.py
@@ -718,11 +718,28 @@ class _RabbitMQConsumerMixin:
             with self._with_channel() as channel:
                 stopped_queue = self._get_stopped_queue_name(thread_id)
 
-                # 先被动声明检查队列是否存在
+                # 先被动声明检查队列是否存在。404 表示用户未点 Stop，队列从未创建。
                 try:
                     channel.queue_declare(queue=stopped_queue, passive=True)
+                except pika.exceptions.ChannelClosedByBroker as e:
+                    if e.reply_code == 404:
+                        logger.debug(
+                            "Stopped queue not found for thread_id=%s, treat as not stopped",
+                            thread_id,
+                        )
+                        return False
+                    logger.warning(
+                        "Unexpected broker error while probing stopped queue for thread_id=%s: %s",
+                        thread_id,
+                        e,
+                    )
+                    return False
                 except Exception as e:
-                    logger.warning(f"Error declaring stopped queue for thread_id={thread_id}: {e}")
+                    logger.warning(
+                        "Failed to probe stopped queue for thread_id=%s: %s",
+                        thread_id,
+                        e,
+                    )
                     return False
 
                 # peek：取出后放回

--- a/src/agent/tests/services/test_rabbitmq_stopped_signal.py
+++ b/src/agent/tests/services/test_rabbitmq_stopped_signal.py
@@ -1,0 +1,39 @@
+import contextlib
+from unittest.mock import MagicMock
+
+import pika
+import pytest
+from aidev_agent.services.messages_handler.rabbitmq import _RabbitMQConsumerMixin
+
+
+class _StoppedProbe(_RabbitMQConsumerMixin):
+    def __init__(self, channel):
+        self._channel = channel
+
+    @contextlib.contextmanager
+    def _with_channel(self):
+        yield self._channel
+
+
+class TestIsStopped:
+    @pytest.mark.parametrize(
+        ("exc", "expect_warning"),
+        [
+            (pika.exceptions.ChannelClosedByBroker(404, "NOT_FOUND - no queue"), False),
+            (pika.exceptions.ChannelClosedByBroker(406, "PRECONDITION_FAILED"), True),
+            (RuntimeError("channel failed"), True),
+        ],
+    )
+    def test_is_stopped_treats_missing_queue_as_false(self, caplog, exc, expect_warning):
+        channel = MagicMock()
+        channel.queue_declare.side_effect = exc
+        with caplog.at_level("WARNING"):
+            assert _StoppedProbe(channel).is_stopped("new_session") is False
+        assert ("stopped queue" in caplog.text) is expect_warning
+        assert "Error declaring stopped queue" not in caplog.text
+
+    def test_is_stopped_when_signal_present(self):
+        channel = MagicMock()
+        channel.basic_get.return_value = (MagicMock(), None, b'{"stopped": true}')
+        assert _StoppedProbe(channel).is_stopped("new_session") is True
+        channel.basic_reject.assert_called_once()


### PR DESCRIPTION
## 背景

正常完成的流式会话仍会打出 `Error declaring stopped queue ... NOT_FOUND` 警告，容易被当成会话失败。

## 原因

`is_stopped()` 用 RabbitMQ 被动声明探测 `aidev_agent.stopped.{thread_id}`。用户未点 Stop 时队列不存在，broker 返回 404 其实表示「未停止」，代码也按 `False` 处理，但日志文案写成了 Error declaring。

## 改动内容

- 404 视为未停止，改记 debug：`Stopped queue not found ... treat as not stopped`
- 非 404 的 broker 错误和其他探测失败仍记 WARNING
- 补充单测覆盖缺失队列、非 404 异常和存在停止信号

不包含：Stop 信号存储实现、队列生命周期或会话终态逻辑变更。

## 收益

减少误导性 WARNING 噪声，保留真实探测失败告警。

## 测试验证

- `make test path=tests/services/test_rabbitmq_stopped_signal.py`
- 结果：4 passed
