### PR TITLE
feat: 让 wxbot Span 使用 appcode+module 服务名 --story=1070093903137679449

### DIFF
--- a/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/tracing.py
+++ b/src/plugins/aidev_wxbot/aidev_wxbot/wxaibot/tracing.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from typing import Any, Iterator
 
-from aidev_agent.utils.tracing import get_agent_tracer
+from aidev_agent.utils.tracing import recording_span
 
 try:
     from opentelemetry import context, trace
@@ -72,21 +72,18 @@ def record_ack(span: Any, response: Any) -> None:
 
 @contextmanager
 def wxbot_span(name: str, *, root: bool = False, kind=None, attributes: dict | None = None) -> Iterator[Any]:
-    """使用 Agent 的 tracer；禁用 OTel 自动采集异常正文和堆栈。"""
-    tracer = get_agent_tracer(__name__) if trace else None
-    if tracer is None:
+    """使用应用全局 tracer，使 service.name 与 MCP tool 一样为 appcode + module。"""
+    if trace is None:
         yield _NoOpSpan()
         return
-    options = {
-        "attributes": {"aidev.channel": "rtx", **(attributes or {})},
-        "record_exception": False,
-        "set_status_on_exception": False,
-    }
-    if root:
-        options["context"] = context.Context()
-    if kind is not None:
-        options["kind"] = kind
-    with tracer.start_as_current_span(name, **options) as span:
+    with recording_span(
+        name,
+        attributes={"aidev.channel": "rtx", **(attributes or {})},
+        kind=kind,
+        root=root,
+        record_exception=False,
+        use_global_tracer=True,
+    ) as span:
         try:
             yield span
         except BaseException as error:

--- a/src/plugins/aidev_wxbot/tests/conftest.py
+++ b/src/plugins/aidev_wxbot/tests/conftest.py
@@ -100,6 +100,8 @@ def wxbot_spans(monkeypatch):
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("wxbot-test"))
+    tracer = provider.get_tracer("wxbot-test")
+    monkeypatch.setattr(tracing, "_agent_tracer", tracer)
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: tracer)
     yield exporter
     provider.shutdown()

--- a/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
+++ b/src/plugins/aidev_wxbot/tests/database_events/process_helpers.py
@@ -330,6 +330,7 @@ def wxbot_process(path, sent, status, expected_messages, trace_records=None, app
 def configure_tracing(records):
     import threading
 
+    from aidev_agent.utils import tracing as agent_tracing
     from aidev_agent.utils.tracing import set_agent_tracer
     from opentelemetry.sdk.trace import TracerProvider
     from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter, SpanExportResult
@@ -356,7 +357,10 @@ def configure_tracing(records):
 
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(QueueExporter()))
-    set_agent_tracer(provider.get_tracer("cross-process-test"))
+    tracer = provider.get_tracer("cross-process-test")
+    set_agent_tracer(tracer)
+    if agent_tracing.trace is not None:
+        agent_tracing.trace.get_tracer = lambda _name: tracer
     return published
 
 

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_long_connection.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 import types
+from contextlib import suppress
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -24,10 +25,8 @@ try:
 
     settings.SECRET_KEY = "test-secret-key"
     settings.AIDEV_AGENT = "aidev_agent.services.common_agent.CommonQAAgent"
-    try:
+    with suppress(RuntimeError):
         settings.INSTALLED_APPS = [*settings.INSTALLED_APPS, "aidev_bkplugin"]
-    except RuntimeError:
-        pass
     # 根 conftest 已 configure 时 setup 会 RuntimeError；吞掉会导致整文件被 skip。
     if not apps.ready:
         django.setup()
@@ -743,9 +742,7 @@ class TestLongConnectionStreaming:
             yield 'data: {"type":"RUN_FINISHED"}\n'
 
         strategy = ChatAgentStrategy()
-        strategy.open_stream = MagicMock(
-            return_value=AgentStream("chat", generator(), "session-1")
-        )
+        strategy.open_stream = MagicMock(return_value=AgentStream("chat", generator(), "session-1"))
         request = SimpleNamespace(content="q", stream_id="chat-placeholder", username="u", group_id="g1")
 
         with (
@@ -863,6 +860,7 @@ class TestLongConnectionStreaming:
         provider.add_span_processor(SimpleSpanProcessor(exporter))
         tracer = provider.get_tracer(__name__)
         monkeypatch.setattr(tracing, "_agent_tracer", tracer)
+        monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: tracer)
         captured = {}
 
         def open_stream(**_kwargs):

--- a/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
+++ b/src/plugins/aidev_wxbot/tests/wxaibot/test_tracing.py
@@ -124,11 +124,44 @@ class TestWxBotSpan:
         assert not tracing.message_trace_active.get()
 
     def test_disabled_tracer_preserves_business_exception(self, monkeypatch):
-        monkeypatch.setattr(tracing, "get_agent_tracer", lambda _: None)
+        from contextlib import contextmanager
+
+        @contextmanager
+        def _noop(*_args, **_kwargs):
+            yield tracing._NoOpSpan()
+
+        monkeypatch.setattr(tracing, "recording_span", _noop)
         error = RuntimeError("business-error")
         with pytest.raises(RuntimeError) as caught, tracing.wxbot_span("disabled"):
             raise error
         assert caught.value is error
+
+    def test_wxbot_span_uses_application_service_name(self, monkeypatch):
+        from aidev_agent.utils import tracing as agent_tracing
+        from opentelemetry.sdk.resources import Resource
+        from opentelemetry.sdk.trace import TracerProvider
+        from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+        from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+        def _provider(service_name):
+            exporter = InMemorySpanExporter()
+            provider = TracerProvider(resource=Resource.create({"service.name": service_name}))
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            return provider, exporter
+
+        agent_provider, agent_exporter = _provider("ai-skill-stag")
+        app_provider, app_exporter = _provider("ai-skill-stag-default")
+        monkeypatch.setattr(agent_tracing, "_agent_tracer", agent_provider.get_tracer("agent"))
+        monkeypatch.setattr(agent_tracing.trace, "get_tracer", lambda _: app_provider.get_tracer("app"))
+        try:
+            with tracing.wxbot_span("wxbot.message.receive"):
+                pass
+            [span] = app_exporter.get_finished_spans()
+            assert span.resource.attributes["service.name"] == "ai-skill-stag-default"
+            assert not agent_exporter.get_finished_spans()
+        finally:
+            agent_provider.shutdown()
+            app_provider.shutdown()
 
     @pytest.mark.parametrize("fallback", [False, True])
     def test_identity_conversion_records_fallback_without_identity(self, wxbot_spans, fallback):


### PR DESCRIPTION
## 背景

WeCom protocol spans previously used the Agent private tracer, so APM `service.name` did not match MCP tool spans.

## 原因

`wxbot_span()` always called `get_agent_tracer()`. MCP tools already use `recording_span(..., use_global_tracer=True)` so their `service.name` follows app code + module.

## 改动内容

- Route all `wxbot_span` calls through `recording_span(..., use_global_tracer=True)`.
- Keep WeCom ACK, failure attributes, and cross-process `traceparent` behavior in `wxbot_span`.
- Update test fixtures so in-memory exporters still collect global-tracer spans.
- Add a test that wx spans use the application `service.name`, not the Agent tracer.

## 收益

WeCom spans show as `<app_code>-<module>` in APM, same as MCP tool spans.

## 测试验证

- `make test path=tests` in `src/plugins/aidev_wxbot`: 547 passed, 10 skipped, 5 xfailed.
- All `tests/wxaibot/test_tracing.py` cases passed, including `test_wxbot_span_uses_application_service_name`.
- Target-file pre-commit passed.
- Three long-connection busy-hint assertions already fail on current develop (`正在准备回复中...` extra frames). Not caused by this change.
