### PR TITLE
fix: checkpoint 写入重试覆盖连接中断并降级收尾失败 --story=1070093903137903061

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/packages/checkpoint/bk_django_saver.py
@@ -19,15 +19,17 @@ to the current version of the project delivered to anyone in the future.
 from __future__ import annotations
 
 import json
+import logging
 import random
 import threading
 import time
 from collections.abc import AsyncIterator, Iterator, Sequence
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from typing import Any, Callable, Optional, Tuple, cast
 
 from asgiref.sync import sync_to_async
-from django.db import OperationalError, close_old_connections, connections, router, transaction
+from django.conf import settings
+from django.db import InterfaceError, OperationalError, close_old_connections, connections, router, transaction
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.base import (
     WRITES_IDX_MAP,
@@ -43,7 +45,11 @@ from langgraph.checkpoint.base import (
 from langgraph.checkpoint.serde.jsonplus import JsonPlusSerializer
 from langgraph.checkpoint.serde.types import ChannelProtocol
 
+logger = logging.getLogger(__name__)
+
 RETRYABLE_DATABASE_ERROR_CODES = {1205, 1213}
+# 服务端或中间代理关闭连接后，客户端要到下一次使用时才发现；语句本身没有问题，重建连接即可恢复。
+CONNECTION_LOST_DATABASE_ERROR_CODES = {2006, 2013, 2055}
 CHECKPOINT_WRITE_MAX_RETRIES = 3
 CHECKPOINT_WRITE_RETRY_DELAY_SECONDS = 0.05
 _SQLITE_WRITE_LOCKS: dict[str, threading.RLock] = {}
@@ -69,23 +75,63 @@ def _database_write_lock(model):
         yield
 
 
-def _is_retryable_database_error(exc: OperationalError, model) -> bool:
+def _is_connection_lost_error(exc: Exception) -> bool:
+    """判断异常是否来自已经失效的数据库连接。
+
+    ``InterfaceError`` 表示驱动层连接已不可用（例如 socket 已被置空），
+    ``CONNECTION_LOST_DATABASE_ERROR_CODES`` 表示连接在使用中被对端关闭。
+    """
+    if isinstance(exc, InterfaceError):
+        return True
+    error_code = exc.args[0] if exc.args else None
+    return error_code in CONNECTION_LOST_DATABASE_ERROR_CODES
+
+
+def _is_retryable_database_error(exc: Exception, model) -> bool:
     error_code = exc.args[0] if exc.args else None
     if error_code in RETRYABLE_DATABASE_ERROR_CODES:
+        return True
+    if _is_connection_lost_error(exc):
         return True
     _, vendor = _database_vendor(model)
     return vendor == "sqlite" and "database is locked" in str(exc).lower()
 
 
-def _run_database_write_with_retry(operation: Callable[[], None], model) -> None:
+def _discard_connection(model) -> None:
+    """丢弃写库当前线程持有的连接，确保重试不会复用同一个坏 socket。
+
+    只靠 ``close_old_connections()`` 不够：它依赖 ``CONN_MAX_AGE`` 是否到期以及驱动 ping 的结果，
+    而 pymysql 的 ``ping()`` 默认会自动重连并把连接判定为可用。
+    """
+    alias, _ = _database_vendor(model)
+    with suppress(Exception):
+        connections[alias].close()
+
+
+def _is_best_effort_write() -> bool:
+    """连接持续不可用时，是否放弃本次写入而不是让整轮会话失败。"""
+    return bool(getattr(settings, "CHECKPOINT_WRITE_BEST_EFFORT", True))
+
+
+def _run_database_write_with_retry(operation: Callable[[], None], model, description: str = "") -> None:
     for attempt in range(CHECKPOINT_WRITE_MAX_RETRIES):
         try:
             operation()
             return
-        except OperationalError as exc:
+        except (OperationalError, InterfaceError) as exc:
+            connection_lost = _is_connection_lost_error(exc)
             exhausted = attempt == CHECKPOINT_WRITE_MAX_RETRIES - 1
-            if not _is_retryable_database_error(exc, model) or exhausted:
+            if not _is_retryable_database_error(exc, model):
                 raise
+            if exhausted:
+                if not (connection_lost and _is_best_effort_write()):
+                    raise
+                # 推理结果由平台侧单独持久化，这里放弃写入只影响 interrupt / resume 的可恢复性，
+                # 比让已经产出回答的会话整体失败更可接受。
+                logger.exception("放弃 checkpoint 写入，数据库连接持续不可用：%s", description)
+                return
+            if connection_lost:
+                _discard_connection(model)
             close_old_connections()
             time.sleep(CHECKPOINT_WRITE_RETRY_DELAY_SECONDS * (2**attempt))
 
@@ -687,7 +733,11 @@ class BKDjangoSaver(BaseCheckpointSaver[str]):
 
         # SQLite 只允许单写者；跨 saver 实例串行本进程写入，MySQL 等数据库仍保持并行。
         with self.lock, _database_write_lock(self.checkpoint_model):
-            _run_database_write_with_retry(save_checkpoint, self.checkpoint_model)
+            _run_database_write_with_retry(
+                save_checkpoint,
+                self.checkpoint_model,
+                f"checkpoint thread_id={thread_id} checkpoint_id={checkpoint['id']}",
+            )
 
         return {
             "configurable": {
@@ -750,7 +800,11 @@ class BKDjangoSaver(BaseCheckpointSaver[str]):
                 )
 
         with self.lock, _database_write_lock(self.writes_model):
-            _run_database_write_with_retry(save_writes, self.writes_model)
+            _run_database_write_with_retry(
+                save_writes,
+                self.writes_model,
+                f"writes thread_id={thread_id} checkpoint_id={checkpoint_id} task_id={task_id}",
+            )
 
     def delete_thread(self, thread_id: str) -> None:
         """删除与线程ID关联的所有检查点和写入记录

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -16,6 +16,10 @@ AIDEV_AGENT_MAX_PENDING = int(os.environ.get("BKAPP_AIDEV_AGENT_MAX_PENDING", 32
 AIDEV_AGENT_CLEANUP_MAX_WORKERS = int(os.environ.get("BKAPP_AIDEV_AGENT_CLEANUP_MAX_WORKERS", 2))
 AIDEV_AGENT_CLEANUP_MAX_PENDING = int(os.environ.get("BKAPP_AIDEV_AGENT_CLEANUP_MAX_PENDING", 32))
 
+# checkpoint 写入重试耗尽且连接仍不可用时，放弃本次写入而不是让整轮会话失败。
+# 关闭后连接抖动会重新变成会话级错误，只在需要严格保证 interrupt / resume 可恢复时使用。
+CHECKPOINT_WRITE_BEST_EFFORT = os.environ.get("BKAPP_CHECKPOINT_WRITE_BEST_EFFORT", "1") == "1"
+
 # 客服渠道
 CHAT_GROUP_ENABLED = os.environ.get("CHAT_GROUP_ENABLED") == "1"
 CHAT_GROUP_STAFF = os.environ.get("CHAT_GROUP_STAFF")

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver.py
@@ -4,7 +4,7 @@ import threading
 
 import pytest
 from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver, _database_write_lock, bulk_upsert
-from django.db import OperationalError, connection, models
+from django.db import InterfaceError, OperationalError, connection, models
 
 
 class WriteForTest(models.Model):
@@ -59,7 +59,7 @@ def test_put_retries_transient_database_lock_error(mocker, saver, checkpoint_arg
 
 
 def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args):
-    error = OperationalError(2006, "server has gone away")
+    error = OperationalError(1146, "table doesn't exist")
     saver.checkpoint_model.objects.update_or_create.side_effect = error
     sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
 
@@ -69,6 +69,58 @@ def test_put_does_not_retry_other_database_error(mocker, saver, checkpoint_args)
     assert exc_info.value is error
     assert saver.checkpoint_model.objects.update_or_create.call_count == 1
     sleep.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        OperationalError(2013, "Lost connection to MySQL server during query"),
+        OperationalError(2006, "MySQL server has gone away"),
+        InterfaceError(0, ""),
+    ],
+)
+def test_put_retries_lost_database_connection(mocker, saver, checkpoint_args, error):
+    saver.checkpoint_model.objects.update_or_create.side_effect = [error, (mocker.Mock(), True)]
+    connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.connections")
+    close_old_connections = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    sleep = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    saver.put(*checkpoint_args)
+
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 2
+    # 失效连接必须被显式关闭，否则重试会继续复用同一个坏 socket
+    connections.__getitem__.return_value.close.assert_called_once_with()
+    close_old_connections.assert_called_once_with()
+    sleep.assert_called_once_with(0.05)
+
+
+def test_put_gives_up_when_database_connection_stays_unavailable(mocker, saver, checkpoint_args):
+    saver.checkpoint_model.objects.update_or_create.side_effect = OperationalError(2013, "lost connection")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.connections")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+    logger = mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.logger")
+
+    saved = saver.put(*checkpoint_args)
+
+    assert saved["configurable"]["checkpoint_id"] == "checkpoint-id"
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 3
+    logger.exception.assert_called_once()
+
+
+def test_put_raises_lost_connection_when_best_effort_disabled(mocker, saver, checkpoint_args, settings):
+    settings.CHECKPOINT_WRITE_BEST_EFFORT = False
+    error = OperationalError(2013, "lost connection")
+    saver.checkpoint_model.objects.update_or_create.side_effect = error
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.connections")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.close_old_connections")
+    mocker.patch("aidev_bkplugin.packages.checkpoint.bk_django_saver.time.sleep")
+
+    with pytest.raises(OperationalError) as exc_info:
+        saver.put(*checkpoint_args)
+
+    assert exc_info.value is error
+    assert saver.checkpoint_model.objects.update_or_create.call_count == 3
 
 
 def test_put_raises_after_database_lock_retries_exhausted(mocker, saver, checkpoint_args):

--- a/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver_async.py
+++ b/src/plugins/aidev_bkplugin/tests/packages/test_bk_django_saver_async.py
@@ -17,6 +17,7 @@ import uuid
 import pytest
 from aidev_bkplugin.models import Checkpoint, Write
 from aidev_bkplugin.packages.checkpoint.bk_django_saver import BKDjangoSaver
+from django.db import OperationalError
 from langgraph.checkpoint.base import empty_checkpoint
 
 # transaction=True：a* 方法在别的线程/连接里读写，数据必须真实提交才可见
@@ -61,6 +62,24 @@ async def test_aput_then_aget_tuple_roundtrips_through_real_orm(saver, thread_id
 
 async def test_aget_tuple_returns_none_for_unknown_thread(saver, thread_id):
     assert await saver.aget_tuple(_config(thread_id)) is None
+
+
+async def test_aput_recovers_from_lost_database_connection(mocker, saver, thread_id):
+    """连接中断只应触发重建连接后的重试，不能让已经完成推理的会话失败。"""
+    config = _config(thread_id)
+    checkpoint = empty_checkpoint()
+    update_or_create = mocker.patch.object(
+        Checkpoint.objects,
+        "update_or_create",
+        wraps=Checkpoint.objects.update_or_create,
+        side_effect=[OperationalError(2013, "Lost connection to MySQL server during query"), mocker.DEFAULT],
+    )
+
+    saved = await saver.aput(config, checkpoint, {"source": "input"}, {})
+
+    assert update_or_create.call_count == 2
+    assert saved["configurable"]["checkpoint_id"] == checkpoint["id"]
+    assert await Checkpoint.objects.filter(thread_id=thread_id).acount() == 1
 
 
 async def test_aput_writes_are_visible_through_aget_tuple(saver, thread_id):


### PR DESCRIPTION
## 问题

线上智能体会话在推理已经完成、进入 LangGraph 收尾写入时整体失败：

```
File ".../aidev_bkplugin/packages/checkpoint/bk_django_saver.py", line 709, in put_writes
    self.writes_model.objects.bulk_create(
django.db.utils.OperationalError: (2013, 'Lost connection to MySQL server during query')
```

异常抛在 `transaction.atomic()` 进入时的 `set_autocommit`，即语句还没发出、连接就已经失效——这是复用了被服务端/中间代理关闭的连接，不是慢查询或死锁。

排查记录见 `work-items/2.2.4/20260903_智能体会话checkpoint写入MySQL连接中断/`：同一天 20 次 agent 执行中有 11 次以该错误结束，且 45s 内出现 63 次连接建立，说明连接复用与健康检查都不到位。

## 变更

`bk_django_saver.py` 的写入重试此前只覆盖锁冲突（1205/1213）与 SQLite `database is locked`，连接级错误直接抛出，导致会话失败。本次：

1. **连接级错误纳入重试**：新增 `CONNECTION_LOST_DATABASE_ERROR_CODES = {2006, 2013, 2055}` 与 `InterfaceError` 判定。
2. **重试前显式丢弃坏连接**：`_discard_connection()` 关闭该 alias 当前线程的连接。只调 `close_old_connections()` 不够，它受 `CONN_MAX_AGE` 与驱动 ping 影响，而 pymysql 的 `ping()` 默认会自动重连并把连接判定为可用。
3. **收尾写入失败降级**：重试耗尽且仍是连接不可用时，记录 `logger.exception` 后返回，不再让已经产出回答的会话整体失败。由 `CHECKPOINT_WRITE_BEST_EFFORT`（`BKAPP_CHECKPOINT_WRITE_BEST_EFFORT`，默认开启）控制；关闭后恢复原有抛错行为。

非连接类错误（如 1146）行为不变，仍然不重试直接抛出。

## 验证

- `make test`（`src/plugins/aidev_bkplugin`）：345 passed。
- 新增用例：2013/2006/`InterfaceError` 各自触发一次重试后成功并断言连接被关闭；重试耗尽时 `put()` 正常返回且写告警日志；`CHECKPOINT_WRITE_BEST_EFFORT=False` 时仍抛 `OperationalError`。
- 异步链路新增真实 ORM 用例，验证 `aput()` 在首次连接中断后重试落库成功。
- `ruff check` / `ruff format --check`：通过。

## 后续（不在本 PR）

- 配置 `CONN_HEALTH_CHECKS=True` 与合适的 `CONN_MAX_AGE`，从源头减少连接频繁重建与复用坏连接。
- 补齐 MySQL 侧证据（`Aborted_clients`、主备切换、代理回收）确认连接被关闭的根因。
