### PR TITLE
feat: 让审批续流与 database event Span 使用应用服务名 --story=1070093903137679449

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -96,7 +96,7 @@ def _approval_resume_worker(session_code: str, username: str, graph_thread_id: s
     # 上下文覆盖生成器构造和排空，保证延迟发布的恢复事件也关联到审批回调。
     with (
         propagated_trace_context(approve_info.get("approval_trace_context")),
-        recording_span("bkplugin.approval.resume", record_exception=False),
+        recording_span("bkplugin.approval.resume", record_exception=False, use_global_tracer=True),
     ):
         _resume_approval(session_code, username, graph_thread_id, interrupts, approve_info)
 

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_tracing.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/event_tracing.py
@@ -2,7 +2,7 @@
 
 from contextlib import contextmanager
 
-from aidev_agent.utils.tracing import get_agent_tracer, propagated_trace_context
+from aidev_agent.utils.tracing import propagated_trace_context, recording_span
 
 try:
     from opentelemetry.trace import SpanKind, StatusCode
@@ -13,27 +13,27 @@ except ImportError:
 @contextmanager
 def event_span(name: str, envelope: dict, *, producer: bool = False, attributes: dict | None = None):
     value = envelope.get("value") or {}
-    with propagated_trace_context(value.get("traceContext")):
-        tracer = get_agent_tracer(__name__)
-        if tracer is None:
-            yield None
-            return
-        options = {
-            "attributes": {
+    kind = None
+    if SpanKind is not None:
+        kind = SpanKind.PRODUCER if producer else SpanKind.CONSUMER
+    with (
+        propagated_trace_context(value.get("traceContext")),
+        recording_span(
+            name,
+            kind=kind,
+            use_global_tracer=True,
+            record_exception=False,
+            attributes={
                 "messaging.system": "database",
                 "event.name": envelope.get("name", ""),
                 **(attributes or {}),
             },
-            "record_exception": False,
-            "set_status_on_exception": False,
-        }
-        if SpanKind is not None:
-            options["kind"] = SpanKind.PRODUCER if producer else SpanKind.CONSUMER
-        with tracer.start_as_current_span(name, **options) as span:
-            try:
-                yield span
-            except Exception as error:
-                span.set_attribute("error.type", type(error).__name__)
-                if StatusCode is not None:
-                    span.set_status(StatusCode.ERROR)
-                raise
+        ) as span,
+    ):
+        try:
+            yield span
+        except Exception as error:
+            span.set_attribute("error.type", type(error).__name__)
+            if StatusCode is not None:
+                span.set_status(StatusCode.ERROR)
+            raise

--- a/src/plugins/aidev_bkplugin/tests/database_events/test_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/database_events/test_tracing.py
@@ -10,7 +10,9 @@ def spans(monkeypatch):
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("test"))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr(tracing, "_agent_tracer", tracer)
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: tracer)
     yield exporter
     provider.shutdown()
 

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume_tracing.py
@@ -16,7 +16,9 @@ def resume_case(monkeypatch):
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
     provider.add_span_processor(SimpleSpanProcessor(exporter))
-    monkeypatch.setattr(tracing, "_agent_tracer", provider.get_tracer("test"))
+    tracer = provider.get_tracer("test")
+    monkeypatch.setattr(tracing, "_agent_tracer", tracer)
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: tracer)
     monkeypatch.setattr(ApprovalStateHandler, "check_resume", lambda *_: True)
     monkeypatch.setattr(approval_resume, "AgentBuilder", MagicMock())
     executor = MagicMock()
@@ -57,3 +59,25 @@ def test_approval_reader_keeps_callback_context_from_same_record(monkeypatch, ne
         ApprovalStateHandler().fetch_approve_result("session")["approval_trace_context"]
         == fields["approval_trace_context"]
     )
+
+
+def test_approval_resume_span_uses_application_service_name(resume_case, monkeypatch):
+    from opentelemetry.sdk.resources import Resource
+
+    exporter, _ = resume_case
+    module_exporter = InMemorySpanExporter()
+    module_provider = TracerProvider(resource=Resource.create({"service.name": "ai-skill-stag-default"}))
+    module_provider.add_span_processor(SimpleSpanProcessor(module_exporter))
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: module_provider.get_tracer("module"))
+    monkeypatch.setattr(
+        ApprovalStateHandler,
+        "_get_latest_interrupt_record",
+        lambda *_: {"property": {"builtin_property": {"approve_result": "approved"}}},
+    )
+    try:
+        approval_resume._approval_resume_worker("session", "author", "thread", [{"id": "approval"}])
+        resumed = next(span for span in module_exporter.get_finished_spans() if span.name == "bkplugin.approval.resume")
+        assert resumed.resource.attributes["service.name"] == "ai-skill-stag-default"
+        assert not any(span.name == "bkplugin.approval.resume" for span in exporter.get_finished_spans())
+    finally:
+        module_provider.shutdown()

--- a/src/plugins/aidev_bkplugin/tests/services/test_event_tracing.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_event_tracing.py
@@ -1,0 +1,27 @@
+from aidev_agent.utils import tracing
+from aidev_bkplugin.services.event_tracing import event_span
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+def test_event_span_uses_application_service_name(monkeypatch):
+    agent_exporter = InMemorySpanExporter()
+    module_exporter = InMemorySpanExporter()
+    agent_provider = TracerProvider(resource=Resource.create({"service.name": "ai-skill-stag"}))
+    module_provider = TracerProvider(resource=Resource.create({"service.name": "ai-skill-stag-default"}))
+    agent_provider.add_span_processor(SimpleSpanProcessor(agent_exporter))
+    module_provider.add_span_processor(SimpleSpanProcessor(module_exporter))
+    monkeypatch.setattr(tracing, "_agent_tracer", agent_provider.get_tracer("agent"))
+    monkeypatch.setattr(tracing.trace, "get_tracer", lambda _: module_provider.get_tracer("module"))
+    try:
+        with event_span("database_event.publish", {"name": "AIDEV_CHAT_RESUME_READY"}, producer=True):
+            pass
+        published = module_exporter.get_finished_spans()[0]
+        assert published.name == "database_event.publish"
+        assert published.resource.attributes["service.name"] == "ai-skill-stag-default"
+        assert not agent_exporter.get_finished_spans()
+    finally:
+        agent_provider.shutdown()
+        module_provider.shutdown()


### PR DESCRIPTION
## 背景

审批续流与 database event Span 仍走 Agent 私有 Tracer，APM 上的 `service.name` 与已对齐的 wxbot / MCP / 流式模型子 Span 不一致。

## 原因

`bkplugin.approval.resume` 使用默认 `recording_span`，`event_span()` 手开 `get_agent_tracer`。两者都会落到 Agent 私有服务名。

## 改动内容

- `bkplugin.approval.resume` 改为 `recording_span(..., use_global_tracer=True)`
- `event_span()` 改为同一开关，覆盖 `database_event.publish` / `database_event.claim`
- 保留 PRODUCER/CONSUMER、`error.type`、不记录消息体
- 测试夹具同时挂 Agent tracer 与应用 tracer，并增加 service.name 断言

## 收益

审批续流与 database event 在 APM 中归入 `appcode + module`，与 wxbot / MCP 同一服务。

## 测试验证

- bkplugin：`tests/services/test_approval_resume_tracing.py`、`tests/services/test_event_tracing.py`、`tests/database_events/test_tracing.py`，10 passed
- 目标文件 pre-commit 通过

Made with [Cursor](https://cursor.com)