### PR TITLE
feat: 调整入口与 MCP 工具发现 Span 服务归属 --story=1070093903137679449

### DIFF
--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -617,6 +617,7 @@ class BaseResourceManager(abc.ABC):
                     with recording_span(
                         "mcp.tools.list",
                         kind=CLIENT_SPAN_KIND,
+                        use_global_tracer=True,
                         attributes={
                             "rpc.system": "mcp",
                             "mcp.operation.name": "tools/list",

--- a/src/agent/aidev_agent/utils/tracing.py
+++ b/src/agent/aidev_agent/utils/tracing.py
@@ -93,15 +93,20 @@ def recording_span(
     kind: Any = None,
     root: bool = False,
     record_exception: bool = True,
+    use_global_tracer: bool = False,
 ) -> Iterator[Any]:
-    """Create a span with the Agent tracer, or safely no-op without OTel.
+    """Create a span with the selected tracer, or safely no-op without OTel.
+
+    ``use_global_tracer=True`` keeps application-module spans on the global
+    provider and its ``service.name`` resource. The default remains the Agent
+    provider so existing SDK spans keep their current service identity.
 
     ``root=True`` starts a new trace even when the caller happens to have an
     active context. This is intended for protocol entrypoints that represent a
     new inbound request rather than a child operation of a long-lived client.
     """
 
-    tracer = get_agent_tracer(__name__)
+    tracer = trace.get_tracer(__name__) if use_global_tracer and trace is not None else get_agent_tracer(__name__)
     if tracer is None:
         yield _NoOpSpan()
         return

--- a/src/agent/tests/packages/langchain_core/tools/test_base.py
+++ b/src/agent/tests/packages/langchain_core/tools/test_base.py
@@ -502,6 +502,7 @@ def test_make_mcp_tools_records_list_semantics(mock_mcp_client_class, mock_recor
     mock_recording_span.assert_called_once_with(
         "mcp.tools.list",
         kind=CLIENT_SPAN_KIND,
+        use_global_tracer=True,
         attributes={
             "rpc.system": "mcp",
             "mcp.operation.name": "tools/list",

--- a/src/agent/tests/utils/test_tracing.py
+++ b/src/agent/tests/utils/test_tracing.py
@@ -35,11 +35,61 @@ def test_recording_span_can_force_a_new_root(monkeypatch):
     tracer.start_as_current_span.assert_called_once_with("entrypoint", attributes={}, context=context)
 
 
+def test_recording_span_can_use_global_tracer(monkeypatch):
+    agent_tracer = MagicMock()
+    global_tracer = MagicMock()
+    trace_api = MagicMock()
+    trace_api.get_tracer.return_value = global_tracer
+    monkeypatch.setattr(tracing, "_agent_tracer", agent_tracer)
+    monkeypatch.setattr(tracing, "trace", trace_api)
+
+    with tracing.recording_span("application-module", use_global_tracer=True):
+        pass
+
+    trace_api.get_tracer.assert_called_once_with(tracing.__name__)
+    global_tracer.start_as_current_span.assert_called_once_with("application-module", attributes={})
+    agent_tracer.start_as_current_span.assert_not_called()
+
+
+def test_global_tracer_changes_only_selected_span_service(monkeypatch):
+    agent_provider, agent_exporter = _memory_provider("ai-skill-stag")
+    module_provider, module_exporter = _memory_provider("ai-skill-stag-default")
+    monkeypatch.setattr(tracing, "_agent_tracer", agent_provider.get_tracer("agent"))
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: module_provider.get_tracer("module"))
+    try:
+        with tracing.recording_span("parent") as parent:
+            with tracing.recording_span("selected", use_global_tracer=True):
+                pass
+            with tracing.recording_span("unchanged"):
+                pass
+        selected = module_exporter.get_finished_spans()[0]
+        unchanged = next(span for span in agent_exporter.get_finished_spans() if span.name == "unchanged")
+        assert selected.resource.attributes["service.name"] == "ai-skill-stag-default"
+        assert unchanged.resource.attributes["service.name"] == "ai-skill-stag"
+        assert selected.parent.span_id == unchanged.parent.span_id == parent.context.span_id
+    finally:
+        agent_provider.shutdown()
+        module_provider.shutdown()
+
+
 # ---------------------------------------------------------------------- #
 # propagated_trace_context / trace_headers（原 test_approval_trace.py 并入；
 # 其 test 1 依赖的 _create_approval_from_target 已随 43-04 建单迁移删除，
 # X-BKAIDEV-USER 头注入由 test_approval_methods.py 覆盖）
 # ---------------------------------------------------------------------- #
+
+
+def _memory_provider(service_name):
+    pytest.importorskip("opentelemetry.sdk")
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+    from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+    provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+    exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    return provider, exporter
 
 
 def _install_memory_tracer(monkeypatch):

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/chat_tracing.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/chat_tracing.py
@@ -26,6 +26,7 @@ def chat_request_span(function):
                 "bkplugin.chat.request",
                 kind=SpanKind.INTERNAL if SpanKind else None,
                 record_exception=False,
+                use_global_tracer=True,
             ),
         ):
             return function(self, request, *args, **kwargs)

--- a/src/plugins/aidev_bkplugin/tests/services/test_chat_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_chat_tracing.py
@@ -1,0 +1,23 @@
+from unittest.mock import MagicMock, patch
+
+from aidev_bkplugin.services import chat_tracing
+
+
+def test_chat_request_span_uses_application_module_tracer():
+    view = MagicMock()
+    request = MagicMock(headers={})
+    handler = MagicMock(return_value="response")
+
+    with (
+        patch("aidev_bkplugin.services.chat_tracing.trace_headers", return_value={"traceparent": "active"}),
+        patch("aidev_bkplugin.services.chat_tracing.recording_span") as recording_span,
+    ):
+        result = chat_tracing.chat_request_span(handler)(view, request)
+
+    assert result == "response"
+    recording_span.assert_called_once_with(
+        "bkplugin.chat.request",
+        kind=chat_tracing.SpanKind.INTERNAL if chat_tracing.SpanKind else None,
+        record_exception=False,
+        use_global_tracer=True,
+    )


### PR DESCRIPTION
## 背景

`bkplugin.chat.request` 与 `mcp.tools.list` 当前使用 Agent 私有 Tracer，导致这两个应用模块阶段 Span 被归入 Agent service。

## 原因

共享 `recording_span` 默认优先使用 Agent 私有 TracerProvider；两个应用模块 Span 未显式选择应用全局 TracerProvider。

## 改动内容

- 为 `recording_span` 增加显式的应用全局 Tracer 选择开关，默认行为不变。
- 仅在 `bkplugin.chat.request` 与 `mcp.tools.list` 启用该开关。
- 补充双 Provider 父子关系和两个调用点的回归测试。

## 收益

两个目标 Span 跟随应用模块的 service identity，其余 Agent、Sandbox、审批等 Span 归属保持不变。

## 测试验证

- 12 项定向测试通过。
- 目标文件的提交前检查全部通过。
- 全仓检查仍被 6 个既有 Ruff 问题阻塞，本次未修改相关文件。
