### PR TITLE
refactor: 移除默认 LangChain Instrumentor --story=1070093903136959970

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -27,16 +27,6 @@ CHAT_GROUP_TYPE = os.environ.get("CHAT_GROUP_TYPE", "qyweixin_chat_group")
 ENABLE_OTEL_TRACE = os.getenv("BKAPP_ENABLE_OTEL_TRACE", "1") == "1"
 BK_APP_OTEL_INSTRUMENT_DB_API = os.getenv("BKAPP_OTEL_INSTRUMENT_DB_API", "1") == "1"
 
-# OpenTelemetry 是可选 extras，未安装时不注册任何额外 instrumentor。
-# 安装方式：pip install aidev-bkplugin[opentelemetry]
-BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS: list = []
-try:
-    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
-
-    BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS = [LangchainInstrumentor()]
-except ImportError:
-    pass
-
 # SaaS运行版本
 RUN_VER = "ieod" if os.environ.get("BKPAAS_ENGINE_REGION", "default") == "ieod" else "open"
 


### PR DESCRIPTION
## 背景

- bkplugin 设置不再需要默认注册额外的 LangChain OpenTelemetry instrumentor。

## 原因

- 应用级设置中的可选导入会在依赖存在时隐式启用 LangChain instrumentation，不符合当前的初始化边界。

## 改动内容

- 移除 `LangchainInstrumentor` 的可选导入与实例化。
- 移除 `BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS` 默认配置及对应安装说明。
- 保留现有 OpenTelemetry Trace 与数据库 API 开关。

## 收益

- 避免 bkplugin 设置模块隐式注册额外 instrumentor，使 OpenTelemetry 初始化职责更清晰。

## 测试验证

- 设置文件语法检查与导入断言通过。
- bkplugin OpenTelemetry 初始化专项测试：50 项通过。
- 完整 pre-commit 已执行；上游基线仍有 6 条既有 Ruff 问题，均不在本次变更文件中。
