### PR TITLE
feat: skill 沙箱优化 - 延迟关闭 --story=137086359

### DIFF
--- a/src/agent/aidev_agent/config.py
+++ b/src/agent/aidev_agent/config.py
@@ -148,6 +148,16 @@ SBX_PAAS_NOT_READY_MAX_RETRIES = env.int("SBX_PAAS_NOT_READY_MAX_RETRIES", 5)
 SBX_PAAS_NOT_READY_SLEEP_SECONDS = env.int("SBX_PAAS_NOT_READY_SLEEP_SECONDS", 2)
 SBX_SENSITIVE_VALUES: list[str] = [v.strip() for v in env.str("SBX_SENSITIVE_VALUES", "").split(",") if v.strip()]
 
+# 沙箱延迟销毁与会话级复用配置
+BKAI_RUNTIME_SANDBOX_IDLE_TTL = env.int("BKAI_RUNTIME_SANDBOX_IDLE_TTL", 300)
+BKAI_RUNTIME_SANDBOX_SWEEP_INTERVAL = env.int("BKAI_RUNTIME_SANDBOX_SWEEP_INTERVAL", 60)
+# 超级过期记录 GC 阈值（秒）：超过该值的共享存储记录由 sweep 末尾 delete_expired 直接删除
+# （其远端沙箱早已被平台 TTL 回收，不再做二阶段销毁）。
+BKAI_RUNTIME_SANDBOX_RECORD_MAX_AGE = env.int("BKAI_RUNTIME_SANDBOX_RECORD_MAX_AGE", 3 * 24 * 3600)
+# 功能开关：启用延迟销毁 RuntimeBackendResolver（RuntimeBackendDeferManager 装配 + 会话级复用）
+# 关闭时 resolver 为纯路由，release 立即销毁。原 RUNTIME_SANDBOX_REUSE_ENABLED 已由本开关取代
+BKAI_RUNTIME_SANDBOX_DEFERRED_DESTROY_ENABLED = env.bool("BKAI_RUNTIME_SANDBOX_DEFERRED_DESTROY_ENABLED", True)
+
 # SSM相关配置
 BK_SSM_ENDPOINT = env.str("BK_SSM_ENDPOINT", "https://bkssm.service.consul")  # noqa
 

--- a/src/agent/aidev_agent/core/graphs/react/graph.py
+++ b/src/agent/aidev_agent/core/graphs/react/graph.py
@@ -194,7 +194,6 @@ class ReActAgentBuilder:
         self._extra_tools: list[BaseTool] = []
         self._enable_runtime_tool: bool = False
         self._runtime_backend_resolver = None
-        self._runtime_types: dict[str, type] = {}  # runtime_name -> backend_class
         self._enable_security_runtime: bool = True  # 默认启用安全校验
         self._enable_ask_user_question_tool: bool = True
         # Graph 运行时参数设置
@@ -434,20 +433,25 @@ class ReActAgentBuilder:
         self._enable_ask_user_question_tool = bool(enable)
         return self
 
-    def register_runtime_type(self, name: str, cls: type) -> "ReActAgentBuilder":
-        """注册 runtime 名称到 backend 类的映射。
+    def register_runtime_type(self, name: str, cls: type | None) -> "ReActAgentBuilder":
+        """注册 runtime 类型名到 backend 类的映射（委托 RuntimeBackendResolver）。
 
-        skill 的 ``runtime`` frontmatter 字段引用此处注册的名称。
-        ``build()`` 时会根据映射实例化对应 backend。
+        skill 的 ``runtime`` frontmatter 字段引用此处注册的类型名。类型注册表（``_backend_cls``）唯一归属 RuntimeBackendResolver
+        本方法仅委托其``register_runtime_cls`` 维护，使 resolver 成为运行时类型注册+实例注册+沙箱生命周期的唯一事实源
 
         Args:
-            name: runtime 名称（如 ``"sandbox"``）。
-            cls: 对应的 backend 类（如 ``E2BSandboxBackend``）。
+            name: runtime 类型名（如 ``"sandbox"``）。
+            cls: 对应的 backend 类（如 ``E2BSandboxBackend``）；None 表示注销该类型名（pop 静默）
 
         Returns:
             self（支持链式调用）。
+
+        Raises:
+            RuntimeError: 未注入 runtime_backend_resolver（先经
+                set_bkai_options/set_runtime_backend_resolver 注入）。
         """
-        self._runtime_types[name] = cls
+        self._require_runtime_backend_resolver()
+        self._runtime_backend_resolver.register_runtime_cls(name, cls)
         return self
 
     def enable_runtime_local(self, enable: bool = True) -> "ReActAgentBuilder":
@@ -455,39 +459,74 @@ class ReActAgentBuilder:
 
         - enable=True：注册 runtime type `local` -> `FilesystemBackend`，并注册参数提取函数
         - enable=False：移除 runtime type `local`
+
+        Raises:
+            RuntimeError: 未注入 runtime_backend_resolver（经 ``register_runtime_type``转发校验，要求 resolver 已存在）。
         """
         if enable:
             self._runtime_param_with_skill["local"] = _extract_local_params
             return self.register_runtime_type("local", FilesystemBackend)
 
-        self._runtime_types.pop("local", None)
-        return self
+        return self.register_runtime_type("local", None)
 
     def enable_runtime_agent_run(self, enable: bool = True) -> "ReActAgentBuilder":
         """启用/禁用 agent_run 沙箱运行时类型（sandbox）。
 
         - enable=True：注册 runtime type `sandbox` -> `E2BSandboxBackend`，并注册参数提取函数
         - enable=False：移除 runtime type `sandbox`
+
+        Raises:
+            RuntimeError: 未注入 runtime_backend_resolver（经 ``register_runtime_type``转发校验，要求 resolver 已存在）。
         """
         if enable:
             self._runtime_param_with_skill["agent_run"] = _extract_e2b_params
             return self.register_runtime_type("agent_run", E2BSandboxBackend)
 
-        self._runtime_types.pop("agent_run", None)
-        return self
+        return self.register_runtime_type("agent_run", None)
 
     def enable_runtime_paas(self, enable: bool = True) -> "ReActAgentBuilder":
         """启用/禁用蓝鲸 PaaS 沙箱运行时类型（paas_sandbox）。
 
         - enable=True：注册 runtime type `paas_sandbox` -> `PaasSandboxBackend`，并注册参数提取函数
         - enable=False：移除 runtime type `paas_sandbox`
+
+        Raises:
+            RuntimeError: 未注入 runtime_backend_resolver（经 ``register_runtime_type``转发校验，要求 resolver 已存在）。
         """
         if enable:
             self._runtime_param_with_skill["paas_sandbox"] = _extract_paas_params
             return self.register_runtime_type("paas_sandbox", PaasSandboxBackend)
 
-        self._runtime_types.pop("paas_sandbox", None)
+        return self.register_runtime_type("paas_sandbox", None)
+
+    def set_runtime_backend_resolver(self, resolver) -> "ReActAgentBuilder":
+        """注入 RuntimeBackendResolver（公开 setter，链式调用风格）。
+
+        供测试与装配层注入 resolver，避免直捅私有属性。
+        运行时类型注册（``register_runtime_type``/``enable_runtime_*``）要求 resolver 已存在
+        须先调用本方法（或经 ``set_bkai_options`` 注入）再启用运行时类型。
+
+        Args:
+            resolver: RuntimeBackendResolver 实例。
+
+        Returns:
+            self（支持链式调用）。
+        """
+        self._runtime_backend_resolver = resolver
         return self
+
+    def _require_runtime_backend_resolver(self) -> None:
+        """校验已注入 runtime_backend_resolver，缺失则抛异常。
+
+        enable_runtime_* 在 ``build()`` 前的配置期即须把 runtime 类型注册到 resolver
+        因此要求 resolver 已经存在，否则抛 ``RuntimeError``
+        提示先经``set_bkai_options``/``set_runtime_backend_resolver`` 注入
+        """
+        if self._runtime_backend_resolver is None:
+            raise RuntimeError(
+                "ReActAgentBuilder 启用了 runtime 注册，但未提供 runtime_backend_resolver，"
+                "请先经 set_bkai_options/set_runtime_backend_resolver 注入"
+            )
 
     def enable_security_runtime(self, enable: bool = True) -> "ReActAgentBuilder":
         """启用/禁用运行时命令安全校验。
@@ -562,6 +601,11 @@ class ReActAgentBuilder:
         if options.model_context_options is not None:
             self._model_context_options = options.model_context_options
 
+        # RuntimeBackendResolver（由调用方构造并注入）——必须先于 skills 块内
+        # enable_runtime_paas/local（新方案下这些调用要求 resolver 已存在）
+        if options.runtime_backend_resolver is not None:
+            self._runtime_backend_resolver = options.runtime_backend_resolver
+
         # Skills（从配置链路传入的关联技能配置 list）
         # options.skills 允许混合两种元素：
         #   1. 满足 SkillProviderBackend 协议的后端实例（如 LocalSkillBackend）——直接作为 source 注册
@@ -592,10 +636,6 @@ class ReActAgentBuilder:
             # 存在本地技能后端时才启用 local runtime（LocalSkillBackend 的技能默认 runtime="local"）
             if any(isinstance(s, LocalSkillBackend) for s in skill_backends):
                 self.enable_runtime_local(True)
-
-        # RuntimeBackendResolver（由调用方构造并注入）
-        if options.runtime_backend_resolver is not None:
-            self._runtime_backend_resolver = options.runtime_backend_resolver
 
         # Subagents（子 Agent 规格，注册后端 + 注入 A2A 工具）
         if options.subagent_specs is not None and options.subagent_specs:
@@ -684,7 +724,11 @@ class ReActAgentBuilder:
 
         # A2A 依赖 PaaS 沙箱：子 Agent PV 创建需要 paas_client，仅启用 A2A 而未启用
         # paas_sandbox runtime 时，paas_client 为 None，调用 Agent/sendMessages 会触发崩溃
-        if self._enable_a2a_tool and not (self._enable_runtime_tool and "paas_sandbox" in self._runtime_types):
+        if self._enable_a2a_tool and not (
+            self._enable_runtime_tool
+            and self._runtime_backend_resolver is not None
+            and self._runtime_backend_resolver.have_runtime_cls("paas_sandbox")
+        ):
             raise ValueError(
                 "ReActAgentBuilder 构建失败：启用了 A2A 工具但未启用 PaaS 沙箱 runtime，"
                 "请同时调用 set_enable_runtime_tool(True) 和 enable_runtime_paas(True)"
@@ -846,7 +890,11 @@ class ReActAgentBuilder:
 
         - 初始化 SkillRegistry
         - 将 activate_skill 工具与 prompt middleware 所需的 registry 写入 self._skill_registry
-        - 为每个 skill 根据其 runtime 创建并注册独立 backend 到 self._runtime_backend_resolver
+        - 为每个 skill 根据其 runtime 创建并注册 backend 到 self._runtime_backend_resolver。
+
+        所有 runtime（含 local）统一经 ``resolver.get_or_create_backend`` 获取/复用。
+        模型可见路由名（runtime_name）为 ``{skill_runtime}_{skill_name}``（与 skill 提示/工具 target_runtime 一致）
+        runtime_id 由 resolver 内部 ``compose_runtime_id`` 幂等推导（``{agent_code}:{session_code}:{runtime}_{skill}``）
         """
         registry = SkillRegistry(self._skill_sources or [])
         self._skill_registry = registry
@@ -855,12 +903,14 @@ class ReActAgentBuilder:
         for skill in registry.list_skills():
             skill_name = skill["name"]
             skill_runtime = skill.get("runtime")
-            logger.debug(f"ReActBuilderSkill {skill_runtime} {self._runtime_types}")
-            if skill_runtime is None or skill_runtime not in self._runtime_types:
+            logger.debug(f"ReActBuilderSkill {skill_runtime} {sorted(resolver._backend_cls) if resolver else None}")
+            # 预检：runtime 类型须已注册到 resolver。resolver 为 None（未启用
+            # runtime_tool 的 skills 场景）时视作无任何类型注册，跳过所有带
+            # runtime 的 skill（与旧实现空 _runtime_types 的跳过语义一致）。
+            if skill_runtime is None or resolver is None or not resolver.have_runtime_cls(skill_runtime):
                 logger.warning(f"Skill '{skill_name}' 声明 runtime='{skill_runtime}' 但未注册对应类型，跳过该 skill")
                 continue
-            # 实例化独立 backend
-            backend_cls = self._runtime_types[skill_runtime]
+            # 实例化独立 backend 所需构造参数
             extractor = self._runtime_param_with_skill.get(skill_runtime)
             params = extractor(skill, self._executor_info or {}) if extractor is not None else {}
             if skill_runtime == "paas_sandbox" and self._resource_manager is not None:
@@ -871,13 +921,17 @@ class ReActAgentBuilder:
                 f"executor_info_keys={list((self._executor_info or {}).keys())}, "
                 f"has_app_code={bool((self._executor_info or {}).get('app_code'))}, "
                 f"has_access_token={bool((self._executor_info or {}).get('access_token'))}, "
-                f"backend_cls={backend_cls.__name__}"
+                f"runtime_cls_name={skill_runtime}"
             )
-            skill_backend = backend_cls(**params)
-            # 注册这个 backend
-            resolver.register_runtime(
-                f"{skill_runtime}_{skill_name}",
-                skill_backend,
+            # 所有 runtime（含 local）统一走 get_or_create_backend：
+            # runtime_name = {runtime}_{skill}（模型可见路由名，注册 _backends 供 target_runtime 解析）；
+            # runtime_id 由 resolver 内部 compose_runtime_id 幂等推导（{agent_code}:{session_code}:{runtime}_{skill}），
+            # resolver 内部按 runtime_cls_name 从 _backend_cls 查类构造实例。
+            runtime_name = f"{skill_runtime}_{skill_name}"
+            resolver.get_or_create_backend(
+                runtime_name=runtime_name,
+                runtime_cls_name=skill_runtime,  # resolver 内部按名查 _backend_cls
+                construct_params=params,
             )
 
     def _prepare_a2a(self) -> None:
@@ -905,7 +959,11 @@ class ReActAgentBuilder:
         """
         paas_client = None
         paas_app_code = ""
-        if self._enable_runtime_tool and "paas_sandbox" in self._runtime_types:
+        if (
+            self._enable_runtime_tool
+            and self._runtime_backend_resolver is not None
+            and self._runtime_backend_resolver.have_runtime_cls("paas_sandbox")
+        ):
             executor_info = self._executor_info or {}
             paas_app_code = executor_info.get("app_code", "")
             if paas_app_code and self._resource_manager is not None:

--- a/src/agent/aidev_agent/core/tools/runtime_tools/__init__.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/__init__.py
@@ -3,14 +3,16 @@
 
 该包合并了原有的 runtime_base/runtime_local/runtime_e2b/runtime_paas 四个子包，
 集中存放运行时子系统的所有组件：
-- 共享类型定义（types）
+- 共享类型定义（types），含延迟销毁 store 抽象契约
 - 共享工具函数（utils），含 skill 打包工具
 - 运行时工具提供者与路由（provider）
+- 沙箱延迟销毁：内存版 store 与 DeferManager（defer_manager）
 - 本地文件系统后端（local_backend）
 - E2B 远程沙箱后端（e2b_backend）
 - PaaS 远程沙箱后端（paas_backend）
 """
 
+from .defer_manager import RuntimeBackendDeferInMemoryStore, RuntimeBackendDeferManager
 from .e2b_backend import E2BSandboxBackend
 from .local_backend import FilesystemBackend
 from .paas_backend import PaasSandboxBackend
@@ -33,6 +35,7 @@ from .types import (
     FileUploadResponse,
     GrepMatch,
     RuntimeBackend,
+    RuntimeBackendDeferStore,
     WriteResult,
 )
 from .utils import (
@@ -62,6 +65,9 @@ __all__ = [
     "get_grep_tool",
     "get_execute_tool",
     "get_client_tools_with_runtime",
+    # defer_manager
+    "RuntimeBackendDeferInMemoryStore",
+    "RuntimeBackendDeferManager",
     # types
     "FileInfo",
     "GrepMatch",
@@ -71,6 +77,7 @@ __all__ = [
     "FileUploadResponse",
     "FileDownloadResponse",
     "RuntimeBackend",
+    "RuntimeBackendDeferStore",
     # utils
     "EMPTY_CONTENT_WARNING",
     "LINE_NUMBER_WIDTH",

--- a/src/agent/aidev_agent/core/tools/runtime_tools/defer_manager.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/defer_manager.py
@@ -1,0 +1,302 @@
+# -*- coding: utf-8 -*-
+"""沙箱延迟销毁（token 化）—— 内存版 store + 所有权接管（defer）/ 挂载查询 / 单阶段 token 销毁 sweep。
+
+本模块提供：
+- ``RuntimeBackendDeferInMemoryStore``：``RuntimeBackendDeferStore``
+    抽象契约见``types`` 模块，4 原语 get/put/delete_if_token/delete_expired）的内存实现
+- ``RuntimeBackendDeferManager``：纯策略层，配合 resolver 的「先构造再挂载 + close 移交所有权」流程
+    不接触 store 内部 token 语义（payload/token/last_access_at 完全封装在 store 4 原语内），只关心 TTL/自有实例的 close；
+- ``default_runtime_backend_defer_manager``：进程级默认单例（InMemory store，start 幂等），供 chat 装配层直接取用实现跨请求的会话级复用/延迟销毁。
+
+分层：
+- store 4 原语（get/put/delete_if_token/delete_expired）
+    承载记录 schema（含 token） 与并发控制（get 摘 token 与 delete_if_token 比较删除原子串行）；
+- DeferManager 维护自有 ``_owned`` 注册表（``_OwnedBackend`` dataclass 承载 backend + token + expires_at），
+    defer 用 uuid4() 生成 token 传入 store.put； sweep 遍历 ``_owned`` 驱动单阶段 token 销毁，周期末尾调用 ``store.delete_expired`` 做超 max_age 记录的 GC
+
+token 语义正确性论证：
+- ``get``（有请求挂载复用沙箱）先行动作会原子摘除记录内 token，此后任何旧 entry 的 ``delete_if_token`` 必失败（token 已摘 / 已被新 put 覆盖）
+- ``shutdown`` 也先 token 校验再 close，为将来多 pod 分布式 store 提供安全销毁语义（不误杀其他 pod 正在使用的沙箱）。
+
+流程：
+- ``defer``：resolver close 时把本请求经手的 backend 移交到本管理器 —— 生成 token = uuid4().hex，save() 导出 payload 经 store.put(runtime_id, payload, token)
+  登记记录（供后续请求挂载复用），并保留实例强引用 + token + expires_at；
+  store.put/save 失败时立即 close 该 backend 销毁（close 异常自吞记 warning 不中断循环），且不登记 _owned（token 从未落地，登记只会留死 entry）
+- ``get_runtime``：原沙箱未被销毁时返回挂载 payload（store.get 纯透传，命中即摘 token 续期）；
+- sweep 线程（daemon）周期遍历自有 ``_owned``，对过期的 entry 单阶段销毁
+  （delete_if_token 原子校验 → close 持有实例 → pop-if-same 清理本地注册表）；
+  ``atexit shutdown`` 停线程并对持有实例先 token 校验再 close。
+"""
+
+from __future__ import annotations
+
+import atexit
+import dataclasses
+import logging
+import threading
+import time
+import uuid
+
+from aidev_agent.config import settings
+
+from .types import RuntimeBackend
+
+logger = logging.getLogger(__name__)
+
+
+class RuntimeBackendDeferInMemoryStore:
+    """内存版 RuntimeBackendDeferStore —— 用于本地开发与单测模拟多 pod 共享存储，作为默认实现
+    生产环境为单 pod 单进程时也可以使用本类，如果多进程使用本类，pod 之间不会互相影响，此时退化 runtime 没有 defer 的情况
+
+    记录结构：``_records[key] = {"payload": dict, "token": str | None, "last_access_at": float}``。
+    用 ``threading.Lock`` 保证 ``get`` 的摘 token 与 ``delete_if_token`` 的比较删除在 store 内部串行（原子性硬契约）。
+    ``get`` 返回 payload 本身而非整个记录。不存 pod 归属字段（sweep 遍历 DeferManager 自有注册表，非按 pod 扫描共享存储）。
+
+    若需跨进程共享（上 MySQL / django cache），写入方需额外在 payload 中带可序列化
+    兜底字段（如 ``backend_type`` 字符串或 import_path），load 前先经类引用/导入路径
+    恢复。本内存实现以最小改动满足单测为准，不额外加序列化兜底字段。
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, dict] = {}
+        self._lock = threading.Lock()
+
+    def get(self, key: str) -> dict | None:
+        with self._lock:
+            record = self._records.get(key)
+            if record is None:
+                return None
+            # 原子摘除 token + 刷新 last_access_at（写回新记录），与 delete_if_token
+            # 的比较删除在 store 内部串行 —— 摘 token 后旧 entry 永远无法删除本记录
+            record = dict(record)
+            record["token"] = None
+            record["last_access_at"] = time.time()
+            self._records[key] = record
+            return dict(record.get("payload") or {})
+
+    def put(self, key: str, payload: dict, token: str) -> None:
+        with self._lock:
+            self._records[key] = {
+                "payload": dict(payload),
+                "token": token,
+                "last_access_at": time.time(),
+            }
+
+    def delete_if_token(self, key: str, token: str) -> bool:
+        with self._lock:
+            record = self._records.get(key)
+            if record is None:
+                return False
+            if record.get("token") != token:
+                return False
+            self._records.pop(key, None)
+            return True
+
+    def delete_expired(self, max_age: float) -> int:
+        with self._lock:
+            now = time.time()
+            expired_keys = [k for k, r in self._records.items() if now - r.get("last_access_at", 0) > max_age]
+            for k in expired_keys:
+                self._records.pop(k, None)
+            return len(expired_keys)
+
+
+@dataclasses.dataclass
+class _OwnedBackend:
+    """DeferManager 自有实例注册表条目 —— backend 实例 + 本进程曾持 token + 计划销毁时刻。"""
+
+    backend: RuntimeBackend
+    token: str  # 本进程 defer 时生成的 token（经 store.put 写入记录），供 sweep/shutdown 校验
+    expires_at: float  # defer 时 = time.time() + idle_ttl；同 runtime_id 再次 defer 覆盖刷新
+
+
+class RuntimeBackendDeferManager:
+    """沙箱延迟销毁管理器（token 化）—— 纯策略层（所有权接管 / 挂载查询 / 单阶段 token 销毁）。"""
+
+    def __init__(
+        self,
+        store,
+        *,
+        idle_ttl: int,
+        sweep_interval: int,
+        record_max_age: float,
+    ) -> None:
+        self._store = store
+        self._idle_ttl = idle_ttl
+        self._sweep_interval = sweep_interval
+        self._record_max_age = record_max_age
+        # defer 接管的 backend（runtime_id → 实例 + token + 过期时刻），TTL 到期销毁 / 进程退出时 close
+        self._owned: dict[str, _OwnedBackend] = {}
+        self._owned_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._start_lock = threading.Lock()
+        self._atexit_registered = False
+
+    def defer(self, backends: dict[str, RuntimeBackend]) -> None:
+        """接管 backend 所有权（延迟销毁，resolver close 时调用）。
+
+        对每个 runtime_id：
+        - ``token = uuid4().hex`` 由本管理器生成（调用方生成后传入 store.put，store 保持哑存储）；
+        - ``backend.save()`` 导出挂载 payload，经 ``store.put(runtime_id, payload, token)`` 登记/覆盖记录
+            lazy 未创建的沙箱导出 ``{}``，照常登记保持记录新鲜度；同 runtime_id 再次 defer 用新 token 覆盖，旧 token 失效
+        - ``_owned`` 登记实例 + token + expires_at = now + idle_ttl
+            同 runtime_id 再次 defer 覆盖刷新 expires_at
+        - 异常分支：``store.put``（含 ``backend.save()``，同一 try 块）失败 → 记 warning + 立即
+            ``backend.close()`` 真实销毁远端（close 异常自吞记 warning，不中断循环）+
+            不登记 _owned（token 从未写入 store，登记只会留死 entry，且后续 delete_if_token 校验必然 False 无法销毁）
+
+        Args:
+            backends: runtime_id → backend 实例（resolver 经 compose_runtime_id 组合）。
+        """
+        for runtime_id, backend in backends.items():
+            token = uuid.uuid4().hex
+            try:
+                self._store.put(runtime_id, backend.save(), token)
+            except Exception:  # noqa: BLE001
+                # put 失败：记录从未落地，不可能有人挂载/复用，本进程持唯一引用。
+                # 立即 close 真实销毁远端（自吞异常，避免中断循环影响其余 backends 的 defer）。
+                logger.warning("defer: store.put(%s) 失败，立即销毁该 backend", runtime_id, exc_info=True)
+                try:
+                    backend.close()
+                except Exception:  # noqa: BLE001
+                    logger.warning("defer: close %s 失败（store.put 失败后）", runtime_id, exc_info=True)
+                continue  # 不登记 _owned —— token 从未写入 store，登记只会留死 entry，且后续 delete_if_token 校验永远失败无法销毁
+            with self._owned_lock:
+                self._owned[runtime_id] = _OwnedBackend(
+                    backend=backend, token=token, expires_at=time.time() + self._idle_ttl
+                )
+            logger.debug("sandbox %s 所有权移交 DeferManager（延迟销毁）", runtime_id)
+
+    def get_runtime(self, runtime_id: str) -> dict | None:
+        """查询原沙箱挂载 payload（纯透传 store.get，命中即摘 token 续期）。
+
+        token 语义：``get`` 意味着有 Agent 复用该沙箱 —— store 内**原子摘除记录内
+        token**（置 None）+ 刷新 last_access_at。token 被摘除后，任何旧 entry 的 ``delete_if_token`` 必失败（token 已摘 / 已被新 put 覆盖）
+        旧记录永远无法被 close 销毁 —— 彻底关闭「turn 超 idle_ttl 被误杀」窗口，无需心跳
+        记录不存在返回 None 且不创建记录。
+
+        Args:
+            runtime_id: 沙箱生命周期标识（resolver ``compose_runtime_id`` 产出）。
+
+        Returns:
+            记录的挂载 payload（``backend.save()`` 产出）。payload 为 ``{}``
+            表示原沙箱从未真正拉起过（``backend.load({})`` 应为 no-op）；记录不存在时返回 None。
+        """
+        return self._store.get(runtime_id)
+
+    def _pop_owned_if_same(self, key: str, entry: _OwnedBackend) -> bool:
+        """本地注册表卫生：仅当 ``_owned[key] is entry`` 时移除。
+
+        身份比较防止弹掉并发 defer 刚登记的新 entry（旧 entry 被覆盖时本方法是 no-op，旧 backend 的回收由接管方负责）。
+        每个销毁出口统一调用，防止 sweep 每周期对同一 entry 无限重试。
+        """
+        with self._owned_lock:
+            if self._owned.get(key) is entry:
+                self._owned.pop(key, None)
+                return True
+            return False
+
+    def _destroy_entry(self, key: str, entry: _OwnedBackend) -> None:
+        """单阶段 token 销毁单条自有 entry（delete_if_token 原子校验 → close → pop）。
+
+        ``store.delete_if_token(key, entry.token)``：
+        - 返回 True（记录仍持本进程 token → 无人挂载、未被新 defer 覆盖）→ close 持有实例（真实销毁远端，异常 warning 包裹）→ pop-if-same 清理本地注册表；
+        - 返回 False（token 被摘 = 有请求挂载中，或被新 defer 覆盖 = 新 entry 接管）
+          → **不 close**，仅 pop-if-same 回收本地旧 entry（远端由挂载方结束时的
+          defer / 新 entry 到期 sweep 接管）。
+        """
+        try:
+            if not self._store.delete_if_token(key, entry.token):
+                # 未获销毁权：token 已摘（有请求挂载中）/ 已被新 put 覆盖 / 记录不存在。
+                # 绝不 close 远端 —— 可能是其他 pod / 挂载方正在使用同一沙箱
+                logger.info("sandbox %s token 校验失败，不销毁（挂载中/已被接管）", key)
+                self._pop_owned_if_same(key, entry)
+                return
+            try:
+                entry.backend.close()
+                logger.info("sandbox %s 持有实例已 close（远端真实销毁）", key)
+            except Exception:  # noqa: BLE001
+                logger.warning("sandbox %s 持有实例 close 失败", key, exc_info=True)
+            self._pop_owned_if_same(key, entry)
+        except Exception:  # noqa: BLE001
+            logger.warning("sweep 处理 %s 失败", key, exc_info=True)
+
+    def _sweep_once(self) -> None:
+        """遍历自有 _owned 驱动单阶段 token 销毁；周期末尾 delete_expired 做 GC。"""
+        if self._store is None:
+            return
+        with self._owned_lock:
+            snapshot = list(self._owned.items())
+        now = time.time()
+        for key, entry in snapshot:
+            if now <= entry.expires_at:
+                continue
+            self._destroy_entry(key, entry)
+        try:
+            removed = self._store.delete_expired(self._record_max_age)
+            if removed:
+                logger.info("sweep GC: 删除 %s 条超 max_age 的过期记录", removed)
+        except Exception:  # noqa: BLE001
+            logger.warning("sweep delete_expired GC 失败", exc_info=True)
+
+    def _sweep_loop(self) -> None:
+        while not self._stop_event.wait(self._sweep_interval):
+            self._sweep_once()
+
+    def start(self) -> None:
+        """懒启动 sweep 线程（daemon=True，幂等）。"""
+        with self._start_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._stop_event.clear()
+            self._thread = threading.Thread(
+                target=self._sweep_loop,
+                name="sandbox-lifecycle-sweep",
+                daemon=True,
+            )
+            self._thread.start()
+            if not self._atexit_registered:
+                atexit.register(self.shutdown)
+                self._atexit_registered = True
+
+    def shutdown(self) -> None:
+        """进程退出兜底：停 sweep 线程并对持有实例先 token 校验再 close（真实销毁远端）。
+
+        先 ``store.delete_if_token(runtime_id, owned.token)``：
+            返回 True 记录仍持本进程 token → 无人挂载、未被新 defer 覆盖才 close 持有实例
+            返回 False（token 被摘 = 其他 pod / 请求在使用）则**不 close**，仅丢弃本地引用
+        对将来多 pod 分布式 store 更安全 —— 避免误杀其他 pod 正在使用的沙箱。
+        InMemory store 的记录随进程消亡；无持有实例的记录由其他 pod 的 sweep 按 TTL 清理（远端由平台 TTL 兜底）。
+        """
+        self._stop_event.set()
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+        with self._owned_lock:
+            items = list(self._owned.items())
+            self._owned.clear()
+        for runtime_id, owned in items:
+            try:
+                if not self._store.delete_if_token(runtime_id, owned.token):
+                    logger.info("shutdown: %s token 校验失败，不 close（他方使用中）", runtime_id)
+                    continue
+                owned.backend.close()
+            except Exception:  # noqa: BLE001
+                logger.warning("shutdown: close %s 失败", runtime_id, exc_info=True)
+
+
+# ---- 进程级默认单例（决策 1 + CR6）----
+# 每个 pod 一个进程级 InMemory store + DeferManager，跨请求共享以实现会话级
+# 复用/延迟销毁。start() 幂等：daemon sweep 线程与 atexit shutdown 随模块导入
+# 注册（sweep 空转开销可忽略）。将来接入真实分布式 store 时，替换本单例的
+# store 构造来源即可（换成 Redis/MySQL 实现的 RuntimeBackendDeferStore）。
+default_runtime_backend_defer_manager = RuntimeBackendDeferManager(
+    RuntimeBackendDeferInMemoryStore(),
+    idle_ttl=settings.BKAI_RUNTIME_SANDBOX_IDLE_TTL,
+    sweep_interval=settings.BKAI_RUNTIME_SANDBOX_SWEEP_INTERVAL,
+    record_max_age=settings.BKAI_RUNTIME_SANDBOX_RECORD_MAX_AGE,
+)
+default_runtime_backend_defer_manager.start()
+
+
+__all__ = ["RuntimeBackendDeferInMemoryStore", "RuntimeBackendDeferManager", "default_runtime_backend_defer_manager"]

--- a/src/agent/aidev_agent/core/tools/runtime_tools/e2b_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/e2b_backend.py
@@ -26,6 +26,7 @@ E2BSandboxBackend: 基于 E2B Code Interpreter 的远程沙箱后端实现。
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -33,7 +34,14 @@ import shlex
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
+from e2b.api.client.types import Unset
+from e2b.connection_config import ConnectionConfig
+from e2b.exceptions import SandboxNotFoundException
+from e2b.sandbox.commands.command_handle import CommandExitException
+from e2b.sandbox.filesystem.filesystem import FileType
+from e2b_code_interpreter import Sandbox  # type: ignore
 from langchain_core.runnables import RunnableConfig
+from packaging.version import Version
 
 from .types import (
     EditResult,
@@ -45,7 +53,7 @@ from .types import (
     RuntimeBackend,
     WriteResult,
 )
-from .utils import check_empty_content, perform_string_replacement
+from .utils import check_empty_content, package_dir, perform_string_replacement
 
 logger = logging.getLogger(__name__)
 
@@ -91,7 +99,7 @@ class E2BSandboxBackend(RuntimeBackend):
     设计要点：
     - 与 `FilesystemBackend` 保持相同的方法签名和返回类型
     - 惰性创建沙箱实例（首次调用任一方法时创建）
-    - 支持通过 ``from_sandbox_info()`` 从已有连接信息重建实例（绕过 connect API）
+    - 支持通过实例方法 ``load(sandbox_info)`` 挂载已有沙箱（绕过 connect API）
     - 提供 `kill()` 方法显式销毁沙箱
 
     Args:
@@ -159,14 +167,30 @@ class E2BSandboxBackend(RuntimeBackend):
         Returns:
             已连接到指定沙箱的 E2BSandboxBackend 实例。
         """
-        from e2b.api.client.types import Unset
-        from e2b.connection_config import ConnectionConfig
-        from e2b_code_interpreter import Sandbox  # type: ignore
-        from packaging.version import Version
+        instance = cls.__new__(cls)
+        instance._template = ""
+        instance._timeout = 0
+        instance._api_key = api_key or os.getenv("E2B_API_KEY")
+        instance._domain = domain or os.getenv("E2B_DOMAIN")
+        instance._pending_sandbox_env = None
+        instance._sandbox = cls._build_sandbox_from_info(
+            sandbox_info, api_key=instance._api_key, domain=instance._domain
+        )
+        return instance
 
-        resolved_api_key = api_key or os.getenv("E2B_API_KEY")
-        resolved_domain = domain or os.getenv("E2B_DOMAIN")
+    @staticmethod
+    def _build_sandbox_from_info(
+        sandbox_info: Dict[str, str],
+        *,
+        api_key: str | None = None,
+        domain: str | None = None,
+    ):
+        """由 sandbox_info 构造 ``Sandbox`` 实例（复现 ``Sandbox._create`` 的头信息逻辑）。
 
+        自定义 E2B 部署可能未实现 ``/sandboxes/{id}/connect`` 端点，
+        直接使用 sandbox_info 导出的连接信息构造 ``Sandbox``，
+        无需调用 connect API。
+        """
         sandbox_id = sandbox_info["sandbox_id"]
         sandbox_domain = sandbox_info["sandbox_domain"]
         envd_access_token = sandbox_info.get("envd_access_token")
@@ -181,14 +205,14 @@ class E2BSandboxBackend(RuntimeBackend):
         extra_sandbox_headers["E2b-Sandbox-Port"] = str(ConnectionConfig.envd_port)
 
         config_kwargs: Dict[str, Any] = {"extra_sandbox_headers": extra_sandbox_headers}
-        if resolved_api_key:
-            config_kwargs["api_key"] = resolved_api_key
-        if resolved_domain:
-            config_kwargs["domain"] = resolved_domain
+        if api_key:
+            config_kwargs["api_key"] = api_key
+        if domain:
+            config_kwargs["domain"] = domain
 
         connection_config = ConnectionConfig(**config_kwargs)
 
-        sandbox = Sandbox(
+        return Sandbox(
             sandbox_id=sandbox_id,
             sandbox_domain=sandbox_domain,
             connection_config=connection_config,
@@ -196,22 +220,6 @@ class E2BSandboxBackend(RuntimeBackend):
             envd_access_token=envd_access_token,
             traffic_access_token=traffic_access_token,
         )
-
-        instance = cls.__new__(cls)
-        instance._template = ""
-        instance._timeout = 0
-        instance._api_key = resolved_api_key
-        instance._domain = resolved_domain
-        instance._sandbox = sandbox
-        instance._pending_sandbox_env = None
-
-        logger.info(
-            "E2B sandbox reconnected | sandbox_id=%s, domain=%s, envd_api_url=%s",
-            sandbox_id,
-            sandbox_domain,
-            sandbox.envd_api_url,
-        )
-        return instance
 
     def _ensure_sandbox(self):
         """确保沙箱实例已创建（惰性初始化）。
@@ -221,8 +229,6 @@ class E2BSandboxBackend(RuntimeBackend):
         - 若 ``envs`` 中包含 ``SKILL_DIR`` 和 ``SKILL_NAME``，沙箱创建后
           会自动打包上传解压 skill 目录，完成 runtime 环境准备。
         """
-        from e2b_code_interpreter import Sandbox  # type: ignore
-
         if self._sandbox is not None:
             return self._sandbox
 
@@ -258,7 +264,7 @@ class E2BSandboxBackend(RuntimeBackend):
 
     @property
     def sandbox_info(self) -> Dict[str, Any] | None:
-        """返回当前沙箱的连接信息，可用于 ``from_sandbox_info()`` 重建实例。
+        """返回当前沙箱的连接信息，可用于实例方法 ``load()`` 挂载复用。
 
         Returns:
             包含 sandbox_id、sandbox_domain、envd_access_token、envd_version、
@@ -266,8 +272,6 @@ class E2BSandboxBackend(RuntimeBackend):
         """
         if self._sandbox is None:
             return None
-
-        from e2b.api.client.types import Unset
 
         traffic_token = self._sandbox.traffic_access_token
         if isinstance(traffic_token, Unset):
@@ -280,6 +284,51 @@ class E2BSandboxBackend(RuntimeBackend):
             "envd_version": str(self._sandbox._envd_version),
             "traffic_access_token": traffic_token,
         }
+
+    # ---- 沙箱复用序列化 ----
+
+    def save(self) -> dict:
+        """导出 E2B 沙箱挂载 payload（写入共享存储用）。
+
+        即「保存 sandbox_info 的内容」：返回 ``sandbox_info`` 字典，
+        由实例方法 ``load`` 就地挂载复用。沙箱未创建时 ``sandbox_info`` 为
+        None，默认导出 ``{}``（不抛异常），表示该槽位此前没有真正拉起过沙箱。
+
+        Returns:
+            sandbox_info 字典（sandbox_id/sandbox_domain/envd_access_token/
+            envd_version/traffic_access_token），未创建沙箱时为 ``{}``。
+        """
+        info = self.sandbox_info
+        if info is None:
+            return {}
+        return info
+
+    def load(self, payload: dict) -> None:
+        """挂载到既有 E2B 沙箱（实例方法，就地覆盖 ``self._sandbox``）。
+
+        CR：payload 即 sandbox_info（save 导出内容），经
+        ``_build_sandbox_from_info`` 用连接信息直接构造 ``Sandbox``（跳过
+        ``Sandbox.create``）；client/凭据保持本实例构造时来源。
+        payload 为 ``{}`` 说明原沙箱之前没有真正拉起来过，保持 lazy（不创建沙箱）。
+
+        Args:
+            payload: 由 ``save()`` 导出的 sandbox_info 字典。
+        """
+        if not payload:
+            return
+        self._sandbox = self._build_sandbox_from_info(payload, api_key=self._api_key, domain=self._domain)
+        # 已挂载既有沙箱，构造时预留的创建参数不再适用
+        self._pending_sandbox_env = None
+        # 挂载即续期：远端沙箱生命周期从创建时刻起算，续期到本 backend 配置的
+        # timeout，保证复用期间远端存活；失败不阻断挂载，交由自愈兜底
+        try:
+            self._sandbox.set_timeout(self._timeout)
+        except Exception:  # noqa: BLE001
+            logger.warning("E2B sandbox set_timeout 失败（挂载继续）", exc_info=True)
+        logger.info(
+            "E2B sandbox reattached | sandbox_id=%s",
+            payload.get("sandbox_id"),
+        )
 
     def _log_sandbox_info(self) -> None:
         """输出沙箱连接信息到日志（INFO 级别）。
@@ -313,8 +362,6 @@ class E2BSandboxBackend(RuntimeBackend):
         Returns:
             skill scripts 在远程沙箱中的路径。
         """
-        from .utils import package_dir
-
         zip_data = package_dir(skill_dir)
         remote_base = "/home/user"
         remote_zip = f"{remote_base}/{skill_name}.zip"
@@ -329,18 +376,30 @@ class E2BSandboxBackend(RuntimeBackend):
         E2B SDK 在命令以非零退出码结束时会抛出 ``CommandExitException``，
         本方法会捕获该异常并将其转换为 ``_CommandResult``，使调用方可以
         通过 ``exit_code`` 字段判断命令执行结果，而非面临未处理的异常。
+
+        挂载复用的原沙箱可能已被平台 TTL / 外部销毁（记录仍 ACTIVE）：
+        首次执行遇到 ``SandboxNotFoundException`` 时丢弃失效沙箱引用并重建，
+        重试一次（CR-A 首用失败自愈）。重建的新沙箱经 release save() 重新登记。
         """
 
-        from e2b.sandbox.commands.command_handle import CommandExitException
-
-        sandbox = self._ensure_sandbox()
-        try:
+        def _exec() -> _CommandResult:
+            sandbox = self._ensure_sandbox()
             res = (
                 sandbox.commands.run(command, timeout=timeout) if timeout is not None else sandbox.commands.run(command)
             )
+            return _normalize_command_result(res)
+
+        try:
+            return _exec()
+        except SandboxNotFoundException:
+            logger.warning(
+                "E2B sandbox 已失效（NotFound），丢弃并重建后重试一次",
+                exc_info=True,
+            )
+            self._sandbox = None  # 丢弃死沙箱引用，_ensure_sandbox 走全新创建
+            return _exec()
         except CommandExitException as exc:
             return _CommandResult(stdout=exc.stdout, stderr=exc.stderr, exit_code=exc.exit_code)
-        return _normalize_command_result(res)
 
     def kill(self) -> None:
         """销毁沙箱实例。
@@ -362,8 +421,6 @@ class E2BSandboxBackend(RuntimeBackend):
 
     def ls_info(self, path: str, *, config: RunnableConfig | None = None, state: dict | None = None) -> list[FileInfo]:
         """列出目录中的文件和目录（非递归）。"""
-
-        from e2b.sandbox.filesystem.filesystem import FileType
 
         sandbox = self._ensure_sandbox()
         try:
@@ -632,7 +689,5 @@ class E2BSandboxBackend(RuntimeBackend):
         state: dict | None = None,
     ) -> ExecuteResult:
         """异步执行 shell 命令。"""
-
-        import asyncio
 
         return await asyncio.to_thread(self.execute, command, timeout, max_output_size)

--- a/src/agent/aidev_agent/core/tools/runtime_tools/local_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/local_backend.py
@@ -23,6 +23,7 @@ https://github.com/langchain-ai/deepagents/blob/master/libs/deepagents/deepagent
 
 from __future__ import annotations
 
+import asyncio
 import fnmatch
 import json
 import os
@@ -844,8 +845,6 @@ class FilesystemBackend(RuntimeBackend):
         Returns:
             ExecuteResult，包含输出、退出码和截断标志
         """
-        import asyncio
-
         try:
             proc = await asyncio.create_subprocess_shell(
                 command,
@@ -897,3 +896,34 @@ class FilesystemBackend(RuntimeBackend):
                 exit_code=None,
                 truncated=False,
             )
+
+    # --- 沙箱复用序列化契约（save/load） ---
+
+    def save(self) -> dict:
+        """导出挂载 FilesystemBackend 所需的 payload。
+
+        本地后端的实际状态就是文件系统本身（随 pod 持久化），只需保存构造参数：
+        ``cwd`` 已包含 ``envs`` 中 SKILL_DIR 触发的目录切换结果，envs 无需单独序列化。
+
+        Returns:
+            JSON 可序列化的挂载 payload 字典。
+        """
+        return {
+            "root_dir": str(self.cwd),
+            "virtual_mode": self.virtual_mode,
+            "max_file_size_mb": int(self.max_file_size_bytes // (1024 * 1024)),
+        }
+
+    def load(self, payload: dict) -> None:
+        """挂载到既有本地目录（实例方法，就地覆盖 cwd/virtual_mode/max_file_size）。
+
+        Args:
+            payload: ``save()`` 产出的 dict。
+        """
+        root_dir = payload.get("root_dir")
+        if root_dir:
+            self.cwd = Path(root_dir).resolve()
+        if "virtual_mode" in payload:
+            self.virtual_mode = payload["virtual_mode"]
+        if "max_file_size_mb" in payload:
+            self.max_file_size_bytes = int(payload["max_file_size_mb"]) * 1024 * 1024

--- a/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/paas_backend.py
@@ -27,6 +27,7 @@ PaasSandboxBackend: 基于蓝鲸 PaaS 平台 Agent Sandbox HTTP API 的远程沙
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import re
@@ -524,10 +525,37 @@ class PaasSandboxBackend(RuntimeBackend):
         return mounts or None
 
     def _run(self, command: str | list, timeout: int | None = None, *, state: dict | None = None) -> ExecResult:
-        """在远程沙箱中执行 shell 命令并返回结果。"""
+        """在远程沙箱中执行 shell 命令。
 
-        sandbox_id = self._ensure_sandbox(state=state)
-        return self.exec_command(sandbox_id, command, timeout=timeout)
+        挂载复用的原沙箱可能已被平台 TTL / 外部销毁（记录仍 ACTIVE）：
+        首次执行遇到 404（沙箱不存在）时丢弃失效沙箱引用并重建，重试一次
+        （CR-A 首用失败自愈）。重建的新沙箱经 release save() 重新登记。
+        """
+
+        def _exec() -> ExecResult:
+            sandbox_id = self._ensure_sandbox(state=state)
+            return self.exec_command(sandbox_id, command, timeout=timeout)
+
+        try:
+            return _exec()
+        except Exception as exc:  # noqa: BLE001
+            if not self._is_sandbox_gone_error(exc):
+                raise
+            logger.warning(
+                "PaaS sandbox %s 已失效（404），丢弃并重建后重试一次",
+                self._sandbox_id,
+                exc_info=True,
+            )
+            # 远端已不存在，直接置空引用（无需调 destroy）；home 目录一并失效
+            self._sandbox_id = None
+            self._home_dir = None
+            return _exec()
+
+    @staticmethod
+    def _is_sandbox_gone_error(exc: Exception) -> bool:
+        """判定异常是否为「沙箱不存在」（HTTP 404，平台 TTL/外部销毁所致）。"""
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        return status_code == 404
 
     def _resolve_path(self, path: str, *, state: dict | None = None) -> str:
         """将 ``$STORAGE_PATH`` 或 ``~`` 展开为沙箱内绝对路径。
@@ -547,6 +575,39 @@ class PaasSandboxBackend(RuntimeBackend):
             res = self._run(["bash", "-c", "echo $HOME"], state=state)
             self._home_dir = res.stdout.strip() or "/root"  # PaaS 沙箱默认以 root 用户运行
         return self._home_dir + path[1:] if len(path) > 1 else self._home_dir
+
+    # ---- 沙箱复用序列化 ----
+
+    def save(self) -> dict:
+        """导出 PaaS 沙箱挂载 payload（写入共享存储用）。
+
+        CR：只保存 sandbox_id —— executor_info / construct_params 含凭据与
+        连接参数，不允许写入共享存储；client 由每请求 construct_params 全新注入。
+        沙箱未创建（sandbox_id 为 None，本次请求未实际用到）时导出 ``{}``，
+        表示该槽位此前没有真正拉起过沙箱。
+
+        Returns:
+            dict（仅含 sandbox_id，未创建时为 ``{}``）。
+        """
+        if self._sandbox_id is None:
+            return {}
+        return {"sandbox_id": self._sandbox_id}
+
+    def load(self, payload: dict) -> None:
+        """挂载到既有 PaaS 沙箱（实例方法，就地覆盖 ``self._sandbox_id``）。
+
+        CR：仅从 payload 取 sandbox_id；client/凭据保持本实例构造时来源
+        （construct_params 注入），后续 ``_ensure_sandbox`` 跳过创建直接复用。
+
+        Args:
+            payload: 由 ``save()`` 导出的 dict。为空（``{}``）说明原沙箱之前
+                没有真正拉起来过，保持 lazy（不创建沙箱），不做任何覆盖。
+        """
+        sandbox_id = payload.get("sandbox_id")
+        if not sandbox_id:
+            return
+        self._sandbox_id = sandbox_id
+        self._home_dir = None  # 原沙箱 home 目录未知，待首次使用时重新获取
 
     def kill(self) -> None:
         """销毁沙箱实例。
@@ -863,7 +924,5 @@ class PaasSandboxBackend(RuntimeBackend):
         state: dict | None = None,
     ) -> ExecuteResult:
         """异步执行 shell 命令。"""
-
-        import asyncio
 
         return await asyncio.to_thread(self.execute, command, timeout, max_output_size, state=state)

--- a/src/agent/aidev_agent/core/tools/runtime_tools/provider.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/provider.py
@@ -43,7 +43,7 @@ from langgraph.prebuilt import InjectedState
 
 from aidev_agent.config import settings
 
-from .security import redact_output, validate_path
+from .security import redact_output, validate_command, validate_path
 from .types import RuntimeBackend
 from .utils import format_grep_matches, truncate_if_too_long
 
@@ -165,23 +165,63 @@ EXECUTE_TOOL_DESCRIPTION = """执行 shell 命令。
 
 
 class RuntimeBackendResolver:
-    """运行时中间件（运行时解析器）。
+    """运行时中间件（运行时解析器）—— 纯路由层 + 沙箱挂载协调（CR4/CR5）。
 
-    该类负责运行时的注册与解析：
-    - 注册多个命名运行时后端（register_runtime）
+    该类负责运行时的注册与解析，并把沙箱复用交给所持有的 RuntimeBackendDeferManager：
+    - 注册多个命名运行时后端（register_runtime，同名同实例幂等 / 异实例抛错）
     - 根据 runtime 参数解析 backend（resolve_backend / _resolve_backend）
     - 提供 runtime 参数描述文本（runtime_param_description / _runtime_param_description）
+    - 沙箱 get_or_create：先构造全新实例，原沙箱未销毁时经实例 ``load`` 挂载（CR）；
+      runtime_id 由 ``compose_runtime_id`` 从 runtime_name 幂等推导（同一 name 恒为
+      同一 runtime_id）；延迟销毁策略在 ``__init__`` 由 defer_manager + agent_code/
+      session_code 一次性判定。
 
-    注意：本类不负责构造工具集合；工具构造由本模块的 get_xxx_tool / get_client_tools 等函数承担。
+    三个名字的语义边界（不要混淆）：
+    - ``runtime 类型名``：运行时类型标识（如 ``local`` / ``sandbox`` / ``paas_sandbox``），注册到 ``_backend_cls``
+    （类型名 -> backend 类，运行时 **类型注册唯一事实源**）
+    由 builder 的 ``enable_runtime_*`` 经 ``register_runtime_cls`` 注册
+    ``get_or_create_backend`` 按此名查类构造实例
+    - ``runtime_name``：模型可见的路由名（``{runtime}_{skill}``），注册到 ``_backends``（实例注册表），供工具 ``target_runtime`` 解析。
+    - ``runtime_id``：沙箱生命周期标识（``{agent_code}:{session_code}:{runtime}_{skill}``，
+      由 ``compose_runtime_id(runtime_name)`` 幂等产出），provider/lifecycle 层用它识别沙箱（get_runtime / defer 延迟销毁）。
+
+    类型注册表与实例注册表解耦：``_backend_cls`` 只管「类型名 -> 类」的映射（builder 配置期注册）
+    ``_backends`` 只管「runtime_name -> backend 实例」的实例路由（``_prepare_skills`` 运行时按需构造挂载）
+
+    注意：本类不负责构造工具集合；工具构造由本模块的 get_xxx_tool / get_client_tools 等函数承担
 
     Args:
         default_runtime: 当未指定 runtime 参数时使用的默认运行时名称。
+        defer_manager: RuntimeBackendDeferManager 实例（延迟销毁 + 会话级复用），可选。
+        agent_code: 智能体代码（runtime_id 的 scoping 维度，由装配层构造时注入）。
+        session_code: 会话代码（同上）。延迟销毁策略要求两者齐备 —— 无 scoping 的
+            复用会命中其他会话/智能体的沙箱，实质导致越权。
     """
 
-    def __init__(self, default_runtime: str = "local") -> None:
+    def __init__(
+        self,
+        default_runtime: str = "local",
+        *,
+        defer_manager=None,
+        agent_code: str | None = None,
+        session_code: str | None = None,
+    ) -> None:
         self._backends: dict[str, RuntimeBackend] = {}
+        self._backend_cls: dict[str, type] = {}  # runtime 类型名 -> backend 类（唯一事实源）
         self._default_runtime = default_runtime
         self._exit_stack = contextlib.ExitStack()
+        # scoping 维度（CR：仅经构造参数注入，禁止外部改写内部变量）；
+        # 供 compose_runtime_id 幂等组合沙箱生命周期标识 runtime_id
+        self._agent_code = agent_code
+        self._session_code = session_code
+        # CR：初始化时确定是否开启延迟销毁策略 —— defer_manager 就绪且
+        # agent_code/session_code 齐备才开启；否则 close 立即销毁全部
+        if defer_manager is not None and agent_code and session_code:
+            self._defer_manager = defer_manager
+            self._enable_deferred_destroy = True
+        else:
+            self._defer_manager = None
+            self._enable_deferred_destroy = False
 
     @property
     def default_runtime(self) -> str:
@@ -196,18 +236,80 @@ class RuntimeBackendResolver:
     ) -> "RuntimeBackendResolver":
         """注册一个命名运行时后端。
 
+        同一 name 不允许注册不同 backend 实例（沙箱复用语义下同一 runtime 槽位始终指向同一沙箱）：
+        已注册同实例时幂等返回；已注册不同实例时抛出``ValueError``。
+
         Args:
-            name: 运行时名称（如 "local"、"sandbox_1"）
+            name: 运行时名称（模型可见路由名，``{runtime}_{skill}``； 工具 ``target_runtime`` 传该值解析 backend）
             backend: 对应运行时的后端实例
 
         Returns:
             self（便于链式调用）
+
+        Raises:
+            ValueError: name 为空，或该 name 已注册了不同的 backend 实例。
         """
 
         if not name:
             raise ValueError("runtime name must be non-empty")
+        existing = self._backends.get(name)
+        if existing is not None:
+            if existing is backend:
+                return self  # 幂等：同一实例重复注册
+            raise ValueError(f"runtime '{name}' 已注册不同的 backend 实例")
         self._backends[name] = backend
+        # 统一注册到 ExitStack，未启用延迟销毁时 resolver.close() 立即关闭全部
+        if isinstance(backend, RuntimeBackend):
+            self._exit_stack.enter_context(backend)
         return self
+
+    def register_runtime_cls(
+        self,
+        name: str,
+        cls: type | None,
+    ) -> "RuntimeBackendResolver":
+        """注册一个 runtime 类型名到 backend 类的映射（类型注册唯一事实源）。
+
+        builder 配置期经 ``enable_runtime_*``/``register_runtime_type`` 调用
+        把 runtime 类型名（如 ``local``/``sandbox``/``paas_sandbox``）映射到 backend类，供 ``get_or_create_backend`` 按名查类构造实例
+
+        - ``cls`` 非 None：同名已注册**同一**类时幂等返回 self；已注册**不同**类时抛出 ``ValueError``（文案带当前冲突类名，便于定位）
+        - ``cls`` 为 None：注销该类型名（``pop``，name 不存在时静默，无副作用）
+
+        Args:
+            name: runtime 类型名（非空）。
+            cls: backend 类；None 表示注销该类型名。
+
+        Returns:
+            self（便于链式调用）
+
+        Raises:
+            ValueError: name 为空，或该 name 已注册了不同的 backend 类。
+        """
+        if not name:
+            raise ValueError("runtime name must be non-empty")
+        if cls is None:
+            self._backend_cls.pop(name, None)  # 注销：pop 不存在的 name 静默
+            return self
+        existing = self._backend_cls.get(name)
+        if existing is not None:
+            if existing is cls:
+                return self  # 幂等：同一类重复注册
+            raise ValueError(f"runtime '{name}' 已注册不同的 backend 类 {existing.__name__}（现注册 {cls.__name__}）")
+        self._backend_cls[name] = cls
+        return self
+
+    def have_runtime_cls(self, name: str) -> bool:
+        """判断某 runtime 类型名是否已注册（替代 builder 侧 ``name in _runtime_types``）。
+
+        Args:
+            name: runtime 类型名（如 ``paas_sandbox``）。
+
+        Returns:
+            已注册返回 True，否则 False。
+        """
+
+        return name in self._backend_cls
 
     def runtime_param_description(self) -> str:
         """返回 runtime 参数的描述文本（用于工具 schema）。"""
@@ -232,29 +334,101 @@ class RuntimeBackendResolver:
             raise ValueError(f"Unknown runtime '{resolved_runtime}'. Available runtimes: {available or '(none)'}")
 
         backend = self._backends[resolved_runtime]
-        # 若后端尚未注册到 ExitStack，则注册以便统一关闭
-        if isinstance(backend, RuntimeBackend):
-            self._exit_stack.enter_context(backend)
         return backend
 
-    def close(self) -> None:
-        """关闭所有已解析后端的远程资源。
+    def get_or_create_backend(
+        self,
+        runtime_name: str,
+        runtime_cls_name: str,
+        construct_params: dict | None = None,
+    ) -> RuntimeBackend:
+        """获取/创建沙箱 backend（CR：先构造再挂载）。
 
-        通过 ExitStack 统一关闭所有注册的 RuntimeBackend 实例。
-        对于 RuntimeBackend 子类，将调用其 ``close()`` 方法
-        （PaasSandboxBackend 和 E2BSandboxBackend 的 ``close()`` 委托给 ``kill()``）。
-        FilesystemBackend 的 ``close()`` 为空操作。
+        runtime_id 由 ``compose_runtime_id(runtime_name)`` 幂等推导（同一 name 恒为同一 runtime_id），不由外部传入。
+
+        流程：
+        1. 先按 ``runtime_cls_name`` 从 ``_backend_cls`` 查到 backend 类，再``backend_cls(**construct_params)`` 构造全新实例
+            lazy： 后端此时尚无远端沙箱，client/凭据全部来自本次请求的构造参数
+        2. 延迟销毁策略启用时（``__init__`` 判定），
+            若原沙箱未被销毁，调用实例方法``backend.load(payload)`` 挂载到原沙箱，后续首次使用跳过创建；
+           原沙箱已销毁/无记录时保持全新实例
+           close 移交所有权后由 defer_manager``defer`` 登记新沙箱
+
+        Args:
+            runtime_name: 模型可见的路由名（``{runtime}_{skill}``），注册到 ``_backends`` 供工具 ``target_runtime`` 解析；runtime_id 由此幂等推导
+            runtime_cls_name: runtime 类型名，须先经 ``register_runtime_cls`` 注册；内部据此从 ``_backend_cls`` 查类构造实例
+            construct_params: 传给查到的 ``backend_cls(**construct_params)`` 的参数（含本次请求的 client/凭据）。
+
+        Returns:
+            已挂载原沙箱或全新待用的 backend 实例（注册到 self._backends[runtime_name]）。
+
+        Raises:
+            ValueError: ``runtime_cls_name`` 未注册（带当前注册表内容，便于定位
+                误传的类名/未注册类型）。
+        """
+        construct_params = construct_params or {}
+        backend_cls = self._backend_cls.get(runtime_cls_name)
+        if backend_cls is None:
+            raise ValueError(
+                f"unknown runtime class '{runtime_cls_name}'. registered classes: {sorted(self._backend_cls)}"
+            )
+        runtime_id = self.compose_runtime_id(runtime_name)
+        # 1. 先构造全新实例（lazy，不创建远端沙箱）
+        backend = backend_cls(**construct_params)
+        if self._enable_deferred_destroy:
+            original = self._defer_manager.get_runtime(runtime_id=runtime_id)
+            if original is not None:
+                # 2a. 原沙箱未被销毁：挂载到原沙箱（payload 为 {} 表示原沙箱从未
+                # 真正拉起过，load 为 no-op，backend 保持 lazy）；get 读即续期，
+                # sweep 在 idle_ttl 内抢不到销毁权
+                backend.load(original)
+            # 2b. 原沙箱已销毁/无记录：保持全新实例，close 移交所有权后由
+            # defer_manager defer 登记新沙箱
+        self.register_runtime(runtime_name, backend)
+        return backend
+
+    def compose_runtime_id(self, name: str) -> str:
+        """组合沙箱生命周期标识 runtime_id：``{agent_code}:{session_code}:{name}``。
+
+        幂等：同一 name 恒产出同一 runtime_id。内部维度缺失（测试/CLI 未注入 agent_code/session_code）时回退原名
+        此时延迟销毁策略在 ``__init__``已关闭
+
+        Args:
+            name: 模型可见路由名（``{runtime}_{skill}``）。
+
+        Returns:
+            完整沙箱生命周期标识。
+        """
+        if self._agent_code and self._session_code and name:
+            return f"{self._agent_code}:{self._session_code}:{name}"
+        return name
+
+    def close(self) -> None:
+        """关闭/移交所有已注册后端（语义随延迟销毁策略分流）。
+
+        - 未启用延迟销毁：立即销毁全部（ExitStack 依次 ``close()``）。
+        - 启用延迟销毁：所有权整体移交给 RuntimeBackendDeferManager（``defer``）
+          save() 登记记录供后续请求挂载复用，实例由 defer_manager 持有TTL 到期或进程退出时才真实销毁
+          移交后 ``_backends`` 清空
 
         此方法是幂等的 — 多次调用不会产生副作用。
-        适用于会话结束、进程退出前等需要显式释放远程沙箱资源的场景。
         """
-        try:
-            self._exit_stack.close()
-        except Exception:
-            logger.warning("RuntimeBackendResolver.close: 关闭后端资源失败", exc_info=True)
-        finally:
-            # 关闭后重建 ExitStack，使 close() 幂等
-            self._exit_stack = contextlib.ExitStack()
+        if not self._enable_deferred_destroy:
+            try:
+                self._exit_stack.close()
+            except Exception:
+                logger.warning("RuntimeBackendResolver.close: 关闭后端资源失败", exc_info=True)
+            finally:
+                # 关闭后重建 ExitStack，使 close() 幂等
+                self._exit_stack = contextlib.ExitStack()
+            return
+        # 延迟销毁：所有权整体移交 defer_manager（含 lazy 未创建的 backend，save() 导出 {} 照常登记），之后本 resolver 不再持有任何沙箱
+        pending = self._backends
+        self._backends = {}
+        # ExitStack 不执行 close（所有权已移交），重建使 close() 幂等
+        self._exit_stack = contextlib.ExitStack()
+        runtime_id_map = {self.compose_runtime_id(name): backend for name, backend in pending.items()}
+        self._defer_manager.defer(runtime_id_map)
 
 
 # ========== 工具生成器函数 ==========
@@ -483,8 +657,6 @@ def get_execute_tool(
             默认为 None 时启用校验（True）。
             设为 False 可完全跳过安全校验（仅用于测试或迁移过渡期）。
     """
-
-    from .security import validate_command
 
     # 确定是否启用安全校验（默认启用）
     if enable_security is None:

--- a/src/agent/aidev_agent/core/tools/runtime_tools/types.py
+++ b/src/agent/aidev_agent/core/tools/runtime_tools/types.py
@@ -23,6 +23,7 @@ to the current version of the project delivered to anyone in the future.
 - grep 返回的 GrepMatch
 - write/edit/execute 返回的结果结构
 - upload/download 返回的结构
+- 延迟销毁记录共享存储抽象契约 RuntimeBackendDeferStore（内存实现见 defer_manager）
 
 注意：该模块不包含任何具体后端实现。
 """
@@ -30,6 +31,7 @@ to the current version of the project delivered to anyone in the future.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Protocol
 
 from langchain_core.runnables import RunnableConfig
 from typing_extensions import NotRequired, TypedDict
@@ -235,6 +237,38 @@ class RuntimeBackend:
         """
         self.close()
 
+    # --- 沙箱复用序列化契约（save/load） ---
+
+    def save(self) -> dict:
+        """导出当前 backend 挂载所需 payload（写入共享存储，不含任何凭据）。
+
+        子类必须重写。调用时机：请求结束时由 resolver 的 close 经 defer →
+        store.put 登记沙箱（token 由 defer 管理器生成并持有）；lazy 后端在远端
+        沙箱尚未创建时应抛异常（无沙箱可登记）。
+
+        Returns:
+            JSON 可序列化的挂载 payload 字典（如 sandbox_id / sandbox_info）。
+
+        Raises:
+            NotImplementedError: 子类未重写时抛出。
+        """
+        raise NotImplementedError
+
+    def load(self, payload: dict) -> None:
+        """挂载到 ``save()`` 导出的既有沙箱（实例方法，就地覆盖内部沙箱引用）。
+
+        调用时机：``backend_cls(**construct_params)`` 先构造全新实例（lazy，
+        尚无远端沙箱），原沙箱未被销毁时由 resolver 调 ``backend.load(payload)``
+        挂载到原沙箱，后续首次使用跳过创建。client/凭据保持本实例构造时来源。
+
+        Args:
+            payload: 由 ``save()`` 产出的 dict。
+
+        Raises:
+            NotImplementedError: 子类未重写时抛出。
+        """
+        raise NotImplementedError
+
     def __enter__(self) -> "RuntimeBackend":
         return self
 
@@ -248,6 +282,62 @@ class RuntimeBackend:
         await self.aclose()
 
 
+class RuntimeBackendDeferStore(Protocol):
+    """沙箱延迟销毁记录共享存储抽象契约（4 原语 token 化，跨 pod 复用）。
+
+    供上层应用（django cache / MySQL / Redis）实现；内存实现
+    ``RuntimeBackendDeferInMemoryStore`` 见 ``defer_manager`` 模块。
+
+    记录 schema 统一为 ``{"payload": dict, "token": str | None, "last_access_at": float}``。
+    payload 为 ``backend.save()`` 产出的 JSON 可序列化挂载 dict（如
+    ``{"sandbox_id": ...}``），不含任何凭据；token 由调用方（DeferManager 用
+    ``uuid4()`` 生成）经 ``put`` 写入，store 保持哑存储、不自行生成 token。
+    调用方（defer_manager/provider）不做任何状态判断，仅通过四个语义化原语交互：
+
+    - ``get``：记录存在则返回 payload 并**原子摘除 token**（置 None）+ 刷新
+      last_access_at；token 已为 None 时照常返回 payload；不创建记录；
+    - ``put``：upsert 整体覆盖记录（payload + token + last_access_at=now）；
+    - ``delete_if_token``：**原子 compare-and-delete**——仅当记录存在且记录内
+      token 与参数相等才删记录返回 True，否则不动记录返回 False；
+    - ``delete_expired``：GC 直接删除超 max_age 的记录（不 close 实例
+      —— 超过阈值的记录其远端沙箱早已被平台 TTL 回收）。
+
+    原子性硬契约：``get`` 的摘 token 与 ``delete_if_token`` 的比较删除必须在
+    store 内部串行。InMemory 实现用 ``threading.Lock`` 保证；将来接入 Redis /
+    SQL 时分别用 Lua 脚本 / 条件 UPDATE 复刻，不可拆分到应用层。
+    """
+
+    def get(self, key: str) -> dict | None:
+        """记录存在则返回 payload（深拷贝），不存在返回 None；**不创建记录**。
+
+        ``get`` 表示有 Agent 复用该沙箱：返回 payload 的同时**原子摘除记录内
+        token**（置 None）+ 刷新 last_access_at=now。token 被摘除后，任何旧 entry
+        的 ``delete_if_token`` 必失败（token 已为 None），旧记录永远无法被 close
+        销毁 —— 这彻底关闭「turn 时长超 idle_ttl 被误杀」窗口，无需心跳。
+        token 已为 None（并发挂载场景）时照常返回 payload。
+        """
+        ...
+
+    def put(self, key: str, payload: dict, token: str) -> None:
+        """upsert：整体覆盖记录（payload + token + last_access_at=now）。
+
+        token 由调用方生成（DeferManager 用 ``uuid4()`` 生成后传入），store 保持
+        哑存储、不自行生成 token。同 key 再次 put 用新 token/payload 覆盖旧记录
+        （旧 token 失效 —— 旧 entry 的 delete_if_token 因此必失败）。"""
+        ...
+
+    def delete_if_token(self, key: str, token: str) -> bool:
+        """原子 compare-and-delete：仅当记录存在且记录内 token 与参数相等时删除
+        记录返回 True；否则（记录不存在 / 记录内 token 与参数不等 / token 已摘除
+        为 None / 已被新 put 覆盖）不动记录返回 False。"""
+        ...
+
+    def delete_expired(self, max_age: float) -> int:
+        """GC：直接删除 now-last_access_at > max_age 的记录（不做二阶段、不 close
+        实例 —— 超过阈值的记录其远端沙箱早已被平台 TTL 回收）。返回删除条数。"""
+        ...
+
+
 __all__ = [
     "FileInfo",
     "GrepMatch",
@@ -257,4 +347,5 @@ __all__ = [
     "FileUploadResponse",
     "FileDownloadResponse",
     "RuntimeBackend",
+    "RuntimeBackendDeferStore",
 ]

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -40,6 +40,7 @@ from aidev_agent.core.ag_ui.utils import (
 from aidev_agent.core.nodes.model import convert_chat_history_to_messages
 from aidev_agent.core.tools.a2a_tools.types import AgentBackendType, AgentSpec
 from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
+from aidev_agent.core.tools.runtime_tools.defer_manager import default_runtime_backend_defer_manager
 from aidev_agent.enums import AgentType, PromptRole
 from aidev_agent.exceptions import AgentDeadlineExceededError, AgentException
 from aidev_agent.packages.interrupt_manager import (
@@ -469,8 +470,11 @@ class ChatCompletionAgent(BaseModel):
     def release_resources(self) -> None:
         """释放 agent 持有的资源（沙箱后端等）。
 
-        调用 RuntimeBackendResolver.close() 关闭所有已解析的沙箱后端。
-        此方法是幂等的 — 多次调用不会产生副作用。
+        统一走 ``resolver.close()``，销毁语义由 resolver 按延迟销毁策略分流：
+        - 未启用延迟销毁：立即销毁全部；
+        - 启用延迟销毁：所有权移交 LifecycleManager（``defer``）
+        —— save() 登记记录供后续请求挂载复用，实例由 defer_manager 持有，TTL 到期或进程退出时真实销毁
+        此方法是幂等的 — 多次调用不会产生副作用
         """
         if self.runtime_backend_resolver is not None:
             try:
@@ -1590,12 +1594,25 @@ class ChatAgentBuilder:
         return list(self._file_resources)
 
     def build_runtime_backend_resolver(self) -> RuntimeBackendResolver:
-        """构造 RuntimeBackendResolver。
+        """构造 RuntimeBackendResolver（每会话一个，scoping 归 RuntimeBackendDeferManager，决策 1）。
 
-        resolver 将通过 AgentExecutorKwargs 传入 ReActAgentBuilder。
+        功能开关 ``BKAI_RUNTIME_SANDBOX_DEFERRED_DESTROY_ENABLED``：
+            开启时使用``defer_manager`` 模块的进程级默认单例 ``default_runtime_backend_defer_manager``（延迟销毁 + 会话级复用，start 幂等多请求安全）；
+            关闭时构造纯路由 resolver（release 立即销毁）
+        agent_code/session_code 经构造参数注入
+        任一为空时 resolver 内部强制 create-only —— 无 scoping 的复用会命中其他会话/智能体的沙箱，实质导致越权。
         """
-        self._runtime_backend_resolver = RuntimeBackendResolver(default_runtime="local")
-        return self._runtime_backend_resolver
+        defer_manager = None
+        if settings.BKAI_RUNTIME_SANDBOX_DEFERRED_DESTROY_ENABLED and self.ctx.agent_code and self.ctx.session_code:
+            defer_manager = default_runtime_backend_defer_manager
+        resolver = RuntimeBackendResolver(
+            default_runtime="local",
+            defer_manager=defer_manager,
+            agent_code=self.ctx.agent_code,
+            session_code=self.ctx.session_code,
+        )
+        self._runtime_backend_resolver = resolver
+        return resolver
 
     # ---------- 公共：装配方法（被 ChatCompletionAgent.build 调用） ----------
 

--- a/src/agent/tests/core/graphs/test_react.py
+++ b/src/agent/tests/core/graphs/test_react.py
@@ -15,6 +15,7 @@ from aidev_agent.core.graphs.react.team_middleware import TeamPromptMiddleware
 from aidev_agent.core.nodes.model.pydantic_models import ModelNodeSettings
 from aidev_agent.core.nodes.tool import ToolNodeSettings
 from aidev_agent.core.tools.a2a_tools.types import AgentSpec
+from aidev_agent.core.tools.runtime_tools import RuntimeBackendResolver
 from aidev_agent.packages.langchain_core.models import ChatModel
 from aidev_agent.packages.langgraph.streaming.streaming_protocol import AgentStreamAdapter
 from aidev_agent.pydantic_models import AgentExecutorKwargs, KnowledgeSettings, ModelContextSettings
@@ -226,36 +227,74 @@ class TestReActAgentBuilder:
     def test_register_runtime_type(self):
         builder = ReActAgentBuilder()
         fake_cls = type("FakeBackend", (), {})
-        result = builder.register_runtime_type("custom", fake_cls)
-        assert builder._runtime_types["custom"] is fake_cls
+        resolver = RuntimeBackendResolver()
+        result = builder.set_runtime_backend_resolver(resolver).register_runtime_type("custom", fake_cls)
+        assert resolver._backend_cls["custom"] is fake_cls
         assert result is builder
+        # 注销分支：cls=None 时 pop 静默
+        builder.register_runtime_type("custom", None)
+        assert "custom" not in resolver._backend_cls
+
+    def test_register_runtime_type_conflict_raises(self):
+        builder = ReActAgentBuilder()
+        fake_cls_a = type("FakeBackendA", (), {})
+        fake_cls_b = type("FakeBackendB", (), {})
+        resolver = RuntimeBackendResolver()
+        builder.set_runtime_backend_resolver(resolver).register_runtime_type("custom", fake_cls_a)
+        with pytest.raises(ValueError):
+            builder.register_runtime_type("custom", fake_cls_b)
+        # 同名同类幂等
+        builder.register_runtime_type("custom", fake_cls_a)
+        assert resolver._backend_cls["custom"] is fake_cls_a
+
+    def test_enable_runtime_requires_resolver(self):
+        """未注入 resolver 时 enable_runtime_* 应抛异常（_require_runtime_backend_resolver 生效）。"""
+        builder = ReActAgentBuilder()
+        with pytest.raises(RuntimeError, match="runtime_backend_resolver"):
+            builder.enable_runtime_local(True)
+        with pytest.raises(RuntimeError, match="runtime_backend_resolver"):
+            builder.enable_runtime_agent_run(True)
+        with pytest.raises(RuntimeError, match="runtime_backend_resolver"):
+            builder.enable_runtime_paas(True)
 
     def test_enable_runtime_local_registers_and_removes(self):
         builder = ReActAgentBuilder()
+        resolver = RuntimeBackendResolver()
+        builder.set_runtime_backend_resolver(resolver)
         result = builder.enable_runtime_local(True)
-        assert "local" in builder._runtime_types
+        assert resolver.have_runtime_cls("local")
+        assert "local" in resolver._backend_cls
         assert "local" in builder._runtime_param_with_skill
         assert result is builder
         builder.enable_runtime_local(False)
-        assert "local" not in builder._runtime_types
+        assert not resolver.have_runtime_cls("local")
+        assert "local" not in resolver._backend_cls
 
     def test_enable_runtime_agent_run_registers_and_removes(self):
         builder = ReActAgentBuilder()
+        resolver = RuntimeBackendResolver()
+        builder.set_runtime_backend_resolver(resolver)
         result = builder.enable_runtime_agent_run(True)
-        assert "agent_run" in builder._runtime_types
+        assert resolver.have_runtime_cls("agent_run")
+        assert "agent_run" in resolver._backend_cls
         assert "agent_run" in builder._runtime_param_with_skill
         assert result is builder
         builder.enable_runtime_agent_run(False)
-        assert "agent_run" not in builder._runtime_types
+        assert not resolver.have_runtime_cls("agent_run")
+        assert "agent_run" not in resolver._backend_cls
 
     def test_enable_runtime_paas_registers_and_removes(self):
         builder = ReActAgentBuilder()
+        resolver = RuntimeBackendResolver()
+        builder.set_runtime_backend_resolver(resolver)
         result = builder.enable_runtime_paas(True)
-        assert "paas_sandbox" in builder._runtime_types
+        assert resolver.have_runtime_cls("paas_sandbox")
+        assert "paas_sandbox" in resolver._backend_cls
         assert "paas_sandbox" in builder._runtime_param_with_skill
         assert result is builder
         builder.enable_runtime_paas(False)
-        assert "paas_sandbox" not in builder._runtime_types
+        assert not resolver.have_runtime_cls("paas_sandbox")
+        assert "paas_sandbox" not in resolver._backend_cls
 
     def test_enable_security_runtime_default_true(self):
         """测试默认情况下 _enable_security_runtime 为 True"""
@@ -496,9 +535,9 @@ class TestReActAgentBuilder:
             .set_enable_skills(True)
             .set_enable_runtime_tool(True)
             .set_skill_sources([str(skills_root)])
+            .set_runtime_backend_resolver(resolver)
             .enable_runtime_local(True)
         )
-        builder._runtime_backend_resolver = resolver
 
         with (
             patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node),
@@ -526,8 +565,13 @@ class TestReActAgentBuilder:
 
         resolver = MagicMock()
         resolver.runtime_param_description.return_value = "runtime target"
-        builder = ReActAgentBuilder().set_llm(llm).set_enable_runtime_tool(True).enable_runtime_local(True)
-        builder._runtime_backend_resolver = resolver
+        builder = (
+            ReActAgentBuilder()
+            .set_llm(llm)
+            .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(resolver)
+            .enable_runtime_local(True)
+        )
 
         with (
             patch("aidev_agent.core.graphs.react.graph.std_make_model_node", new=_fake_make_model_node),
@@ -577,8 +621,9 @@ class TestReActAgentBuilder:
                 return_value=(MagicMock(), {}),
             ),
         ):
-            builder = ReActAgentBuilder().set_llm(llm).set_enable_runtime_tool(True)
-            builder._runtime_backend_resolver = resolver
+            builder = (
+                ReActAgentBuilder().set_llm(llm).set_enable_runtime_tool(True).set_runtime_backend_resolver(resolver)
+            )
             builder.build()
 
         assert builder._runtime_backend_resolver is resolver
@@ -662,7 +707,7 @@ class TestReActAgentBuilder:
             assert kwargs["llm"] is llm
 
     def test_build_skill_runtime_registers_backend(self, tmp_path, monkeypatch):
-        """skill 的 runtime 匹配已注册类型时，应为该 skill 创建并注册独立 backend"""
+        """skill 的 runtime 匹配已注册类型时，复用沙箱经 resolver.get_or_create_backend 获取（路由名 {runtime}_{skill}）。"""
         monkeypatch.chdir(tmp_path)
         skills_root = tmp_path / ".agent" / "skills"
         _write_skill(skills_root, name="my-skill", description="d", body="b", runtime="sandbox")
@@ -670,8 +715,7 @@ class TestReActAgentBuilder:
         llm = MagicMock()
         llm.model_name = "gpt-4o"
 
-        mock_backend_instance = MagicMock()
-        MockBackendCls = MagicMock(return_value=mock_backend_instance)
+        MockBackendCls = MagicMock()
         MockBackendCls.__name__ = "MockBackend"
 
         with (
@@ -691,15 +735,54 @@ class TestReActAgentBuilder:
                 .set_enable_skills(True)
                 .set_enable_runtime_tool(True)
                 .set_skill_sources([str(skills_root)])
+                .set_runtime_backend_resolver(mock_resolver_instance)
                 .register_runtime_type("sandbox", MockBackendCls)
             )
-            builder._runtime_backend_resolver = mock_resolver_instance
             builder.build()
 
-        MockBackendCls.assert_called_once()
-        builder._runtime_backend_resolver.register_runtime.assert_called_once_with(
-            "sandbox_my-skill", mock_backend_instance
+        # runtime_id 由 resolver 内部 compose_runtime_id 幂等推导，调用方只传 runtime_name
+        builder._runtime_backend_resolver.get_or_create_backend.assert_called_once_with(
+            runtime_name="sandbox_my-skill",
+            runtime_cls_name="sandbox",
+            construct_params={},
         )
+
+    def test_build_local_skill_runtime_also_uses_get_or_create(self, tmp_path, monkeypatch):
+        """runtime=local 的 skill 也统一走 resolver.get_or_create_backend（无独立分支）。"""
+        monkeypatch.chdir(tmp_path)
+        skills_root = tmp_path / ".agent" / "skills"
+        _write_skill(skills_root, name="local-skill", description="d", body="b", runtime="local")
+
+        llm = MagicMock()
+        llm.model_name = "gpt-4o"
+
+        with (
+            patch("aidev_agent.core.graphs.react.graph.std_make_model_node", return_value=MagicMock()),
+            patch(
+                "aidev_agent.core.graphs.react.graph.ReActAgentBuilder._build_graph",
+                return_value=(MagicMock(), {}),
+            ),
+        ):
+            mock_resolver_instance = MagicMock()
+            mock_resolver_instance._backends = {}
+            mock_resolver_instance.runtime_param_description.return_value = "runtime target"
+
+            builder = (
+                ReActAgentBuilder()
+                .set_llm(llm)
+                .set_enable_skills(True)
+                .set_enable_runtime_tool(True)
+                .set_skill_sources([str(skills_root)])
+                .set_runtime_backend_resolver(mock_resolver_instance)
+                .enable_runtime_local(True)
+            )
+            builder.build()
+
+        call = builder._runtime_backend_resolver.get_or_create_backend.call_args
+        assert call.kwargs["runtime_name"] == "local_local-skill"
+        assert call.kwargs["runtime_cls_name"] == "local"
+        # local 不再走独立注册分支
+        builder._runtime_backend_resolver.register_runtime.assert_not_called()
 
     def test_build_skill_unknown_runtime_skipped(self, tmp_path, monkeypatch):
         """skill 声明的 runtime 未注册时应跳过并记录警告"""
@@ -720,15 +803,16 @@ class TestReActAgentBuilder:
         ):
             resolver = MagicMock()
             resolver.runtime_param_description.return_value = "runtime target"
+            resolver.have_runtime_cls.side_effect = lambda name: name == "local"
             builder = (
                 ReActAgentBuilder()
                 .set_llm(llm)
                 .set_enable_skills(True)
                 .set_enable_runtime_tool(True)
                 .set_skill_sources([str(skills_root)])
+                .set_runtime_backend_resolver(resolver)
                 .enable_runtime_local(True)
             )
-            builder._runtime_backend_resolver = resolver
             builder.build()
 
         mock_logger.warning.assert_called()
@@ -752,8 +836,9 @@ class TestReActAgentBuilder:
             resolver = MagicMock()
             resolver._backends = {}
             resolver.runtime_param_description.return_value = "runtime target"
-            builder = ReActAgentBuilder().set_llm(llm).set_enable_runtime_tool(True)
-            builder._runtime_backend_resolver = resolver
+            builder = (
+                ReActAgentBuilder().set_llm(llm).set_enable_runtime_tool(True).set_runtime_backend_resolver(resolver)
+            )
             builder.build()
 
         assert builder._runtime_backend_resolver._backends.get("local") is None
@@ -846,8 +931,12 @@ class TestReActAgentBuilder:
     def test_prepare_agent_options_runtime_tool_passes_with_resolver(self):
         """enable_runtime_tool=True 且提供了 runtime_backend_resolver 时应通过校验"""
         resolver = MagicMock()
-        builder = ReActAgentBuilder().set_llm(MagicMock(model_name="gpt-4o")).set_enable_runtime_tool(True)
-        builder._runtime_backend_resolver = resolver
+        builder = (
+            ReActAgentBuilder()
+            .set_llm(MagicMock(model_name="gpt-4o"))
+            .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(resolver)
+        )
         # 不应抛出异常
         builder._prepare_agent_options()
         assert builder._runtime_backend_resolver is resolver
@@ -880,14 +969,24 @@ class TestReActAgentBuilder:
 
     def test_prepare_agent_pv_node_paas_sandbox_without_app_code(self):
         """启用 paas_sandbox runtime 但 executor_info 无 app_code 时不应注入 client"""
-        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder = (
+            ReActAgentBuilder()
+            .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(RuntimeBackendResolver())
+            .enable_runtime_paas(True)
+        )
         builder._executor_info = {}  # 无 app_code
         pv_node = builder._prepare_agent_pv_node()
         assert callable(pv_node)
 
     def test_prepare_agent_pv_node_paas_sandbox_with_app_code_and_resource_manager(self):
         """启用 paas_sandbox runtime 且有 app_code + resource_manager 时应注入 client"""
-        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder = (
+            ReActAgentBuilder()
+            .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(RuntimeBackendResolver())
+            .enable_runtime_paas(True)
+        )
         builder._executor_info = {"app_code": "test-app"}
         resource_manager = MagicMock()
         expected_client = MagicMock()
@@ -905,7 +1004,12 @@ class TestReActAgentBuilder:
 
     def test_prepare_agent_pv_node_paas_sandbox_with_app_code_but_no_resource_manager(self):
         """启用 paas_sandbox runtime 有 app_code 但无 resource_manager 时 client 应为 None"""
-        builder = ReActAgentBuilder().set_enable_runtime_tool(True).enable_runtime_paas(True)
+        builder = (
+            ReActAgentBuilder()
+            .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(RuntimeBackendResolver())
+            .enable_runtime_paas(True)
+        )
         builder._executor_info = {"app_code": "test-app"}
         # _resource_manager 默认为 None
         with patch("aidev_agent.core.graphs.react.graph.make_pv_node") as mock_make_pv_node:
@@ -956,9 +1060,9 @@ class TestReActAgentBuilder:
             .enable_a2a_tool(True)
             .enable_a2a_backend_local(True)
             .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(MagicMock())
             .enable_runtime_paas(True)
         )
-        builder._runtime_backend_resolver = MagicMock()
         with (
             patch("aidev_agent.core.graphs.react.graph.std_make_model_node", return_value=MagicMock()),
             patch(
@@ -975,15 +1079,18 @@ class TestReActAgentBuilder:
         """启用 A2A 但未启用 PaaS 沙箱 runtime 时应抛 ValueError（PV 缺失会崩溃）"""
         llm = MagicMock()
         llm.model_name = "gpt-4o"
+        mock_resolver = MagicMock()
+        # 仅 local 视为已注册：have_runtime_cls("paas_sandbox") 返回 False，恢复抛错
+        mock_resolver.have_runtime_cls.side_effect = lambda name: name == "local"
         builder = (
             ReActAgentBuilder()
             .set_llm(llm)
             .enable_a2a_tool(True)
             .enable_a2a_backend_local(True)
             .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(mock_resolver)
             .enable_runtime_local(True)  # 仅启用 local，未启用 paas_sandbox
         )
-        builder._runtime_backend_resolver = MagicMock()
         with pytest.raises(ValueError, match="未启用 PaaS 沙箱 runtime"):
             builder.build()
 
@@ -1206,18 +1313,20 @@ class TestReActAgentBuilder:
         opts = AgentExecutorKwargs(
             resource_manager=rm,
             skills=[{"skill_name": "demo", "id": 1}],
+            runtime_backend_resolver=RuntimeBackendResolver(),
         )
         builder = ReActAgentBuilder().set_bkai_options(opts)
         assert builder._enable_skills is True
         assert builder._enable_runtime_tool is True
-        assert "paas_sandbox" in builder._runtime_types
+        assert "paas_sandbox" in builder._runtime_backend_resolver._backend_cls
+        assert builder._runtime_backend_resolver.have_runtime_cls("paas_sandbox")
         # skill_sources 应包含一个 BkAiBackend 实例
         assert len(builder._skill_sources) == 1
 
     def test_set_bkai_options_subagent_specs_chain_enables_a2a_team_task(self):
         """set_bkai_options 收到 subagent_specs 时应启用 a2a_tool/team/task 并注册后端"""
         specs = [AgentSpec(name="helper", description="d", backend_type="bkai")]
-        opts = AgentExecutorKwargs(subagent_specs=specs)
+        opts = AgentExecutorKwargs(subagent_specs=specs, runtime_backend_resolver=RuntimeBackendResolver())
         builder = ReActAgentBuilder().set_bkai_options(opts)
         assert builder._enable_a2a_tool is True
         assert builder._enable_team is True
@@ -1288,7 +1397,7 @@ class TestReActAgentBuilder:
     # ----------------------------------------------------------------
 
     def test_prepare_skills_paas_sandbox_with_resource_manager(self, tmp_path, monkeypatch):
-        """paas_sandbox runtime skill + resource_manager 时应注入 client 到 params"""
+        """paas_sandbox runtime skill + resource_manager 时应注入 client 到 construct_params"""
         monkeypatch.chdir(tmp_path)
         skills_root = tmp_path / ".agent" / "skills"
         _write_skill(skills_root, name="paas-skill", description="d", body="b", runtime="paas_sandbox")
@@ -1297,27 +1406,27 @@ class TestReActAgentBuilder:
         expected_client = MagicMock()
         rm.get_paas_sbx_client.return_value = expected_client
 
+        mock_resolver = MagicMock()
         builder = (
             ReActAgentBuilder()
             .set_llm(MagicMock(model_name="gpt-4o"))
             .set_enable_skills(True)
             .set_skill_sources([str(skills_root)])
             .set_enable_runtime_tool(True)
+            .set_runtime_backend_resolver(mock_resolver)
             .enable_runtime_paas(True)
         )
         builder._resource_manager = rm
-        builder._runtime_backend_resolver = MagicMock()
-
-        # 捕获 register_runtime 收到的 params
-        captured_params = {}
-        builder._runtime_backend_resolver.register_runtime = lambda key, backend: captured_params.__setitem__(
-            key, backend
-        )
 
         builder._prepare_skills()
-        # paas_sandbox_{skill_name} 应被注册，且 backend 持有 client
-        registered_key = next((k for k in captured_params if k.startswith("paas_sandbox_")), None)
-        assert registered_key is not None
+
+        # paas_sandbox（非 local）走 get_or_create_backend，construct_params 注入 client
+        call = builder._runtime_backend_resolver.get_or_create_backend.call_args
+        assert call is not None
+        assert call.kwargs.get("runtime_name") == "paas_sandbox_paas-skill"
+        assert call.kwargs.get("runtime_cls_name") == "paas_sandbox"
+        params = call.kwargs.get("construct_params") or {}
+        assert params.get("client") is expected_client
         rm.get_paas_sbx_client.assert_called_once()
 
     # ----------------------------------------------------------------

--- a/src/agent/tests/core/nodes/test_model_skill.py
+++ b/src/agent/tests/core/nodes/test_model_skill.py
@@ -213,18 +213,21 @@ class TestReActBuilderSkillsIntegration:
                 return_value=(MagicMock(), {}),
             ),
         ):
+            # P0 调序：resolver 注入（set_bkai_options）须先于 skills 链式 enable_runtime_local
+            # （新方案 enable_runtime_* 要求 resolver 已存在）；真实 resolver 会让
+            # enable_runtime_local 经 register_runtime_cls("local", FilesystemBackend) 注册
             builder = (
                 ReActAgentBuilder()
                 .set_llm(llm)
+                .set_bkai_options(
+                    AgentExecutorKwargs(
+                        runtime_backend_resolver=RuntimeBackendResolver(),
+                    )
+                )
                 .set_enable_skills(True)
                 .set_enable_runtime_tool(True)
                 .set_skill_sources([str(skills_root)])
                 .enable_runtime_local(True)
-            )
-            builder.set_bkai_options(
-                AgentExecutorKwargs(
-                    runtime_backend_resolver=RuntimeBackendResolver(),
-                )
             )
             builder.build()
 

--- a/src/agent/tests/core/tools/runtime_tools/test_backend_handle.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_backend_handle.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+"""RuntimeBackend save / load 单元测试（load 为实例方法，挂载式复用）。
+
+测试范围：
+1. PaasSandboxBackend.save 只返回 sandbox_id（CR：executor_info/construct_params 不允许保存）
+2. PaasSandboxBackend.load 实例方法：就地覆盖 _sandbox_id；payload 为 {} 时 no-op（原沙箱未拉起过）
+3. PaasSandboxBackend.save 在 sandbox_id 为 None 时导出 {}（不抛异常）
+4. E2BSandboxBackend.save 返回 sandbox_info 内容；未创建时导出 {}（不抛异常）
+5. E2BSandboxBackend.load 实例方法：就地重建 self._sandbox（跳过 Sandbox.create）；payload {} 时 no-op
+6. FilesystemBackend.save/load 往返（root_dir/virtual_mode/max_file_size_mb）
+
+注意：PaaS 测试用 MagicMock 作为 client；E2B 测试 mock e2b_code_interpreter.Sandbox
+避免真实创建沙箱。
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from aidev_agent.core.tools.runtime_tools.e2b_backend import E2BSandboxBackend
+from aidev_agent.core.tools.runtime_tools.local_backend import FilesystemBackend
+from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
+
+
+def _make_paas_backend(sandbox_id="sbx-1"):
+    """构造一个 PaasSandboxBackend（用 MagicMock 作为 client）。"""
+    return PaasSandboxBackend(
+        app_code="app1",
+        bk_username="user1",
+        client=mock.MagicMock(),
+        snapshot="snap",
+        snapshot_entrypoint=["python"],
+        env_vars={"A": "1"},
+        sandbox_id=sandbox_id,
+        workspace="/ws",
+        ttl_seconds=3600,
+        extra_sensitive_values=["sec"],
+    )
+
+
+def _make_e2b_sandbox_info():
+    """构造一个 E2B sandbox_info 字典。"""
+    return {
+        "sandbox_id": "e2b-1",
+        "sandbox_domain": "dom",
+        "envd_access_token": "tok",
+        "envd_version": "0.1.0",
+        "traffic_access_token": None,
+    }
+
+
+class TestPaasSaveShape(unittest.TestCase):
+    """测试 1：PaasSandboxBackend.save 只返回 sandbox_id。"""
+
+    def test_paas_save_shape(self):
+        """save 只含 sandbox_id；executor_info/construct_params 不允许出现（CR）。"""
+        backend = _make_paas_backend()
+        payload = backend.save()
+
+        self.assertEqual(payload, {"sandbox_id": "sbx-1"})
+
+
+class TestPaasLoadInstanceAttach(unittest.TestCase):
+    """测试 2：load 为实例方法，就地挂载。"""
+
+    def test_paas_load_overrides_sandbox_id(self):
+        """load 覆盖 self._sandbox_id；client 保持本实例构造时来源（不来自 payload）。"""
+        backend = _make_paas_backend(sandbox_id="sbx-old")
+        client = backend.client
+
+        backend.load({"sandbox_id": "sbx-new"})
+
+        self.assertEqual(backend._sandbox_id, "sbx-new")
+        self.assertIs(backend.client, client)
+
+    def test_paas_load_missing_sandbox_id_noop(self):
+        """payload 为 {}（原沙箱未真正拉起过）时 no-op，保持 lazy。"""
+        backend = _make_paas_backend(sandbox_id=None)
+        backend.load({})
+        self.assertIsNone(backend._sandbox_id)  # 未创建，保持 lazy
+
+    def test_paas_load_noop_keeps_existing(self):
+        """payload 缺 sandbox_id 时 no-op，不覆盖已有挂载。"""
+        backend = _make_paas_backend(sandbox_id="sbx-keep")
+        backend.load({})
+        self.assertEqual(backend._sandbox_id, "sbx-keep")
+
+
+class TestPaasSaveWithoutSandbox(unittest.TestCase):
+    """测试 3：save 在 sandbox_id 为 None 时导出 {}（不抛异常）。"""
+
+    def test_paas_save_without_sandbox_returns_empty(self):
+        """sandbox_id 为 None（沙箱未真正拉起过）时 save 返回 {}。"""
+        backend = _make_paas_backend(sandbox_id=None)
+        self.assertEqual(backend.save(), {})
+
+
+class TestE2bSaveShape(unittest.TestCase):
+    """测试 4：E2BSandboxBackend.save 返回结构。"""
+
+    def test_e2b_save_shape(self):
+        """save 返回 sandbox_info 内容。"""
+        info = _make_e2b_sandbox_info()
+        sandbox = mock.MagicMock()
+        sandbox.sandbox_id = info["sandbox_id"]
+        sandbox.sandbox_domain = info["sandbox_domain"]
+        sandbox._envd_access_token = info["envd_access_token"]
+        sandbox._envd_version = info["envd_version"]
+        sandbox.traffic_access_token = info["traffic_access_token"]
+
+        backend = E2BSandboxBackend.__new__(E2BSandboxBackend)
+        backend._sandbox = sandbox
+
+        payload = backend.save()
+
+        self.assertEqual(payload, info)
+
+    def test_e2b_save_uncreated_returns_empty(self):
+        """沙箱未创建（sandbox_info 为 None）时 save 返回 {}，不抛异常。"""
+        backend = E2BSandboxBackend(template="t", timeout=1)
+        self.assertIsNone(backend.sandbox_info)
+        self.assertEqual(backend.save(), {})
+
+
+class TestE2bLoadInstanceAttach(unittest.TestCase):
+    """测试 5：load 为实例方法，就地重建 self._sandbox（跳过 Sandbox.create）。"""
+
+    def test_e2b_load_rebuilds_sandbox_inplace(self):
+        """load 用 sandbox_info 构造 Sandbox 并覆盖 self._sandbox；挂载后续期远端 TTL。"""
+        info = _make_e2b_sandbox_info()
+        backend = E2BSandboxBackend(template="t", timeout=1)
+        self.assertIsNone(backend._sandbox)  # lazy：构造时不创建
+
+        with mock.patch("aidev_agent.core.tools.runtime_tools.e2b_backend.Sandbox") as mock_sandbox_cls:
+            backend.load(info)
+
+        self.assertIs(backend._sandbox, mock_sandbox_cls.return_value)
+        kwargs = mock_sandbox_cls.call_args.kwargs
+        self.assertEqual(kwargs["sandbox_id"], "e2b-1")
+        self.assertEqual(kwargs["sandbox_domain"], "dom")
+        self.assertIsNone(backend._pending_sandbox_env)  # 挂载后创建参数失效
+        # 挂载即续期：远端 TTL 续到本 backend 配置的 timeout
+        backend._sandbox.set_timeout.assert_called_once_with(1)
+
+    def test_e2b_load_empty_payload_noop(self):
+        """payload 为 {}（原沙箱未真正拉起过）时 no-op，不创建沙箱。"""
+        backend = E2BSandboxBackend(template="t", timeout=1)
+        with mock.patch("aidev_agent.core.tools.runtime_tools.e2b_backend.Sandbox") as mock_sandbox_cls:
+            backend.load({})
+        mock_sandbox_cls.assert_not_called()  # 不创建沙箱
+        self.assertIsNone(backend._sandbox)  # 保持 lazy
+
+    def test_e2b_run_self_heals_on_sandbox_not_found(self):
+        """CR-A：挂载沙箱失效（NotFound）时丢弃引用重建并重试一次。"""
+        from e2b.exceptions import SandboxNotFoundException
+
+        backend = E2BSandboxBackend(template="t", timeout=1)
+        dead = mock.MagicMock()
+        dead.commands.run.side_effect = SandboxNotFoundException("gone")
+        backend._sandbox = dead  # 模拟已挂载的失效沙箱
+
+        alive = mock.MagicMock()
+        alive.commands.run.return_value = {"stdout": "ok", "exit_code": 0}
+
+        with mock.patch("aidev_agent.core.tools.runtime_tools.e2b_backend.Sandbox") as mock_sandbox_cls:
+            mock_sandbox_cls.create.return_value = alive
+            result = backend._run("echo hi")
+
+        self.assertEqual(result.stdout, "ok")
+        self.assertIs(backend._sandbox, alive)  # 已重建
+        mock_sandbox_cls.create.assert_called_once()  # 重建发生
+        create_kwargs = mock_sandbox_cls.create.call_args.kwargs
+        self.assertEqual(create_kwargs["timeout"], 1)  # 重建沿用 backend 配置的 timeout
+
+
+class TestFilesystemSaveLoad(unittest.TestCase):
+    """测试 6：FilesystemBackend.save/load 往返（实例方法，就地挂载）。"""
+
+    def test_filesystem_save_load_roundtrip(self):
+        """save 保存 cwd/virtual_mode/max_file_size_mb，load 就地覆盖。"""
+        backend = FilesystemBackend(root_dir="/tmp/ws", virtual_mode=True, max_file_size_mb=5)
+        payload = backend.save()
+
+        self.assertEqual(payload["root_dir"], str(backend.cwd))
+        self.assertTrue(payload["virtual_mode"])
+        self.assertEqual(payload["max_file_size_mb"], 5)
+
+        other = FilesystemBackend()
+        other.load(payload)
+        self.assertEqual(str(other.cwd), str(backend.cwd))
+        self.assertTrue(other.virtual_mode)
+        self.assertEqual(other.max_file_size_bytes, 5 * 1024 * 1024)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent/tests/core/tools/runtime_tools/test_defer_manager.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_defer_manager.py
@@ -1,0 +1,318 @@
+# -*- coding: utf-8 -*-
+"""RuntimeBackendDeferManager 单元测试（纯策略层：4 原语 token 透传 + 遍历 _owned 单阶段销毁）。
+
+覆盖 get_runtime 纯透传 token 语义（get 命中即摘 token）、defer 登记
+_owned(_OwnedBackend 持 token) + store 记录带 token、_sweep_once 遍历 _owned 驱动
+单阶段 delete_if_token 销毁（delete_if_token 成功 close / token 被 get 摘除跳 close
+拦截销毁 / 记录被删跳 close / 新 defer 覆盖跳 close）、delete_expired GC、
+shutdown 先 token 校验再 close（校验成功 close / token 被摘跳 close）。
+
+关键：生命周期构造一律 record_max_age=...、不传 grace_period；token 语义封装在
+store 内，测试不 import STATE_*、不 backdate last_access_at（让 entry 到期改
+``mgr._owned[key].expires_at`` 为过去即可）、不 mock time.sleep（已无 sleep）。
+"""
+
+from __future__ import annotations
+
+import time
+import unittest
+from unittest import mock
+
+from aidev_agent.core.tools.runtime_tools.defer_manager import (
+    RuntimeBackendDeferInMemoryStore,
+    RuntimeBackendDeferManager,
+)
+
+
+def _make_mgr(store, **overrides):
+    kwargs = {
+        "store": store,
+        "idle_ttl": 300,
+        "sweep_interval": 0.05,
+        "record_max_age": 259200.0,
+    }
+    kwargs.update(overrides)
+    return RuntimeBackendDeferManager(**kwargs)
+
+
+def _defer_and_expire(mgr, store, key, backend):
+    """defer 登记 _owned + store 记录（持 token），并把该 entry 的 expires_at 改为过去值。"""
+    mgr.defer({key: backend})
+    with mgr._owned_lock:
+        mgr._owned[key].expires_at = time.time() - 1  # 已过期
+
+
+def _token_of(store, key):
+    """取 store 记录内当前 token（None 表示已被摘除/无记录）。"""
+    record = store._records.get(key)
+    return record.get("token") if record else None
+
+
+def _payload_of(store, key):
+    """取 store 记录内 payload（不消费 token）。"""
+    record = store._records.get(key)
+    return dict(record["payload"]) if record else None
+
+
+class TestGetRuntime(unittest.TestCase):
+    """get_runtime 纯透传 store.get token 语义。"""
+
+    def test_active_payload_returns_payload(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "agent:s1:paas_sandbox_pdf"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        mgr = _make_mgr(store)
+        self.assertEqual(mgr.get_runtime(key), {"sandbox_id": "sbx-1"})
+
+    def test_absent_returns_none(self):
+        mgr = _make_mgr(RuntimeBackendDeferInMemoryStore())
+        self.assertIsNone(mgr.get_runtime("agent:s1:paas_sandbox_pdf"))
+
+    def test_empty_payload_returns_empty_dict(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "agent:s1:paas_sandbox_pdf"
+        store.put(key, {}, token="tok-1")
+        mgr = _make_mgr(store)
+        self.assertEqual(mgr.get_runtime(key), {})
+
+    def test_get_removes_token(self):
+        """get_runtime 命中后 store 内 token 被摘除（挂载方获得销毁豁免）。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "agent:s1:paas_sandbox_pdf"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        mgr = _make_mgr(store)
+        self.assertEqual(mgr.get_runtime(key), {"sandbox_id": "sbx-1"})
+        self.assertIsNone(_token_of(store, key))  # token 已摘
+
+
+class TestDefer(unittest.TestCase):
+    """defer 所有权接管：store.put(token) 登记 + _owned 登记 _OwnedBackend(backend+token+expires_at)。"""
+
+    def test_defer_registers_record_and_owns_instance_with_token(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        mgr.defer({"agent:s1:paas_sandbox_pdf": backend})
+        backend.save.assert_called_once()
+        # _owned 持 token，且与 store 记录内 token 一致（本进程所有权身份）
+        owned = mgr._owned["agent:s1:paas_sandbox_pdf"]
+        self.assertIs(owned.backend, backend)
+        self.assertTrue(owned.token)  # 非空
+        self.assertEqual(_token_of(store, "agent:s1:paas_sandbox_pdf"), owned.token)
+        self.assertGreater(owned.expires_at, time.time())  # expires_at = now + idle_ttl
+        backend.close.assert_not_called()
+        # 记录已登记供复用（先核对 token，再 get 命中 payload）
+        self.assertEqual(_payload_of(store, "agent:s1:paas_sandbox_pdf"), {"sandbox_id": "sbx-1"})
+        self.assertEqual(mgr.get_runtime("agent:s1:paas_sandbox_pdf"), {"sandbox_id": "sbx-1"})
+
+    def test_defer_empty_payload_still_registers(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        backend = mock.MagicMock()
+        backend.save.return_value = {}
+        mgr.defer({"agent:s1:paas_sandbox_pdf": backend})
+        self.assertEqual(mgr.get_runtime("agent:s1:paas_sandbox_pdf"), {})
+        self.assertIs(mgr._owned["agent:s1:paas_sandbox_pdf"].backend, backend)
+
+    def test_defer_save_failure_closes_and_does_not_own(self):
+        """save() 失败 → store.put 未落地 → 立即 close backend，不登记 _owned（杜绝死 entry 泄漏）。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        backend = mock.MagicMock()
+        backend.save.side_effect = RuntimeError("boom")
+        mgr.defer({"agent:s1:paas_sandbox_pdf": backend})
+        backend.close.assert_called_once()  # 立即销毁
+        self.assertNotIn("agent:s1:paas_sandbox_pdf", mgr._owned)  # 不登记
+        self.assertIsNone(mgr.get_runtime("agent:s1:paas_sandbox_pdf"))  # store 无记录
+
+    def test_defer_close_failure_does_not_abort_loop(self):
+        """第一个 backend put 失败且 close 也抛异常 → close 异常被吞，循环不中断，第二个 backend 正常登记 defer。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        failing = mock.MagicMock()
+        failing.save.side_effect = RuntimeError("save boom")
+        failing.close.side_effect = RuntimeError("close boom")
+        healthy = mock.MagicMock()
+        healthy.save.return_value = {"sandbox_id": "sbx-2"}
+        mgr.defer(
+            {
+                "agent:s1:paas_sandbox_pdf": failing,
+                "agent:s1:paas_sandbox_skill": healthy,
+            }
+        )
+        failing.close.assert_called_once()  # close 被调过（抛异常被吞）
+        self.assertNotIn("agent:s1:paas_sandbox_pdf", mgr._owned)  # 失败者不登记
+        self.assertIsNone(mgr.get_runtime("agent:s1:paas_sandbox_pdf"))  # store 无记录
+        # 第二个 backend 正常 defer：登记 _owned + store 有记录 + 未被 close
+        self.assertIs(mgr._owned["agent:s1:paas_sandbox_skill"].backend, healthy)
+        self.assertEqual(mgr.get_runtime("agent:s1:paas_sandbox_skill"), {"sandbox_id": "sbx-2"})
+        healthy.close.assert_not_called()
+
+    def test_defer_same_runtime_id_refreshes(self):
+        """同 runtime_id 再次 defer：用新 token 覆盖 store 记录 + _owned 换新实例/刷新 expires_at。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        b1 = mock.MagicMock()
+        b2 = mock.MagicMock()
+        b1.save.return_value = {"sandbox_id": "sbx-1"}
+        b2.save.return_value = {"sandbox_id": "sbx-2"}
+        mgr.defer({"agent:s1:paas_sandbox_pdf": b1})
+        first_token = _token_of(store, "agent:s1:paas_sandbox_pdf")
+        first_expires = mgr._owned["agent:s1:paas_sandbox_pdf"].expires_at
+        mgr.defer({"agent:s1:paas_sandbox_pdf": b2})
+        owned = mgr._owned["agent:s1:paas_sandbox_pdf"]
+        self.assertIs(owned.backend, b2)
+        # 新 token 覆盖旧 token（旧 entry 的 delete_if_token 因此必失败）
+        self.assertNotEqual(_token_of(store, "agent:s1:paas_sandbox_pdf"), first_token)
+        self.assertEqual(_token_of(store, "agent:s1:paas_sandbox_pdf"), owned.token)
+        self.assertGreaterEqual(owned.expires_at, first_expires)
+        self.assertEqual(mgr.get_runtime("agent:s1:paas_sandbox_pdf"), {"sandbox_id": "sbx-2"})
+
+
+class TestSingleStageDestroy(unittest.TestCase):
+    """单阶段 token 销毁（遍历 _owned 驱动 _destroy_entry）各守卫用例。"""
+
+    def test_sweep_delete_if_token_success_closes(self):
+        """delete_if_token 成功（记录仍持本进程 token）→ close 持有实例 + 记录消失。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=0)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        _defer_and_expire(mgr, store, "agent:s1:paas_sandbox_pdf", backend)
+        mgr._sweep_once()
+        backend.close.assert_called_once()  # 真实销毁
+        self.assertIsNone(mgr.get_runtime("agent:s1:paas_sandbox_pdf"))  # 记录已删
+        self.assertNotIn("agent:s1:paas_sandbox_pdf", mgr._owned)
+
+    def test_sweep_token_removed_by_get_skips_close(self):
+        """token 版「读即续期拦截」：get 摘 token（挂载复用）→ sweep 不 close、记录保留。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=0)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        key = "agent:s1:paas_sandbox_pdf"
+        _defer_and_expire(mgr, store, key, backend)
+        mgr.get_runtime(key)  # 挂载请求抢先复用：摘除 token
+        mgr._sweep_once()
+        backend.close.assert_not_called()  # token 已摘：不 close
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-1"})  # 记录保留 payload
+        self.assertNotIn(key, mgr._owned)  # 旧 entry pop，所有权交由挂载方重新 defer
+
+    def test_sweep_delete_if_token_fail_drops_without_close(self):
+        """记录被其他路径删除（key 不存在）→ delete_if_token False → 不 close、_owned 清理。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=0)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        key = "agent:s1:paas_sandbox_pdf"
+        _defer_and_expire(mgr, store, key, backend)
+        # 模拟记录已被其他路径删除（token 校验对不存在返回 False）
+        store.delete_if_token(key, mgr._owned[key].token)  # 直接删记录
+        mgr._sweep_once()
+        backend.close.assert_not_called()  # 未获销毁权：绝不 close 远端
+        self.assertNotIn(key, mgr._owned)  # 本地注册表已清理
+
+    def test_sweep_overwritten_by_new_defer_aborts_without_close(self):
+        """旧 entry 过期时记录已被新 defer 覆盖（新 token）→ 不 close 旧实例、_owned 指向新实例。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=300)
+        old_backend = mock.MagicMock()
+        old_backend.save.return_value = {"sandbox_id": "sbx-1"}
+        key = "agent:s1:paas_sandbox_pdf"
+        mgr.defer({key: old_backend})
+        old_entry = mgr._owned[key]
+        # 新 defer 已用新实例覆盖 _owned[同 key]（记录亦被刷新为新 token 新 payload）
+        new_backend = mock.MagicMock()
+        new_backend.save.return_value = {"sandbox_id": "sbx-2"}
+        mgr.defer({key: new_backend})
+        # 用旧 entry 触发销毁：delete_if_token(old_token) 对新 token 记录返回 False
+        mgr._destroy_entry(key, old_entry)
+        old_backend.close.assert_not_called()  # token 已被新 defer 覆盖：不 close 旧实例
+        self.assertIs(mgr._owned[key].backend, new_backend)  # 新实例保留
+        new_backend.close.assert_not_called()
+
+
+class TestSweep(unittest.TestCase):
+    """_sweep_once 遍历 _owned + delete_expired GC。"""
+
+    def test_sweep_traverses_owned_only(self):
+        """sweep 只销毁 _owned 里到期的 entry；未到期（未来 expires_at）不销毁。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=0)
+        expired_backend = mock.MagicMock()
+        expired_backend.save.return_value = {"sandbox_id": "sbx-expired"}
+        active_backend = mock.MagicMock()
+        active_backend.save.return_value = {"sandbox_id": "sbx-active"}
+        mgr.defer({"agent:s1:paas_sandbox_pdf": expired_backend})
+        mgr.defer({"agent:s1:paas_sandbox_skill": active_backend})
+        # 把 active 那条 expires_at 改为未来（未到期）；expired 保持 defer 时的 expires_at（idle_ttl=0 → 已过期）
+        with mgr._owned_lock:
+            mgr._owned["agent:s1:paas_sandbox_skill"].expires_at = time.time() + 300
+        mgr._sweep_once()
+        expired_backend.close.assert_called_once()
+        active_backend.close.assert_not_called()  # 未到期不销毁
+        self.assertIs(mgr._owned["agent:s1:paas_sandbox_skill"].backend, active_backend)
+
+    def test_sweep_runs_delete_expired_gc(self):
+        """_sweep_once 末尾调用 store.delete_expired(record_max_age) 清超龄记录。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store, idle_ttl=300, record_max_age=259200.0)
+        orphan_key = "agent:s1:paas_sandbox_skill"
+        store.put(orphan_key, {"sandbox_id": "sbx-orphan"}, token="tok-orphan")
+        # 记录太新鲜 max_age 不删 —— 触发一次 sweep（_owned 为空，仅 GC）
+        mgr._sweep_once()
+        self.assertIsNotNone(mgr.get_runtime(orphan_key))
+        # 直接以 max_age=0 语义验证 delete_expired 计数被 store 正确执行
+        removed = store.delete_expired(max_age=0)
+        self.assertEqual(removed, 1)
+
+    def test_sweep_without_owned_instance_only_deletes_record(self):
+        """过期记录在 _owned 中无持有实例则仅删记录（不 close 任何实例）。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "agent:s1:paas_sandbox_pdf"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        mgr = _make_mgr(store, idle_ttl=0)
+        mgr._sweep_once()  # _owned 为空 → 无销毁动作
+        self.assertEqual(mgr._owned, {})
+        self.assertIsNotNone(mgr.get_runtime(key))  # 他方记录不受本 pod sweep 影响
+
+
+class TestAtexitShutdown(unittest.TestCase):
+    """shutdown：停线程 + 对持有实例先 token 校验再 close。"""
+
+    def test_shutdown_stops_thread(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        mgr.start()
+        self.assertIsNotNone(mgr._thread)
+        mgr.shutdown()
+        self.assertFalse(mgr._thread.is_alive())
+
+    def test_shutdown_validates_token_before_close(self):
+        """defer 一条（_owned 有 entry + store 记录持 token）→ shutdown → 校验成功 close。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        mgr.defer({"agent:s1:paas_sandbox_pdf": backend})
+        mgr.shutdown()
+        backend.close.assert_called_once()  # token 校验成功 → close
+        self.assertEqual(mgr._owned, {})  # 清空
+
+    def test_shutdown_token_removed_skips_close(self):
+        """defer 后 get 摘 token → shutdown → token 校验 False → 不 close（他方使用中）。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        mgr = _make_mgr(store)
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-1"}
+        key = "agent:s1:paas_sandbox_pdf"
+        mgr.defer({key: backend})
+        mgr.get_runtime(key)  # 摘除 token（模拟他 pod/请求正在使用）
+        mgr.shutdown()
+        backend.close.assert_not_called()  # token 已摘：不误杀他方正在使用的沙箱
+        self.assertEqual(mgr._owned, {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent/tests/core/tools/runtime_tools/test_defer_store.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_defer_store.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""RuntimeBackendDeferInMemoryStore 单元测试（4 原语 token 化）。
+
+覆盖 get 摘 token（二次 get 仍返回 payload / 不存在 None 且不创建记录）、put
+覆盖、delete_if_token 四分支（token 相等删 / token 不符留 / token 已摘留 / 不存在
+False）、delete_expired 计数，以及多线程并发 delete_if_token 竞态（模拟多 pod 共享
+存储，恰好只有一个成功）。token 语义已封装在 store 内，测试不触碰内部时间戳、
+不 backdate last_access_at、不 import STATE_*。
+"""
+
+from __future__ import annotations
+
+import threading
+import unittest
+
+from aidev_agent.core.tools.runtime_tools.defer_manager import RuntimeBackendDeferInMemoryStore
+
+
+class TestRuntimeBackendDeferInMemoryStore(unittest.TestCase):
+    """RuntimeBackendDeferInMemoryStore 4 原语 token 化语义测试。"""
+
+    def test_get_removes_token_and_returns_payload(self):
+        """put 后 get 返回 payload；再 get（token 已 None）仍返回同一 payload。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "sandbox:session_1:paas_sandbox_skill"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-1"})
+        # 二次 get：token 已摘除为 None，但照常返回 payload（挂载方仍在读）
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-1"})
+        self.assertIsNone(store._records[key]["token"])  # token 已被摘除
+
+    def test_get_absent_returns_none_and_no_record_created(self):
+        """对不存在的 key get 返回 None，且不创建记录。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "sandbox:session_1:paas_sandbox_skill"
+        self.assertIsNone(store.get(key))
+        self.assertEqual(store._records, {})  # get 不创建记录
+
+    def test_put_overwrites_record(self):
+        """同 key 连续 put（不同 token/payload）后 get 返回最后一次 payload。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "sandbox:session_1:paas_sandbox_skill"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        store.put(key, {"sandbox_id": "sbx-2"}, token="tok-2")
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-2"})
+
+    def test_delete_if_token_four_branches(self):
+        """delete_if_token：token 相等删 / token 不符留 / token 已摘留 / 不存在 False。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "sandbox:session_1:paas_sandbox_skill"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        # ① token 相符 → True 且记录消失
+        self.assertTrue(store.delete_if_token(key, "tok-1"))
+        self.assertIsNone(store.get(key))
+        # ② key 不存在 → False
+        self.assertFalse(store.delete_if_token(key, "tok-1"))
+        # ③ token 不符 → False 且记录保留
+        store.put(key, {"sandbox_id": "sbx-2"}, token="tok-2")
+        self.assertFalse(store.delete_if_token(key, "wrong-token"))
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-2"})
+        # ④ token 已被 get 摘除（None）→ False 且记录保留
+        store.put(key, {"sandbox_id": "sbx-3"}, token="tok-3")
+        store.get(key)  # 摘除 token
+        self.assertFalse(store.delete_if_token(key, "tok-3"))
+        self.assertEqual(store.get(key), {"sandbox_id": "sbx-3"})  # 记录保留
+
+    def test_delete_expired_counts(self):
+        """delete_expired：max_age=0 删所有（计数正确）；max_age=1e9 不删任何。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        keys = [f"sandbox:session_{i}:paas_sandbox_skill" for i in range(3)]
+        for idx, k in enumerate(keys):
+            store.put(k, {"sandbox_id": f"sbx-{idx}"}, token=f"tok-{idx}")
+        removed = store.delete_expired(max_age=0)  # 全部过期
+        self.assertEqual(removed, 3)
+        self.assertEqual(len(store._records), 0)  # 内部记录清空
+        # 重新登记后超大 max_age 不删任何
+        for k in keys:
+            store.put(k, {"sandbox_id": "sbx-new"}, token="tok-new")
+        removed = store.delete_expired(max_age=1e9)
+        self.assertEqual(removed, 0)
+        self.assertEqual(len(store._records), 3)
+
+
+class TestDeleteIfTokenAtomicity(unittest.TestCase):
+    """多线程并发 delete_if_token 竞态测试（模拟多 pod 共享存储）。
+
+    并发对同一 put 记录调 delete_if_token(key, same_token)，恰好 1 个成功、其余失败。
+    """
+
+    def test_concurrent_delete_if_token_only_one_wins(self):
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "sandbox:session_1:paas_sandbox_skill"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+        success: list[int] = []
+        lock = threading.Lock()
+
+        def try_delete():
+            barrier.wait()
+            ok = store.delete_if_token(key, "tok-1")
+            if ok:
+                with lock:
+                    success.append(1)
+
+        threads = [threading.Thread(target=try_delete) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(success), 1)  # 只有一个 delete_if_token 成功
+        self.assertIsNone(store.get(key))  # 删除后记录不存在
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent/tests/core/tools/runtime_tools/test_e2b_backend.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_e2b_backend.py
@@ -104,7 +104,7 @@ class DummySandbox:
 
 @pytest.fixture(autouse=True)
 def _patch_e2b_sdk(monkeypatch):
-    """通过 sys.modules 注入假模块，使方法内部延迟导入拿到 Dummy 对象。"""
+    """注入假 SDK：sys.modules 兜底 + 替换 e2b_backend 模块命名空间的顶层绑定。"""
 
     DummySandbox.create_calls = []
     DummySandbox.handler = lambda _cmd, _timeout=None: DummyCmdResult(stdout="", stderr="", exit_code=0)
@@ -114,6 +114,12 @@ def _patch_e2b_sdk(monkeypatch):
     fake_e2b_ci = types.ModuleType("e2b_code_interpreter")
     fake_e2b_ci.Sandbox = DummySandbox
     monkeypatch.setitem(sys.modules, "e2b_code_interpreter", fake_e2b_ci)
+    # e2b_backend 的 Sandbox 为顶层导入（import 绑定在模块命名空间），
+    # 需直接替换该绑定才能让 _ensure_sandbox 拿到 Dummy
+    monkeypatch.setattr(
+        "aidev_agent.core.tools.runtime_tools.e2b_backend.Sandbox",
+        DummySandbox,
+    )
 
 
 class TestE2BSandboxBackendInitialization:

--- a/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_paas_backend.py
@@ -1013,3 +1013,56 @@ class TestConfigStatePassThrough:
         assert "state" in params, "ls_info 缺少 state 参数"
         assert params["config"].kind == inspect.Parameter.KEYWORD_ONLY, "config 应为 keyword-only"
         assert params["state"].kind == inspect.Parameter.KEYWORD_ONLY, "state 应为 keyword-only"
+
+
+# ----------------------------------------------------------------
+# CR-A 自愈 / CR-B TTL 钳制
+# ----------------------------------------------------------------
+
+
+class TestRunSelfHeal:
+    """_run 挂载沙箱失效（404）时丢弃重建并重试一次（CR-A）。"""
+
+    @pytest.fixture(autouse=True)
+    def _no_sleep(self, monkeypatch):
+        """重建后的 not-ready 等待跳过。"""
+        monkeypatch.setattr("aidev_agent.core.tools.runtime_tools.paas_backend.sleep", lambda _: None)
+
+    def test_run_self_heals_on_sandbox_gone(self, backend, mock_ops, monkeypatch):
+        backend.load({"sandbox_id": "sbx-dead"})
+        exec_calls: list[str] = []
+
+        def exec_handler(sandbox_id, cmd, **kw):
+            exec_calls.append(sandbox_id)
+            if sandbox_id == "sbx-dead":
+                exc = HTTPError("404 Sandbox not found")
+                exc.response = MagicMock(status_code=404)
+                raise exc
+            return ExecResult(stdout="ok", stderr="", exit_code=0)
+
+        monkeypatch.setattr(backend, "exec_command", exec_handler)
+        created: list[dict] = []
+        monkeypatch.setattr(backend, "create_sandbox", lambda **kw: (created.append(kw), "sbx-new")[1])
+
+        res = backend._run(["bash", "-c", "echo hi"])
+
+        assert res.stdout == "ok"
+        assert backend._sandbox_id == "sbx-new"  # 已重建
+        assert exec_calls == ["sbx-dead", "sbx-new"]  # 死沙箱一次 + 新沙箱一次
+        assert created  # 重建发生
+
+    def test_run_reraises_non_gone_errors(self, backend, mock_ops, monkeypatch):
+        """非 404 异常不触发自愈，直接抛出。"""
+        backend.load({"sandbox_id": "sbx-1"})
+
+        def exec_handler(sandbox_id, cmd, **kw):
+            exc = HTTPError("500")
+            exc.response = MagicMock(status_code=500)
+            raise exc
+
+        monkeypatch.setattr(backend, "exec_command", exec_handler)
+        created: list[dict] = []
+        monkeypatch.setattr(backend, "create_sandbox", lambda **kw: (created.append(kw), "sbx-new")[1])
+
+        with pytest.raises(HTTPError):
+            backend._run(["bash", "-c", "echo hi"])

--- a/src/agent/tests/core/tools/runtime_tools/test_resolver.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_resolver.py
@@ -16,8 +16,9 @@
 from __future__ import annotations
 
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
+import pytest
 from aidev_agent.core.tools.runtime_tools.provider import RuntimeBackendResolver
 from aidev_agent.core.tools.runtime_tools.types import RuntimeBackend
 
@@ -75,8 +76,9 @@ class TestPaasBackendCloseCallsKill(unittest.TestCase):
     """测试 2：PaasSandboxBackend.close() 委托给 kill()。"""
 
     def test_close_calls_kill(self):
-        from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
         from unittest.mock import MagicMock
+
+        from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
 
         backend = PaasSandboxBackend(
             client=MagicMock(),
@@ -166,19 +168,25 @@ class TestResolverCloseContinuesOnError(unittest.TestCase):
 
 
 class TestRegisterRuntime(unittest.TestCase):
-    """测试 8：register_runtime 使重新注册的运行时生效。"""
+    """测试 8：register_runtime 同名同实例幂等，同名异实例抛错（CR）。"""
 
-    def test_register_invalidates_previous(self):
+    def test_register_same_instance_idempotent(self):
+        resolver = RuntimeBackendResolver()
+        backend_a = RuntimeBackend()
+        resolver.register_runtime("test", backend_a)
+        resolver.register_runtime("test", backend_a)  # 幂等返回
+        assert resolver._resolve_backend("test") is backend_a
+
+    def test_register_different_instance_raises(self):
         resolver = RuntimeBackendResolver()
         backend_a = RuntimeBackend()
         backend_b = RuntimeBackend()
         resolver.register_runtime("test", backend_a)
-        result1 = resolver._resolve_backend("test")
-        assert result1 is backend_a
-        # 重新注册
-        resolver.register_runtime("test", backend_b)
-        result2 = resolver._resolve_backend("test")
-        assert result2 is backend_b
+        # 同名异实例：抛 ValueError，原注册不被覆盖
+        with pytest.raises(ValueError) as ctx:
+            resolver.register_runtime("test", backend_b)
+        assert "test" in str(ctx.value)
+        assert resolver._resolve_backend("test") is backend_a
 
 
 class TestResolveBackendUnknownRuntime(unittest.TestCase):

--- a/src/agent/tests/core/tools/runtime_tools/test_sandbox_reuse_integration.py
+++ b/src/agent/tests/core/tools/runtime_tools/test_sandbox_reuse_integration.py
@@ -1,0 +1,350 @@
+# -*- coding: utf-8 -*-
+"""沙箱复用端到端集成测试（先构造再挂载 + close 移交所有权流程，4 原语 token 语义）。
+
+覆盖完整复用链路：请求 1 全新创建（lazy）→ resolver.close() 移交所有权给
+RuntimeBackendDeferManager（defer：store.put 登记持 token + 持有实例）→ 请求 2
+get_runtime 命中（store.get 摘 token，仍返回 payload）→ backend.load 实例方法挂载复用
+→ close 再次移交续期（新 token put）；TTL 到期 sweep 遍历 _owned close 持有实例（真实
+销毁）+ delete_expired GC；记录已销毁（store 无记录）走全新创建；close defer 用新 token
+续期；安全不变量（agent/session 缺失 → 延迟销毁策略关闭，close 立即销毁）；多 pod
+并发 delete_if_token 竞态（只有一个成功）。
+
+token 语义封装在 store 内，测试不 import STATE_*、不 backdate last_access_at（让某
+_owned entry 到期改为 defer_manager._owned[key].expires_at 为过去即可，不 mock time.sleep）。
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+from unittest import mock
+
+from aidev_agent.core.tools.runtime_tools.defer_manager import (
+    RuntimeBackendDeferInMemoryStore,
+    RuntimeBackendDeferManager,
+)
+from aidev_agent.core.tools.runtime_tools.provider import RuntimeBackendResolver
+from aidev_agent.core.tools.runtime_tools.types import RuntimeBackend
+
+
+def _make_mgr(store, **overrides):
+    kwargs = {
+        "store": store,
+        "idle_ttl": 300,
+        "sweep_interval": 60,
+        "record_max_age": 259200.0,
+    }
+    kwargs.update(overrides)
+    return RuntimeBackendDeferManager(**kwargs)
+
+
+def _make_fake_resolver(**kwargs):
+    """构造 resolver 并预注册 _FakeBackend 到 runtime 类型注册表（fake）。"""
+    resolver = RuntimeBackendResolver(**kwargs)
+    resolver.register_runtime_cls("fake", _FakeBackend)
+    return resolver
+
+
+def _token_of(store, key):
+    """取 store 记录内当前 token（None 表示已被摘除/无记录）。"""
+    record = store._records.get(key)
+    return record.get("token") if record else None
+
+
+def _payload_of(store, key):
+    """取 store 记录内 payload（不消费 token）。"""
+    record = store._records.get(key)
+    return dict(record["payload"]) if record else None
+
+
+class _FakeBackend(RuntimeBackend):
+    """测试用 fake backend：lazy 语义 —— 构造不建沙箱，save 在未创建时导出 {}。"""
+
+    def __init__(self, *, sandbox_id: str | None = None) -> None:
+        self.sandbox_id = sandbox_id  # None = 远端沙箱未创建（lazy）
+        self.created = False
+        self.kill_count = 0
+        self.close_count = 0
+
+    def create(self, sandbox_id: str = "sbx-new") -> str:
+        """模拟首次使用触发远端沙箱创建。"""
+        self.sandbox_id = sandbox_id
+        self.created = True
+        return self.sandbox_id
+
+    def save(self) -> dict:
+        if self.sandbox_id is None:
+            return {}  # 未创建沙箱，默认导出 {}（不抛异常）
+        return {"sandbox_id": self.sandbox_id}
+
+    def load(self, payload: dict) -> None:
+        """实例方法挂载：指向既有沙箱；payload 为 {} 时 no-op（不创建沙箱）。"""
+        sandbox_id = payload.get("sandbox_id")
+        if not sandbox_id:
+            return
+        self.sandbox_id = sandbox_id
+        self.created = False
+
+    def kill(self) -> None:
+        self.kill_count += 1
+
+    def close(self) -> None:  # type: ignore[override]
+        self.close_count += 1
+        self.kill()
+
+
+class TestSandboxReuseIntegration(unittest.TestCase):
+    """沙箱复用端到端集成测试（先构造再挂载 + close 移交所有权）。"""
+
+    def test_reuse_chain_create_close_defer_reattach(self):
+        """完整链路：全新创建 → close 移交（defer 持 token）→ 下请求挂载复用 → close 续期。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+        self.assertEqual(runtime_id, "agent:s1:paas_sandbox_pdf")
+
+        # 请求 1：全新创建（lazy，不写 store）
+        first = resolver.get_or_create_backend(runtime_name, "fake", {})
+        self.assertIsNone(first.sandbox_id)  # 尚无远端沙箱
+        self.assertIsNone(store.get(runtime_id))  # 未写 store
+        first.create("sbx-1")
+        # 请求 1 结束：close 移交所有权（defer：store.put 持 token + 持有实例，不销毁）
+        resolver.close()
+        self.assertIsNotNone(_token_of(store, runtime_id))  # defer 已持 token 登记
+        self.assertEqual(store.get(runtime_id), {"sandbox_id": "sbx-1"})  # get 摘 token 返回 payload
+        self.assertEqual(first.close_count, 0)  # defer 不销毁
+        self.assertIs(defer_manager._owned[runtime_id].backend, first)  # 所有权已移交
+
+        # 请求 2（新 resolver，同 agent/session）：get_runtime 命中（摘 token）→ load 挂载
+        resolver2 = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        second = resolver2.get_or_create_backend(runtime_name, "fake", {})
+        self.assertIsNot(second, first)  # 全新实例
+        self.assertEqual(second.sandbox_id, "sbx-1")  # 挂载到原沙箱
+        self.assertFalse(second.created)  # 跳过创建
+        self.assertIs(resolver2._backends[runtime_name], second)  # 注册到模型可见路由名
+        # get_runtime（挂载）已摘除旧 token —— 旧 entry 无法再删除本记录
+        self.assertIsNone(_token_of(store, runtime_id))
+        # 请求 2 结束：close 再次移交（用新 token put 续期）；payload 经记录直读核对
+        # （不经 store.get —— 以免消费 token 导致 shutdown 无法校验 close）
+        resolver2.close()
+        self.assertEqual(_payload_of(store, runtime_id), {"sandbox_id": "sbx-1"})
+        self.assertIsNotNone(_token_of(store, runtime_id))  # 新 token 已登记
+        self.assertIs(defer_manager._owned[runtime_id].backend, second)
+        defer_manager.shutdown()  # 进程退出兜底：token 校验成功 close 持有实例
+        self.assertEqual(second.close_count, 1)
+
+    def test_deferred_disabled_close_destroys_immediately(self):
+        """agent/session 缺失 → 延迟销毁策略关闭，close 立即销毁、不写 store。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store)
+        resolver = _make_fake_resolver(default_runtime="local", defer_manager=defer_manager, agent_code="agent")
+        runtime_id = resolver.compose_runtime_id("paas_sandbox_pdf")
+        self.assertEqual(runtime_id, "paas_sandbox_pdf")  # scoping 缺失回退原名
+
+        backend = resolver.get_or_create_backend("paas_sandbox_pdf", "fake", {})
+        self.assertIsNone(backend.sandbox_id)  # 全新 lazy 实例
+        self.assertIsNone(store.get(runtime_id))  # 不写 store
+        resolver.close()  # close 立即销毁
+        self.assertEqual(backend.close_count, 1)
+        self.assertEqual(defer_manager._owned, {})  # 无所有权移交
+
+    def test_reattach_refreshes_last_access_at_close(self):
+        """close 移交时 save() → store.put 覆盖续期（payload 更新，持新 token）。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+        store.put(runtime_id, {"sandbox_id": "sbx-1"}, token="tok-pre")
+
+        backend = resolver.get_or_create_backend(runtime_name, "fake", {})
+        self.assertEqual(backend.sandbox_id, "sbx-1")  # 挂载到原沙箱
+        backend.create("sbx-2")  # 本次使用新沙箱
+        resolver.close()  # defer：store.put 覆盖续期（新 token）
+        # payload 经记录直读核对（不经 store.get —— 以免消费 token 使 shutdown 无法 close）
+        self.assertEqual(_payload_of(store, runtime_id), {"sandbox_id": "sbx-2"})
+        self.assertIs(defer_manager._owned[runtime_id].backend, backend)
+        defer_manager.shutdown()
+        self.assertEqual(backend.close_count, 1)  # shutdown 兜底 close
+
+    def test_destroyed_record_not_reattached_creates_fresh(self):
+        """记录已销毁（store 无该 key 记录）→ 不挂载，走全新创建。
+
+        token 语义版「EXPIRING 不挂载」：已销毁沙箱 = delete_if_token 成功删除记录
+        （或从未登记）—— store 无记录，get_runtime 返回 None → 全新 lazy 实例；close
+        移交后用新 token put 登记。
+        """
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+        # 旧沙箱已销毁：无记录（旧记录 token 已被摘除且 payload 已随销毁移除）
+        self.assertIsNone(store.get(runtime_id))
+
+        backend = resolver.get_or_create_backend(runtime_name, "fake", {})
+        self.assertIsNone(backend.sandbox_id)  # 全新 lazy 实例，未挂载旧沙箱
+        backend.create("sbx-new")  # 本次请求实际创建新沙箱
+        resolver.close()  # defer：store.put 登记持新 token
+        # payload 经记录直读核对（不经 store.get —— 以免消费 token 使 shutdown 无法 close）
+        self.assertEqual(_payload_of(store, runtime_id), {"sandbox_id": "sbx-new"})
+        self.assertIsNotNone(_token_of(store, runtime_id))
+        defer_manager.shutdown()
+        self.assertEqual(backend.close_count, 1)
+
+    def test_close_defers_empty_payload_for_unused(self):
+        """本次请求未使用（lazy 未创建）→ save 导出 {}，照常登记空 payload。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+
+        resolver.get_or_create_backend(runtime_name, "fake", {})
+        resolver.close()  # defer：save() {} 照常登记
+        self.assertEqual(store.get(runtime_id), {})
+        # 下请求 get_runtime 返回 {}，load({}) no-op，backend 保持 lazy
+        self.assertEqual(defer_manager.get_runtime(runtime_id), {})
+        resolver2 = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        second = resolver2.get_or_create_backend(runtime_name, "fake", {})
+        self.assertIsNone(second.sandbox_id)  # 未创建沙箱
+        defer_manager.shutdown()
+        resolver.close()
+        resolver2.close()
+
+    def test_sweep_destroys_owned_instance(self):
+        """TTL 到期：sweep 遍历 _owned delete_if_token 校验成功后 close 持有实例（真实销毁）+ 删记录。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store, idle_ttl=0)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+        backend = resolver.get_or_create_backend(runtime_name, "fake", {})
+        backend.create("sbx-1")
+        resolver.close()  # 移交所有权
+        self.assertIs(defer_manager._owned[runtime_id].backend, backend)
+        # 让该 entry 到期（改 defer_manager._owned expires_at 为过去，不触碰 store）
+        with defer_manager._owned_lock:
+            defer_manager._owned[runtime_id].expires_at = time.time() - 1
+        defer_manager._sweep_once()
+        self.assertEqual(backend.close_count, 1)  # 真实销毁
+        self.assertIsNone(store.get(runtime_id))  # 记录已删
+        self.assertNotIn(runtime_id, defer_manager._owned)
+        defer_manager.shutdown()
+
+    def test_sweep_only_touches_owned_expired(self):
+        """sweep 只销毁 defer_manager 自有 _owned 中已到期的 entry，不碰其他共享记录。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store, idle_ttl=0)
+        # 其他 pod/会话写入的无主共享记录（defer_manager._owned 无条目）——不受本 pod sweep 影响
+        orphan_id = "agent:s1:paas_sandbox_skill"
+        store.put(orphan_id, {"sandbox_id": "sbx-orphan"}, token="tok-orphan")
+        # 本 pod defer 一条
+        backend = mock.MagicMock()
+        backend.save.return_value = {"sandbox_id": "sbx-owned"}
+        runtime_id = "agent:s1:paas_sandbox_pdf"
+        defer_manager.defer({runtime_id: backend})
+        with defer_manager._owned_lock:
+            defer_manager._owned[runtime_id].expires_at = time.time() - 1
+        defer_manager._sweep_once()
+        backend.close.assert_called_once()
+        self.assertIsNone(store.get(runtime_id))  # 自有到期记录被销毁删记录
+        self.assertEqual(store.get(orphan_id), {"sandbox_id": "sbx-orphan"})  # 他方记录不动
+
+    def test_sweep_gc_removes_superaged_records(self):
+        """_sweep_once 末尾 delete_expired(record_max_age) 清超龄无主记录。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store, idle_ttl=300, record_max_age=259200.0)
+        orphan_id = "agent:s1:paas_sandbox_skill"
+        store.put(orphan_id, {"sandbox_id": "sbx-orphan"}, token="tok-orphan")
+        # 无自有条目，sweep 仅执行 delete_expired GC；记录太新鲜(max_age 3 天)不被删
+        defer_manager._sweep_once()
+        self.assertEqual(store.get(orphan_id), {"sandbox_id": "sbx-orphan"})
+        # 直测 delete_expired 超龄删除语义（max_age=0 全删）
+        removed = store.delete_expired(max_age=0)
+        self.assertEqual(removed, 1)
+
+    def test_register_runtime_conflict_rules(self):
+        """同名同实例幂等返回；同名异实例抛 ValueError。"""
+        resolver = _make_fake_resolver(default_runtime="local")
+        backend = _FakeBackend()
+        resolver.register_runtime("local_x", backend)
+        resolver.register_runtime("local_x", backend)  # 同实例幂等
+        self.assertIs(resolver._backends["local_x"], backend)
+        with self.assertRaises(ValueError):
+            resolver.register_runtime("local_x", _FakeBackend())  # 同名异实例
+        resolver.close()
+
+    def test_concurrent_pod_race_only_one_wins(self):
+        """多 pod 竞态：并发 delete_if_token(key, same_token) 恰好 1 个成功、其余失败。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        key = "agent:s1:paas_sandbox_pdf"
+        store.put(key, {"sandbox_id": "sbx-1"}, token="tok-1")
+        n_threads = 8
+        barrier = threading.Barrier(n_threads)
+        success: list[int] = []
+        lock = threading.Lock()
+
+        def try_delete():
+            barrier.wait()
+            ok = store.delete_if_token(key, "tok-1")
+            if ok:
+                with lock:
+                    success.append(1)
+
+        threads = [threading.Thread(target=try_delete) for _ in range(n_threads)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(len(success), 1)  # 只有一个 delete_if_token 成功
+        self.assertIsNone(store.get(key))  # 删除后记录不存在
+
+    def test_sweep_skips_close_when_token_consumed_by_mount(self):
+        """集成 CR：请求挂载（get 摘 token）后旧 entry 到期 sweep → 不误杀正在复用沙箱。"""
+        store = RuntimeBackendDeferInMemoryStore()
+        defer_manager = _make_mgr(store, idle_ttl=0)
+        defer_manager.start()
+        resolver = _make_fake_resolver(
+            default_runtime="local", defer_manager=defer_manager, agent_code="agent", session_code="s1"
+        )
+        runtime_name = "paas_sandbox_pdf"
+        runtime_id = resolver.compose_runtime_id(runtime_name)
+        backend = resolver.get_or_create_backend(runtime_name, "fake", {})
+        backend.create("sbx-1")
+        resolver.close()  # 请求 1 结束：defer 持 token
+        # 请求 2 挂载（get 摘 token）并已开始使用；旧 entry 此刻到期触发 sweep
+        defer_manager.get_runtime(runtime_id)
+        with defer_manager._owned_lock:
+            defer_manager._owned[runtime_id].expires_at = time.time() - 1
+        defer_manager._sweep_once()
+        self.assertEqual(backend.close_count, 0)  # token 已摘：不误杀挂载中的沙箱
+        self.assertEqual(store.get(runtime_id), {"sandbox_id": "sbx-1"})  # 记录保留
+        self.assertNotIn(runtime_id, defer_manager._owned)  # 旧 entry pop，交由挂载方 defer
+        defer_manager.shutdown()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent/tests/services/agent/test_chat_release_resources.py
+++ b/src/agent/tests/services/agent/test_chat_release_resources.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+"""ChatCompletionAgent.release_resources 回归测试。
+
+统一走 ``resolver.close()``，销毁语义由 resolver 按延迟销毁策略分流：
+- 延迟销毁启用：close 移交所有权给 LifecycleManager（defer），不立即销毁（D-16）；
+- 未启用：立即销毁（D-02）；
+- release 幂等：多次调用 resolver.close 多次（close 自身幂等），resolver 置 None。
+"""
+
+from __future__ import annotations
+
+import unittest
+from unittest import mock
+
+from aidev_agent.core.tools.runtime_tools.provider import RuntimeBackendResolver
+from aidev_agent.core.tools.runtime_tools.types import RuntimeBackend
+from aidev_agent.services.agent.chat import ChatCompletionAgent
+
+
+class TestReleaseResources(unittest.TestCase):
+    """release_resources 统一走 resolver.close()（销毁语义由 resolver 分流）。"""
+
+    def test_release_resources_calls_close_and_clears_resolver(self):
+        """release_resources 调 resolver.close() 一次，并将 resolver 置 None。"""
+        agent = ChatCompletionAgent()
+        resolver = mock.Mock(spec=RuntimeBackendResolver)
+        agent.runtime_backend_resolver = resolver
+
+        agent.release_resources()
+
+        resolver.close.assert_called_once_with()
+        self.assertIsNone(agent.runtime_backend_resolver)
+
+    def test_release_resources_idempotent(self):
+        """resolver 为 None 时（已释放）重复调用无副作用。"""
+        agent = ChatCompletionAgent()
+        resolver = mock.Mock(spec=RuntimeBackendResolver)
+        agent.runtime_backend_resolver = resolver
+
+        agent.release_resources()
+        agent.release_resources()
+
+        resolver.close.assert_called_once_with()  # 第二次直接跳过
+
+
+class _CloseTrackingBackend(RuntimeBackend):
+    """用于 close 幂等测试的真实 RuntimeBackend 子类。
+
+    ExitStack 通过 __exit__ 触发 close()，记录调用次数验证幂等。
+    """
+
+    def __init__(self) -> None:
+        self.close_count = 0
+
+    def close(self) -> None:  # type: ignore[override]
+        self.close_count += 1
+
+
+class TestCloseIdempotent(unittest.TestCase):
+    """RuntimeBackendResolver.close() 幂等性回归（D-27）。"""
+
+    def test_close_idempotent_preserved(self):
+        """close() 调两次：第二次无异常，backend.close 被调一次（幂等）。"""
+        resolver = RuntimeBackendResolver(default_runtime="local")
+        backend = _CloseTrackingBackend()
+        resolver.register_runtime("paas_sandbox_skill", backend)
+        resolver.resolve_backend("paas_sandbox_skill")  # 触发 enter_context
+
+        # 第一次 close：触发 ExitStack 关闭（调用 backend.close）
+        resolver.close()
+        self.assertEqual(backend.close_count, 1)
+        # 第二次 close：幂等，无异常，不重复 close
+        resolver.close()  # 不应抛异常
+        self.assertEqual(backend.close_count, 1)  # 仍为 1（ExitStack 已重建）
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
背景：
目前 Agent 使用带运行时工具的时候，使用的是 runtime_tools，里面构建的环境每一次都会及时销毁，这会导致模型如果写入了错误的位置，下一次提问重新创建的时候，就会导致无法访问，为此引入了延迟销毁的策略 实现：

1. chat.py 为 build_runtime_backend_resolver 添加了 支持 defer_manager 注入的逻辑，要求启用延迟销毁支持+agent_code和session_code有值
2. graph.py 现在和运行时相关的都迁移到了 runtime_backend_resolver 管理
- 移除了 _runtime_types，register_runtime_type 改为使用 _runtime_backend_resolver 的 register_runtime_cls
- enable_runtime_local、enable_runtime_agent_run、enable_runtime_paas 改为使用 register_runtime_type
- set_bkai_options 中调整了_runtime_backend_resolver的位置
- _prepare_skills 声明 runtime 的时候，使用 get_or_create_backend 来替换原先的实现
3. RuntimeBackendResolver
- 提供对于 _backend_cls 的管理能力, 统一管理 Runtime 类和实例的管理职责。提供 register_runtime_cls、have_runtime_cls 用于管理 _backend_cls
- defer_manager 提供了延迟销毁的能力
- register_runtime 添加了幂等判断，同一个 name 的不同 backend 不可以重复注册
- compose_runtime_id 提供了幂等组装 runtime_id 的部分
- close 提供了关闭/移交所有已注册后端的能力
4. RuntimeBackendDeferInMemoryStore 提供了基于内存的延迟登记
5. RuntimeBackendDeferManager 提供了延迟销毁的能力
- defer 接管 backend 所有权（延迟销毁，resolver close 时调用）
- get_runtime 查询原沙箱挂载 payload（纯透传 store.get，命中即摘 token 续期）
- start 懒启动 sweep 线程，遍历自有 _owned 驱动单阶段 token 销毁；周期末尾 delete_expired 做 GC
6. Local\E2B\Paas 都增加了 save 和 load， 便于保存在执行过程中获取到的状态，例如 sandbox_id