### PR TITLE
feat: 友好展示模型调用异常信息 --story=1070093903137887469

### DIFF
--- a/src/agent/aidev_agent/exceptions.py
+++ b/src/agent/aidev_agent/exceptions.py
@@ -1,13 +1,20 @@
 # -*- coding: utf-8 -*-
 import ast
 import json
+import re
 from logging import getLogger
+from typing import Any
 
 from mcp.shared.exceptions import McpError
 
 from aidev_agent.enums import StreamEventType
 
 _logger = getLogger(__name__)
+
+_MAX_UNWRAP_DEPTH = 8
+_ERROR_CODE_PREFIX = re.compile(r"^Error code:\s*\d+\s*-\s*", re.IGNORECASE)
+_MULTIMODAL_MODEL = re.compile(r"(?P<model>.+?) is not a multimodal model", re.IGNORECASE)
+_RAW_PAYLOAD_MARKERS = ("Error code:", "{'error'", '{"error"', "'type':", '"type":', "'trace_id'", '"trace_id"')
 
 
 class AIDevException(Exception):
@@ -39,17 +46,64 @@ def find_mcp_errors(exc):
             yield from find_mcp_errors(sub_exc)
 
 
-def extract_error_message(error_string):
-    start = error_string.find("{")
-    end = error_string.rfind("}")
-    if start != -1 and end != -1 and end > start:
+def _parse_mapping(text: str) -> dict[str, Any] | None:
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end <= start:
+        return None
+    payload = text[start : end + 1]
+    for loader in (ast.literal_eval, json.loads):
         try:
-            json_str = error_string[start : end + 1]
-            data = ast.literal_eval(json_str)
-            return data.get("message", "")
-        except (ValueError, SyntaxError):
-            return None
+            data = loader(payload)
+        except (ValueError, SyntaxError, json.JSONDecodeError, TypeError):
+            continue
+        if isinstance(data, dict):
+            return data
     return None
+
+
+def _nested_message(data: dict[str, Any]) -> Any:
+    error = data.get("error")
+    if isinstance(error, dict) and error.get("message") not in (None, ""):
+        return error["message"]
+    if data.get("message") not in (None, ""):
+        return data["message"]
+    return None
+
+
+def _looks_like_raw_payload(text: str) -> bool:
+    stripped = text.strip()
+    if not stripped:
+        return True
+    if _ERROR_CODE_PREFIX.search(stripped):
+        return True
+    return any(marker in stripped for marker in _RAW_PAYLOAD_MARKERS)
+
+
+def unwrap_error_message(error_string: str, *, depth: int = 0) -> str:
+    if not error_string or depth >= _MAX_UNWRAP_DEPTH:
+        return (error_string or "").strip()
+    data = _parse_mapping(error_string)
+    if data is None:
+        return error_string.strip()
+    nested = _nested_message(data)
+    if nested is None:
+        return error_string.strip()
+    return unwrap_error_message(str(nested), depth=depth + 1)
+
+
+def extract_error_message(error_string):
+    if not error_string or _parse_mapping(error_string) is None:
+        return None
+    return unwrap_error_message(error_string)
+
+
+def _friendly_known_error(message: str) -> str | None:
+    match = _MULTIMODAL_MODEL.search(message)
+    if not match:
+        return None
+    model = match.group("model").strip().strip("'\"")
+    return f"当前模型 {model} 不支持图片或文档输入。请更换支持多模态的模型，或移除附件后再试。"
 
 
 def streaming_chunk_exception_handling(exception: Exception) -> str:
@@ -64,10 +118,11 @@ def streaming_chunk_exception_handling(exception: Exception) -> str:
 
 def extract_model_error_message(exception: Exception) -> str:
     err_msg = exception.message if hasattr(exception, "message") else str(exception)
-    mcp_errors = list(find_mcp_errors(exception))
-    if mcp_errors:
-        err_msg = "MCP调用工具异常"
-    if json_msg := extract_error_message(err_msg):
-        err_msg = json_msg
-    message = f"模型调用异常: {err_msg}"
-    return message
+    if list(find_mcp_errors(exception)):
+        return "模型调用异常: MCP调用工具异常"
+    unwrapped = unwrap_error_message(str(err_msg or ""))
+    if friendly := _friendly_known_error(unwrapped):
+        return friendly
+    if _looks_like_raw_payload(unwrapped):
+        return "模型调用失败"
+    return f"模型调用异常: {unwrapped}"

--- a/src/agent/tests/utils/test_exceptions.py
+++ b/src/agent/tests/utils/test_exceptions.py
@@ -1,0 +1,42 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from aidev_agent.exceptions import extract_error_message, extract_model_error_message
+
+NESTED_MULTIMODAL = (
+    "Error code: 400 - {'error': {'message': \"Error code: 400 - {'error': "
+    "{'message': 'DeepSeek-V4-Flash is not a multimodal model', "
+    "'type': 'BadRequestError', 'param': None, 'code': 400}}\", "
+    "'code': 400, 'type': 'BadRequestError'}, "
+    "'trace_id': '759ed94f628bcc1ba1ec7c3ad9e98e6e'}"
+)
+FRIENDLY_MULTIMODAL = "当前模型 DeepSeek-V4-Flash 不支持图片或文档输入。请更换支持多模态的模型，或移除附件后再试。"
+
+
+class TestExtractModelErrorMessage:
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            (NESTED_MULTIMODAL, FRIENDLY_MULTIMODAL),
+            (
+                "Authentication failed for model gptoss-999b",
+                "模型调用异常: Authentication failed for model gptoss-999b",
+            ),
+            ("Error code: 400 - {'error': {'code': 400, 'type': 'BadRequestError'}}", "模型调用失败"),
+        ],
+    )
+    def test_extract_model_error_message(self, raw, expected):
+        message = extract_model_error_message(SimpleNamespace(message=raw))
+        assert message == expected
+        assert "Error code:" not in message
+        assert "trace_id" not in message
+
+    def test_extract_error_message_unwraps_nested_dict(self):
+        assert extract_error_message(NESTED_MULTIMODAL) == "DeepSeek-V4-Flash is not a multimodal model"
+
+    def test_streaming_json_uses_friendly_message(self):
+        from aidev_agent.exceptions import streaming_chunk_exception_handling
+
+        payload = json.loads(streaming_chunk_exception_handling(SimpleNamespace(message=NESTED_MULTIMODAL))[6:])
+        assert payload["message"] == FRIENDLY_MULTIMODAL


### PR DESCRIPTION
## 背景

When a model call fails, the chat UI currently shows nested `Error code` payloads and Python dicts instead of a readable explanation.

## 原因

The SDK only reads the outer `message` key. Real upstream errors nest the useful text in `error.message`, sometimes more than once, so the raw payload is shown as-is.

## 改动内容

- Recursively unwrap nested `error.message` / `message` payloads
- Map `is not a multimodal model` to a Chinese action hint
- Replace unrecognized raw payloads with a short `模型调用失败`
- Add focused unit tests

## 收益

Users see a readable, actionable failure message instead of debug fields such as `type`, `param`, `code`, and `trace_id`.

## 测试验证

- `make test path=tests/utils/test_exceptions.py` — 5 passed
- `make test path=tests/services/test_chat.py args='-k test_model_error_case'` — 1 passed
- pre-commit on the changed files — passed
