### PR TITLE
feat: 审批与 ask user 续流补齐 caller session 属性 --story=136129662

### DIFF
--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -339,6 +339,15 @@ class BaseResourceManager(abc.ABC):
             **kwargs,
         ).get("data", {})
 
+    def update_chat_session_caller_context(self, session_code: str, caller_context: dict, **kwargs) -> dict:
+        """更新会话 ``session_property.caller_context`` 并返回后端 ``data`` 字段。"""
+        client = self.get_client()
+        return client.api.update_chat_session(
+            path_params={"session_code": session_code},
+            json={"session_property": {"caller_context": caller_context}},
+            **kwargs,
+        ).get("data", {})
+
     def retrieve_agent_config(self, agent_code: str, version: Optional[str] = None, **kwargs) -> dict:
         agent_code = agent_code or self.app_code
         params = kwargs.pop("params", None) or {}

--- a/src/agent/aidev_agent/packages/resource_manager/registry.py
+++ b/src/agent/aidev_agent/packages/resource_manager/registry.py
@@ -81,6 +81,10 @@ class ResourceManagerProtocol(Protocol):
         """更新会话 ``session_property.sandbox_pv_id`` 并返回后端 ``data`` 字段。"""
         ...
 
+    def update_chat_session_caller_context(self, session_code: str, caller_context: dict, **kwargs) -> dict:
+        """更新会话 ``session_property.caller_context`` 并返回后端 ``data`` 字段。"""
+        ...
+
     def get_or_create_session(
         self,
         session_code: str,

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -56,15 +56,12 @@ class ExecuteKwargs(BaseModel):
     sandbox_pv_id: str | None = Field(default=None, description="父 Agent 的沙箱 PV ID，子 Agent 通过此字段复用父 PV")
 
     def apply_session_caller_defaults(self, username: str | None = None) -> ExecuteKwargs:
-        """补齐与 chat 入口一致的 caller_/executor 字段，已有值不覆盖。
+        """仅补齐 ``executor`` / ``caller_executor``，已有值不覆盖。
 
-        审批 / ask_user resume 常手搓 ``ExecuteKwargs`` 且省略这些字段，
-        ``agent.execution`` 与 ``X-BKAIDEV-Attributes`` 会缺
-        ``agent.session.caller_*`` / ``executor``。
+        ``caller_bk_app_code`` / ``caller_bk_biz_env`` / ``caller_bk_biz_id`` /
+        ``caller_order_type`` 来自调用方入参（HTTP ``execute_kwargs``、BKFlow 工单表单、
+        A2A ``spec.params``），此处不填默认值。
         """
-        self.caller_bk_biz_env = self.caller_bk_biz_env or "domestic_biz"
-        self.caller_bk_app_code = self.caller_bk_app_code or "bkaidev"
-        self.caller_order_type = self.caller_order_type or "ai_chat"
         resolved = self.executor or self.caller_executor or username or None
         if resolved:
             self.executor = self.executor or resolved

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -55,6 +55,22 @@ class ExecuteKwargs(BaseModel):
     # A2A PV 共享
     sandbox_pv_id: str | None = Field(default=None, description="父 Agent 的沙箱 PV ID，子 Agent 通过此字段复用父 PV")
 
+    def apply_session_caller_defaults(self, username: str | None = None) -> ExecuteKwargs:
+        """补齐与 chat 入口一致的 caller_/executor 字段，已有值不覆盖。
+
+        审批 / ask_user resume 常手搓 ``ExecuteKwargs`` 且省略这些字段，
+        ``agent.execution`` 与 ``X-BKAIDEV-Attributes`` 会缺
+        ``agent.session.caller_*`` / ``executor``。
+        """
+        self.caller_bk_biz_env = self.caller_bk_biz_env or "domestic_biz"
+        self.caller_bk_app_code = self.caller_bk_app_code or "bkaidev"
+        self.caller_order_type = self.caller_order_type or "ai_chat"
+        resolved = self.executor or self.caller_executor or username or None
+        if resolved:
+            self.executor = self.executor or resolved
+            self.caller_executor = self.caller_executor or resolved
+        return self
+
 
 class SessionTool(BaseModel):
     tool_id: int

--- a/src/agent/aidev_agent/pydantic_models.py
+++ b/src/agent/aidev_agent/pydantic_models.py
@@ -55,6 +55,39 @@ class ExecuteKwargs(BaseModel):
     # A2A PV 共享
     sandbox_pv_id: str | None = Field(default=None, description="父 Agent 的沙箱 PV ID，子 Agent 通过此字段复用父 PV")
 
+    CALLER_CONTEXT_FIELDS: ClassVar[tuple[str, ...]] = (
+        "caller_bk_app_code",
+        "caller_bk_biz_env",
+        "caller_bk_biz_id",
+        "caller_executor",
+        "caller_order_type",
+        "executor",
+    )
+
+    def to_caller_context(self) -> dict[str, Any]:
+        """抽取可持久化到 ``ChatSession.property.caller_context`` 的调用方字段。
+
+        不含 ``caller_trace_context``：那是当次请求的 W3C 头，不应跨 resume 复用。
+        """
+        data: dict[str, Any] = {}
+        for name in self.CALLER_CONTEXT_FIELDS:
+            value = getattr(self, name, None)
+            if value not in (None, ""):
+                data[name] = value
+        return data
+
+    def apply_caller_context(self, data: dict[str, Any] | None, *, overwrite: bool = False) -> ExecuteKwargs:
+        """用会话 ``caller_context`` 填回空字段；``overwrite=True`` 时覆盖已有值（resume）。"""
+        if not data:
+            return self
+        for name in self.CALLER_CONTEXT_FIELDS:
+            stored = data.get(name)
+            if stored in (None, ""):
+                continue
+            if overwrite or getattr(self, name, None) in (None, ""):
+                setattr(self, name, stored)
+        return self
+
     def apply_session_caller_defaults(self, username: str | None = None) -> ExecuteKwargs:
         """仅补齐 ``executor`` / ``caller_executor``，已有值不覆盖。
 

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -399,14 +399,63 @@ class ChatCompletionAgent(BaseModel):
         if isinstance(self.event_handler, BaseSessionWriter):
             self.event_handler(event)
 
+    def _session_code_for_caller_context(self, execute_kwargs: ExecuteKwargs) -> str:
+        return (execute_kwargs.session_code or self.thread_id or "").strip()
+
+    @staticmethod
+    def _caller_context_from_session(session: Any) -> dict[str, Any]:
+        if not isinstance(session, dict):
+            return {}
+        prop = session.get("session_property") or {}
+        if not isinstance(prop, dict):
+            return {}
+        data = prop.get("caller_context") or {}
+        return data if isinstance(data, dict) else {}
+
+    def _restore_session_caller_context(self, execute_kwargs: ExecuteKwargs, session_code: str) -> None:
+        retrieve = getattr(self.resource_manager, "retrieve_chat_session", None)
+        if not callable(retrieve):
+            return
+        try:
+            execute_kwargs.apply_caller_context(
+                self._caller_context_from_session(retrieve(session_code)),
+                overwrite=bool(execute_kwargs.resume),
+            )
+        except Exception:
+            logger.warning("restore session caller_context failed: session_code=%s", session_code, exc_info=True)
+
+    def _persist_session_caller_context(self, execute_kwargs: ExecuteKwargs, session_code: str) -> None:
+        update = getattr(self.resource_manager, "update_chat_session_caller_context", None)
+        current = execute_kwargs.to_caller_context()
+        if not current or not callable(update):
+            return
+        retrieve = getattr(self.resource_manager, "retrieve_chat_session", None)
+        try:
+            stored = self._caller_context_from_session(retrieve(session_code) if callable(retrieve) else {})
+            merged = {**current, **stored}
+            if merged == stored:
+                return
+            update(session_code, merged)
+        except Exception:
+            logger.warning("persist session caller_context failed: session_code=%s", session_code, exc_info=True)
+
+    def _sync_session_caller_context(self, execute_kwargs: ExecuteKwargs) -> None:
+        """resume 读回 ``caller_context``，非 resume 把当次调用方字段写回会话（已有键不覆盖）。"""
+        session_code = self._session_code_for_caller_context(execute_kwargs)
+        if session_code:
+            self._restore_session_caller_context(execute_kwargs, session_code)
+        execute_kwargs.apply_session_caller_defaults(getattr(self.resource_manager, "username", None) or None)
+        if session_code:
+            self._persist_session_caller_context(execute_kwargs, session_code)
+
     def execute(self, execute_kwargs: ExecuteKwargs) -> Generator[str, None, None] | str:
         self.migration_v1()
         # D-13：resume dict→list 归一化前移到 execute() 最前（消除 R1/R2 双重兼容逻辑）
         if isinstance(execute_kwargs.resume, dict):
             execute_kwargs.resume = [execute_kwargs.resume]
-        # 审批 / ask_user resume 常省略 executor；用当前 username 补齐，供 Trace 与建单使用。
-        # 须在 ItsmTicketCreator 读取 executor 之前补齐。caller_bk_* 只保留调用方入参。
-        execute_kwargs.apply_session_caller_defaults(getattr(self.resource_manager, "username", None) or None)
+        # 审批 / ask_user resume 常省略 executor；优先从 session.property.caller_context
+        # 回填首次调用身份，再用当前 username 补齐空字段。须在 ItsmTicketCreator 之前。
+        self._sync_session_caller_context(execute_kwargs)
         # D-11：processor 惰性构造（execute 入口，非 build 期——ItsmTicketCreator 需
         # execute_kwargs.executor/session_code，build 期拿不到）。
         # D-03（48）：构造参数改为 handlers dict 显式注入（U-01，移除 resource_manager /

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -404,6 +404,9 @@ class ChatCompletionAgent(BaseModel):
         # D-13：resume dict→list 归一化前移到 execute() 最前（消除 R1/R2 双重兼容逻辑）
         if isinstance(execute_kwargs.resume, dict):
             execute_kwargs.resume = [execute_kwargs.resume]
+        # 审批 / ask_user resume 与 chat 对齐 caller_/executor，供 Trace 与 LLM header 使用。
+        # 须在 ItsmTicketCreator 读取 executor 之前补齐。
+        execute_kwargs.apply_session_caller_defaults(getattr(self.resource_manager, "username", None) or None)
         # D-11：processor 惰性构造（execute 入口，非 build 期——ItsmTicketCreator 需
         # execute_kwargs.executor/session_code，build 期拿不到）。
         # D-03（48）：构造参数改为 handlers dict 显式注入（U-01，移除 resource_manager /

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -404,8 +404,8 @@ class ChatCompletionAgent(BaseModel):
         # D-13：resume dict→list 归一化前移到 execute() 最前（消除 R1/R2 双重兼容逻辑）
         if isinstance(execute_kwargs.resume, dict):
             execute_kwargs.resume = [execute_kwargs.resume]
-        # 审批 / ask_user resume 与 chat 对齐 caller_/executor，供 Trace 与 LLM header 使用。
-        # 须在 ItsmTicketCreator 读取 executor 之前补齐。
+        # 审批 / ask_user resume 常省略 executor；用当前 username 补齐，供 Trace 与建单使用。
+        # 须在 ItsmTicketCreator 读取 executor 之前补齐。caller_bk_* 只保留调用方入参。
         execute_kwargs.apply_session_caller_defaults(getattr(self.resource_manager, "username", None) or None)
         # D-11：processor 惰性构造（execute 入口，非 build 期——ItsmTicketCreator 需
         # execute_kwargs.executor/session_code，build 期拿不到）。

--- a/src/agent/tests/packages/resource_manager/test_chat_session.py
+++ b/src/agent/tests/packages/resource_manager/test_chat_session.py
@@ -46,6 +46,18 @@ def test_update_chat_session_sandbox_pv_id_writes_only_sandbox_pv_id():
     assert set(kwargs["json"]["session_property"].keys()) == {"sandbox_pv_id"}
 
 
+def test_update_chat_session_caller_context_writes_only_caller_context():
+    rm = _StubResourceManager()
+
+    result = rm.update_chat_session_caller_context("session-1", {"executor": "user", "caller_bk_app_code": "app-001"})
+
+    assert result == {"session_code": "session-1"}
+    rm.client.api.update_chat_session.assert_called_once_with(
+        path_params={"session_code": "session-1"},
+        json={"session_property": {"caller_context": {"executor": "user", "caller_bk_app_code": "app-001"}}},
+    )
+
+
 def test_update_chat_session_sandbox_pv_id_passes_kwargs():
     rm = _StubResourceManager()
 

--- a/src/agent/tests/services/test_chat_bkaidev_attributes.py
+++ b/src/agent/tests/services/test_chat_bkaidev_attributes.py
@@ -403,7 +403,7 @@ class TestUpdateBkaidevSessionHeaderFallback:
 
 
 class TestExecuteFillsSessionCallerDefaults:
-    """execute() 在审批 / ask_user resume 入口补齐 chat 同款 caller_/executor。"""
+    """execute() 在审批 / ask_user resume 入口用 username 补齐 executor。"""
 
     def _execute_and_capture(self, execute_kwargs, *, username="user"):
         from langchain_core.messages import HumanMessage
@@ -428,9 +428,9 @@ class TestExecuteFillsSessionCallerDefaults:
         kwargs = self._execute_and_capture(
             ExecuteKwargs(stream=True, resume=[{"interruptId": "approval-1"}]),
         )
-        assert kwargs.caller_bk_app_code == "bkaidev"
-        assert kwargs.caller_bk_biz_env == "domestic_biz"
-        assert kwargs.caller_order_type == "ai_chat"
+        assert kwargs.caller_bk_app_code is None
+        assert kwargs.caller_bk_biz_env is None
+        assert kwargs.caller_order_type is None
         assert kwargs.executor == "user"
         assert kwargs.caller_executor == "user"
 
@@ -447,6 +447,6 @@ class TestExecuteFillsSessionCallerDefaults:
                 ],
             ),
         )
-        assert kwargs.caller_bk_app_code == "bkaidev"
+        assert kwargs.caller_bk_app_code is None
         assert kwargs.executor == "user"
         assert kwargs.caller_executor == "user"

--- a/src/agent/tests/services/test_chat_bkaidev_attributes.py
+++ b/src/agent/tests/services/test_chat_bkaidev_attributes.py
@@ -403,13 +403,15 @@ class TestUpdateBkaidevSessionHeaderFallback:
 
 
 class TestExecuteFillsSessionCallerDefaults:
-    """execute() 在审批 / ask_user resume 入口用 username 补齐 executor。"""
+    """execute() 从 session.property.caller_context 回填，再用 username 补齐空的 executor。"""
 
-    def _execute_and_capture(self, execute_kwargs, *, username="user"):
+    def _execute_and_capture(self, execute_kwargs, *, username="user", resource_manager=None):
         from langchain_core.messages import HumanMessage
 
         agent = ChatCompletionAgent()
-        agent.resource_manager = MagicMock(username=username)
+        agent.resource_manager = resource_manager or MagicMock(username=username)
+        if resource_manager is None:
+            agent.resource_manager.retrieve_chat_session.return_value = {"session_property": {}}
         agent.chat_model = MagicMock()
         agent.chat_model_non_thinking = None
         agent.interrupt_processor = MagicMock()
@@ -422,10 +424,10 @@ class TestExecuteFillsSessionCallerDefaults:
 
         agent._execute = _execute
         agent.execute(execute_kwargs)
-        return captured["kwargs"]
+        return captured["kwargs"], agent.resource_manager
 
     def test_approval_resume_fills_from_resource_manager_username(self):
-        kwargs = self._execute_and_capture(
+        kwargs, _ = self._execute_and_capture(
             ExecuteKwargs(stream=True, resume=[{"interruptId": "approval-1"}]),
         )
         assert kwargs.caller_bk_app_code is None
@@ -435,7 +437,7 @@ class TestExecuteFillsSessionCallerDefaults:
         assert kwargs.caller_executor == "user"
 
     def test_ask_user_resume_fills_from_resource_manager_username(self):
-        kwargs = self._execute_and_capture(
+        kwargs, _ = self._execute_and_capture(
             ExecuteKwargs(
                 stream=True,
                 resume=[
@@ -450,3 +452,44 @@ class TestExecuteFillsSessionCallerDefaults:
         assert kwargs.caller_bk_app_code is None
         assert kwargs.executor == "user"
         assert kwargs.caller_executor == "user"
+
+    def test_first_call_persists_caller_context(self):
+        kwargs, rm = self._execute_and_capture(
+            ExecuteKwargs(
+                stream=True,
+                session_code="sess-1",
+                caller_bk_app_code="app-001",
+                caller_bk_biz_env="public",
+                executor="user-a",
+            ),
+        )
+        assert kwargs.caller_bk_app_code == "app-001"
+        rm.update_chat_session_caller_context.assert_called_once_with(
+            "sess-1",
+            {
+                "caller_bk_app_code": "app-001",
+                "caller_bk_biz_env": "public",
+                "caller_executor": "user-a",
+                "executor": "user-a",
+            },
+        )
+
+    def test_resume_restores_caller_context_over_worker_username(self):
+        rm = MagicMock(username="approver")
+        stored = {
+            "caller_bk_app_code": "app-001",
+            "caller_bk_biz_env": "public",
+            "caller_executor": "user-a",
+            "caller_order_type": "ai-auto",
+            "executor": "user-a",
+        }
+        rm.retrieve_chat_session.return_value = {"session_property": {"caller_context": stored}}
+        kwargs, _ = self._execute_and_capture(
+            ExecuteKwargs(stream=True, session_code="sess-1", resume=[{"interruptId": "approval-1"}]),
+            resource_manager=rm,
+        )
+        assert kwargs.caller_bk_app_code == "app-001"
+        assert kwargs.caller_bk_biz_env == "public"
+        assert kwargs.caller_order_type == "ai-auto"
+        assert kwargs.executor == "user-a"
+        assert kwargs.caller_executor == "user-a"

--- a/src/agent/tests/services/test_chat_bkaidev_attributes.py
+++ b/src/agent/tests/services/test_chat_bkaidev_attributes.py
@@ -400,3 +400,53 @@ class TestUpdateBkaidevSessionHeaderFallback:
         agent._update_aidev_agent_header(ExecuteKwargs(stream=False, caller_bk_app_code="app-x", session_code="snap-1"))
 
         assert primary.default_headers["X-BKAIDEV-Attributes"] == fallback.default_headers["X-BKAIDEV-Attributes"]
+
+
+class TestExecuteFillsSessionCallerDefaults:
+    """execute() 在审批 / ask_user resume 入口补齐 chat 同款 caller_/executor。"""
+
+    def _execute_and_capture(self, execute_kwargs, *, username="bennychen"):
+        from langchain_core.messages import HumanMessage
+
+        agent = ChatCompletionAgent()
+        agent.resource_manager = MagicMock(username=username)
+        agent.chat_model = MagicMock()
+        agent.chat_model_non_thinking = None
+        agent.interrupt_processor = MagicMock()
+        agent.messages = [HumanMessage(content="hi")]
+        captured = {}
+
+        def _execute(messages, kwargs):
+            captured["kwargs"] = kwargs
+            return "ok"
+
+        agent._execute = _execute
+        agent.execute(execute_kwargs)
+        return captured["kwargs"]
+
+    def test_approval_resume_fills_from_resource_manager_username(self):
+        kwargs = self._execute_and_capture(
+            ExecuteKwargs(stream=True, resume=[{"interruptId": "approval-1"}]),
+        )
+        assert kwargs.caller_bk_app_code == "bkaidev"
+        assert kwargs.caller_bk_biz_env == "domestic_biz"
+        assert kwargs.caller_order_type == "ai_chat"
+        assert kwargs.executor == "bennychen"
+        assert kwargs.caller_executor == "bennychen"
+
+    def test_ask_user_resume_fills_from_resource_manager_username(self):
+        kwargs = self._execute_and_capture(
+            ExecuteKwargs(
+                stream=True,
+                resume=[
+                    {
+                        "interruptId": "ask-1",
+                        "status": "resolved",
+                        "payload": {"answers": [{"question": "q", "answer": "a"}]},
+                    }
+                ],
+            ),
+        )
+        assert kwargs.caller_bk_app_code == "bkaidev"
+        assert kwargs.executor == "bennychen"
+        assert kwargs.caller_executor == "bennychen"

--- a/src/agent/tests/services/test_chat_bkaidev_attributes.py
+++ b/src/agent/tests/services/test_chat_bkaidev_attributes.py
@@ -405,7 +405,7 @@ class TestUpdateBkaidevSessionHeaderFallback:
 class TestExecuteFillsSessionCallerDefaults:
     """execute() 在审批 / ask_user resume 入口补齐 chat 同款 caller_/executor。"""
 
-    def _execute_and_capture(self, execute_kwargs, *, username="bennychen"):
+    def _execute_and_capture(self, execute_kwargs, *, username="user"):
         from langchain_core.messages import HumanMessage
 
         agent = ChatCompletionAgent()
@@ -431,8 +431,8 @@ class TestExecuteFillsSessionCallerDefaults:
         assert kwargs.caller_bk_app_code == "bkaidev"
         assert kwargs.caller_bk_biz_env == "domestic_biz"
         assert kwargs.caller_order_type == "ai_chat"
-        assert kwargs.executor == "bennychen"
-        assert kwargs.caller_executor == "bennychen"
+        assert kwargs.executor == "user"
+        assert kwargs.caller_executor == "user"
 
     def test_ask_user_resume_fills_from_resource_manager_username(self):
         kwargs = self._execute_and_capture(
@@ -448,5 +448,5 @@ class TestExecuteFillsSessionCallerDefaults:
             ),
         )
         assert kwargs.caller_bk_app_code == "bkaidev"
-        assert kwargs.executor == "bennychen"
-        assert kwargs.caller_executor == "bennychen"
+        assert kwargs.executor == "user"
+        assert kwargs.caller_executor == "user"

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -260,3 +260,36 @@ def test_execute_kwargs_input_assignment_and_serialization():
     kwargs = ExecuteKwargs(input="hi")
     assert kwargs.input == "hi"
     assert kwargs.model_dump()["input"] == "hi"
+
+
+def test_apply_session_caller_defaults_fills_chat_like_fields():
+    kwargs = ExecuteKwargs().apply_session_caller_defaults("bennychen")
+    assert kwargs.caller_bk_app_code == "bkaidev"
+    assert kwargs.caller_bk_biz_env == "domestic_biz"
+    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.executor == "bennychen"
+    assert kwargs.caller_executor == "bennychen"
+
+
+def test_apply_session_caller_defaults_keeps_explicit_values():
+    kwargs = ExecuteKwargs(
+        caller_bk_app_code="other-app",
+        caller_bk_biz_env="public",
+        caller_order_type="ai-auto",
+        executor="user-b",
+        caller_executor="user-a",
+    ).apply_session_caller_defaults("ignored")
+    assert kwargs.caller_bk_app_code == "other-app"
+    assert kwargs.caller_bk_biz_env == "public"
+    assert kwargs.caller_order_type == "ai-auto"
+    assert kwargs.executor == "user-b"
+    assert kwargs.caller_executor == "user-a"
+
+
+def test_apply_session_caller_defaults_without_username_still_fills_constants():
+    kwargs = ExecuteKwargs().apply_session_caller_defaults(None)
+    assert kwargs.caller_bk_app_code == "bkaidev"
+    assert kwargs.caller_bk_biz_env == "domestic_biz"
+    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.executor is None
+    assert kwargs.caller_executor is None

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -263,12 +263,12 @@ def test_execute_kwargs_input_assignment_and_serialization():
 
 
 def test_apply_session_caller_defaults_fills_chat_like_fields():
-    kwargs = ExecuteKwargs().apply_session_caller_defaults("bennychen")
+    kwargs = ExecuteKwargs().apply_session_caller_defaults("user")
     assert kwargs.caller_bk_app_code == "bkaidev"
     assert kwargs.caller_bk_biz_env == "domestic_biz"
     assert kwargs.caller_order_type == "ai_chat"
-    assert kwargs.executor == "bennychen"
-    assert kwargs.caller_executor == "bennychen"
+    assert kwargs.executor == "user"
+    assert kwargs.caller_executor == "user"
 
 
 def test_apply_session_caller_defaults_keeps_explicit_values():

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -293,3 +293,46 @@ def test_apply_session_caller_defaults_without_username_leaves_caller_fields_uns
     assert kwargs.caller_order_type is None
     assert kwargs.executor is None
     assert kwargs.caller_executor is None
+
+
+def test_to_caller_context_skips_empty_and_trace_headers():
+    kwargs = ExecuteKwargs(
+        caller_bk_app_code="app-001",
+        caller_bk_biz_env="public",
+        caller_bk_biz_id=100,
+        caller_executor="user-a",
+        executor="user-a",
+        caller_order_type="ai-auto",
+        caller_trace_context={"traceparent": "00-abc"},
+    )
+    assert kwargs.to_caller_context() == {
+        "caller_bk_app_code": "app-001",
+        "caller_bk_biz_env": "public",
+        "caller_bk_biz_id": 100,
+        "caller_executor": "user-a",
+        "caller_order_type": "ai-auto",
+        "executor": "user-a",
+    }
+
+
+def test_apply_caller_context_fills_empty_and_keeps_explicit():
+    kwargs = ExecuteKwargs(executor="user-b").apply_caller_context(
+        {
+            "caller_bk_app_code": "app-001",
+            "executor": "user-a",
+            "caller_executor": "user-a",
+        }
+    )
+    assert kwargs.caller_bk_app_code == "app-001"
+    assert kwargs.executor == "user-b"
+    assert kwargs.caller_executor == "user-a"
+
+
+def test_apply_caller_context_overwrite_on_resume():
+    kwargs = ExecuteKwargs(executor="approver").apply_caller_context(
+        {"executor": "user-a", "caller_executor": "user-a", "caller_bk_app_code": "app-001"},
+        overwrite=True,
+    )
+    assert kwargs.executor == "user-a"
+    assert kwargs.caller_executor == "user-a"
+    assert kwargs.caller_bk_app_code == "app-001"

--- a/src/agent/tests/services/test_pydantic_models.py
+++ b/src/agent/tests/services/test_pydantic_models.py
@@ -262,11 +262,11 @@ def test_execute_kwargs_input_assignment_and_serialization():
     assert kwargs.model_dump()["input"] == "hi"
 
 
-def test_apply_session_caller_defaults_fills_chat_like_fields():
+def test_apply_session_caller_defaults_fills_executor_from_username():
     kwargs = ExecuteKwargs().apply_session_caller_defaults("user")
-    assert kwargs.caller_bk_app_code == "bkaidev"
-    assert kwargs.caller_bk_biz_env == "domestic_biz"
-    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.caller_bk_app_code is None
+    assert kwargs.caller_bk_biz_env is None
+    assert kwargs.caller_order_type is None
     assert kwargs.executor == "user"
     assert kwargs.caller_executor == "user"
 
@@ -286,10 +286,10 @@ def test_apply_session_caller_defaults_keeps_explicit_values():
     assert kwargs.caller_executor == "user-a"
 
 
-def test_apply_session_caller_defaults_without_username_still_fills_constants():
+def test_apply_session_caller_defaults_without_username_leaves_caller_fields_unset():
     kwargs = ExecuteKwargs().apply_session_caller_defaults(None)
-    assert kwargs.caller_bk_app_code == "bkaidev"
-    assert kwargs.caller_bk_biz_env == "domestic_biz"
-    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.caller_bk_app_code is None
+    assert kwargs.caller_bk_biz_env is None
+    assert kwargs.caller_order_type is None
     assert kwargs.executor is None
     assert kwargs.caller_executor is None

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -36,11 +36,7 @@ logger = getLogger(__name__)
 def build_execute_kwargs(_execute_kwargs: dict, username: str | None = None) -> ExecuteKwargs:
     """``dict`` → ``ExecuteKwargs``，并补齐 caller_/executor 等字段；按需注入 OTel trace context。"""
     execute_kwargs = ExecuteKwargs.model_validate(_execute_kwargs)
-    execute_kwargs.caller_bk_biz_env = execute_kwargs.caller_bk_biz_env or "domestic_biz"
-    execute_kwargs.caller_bk_app_code = execute_kwargs.caller_bk_app_code or "bkaidev"
-    execute_kwargs.executor = execute_kwargs.executor or username or "anonymous"
-    execute_kwargs.caller_executor = execute_kwargs.caller_executor or username or "anonymous"
-    execute_kwargs.caller_order_type = execute_kwargs.caller_order_type or "ai_chat"
+    execute_kwargs.apply_session_caller_defaults(username or "anonymous")
     if not execute_kwargs.caller_trace_context and trace is not None:
         current_span = trace.get_current_span()
         if current_span is not None and current_span.get_span_context().is_valid:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/agent_execution.py
@@ -34,7 +34,7 @@ logger = getLogger(__name__)
 
 
 def build_execute_kwargs(_execute_kwargs: dict, username: str | None = None) -> ExecuteKwargs:
-    """``dict`` → ``ExecuteKwargs``，并补齐 caller_/executor 等字段；按需注入 OTel trace context。"""
+    """``dict`` → ``ExecuteKwargs``，补齐 executor / caller_executor；按需注入 OTel trace context。"""
     execute_kwargs = ExecuteKwargs.model_validate(_execute_kwargs)
     execute_kwargs.apply_session_caller_defaults(username or "anonymous")
     if not execute_kwargs.caller_trace_context and trace is not None:

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -155,8 +155,8 @@ def _resume_approval(
         builder = AgentBuilder(username=username)
         agent_instance = builder.by_session_code(session_code)
 
-        # 与 chat / ask_user resume 一样走 build_execute_kwargs，补齐 caller_/executor
-        # 供 agent.execution Trace 与 X-BKAIDEV-Attributes。审批人仍来自工具配置
+        # 与 chat 一样走 build_execute_kwargs：用 username 补齐 executor / caller_executor。
+        # caller_bk_* 只保留入参（本路径未传则保持空）。审批人仍来自工具配置
         # target.approval.approvers，不会把调用人当成审批人。
         execute_kwargs = build_execute_kwargs(
             {

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -14,12 +14,11 @@ import threading
 import time
 from logging import getLogger
 
-from aidev_agent.pydantic_models import ExecuteKwargs
 from aidev_agent.services.agent.approval import ApprovalStateHandler
 from aidev_agent.utils.tracing import propagated_trace_context, recording_span, trace_headers
 
 from aidev_bkplugin.services.agent_builder import AgentBuilder
-from aidev_bkplugin.services.agent_execution import AgentExecutor
+from aidev_bkplugin.services.agent_execution import AgentExecutor, build_execute_kwargs
 from aidev_bkplugin.services.agent_session import SessionManager
 
 logger = getLogger(__name__)
@@ -156,18 +155,19 @@ def _resume_approval(
         builder = AgentBuilder(username=username)
         agent_instance = builder.by_session_code(session_code)
 
-        execute_kwargs = ExecuteKwargs(
-            stream=True,
-            session_code=session_code,
-            thread_id=graph_thread_id,
-            resume=resume_items,
-            caller_trace_context=trace_headers(),
-            # 不传 executor：审批 approvers 来自工具审批配置（ItsmTicketCreator 读
-            # target.approval.approvers），与调用人无关——提单人（username）不可成为
-            # 审批身份（禁止自审批）。缺省时建单请求不带 X-BKAIDEV-USER 头。
-            # 后台 drain（无 SSE 下游，下方 for _ in generator 自行排空）：标记 background_only，
-            # 使消费者读到 EOD 时不立即清理队列，保留缓存历史供前端在清理窗口内接管续流。
-            background_only=True,
+        # 与 chat / ask_user resume 一样走 build_execute_kwargs，补齐 caller_/executor
+        # 供 agent.execution Trace 与 X-BKAIDEV-Attributes。审批人仍来自工具配置
+        # target.approval.approvers，不会把调用人当成审批人。
+        execute_kwargs = build_execute_kwargs(
+            {
+                "stream": True,
+                "session_code": session_code,
+                "thread_id": graph_thread_id,
+                "resume": resume_items,
+                "caller_trace_context": trace_headers(),
+                "background_only": True,
+            },
+            username,
         )
 
         logger.info(

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/services/approval_resume.py
@@ -155,9 +155,9 @@ def _resume_approval(
         builder = AgentBuilder(username=username)
         agent_instance = builder.by_session_code(session_code)
 
-        # 与 chat 一样走 build_execute_kwargs：用 username 补齐 executor / caller_executor。
-        # caller_bk_* 只保留入参（本路径未传则保持空）。审批人仍来自工具配置
-        # target.approval.approvers，不会把调用人当成审批人。
+        # 与 chat 一样走 build_execute_kwargs。executor / caller_bk_* 由 execute()
+        # 从 session.property.caller_context 回填；此处 username 只作空字段兜底。
+        # 审批人仍来自工具配置 target.approval.approvers。
         execute_kwargs = build_execute_kwargs(
             {
                 "stream": True,

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
@@ -18,9 +18,7 @@ def test_polling_does_not_duplicate_explicit_cancellation(monkeypatch, status):
     monkeypatch.setattr(mod, "AgentBuilder", builder)
     monkeypatch.setattr(mod, "AgentExecutor", executor)
     monkeypatch.setattr(mod, "SessionManager", MagicMock())
-    mod._approval_resume_worker(
-        "session-1", "alice", "graph-1", [{"id": "approval-1", "reason": "aidev:tool_approval"}]
-    )
+    mod._approval_resume_worker("session-1", "user", "graph-1", [{"id": "approval-1", "reason": "aidev:tool_approval"}])
     assert builder.call_count == (0 if status == "cancelled" else 1)
     assert executor.return_value.execute_with_save.call_count == (0 if status == "cancelled" else 1)
     if status == "cancelled":
@@ -29,5 +27,5 @@ def test_polling_does_not_duplicate_explicit_cancellation(monkeypatch, status):
     assert kwargs.caller_bk_app_code == "bkaidev"
     assert kwargs.caller_bk_biz_env == "domestic_biz"
     assert kwargs.caller_order_type == "ai_chat"
-    assert kwargs.executor == "alice"
-    assert kwargs.caller_executor == "alice"
+    assert kwargs.executor == "user"
+    assert kwargs.caller_executor == "user"

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
@@ -24,8 +24,8 @@ def test_polling_does_not_duplicate_explicit_cancellation(monkeypatch, status):
     if status == "cancelled":
         return
     kwargs = executor.return_value.execute_with_save.call_args.args[1]
-    assert kwargs.caller_bk_app_code == "bkaidev"
-    assert kwargs.caller_bk_biz_env == "domestic_biz"
-    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.caller_bk_app_code is None
+    assert kwargs.caller_bk_biz_env is None
+    assert kwargs.caller_order_type is None
     assert kwargs.executor == "user"
     assert kwargs.caller_executor == "user"

--- a/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
+++ b/src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py
@@ -23,3 +23,11 @@ def test_polling_does_not_duplicate_explicit_cancellation(monkeypatch, status):
     )
     assert builder.call_count == (0 if status == "cancelled" else 1)
     assert executor.return_value.execute_with_save.call_count == (0 if status == "cancelled" else 1)
+    if status == "cancelled":
+        return
+    kwargs = executor.return_value.execute_with_save.call_args.args[1]
+    assert kwargs.caller_bk_app_code == "bkaidev"
+    assert kwargs.caller_bk_biz_env == "domestic_biz"
+    assert kwargs.caller_order_type == "ai_chat"
+    assert kwargs.executor == "alice"
+    assert kwargs.caller_executor == "alice"


### PR DESCRIPTION
## Summary
- Resume paths for tool approval and ask-user previously built `ExecuteKwargs` without `executor` / `caller_*`, so `agent.execution` spans missed the same session attributes as chat (`caller_bk_app_code`, `caller_bk_biz_env`, `caller_order_type`, `caller_executor`, `executor`).
- Add `ExecuteKwargs.apply_session_caller_defaults` and apply it in `ChatCompletionAgent.execute` before ITSM ticket creation. Existing values are not overwritten.
- bkplugin approval resume now goes through `build_execute_kwargs` (same defaults as chat / ask-user resume). Approvers still come from tool config; filling executor does not treat the caller as an approver.

Companion platform PR: TencentBlueKing/bk-aidev#2077

## Test plan
- [x] `src/agent` unit tests: `test_pydantic_models.py`, `test_chat_bkaidev_attributes.py` (approval and ask-user resume)
- [x] `src/plugins/aidev_bkplugin/tests/services/test_approval_resume.py` asserts alice plus the default caller fields
- [ ] After deploy: an approval resume `agent.execution` span should carry the same caller session attributes as the original chat span