### PR TITLE
feat: 为流式模型调用补充 first-token 与 read-stream Span --story=1070093903137679449

### DIFF
--- a/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
+++ b/src/agent/aidev_agent/packages/langchain_core/models/llm_gateway.py
@@ -43,6 +43,7 @@ from aidev_agent.api.domains import BKAIDEV_URL
 from aidev_agent.config import settings
 from aidev_agent.exceptions import AIDevException
 from aidev_agent.utils.datetimes import get_current_timestamp_in_milliseconds
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span
 
 try:
     from aidev_agent.packages.opentelemetry.resilience import (
@@ -432,13 +433,76 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
 
         return chunk, reasoning_start_time, current_reasoning_content or ""
 
+    def _llm_stream_span_attributes(self, operation: str) -> dict[str, Any]:
+        return {
+            "gen_ai.operation.name": operation,
+            "gen_ai.request.model": self.model_name or "unknown",
+            "gen_ai.system": "aidev_llm_gateway",
+        }
+
+    def _stream_chunks_with_token_spans(self, chunks: Iterator[ChatGenerationChunk]) -> Iterator[ChatGenerationChunk]:
+        """Split streaming wait into first-token and remaining read-stream spans."""
+        chunk_iter = iter(chunks)
+        with recording_span(
+            "llm.first_token",
+            kind=CLIENT_SPAN_KIND,
+            use_global_tracer=True,
+            attributes=self._llm_stream_span_attributes("first_token"),
+        ) as span:
+            try:
+                first = next(chunk_iter)
+            except StopIteration:
+                span.set_attribute("llm.stream.empty", True)
+                return
+        yield first
+        remaining = 0
+        with recording_span(
+            "llm.read_stream",
+            kind=CLIENT_SPAN_KIND,
+            use_global_tracer=True,
+            attributes=self._llm_stream_span_attributes("read_stream"),
+        ) as span:
+            for chunk in chunk_iter:
+                remaining += 1
+                yield chunk
+            span.set_attribute("llm.stream.remaining_chunks", remaining)
+
+    async def _astream_chunks_with_token_spans(
+        self, chunks: AsyncIterator[ChatGenerationChunk]
+    ) -> AsyncIterator[ChatGenerationChunk]:
+        """Async counterpart of ``_stream_chunks_with_token_spans``."""
+        chunk_iter = chunks.__aiter__()
+        with recording_span(
+            "llm.first_token",
+            kind=CLIENT_SPAN_KIND,
+            use_global_tracer=True,
+            attributes=self._llm_stream_span_attributes("first_token"),
+        ) as span:
+            try:
+                first = await chunk_iter.__anext__()
+            except StopAsyncIteration:
+                span.set_attribute("llm.stream.empty", True)
+                return
+        yield first
+        remaining = 0
+        with recording_span(
+            "llm.read_stream",
+            kind=CLIENT_SPAN_KIND,
+            use_global_tracer=True,
+            attributes=self._llm_stream_span_attributes("read_stream"),
+        ) as span:
+            async for chunk in chunk_iter:
+                remaining += 1
+                yield chunk
+            span.set_attribute("llm.stream.remaining_chunks", remaining)
+
     def _stream(self, *args, **kwargs) -> Iterator[ChatGenerationChunk]:
-        """对reasoning_content字段进行时间统计"""
+        """对reasoning_content字段进行时间统计，并拆出首 Token / 读流 Span。"""
         handle = self._begin_model_observation()
         reasoning_start_time = 0
         last_reasoning_content = ""
         try:
-            for chunk in super()._stream(*args, **kwargs):
+            for chunk in self._stream_chunks_with_token_spans(super()._stream(*args, **kwargs)):
                 chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
                     chunk, reasoning_start_time, last_reasoning_content
                 )
@@ -449,12 +513,12 @@ class ChatModel(RawChatOpenAI, ApiGwMixin):
         self._finish_model_observation_success(handle)
 
     async def _astream(self, *args, **kwargs) -> AsyncIterator[ChatGenerationChunk]:
-        """对reasoning_content字段进行时间统计"""
+        """对reasoning_content字段进行时间统计，并拆出首 Token / 读流 Span。"""
         handle = self._begin_model_observation()
         reasoning_start_time = 0
         last_reasoning_content = ""
         try:
-            async for chunk in super()._astream(*args, **kwargs):
+            async for chunk in self._astream_chunks_with_token_spans(super()._astream(*args, **kwargs)):
                 chunk, reasoning_start_time, last_reasoning_content = self._process_reasoning_chunk(
                     chunk, reasoning_start_time, last_reasoning_content
                 )

--- a/src/agent/tests/packages/langchain_core/models/test_llm_gateway_stream_spans.py
+++ b/src/agent/tests/packages/langchain_core/models/test_llm_gateway_stream_spans.py
@@ -1,0 +1,74 @@
+import asyncio
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from aidev_agent.packages.langchain_core.models.llm_gateway import ChatModel
+from aidev_agent.utils.tracing import CLIENT_SPAN_KIND
+from langchain_core.messages import AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk
+from langchain_openai import ChatOpenAI
+
+
+def _chunk(text: str) -> ChatGenerationChunk:
+    return ChatGenerationChunk(message=AIMessageChunk(content=text))
+
+
+def _install_span_recorder(monkeypatch):
+    calls: list[tuple[str, dict, MagicMock]] = []
+
+    @contextmanager
+    def fake_recording_span(name, **kwargs):
+        span = MagicMock()
+        calls.append((name, kwargs, span))
+        yield span
+
+    monkeypatch.setattr(
+        "aidev_agent.packages.langchain_core.models.llm_gateway.recording_span",
+        fake_recording_span,
+    )
+    return calls
+
+
+@pytest.mark.parametrize("texts", [["a", "b", "c"], ["only"]])
+def test_stream_records_first_token_and_read_stream(monkeypatch, texts):
+    calls = _install_span_recorder(monkeypatch)
+    monkeypatch.setattr(ChatOpenAI, "_stream", lambda self, *args, **kwargs: iter(_chunk(t) for t in texts))
+    model = ChatModel.get_setup_instance(model="aidev-chat-auto", base_url="https://example.com/v1")
+
+    assert [chunk.message.content for chunk in model._stream([])] == texts
+    assert [name for name, _, _ in calls] == ["llm.first_token", "llm.read_stream"]
+    for name, kwargs, _ in calls:
+        assert kwargs["kind"] is CLIENT_SPAN_KIND
+        assert kwargs["use_global_tracer"] is True
+        assert kwargs["attributes"]["gen_ai.request.model"] == "aidev-chat-auto"
+    calls[1][2].set_attribute.assert_called_with("llm.stream.remaining_chunks", len(texts) - 1)
+
+
+def test_stream_empty_only_records_first_token(monkeypatch):
+    calls = _install_span_recorder(monkeypatch)
+    monkeypatch.setattr(ChatOpenAI, "_stream", lambda self, *args, **kwargs: iter(()))
+    model = ChatModel.get_setup_instance(model="aidev-chat-auto", base_url="https://example.com/v1")
+
+    assert list(model._stream([])) == []
+    assert [name for name, _, _ in calls] == ["llm.first_token"]
+    calls[0][2].set_attribute.assert_called_with("llm.stream.empty", True)
+
+
+def test_astream_records_first_token_and_read_stream(monkeypatch):
+    calls = _install_span_recorder(monkeypatch)
+
+    async def fake_astream(self, *args, **kwargs):
+        for text in ("x", "y"):
+            yield _chunk(text)
+
+    async def collect():
+        return [chunk.message.content async for chunk in model._astream([])]
+
+    monkeypatch.setattr(ChatOpenAI, "_astream", fake_astream)
+    model = ChatModel.get_setup_instance(model="aidev-chat-auto", base_url="https://example.com/v1")
+
+    assert asyncio.run(collect()) == ["x", "y"]
+    assert [name for name, _, _ in calls] == ["llm.first_token", "llm.read_stream"]
+    assert calls[0][1]["use_global_tracer"] is True
+    calls[1][2].set_attribute.assert_called_with("llm.stream.remaining_chunks", 1)


### PR DESCRIPTION
## 背景
Streaming LLM calls currently show a short HTTP POST under `chat_model.generate`. Most of the wait stays on `generate` with no child span, so APM cannot tell first-token latency from the rest of SSE consumption.

## 原因
HTTPX auto-instrumentation ends the CLIENT span when response headers arrive or the stream is opened. Reading the remaining SSE tokens is not attributed to that POST span.

## 改动内容
- `ChatModel._stream` and `_astream` now emit `llm.first_token` and `llm.read_stream`
- Both spans use the application global tracer so `service.name` follows app code + module
- `llm.first_token` covers wait until the first chunk, including the outbound HTTP call
- `llm.read_stream` covers remaining chunks and records `llm.stream.remaining_chunks`
- Empty streams only record `llm.first_token` with `llm.stream.empty=true`

## 收益
APM can split first-token wait from later stream reading without changing HTTPX auto-instrumentation or non-stream `_generate`.

## 测试验证
- `make test path=tests/packages/langchain_core/models/test_llm_gateway_stream_spans.py`
- Also ran tracing helper tests and LLM gateway fallback tests: 22 passed, 5 skipped

## 不包含
- Changing the HTTPX CLIENT span lifetime
- Non-stream `_generate` / `_agenerate`
- Gateway or upstream model SERVER spans

Made with [Cursor](https://cursor.com)