### PR TITLE
feat: 从 docSchema 双读解析本轮引用资源 --story=138029049

### DIFF
--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -1569,6 +1569,17 @@ class ChatAgentBuilder:
     - Chat 专属字段读 ``self.ctx.chat.{temperature, max_tokens, auth_headers, checkpointer, ...}``。
     """
 
+    # docSchema tag 的 data.type → 装配期资源形状：tool / mcp 按 code 收窄，知识库按数字 id，
+    # 文件与产物按 PV 相对路径；skill 走渐进式披露（只交出描述、正文按需拉取），全量挂载成本极低，
+    # 且 options.skills 非空还是 runtime 沙箱工具链的开关，故不参与收窄。
+    DOC_SCHEMA_TAG_TYPES = {
+        "tool": ("tool", "code"),
+        "mcp": ("mcp", "code"),
+        "doc": ("knowledgebase", "id"),
+        "knowledgebase": ("knowledgebase", "id"),
+        "artifact": ("file", "path"),
+    }
+
     def __init__(self, ctx: AgentBuildContext):
         self.ctx = ctx
         self._specific_resources: list[dict] = []
@@ -2158,9 +2169,45 @@ class ChatAgentBuilder:
                 f"ChatAgentBuilder: handling last human message with resources in session_context_data->[{item}]"
             )
             if item.get("role") == PromptRole.USER.value:
-                # item.get("extra") 有可能为 None, 和 item.get("extra", {}) 不等价
-                extra = item.get("extra") or {}
-                resources = extra.get("resources") or []
+                resources = self._resolve_last_human_resources(item)
                 self._file_resources = [resource for resource in resources if resource.get("type") == "file"]
                 self._specific_resources = [resource for resource in resources if resource.get("type") != "file"]
                 break
+
+    @classmethod
+    def _resolve_last_human_resources(cls, item: dict) -> list[dict]:
+        """取本轮用户消息声明的资源：优先 docSchema，缺省时降级 extra.resources。
+
+        ``docSchema`` 是前端输入框富文本结构。只要该键存在就以它为唯一事实源——空数组代表
+        本轮确实没有引用任何资源，此时不回退旧字段。
+        """
+        doc_schema = item.get("docSchema")
+        if doc_schema is not None:
+            return cls._convert_doc_schema_to_resources(doc_schema)
+        # item.get("extra") 有可能为 None, 和 item.get("extra", {}) 不等价
+        extra = item.get("extra") or {}
+        return extra.get("resources") or []
+
+    @classmethod
+    def _convert_doc_schema_to_resources(cls, doc_schema: Any) -> list[dict]:
+        """把 docSchema 的 tag 节点转成装配期资源形状，text 节点、未知 type 与空 value 忽略。"""
+        if not isinstance(doc_schema, list):
+            return []
+        resources: list[dict] = []
+        for node in [node for line in doc_schema if isinstance(line, list) for node in line]:
+            if not isinstance(node, dict) or node.get("type") != "tag":
+                continue
+            data = node.get("data") or {}
+            mapping = cls.DOC_SCHEMA_TAG_TYPES.get(data.get("type") or "")
+            value = data.get("value")
+            if mapping is None or value in (None, ""):
+                continue
+            resource_type, value_key = mapping
+            if value_key == "id":
+                try:
+                    value = int(value)
+                except (TypeError, ValueError):
+                    logger.warning("ChatAgentBuilder: docSchema 知识库 tag value 非数字 id->[%s]", value)
+                    continue
+            resources.append({"type": resource_type, value_key: value})
+        return resources

--- a/src/agent/aidev_agent/utils/migrations.py
+++ b/src/agent/aidev_agent/utils/migrations.py
@@ -120,6 +120,8 @@ def _convert_chat_session_content_v1(record: dict) -> dict | None:
 
     - ``role``/``content`` 原样透传（非归一）。
     - ``property.extra`` → ChatPrompt ``extra`` 字段（含 command 等协议字段）。
+    - ``property.docSchema`` → ChatPrompt 顶层 ``docSchema``（前端富文本结构，声明本轮引用资源）；
+      缺省时不塞键，装配期借此判定是否降级读 ``extra.resources``。
     - 平铺顶层字段回嵌 ``builtin_property``
         - tool_calls/tool_call_id/duration/message_id/error/type/activity_type
         - convert 链读取的 turn_id/status/created_at/artifacts
@@ -166,4 +168,6 @@ def _convert_chat_session_content_v1(record: dict) -> dict | None:
             "builtin_property": builtin_property,
         }
     )
+    if property_data.get("docSchema") is not None:
+        prompt["docSchema"] = property_data["docSchema"]
     return prompt

--- a/src/agent/tests/services/test_chat.py
+++ b/src/agent/tests/services/test_chat.py
@@ -1208,6 +1208,63 @@ def test_chat_agent_builder_separates_file_resources_from_config_resources():
     assert builder._specific_resources == [{"type": "tool", "code": "search"}]
 
 
+def _make_doc_schema_chat_ctx(doc_schema, resources: list[dict]):
+    ctx = _make_dummy_chat_ctx()
+    ctx.session_context_data = [
+        {
+            "role": PromptRole.USER.value,
+            "content": "请分析这些文件",
+            "docSchema": doc_schema,
+            "extra": {"resources": resources},
+        }
+    ]
+    return ctx
+
+
+def _tag(tag_type: str, value: str) -> dict:
+    return {"type": "tag", "data": {"label": value, "value": value, "type": tag_type}}
+
+
+@pytest.mark.parametrize(
+    "doc_schema, expected_specific, expected_files",
+    [
+        # docSchema 优先于 extra.resources；text 节点与 skill tag 均不参与收窄
+        (
+            [
+                [
+                    _tag("tool", "weather_query"),
+                    {"type": "text", "text": " "},
+                    _tag("mcp", "bk-itsm-prod-ticket"),
+                    _tag("skill", "file-kit"),
+                    _tag("doc", "259"),
+                    _tag("knowledgebase", "260"),
+                    _tag("artifact", "outputs/report.pdf"),
+                ]
+            ],
+            [
+                {"type": "tool", "code": "weather_query"},
+                {"type": "mcp", "code": "bk-itsm-prod-ticket"},
+                {"type": "knowledgebase", "id": 259},
+                {"type": "knowledgebase", "id": 260},
+            ],
+            [{"type": "file", "path": "outputs/report.pdf"}],
+        ),
+        # 空数组代表本轮未引用资源，不回退 extra.resources
+        ([], [], []),
+        ([[]], [], []),
+    ],
+)
+def test_chat_agent_builder_prefers_doc_schema_over_extra_resources(doc_schema, expected_specific, expected_files):
+    from aidev_agent.services.agent.chat import ChatAgentBuilder
+
+    ctx = _make_doc_schema_chat_ctx(doc_schema, [{"type": "tool", "code": "legacy"}])
+
+    builder = ChatAgentBuilder(ctx)
+
+    assert builder._specific_resources == expected_specific
+    assert builder.file_resources == expected_files
+
+
 def test_agent_builds_llm_history_with_exact_non_image_file_references():
     agent = ChatCompletionAgent(
         chat_history=[

--- a/src/agent/tests/utils/test_migrations.py
+++ b/src/agent/tests/utils/test_migrations.py
@@ -147,3 +147,23 @@ def test_migration_chat_session_context_from_chat_session_contents_v1_merges_bui
     assert bp["status"] == "complete"  # 基底保留（平铺 None 未覆盖）
     assert bp["message_id"] == "base-mid"  # 基底独有键保留
     assert bp["artifacts"] == [{"name": "a.txt"}]  # 非 None 平铺键写入
+
+
+@pytest.mark.parametrize(
+    "property_data, expected",
+    [
+        ({"docSchema": [[{"type": "tag", "data": {"label": "t", "value": "t", "type": "tool"}}]]}, "present"),
+        ({"docSchema": []}, "present"),  # 空数组代表本轮无引用，须保留以阻止降级
+        ({"docSchema": None}, "absent"),
+        ({}, "absent"),
+    ],
+)
+def test_migration_chat_session_context_from_chat_session_contents_v1_lifts_doc_schema(property_data, expected):
+    record = {"id": "1", "role": "user", "content": "你好", "property": property_data}
+
+    result = migration_chat_session_context_from_chat_session_contents_v1([record])[0]
+
+    if expected == "present":
+        assert result["docSchema"] == property_data["docSchema"]
+    else:
+        assert "docSchema" not in result


### PR DESCRIPTION
## 背景

TAPD [#138029049](https://tapd.woa.com/tapd_fe/70093903/story/detail/1070093903138029049)：前端把本轮引用写进 `property.docSchema`；SDK 装配必须优先按它收窄 tool / mcp / 知识库 / 文件，缺省才降级 `extra.resources`。

根因 / 现状：

- `_convert_chat_session_content_v1` 只提升 `property.extra` / `builtin_property`，`docSchema` 到不了 `session_context_data`。
- `_handle_last_human_message` 只读 `extra.resources`，形状是 `{type, id|code|path}`。
- 新 tag 是 `{type: tag, data: {label, value, type, icon, description}}`；知识库 type 兼容 `doc` 与旧值 `knowledgebase`。
- 新版 `IInputMenuItem` 没有 `code`，旧 `extra.resources` 路径在新组件库下 tool / mcp 收窄会静默失效。`docSchema` 是新版下唯一可靠路径。
- 问题定性：新增读取路径；历史消息无 `docSchema` 时仍走旧字段，无需刷库。

## 改动

- `_convert_chat_session_content_v1` 在 `property.docSchema is not None` 时提升到 ChatPrompt 顶层；空数组也保留，用来阻止降级。
- `_handle_last_human_message` 拆出 `_resolve_last_human_resources`：键存在则以 `docSchema` 为唯一事实源；缺省 / `null` 才读 `extra.resources`。
- `_convert_doc_schema_to_resources` 只扫 `tag`，按 `DOC_SCHEMA_TAG_TYPES` 转成现有资源形状，因此 `build_tools` / `build_knowledge_bases` / `file_resources` 不用改：
  - `tool` / `mcp` → `{type, code=value}`
  - `doc` / `knowledgebase` → `{type: knowledgebase, id=int(value)}`，转不了就 warning 跳过
  - `artifact` → `{type: file, path=value}`（PV 相对路径）
  - `skill` 不收窄：渐进式披露只交描述，且 `options.skills` 非空是 runtime 沙箱开关
- 否决「同时合并 docSchema 与 extra.resources」：空数组语义是本轮未引用。

## 测试

- `tests/utils/test_migrations.py::test_migration_chat_session_context_from_chat_session_contents_v1_lifts_doc_schema`：有值 / 空数组提升，`None` / 缺省不塞键。
- `tests/services/test_chat.py::test_chat_agent_builder_prefers_doc_schema_over_extra_resources`：优先解析 tag（含 skill 忽略、知识库双 type、artifact→file）；`[]` / `[[]]` 不回退旧 `extra.resources`。
- 既有 `test_chat_agent_builder_separates_file_resources_from_config_resources` / `test_chat_agent_builder_ignores_none_extra_in_last_user_message` 覆盖降级路径。
- `make test path=tests/services/test_chat.py args="-k 'doc_schema or resources or last_user'"` 通过（10 passed）
- `make test path=tests/utils/test_migrations.py` 通过（14 passed）

## 兼容性

- 非 breaking：无 `docSchema` 时行为与现网一致。
- 无 DDL。未改 `build_tools` / `build_skills` / `build_knowledge_bases` 的过滤键。
- 未改前端 `ai-blueking` 写入；业务层仍只写 `extra.resources`，真实链路要等前端补 `property.docSchema` 后才走新路径。
- 后端存读见配套 PR。

## 关联

tapd: #138029049

后端配套：https://github.com/TencentBlueKing/bk-aidev/pull/2103

发起人：
- @Vellun7