### PR TITLE
feat: 会话附件落草稿卷并支持发送前提交 --story=138056758

### DIFF
--- a/src/agent/aidev_agent/packages/resource_manager/base.py
+++ b/src/agent/aidev_agent/packages/resource_manager/base.py
@@ -36,6 +36,7 @@ from aidev_agent.packages.langchain_core.tools.base import (
     McpToolsResult,
     _extract_mcp_tools_error_detail,
 )
+from aidev_agent.packages.resource_manager.registry import SANDBOX_PV_PROPERTY_KEYS
 from aidev_agent.pydantic_models import AgentConfig
 from aidev_agent.utils.loop import run_coro_sync
 from aidev_agent.utils.tracing import CLIENT_SPAN_KIND, recording_span, trace_headers
@@ -331,11 +332,14 @@ class BaseResourceManager(abc.ABC):
             .get("data", {})
         )
 
-    def update_chat_session_sandbox_pv_id(self, session_code: str, sandbox_pv_id: str, **kwargs) -> dict:
+    def update_chat_session_sandbox_pv_id(
+        self, session_code: str, sandbox_pv_id: str, *, scope: str = "session", **kwargs
+    ) -> dict:
+        property_key = SANDBOX_PV_PROPERTY_KEYS[scope]
         client = self.get_client()
         return client.api.update_chat_session(
             path_params={"session_code": session_code},
-            json={"session_property": {"sandbox_pv_id": sandbox_pv_id}},
+            json={"session_property": {property_key: sandbox_pv_id}},
             **kwargs,
         ).get("data", {})
 

--- a/src/agent/aidev_agent/packages/resource_manager/registry.py
+++ b/src/agent/aidev_agent/packages/resource_manager/registry.py
@@ -25,6 +25,15 @@ if TYPE_CHECKING:
     from aidev_agent.pydantic_models import AgentConfig
 
 
+# 会话沙箱 PV 作用域 → ``ChatSession.session_property`` 字段名。
+# session：agent 运行时挂载的会话卷；
+# draft：只挂给临时上传 sandbox 的草稿卷，运行中的 agent 读不到其中未发送的附件。
+SANDBOX_PV_PROPERTY_KEYS: dict[str, str] = {
+    "session": "sandbox_pv_id",
+    "draft": "sandbox_draft_pv_id",
+}
+
+
 @runtime_checkable
 class ResourceManagerProtocol(Protocol):
     """业务侧资源管理协议。
@@ -77,8 +86,13 @@ class ResourceManagerProtocol(Protocol):
         """取回会话详情（业务返回结构 = 后端 ``data`` 字段）。"""
         ...
 
-    def update_chat_session_sandbox_pv_id(self, session_code: str, sandbox_pv_id: str, **kwargs) -> dict:
-        """更新会话 ``session_property.sandbox_pv_id`` 并返回后端 ``data`` 字段。"""
+    def update_chat_session_sandbox_pv_id(
+        self, session_code: str, sandbox_pv_id: str, *, scope: str = "session", **kwargs
+    ) -> dict:
+        """更新会话属性中的沙箱 PV id 并返回后端 ``data`` 字段。
+
+        ``scope`` 决定写入哪个属性字段，取值见 ``SANDBOX_PV_PROPERTY_KEYS``。
+        """
         ...
 
     def update_chat_session_caller_context(self, session_code: str, caller_context: dict, **kwargs) -> dict:

--- a/src/agent/aidev_agent/services/sandbox_pv_files.py
+++ b/src/agent/aidev_agent/services/sandbox_pv_files.py
@@ -23,7 +23,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from pathlib import PurePosixPath
-from typing import NotRequired, Optional, TypedDict
+from typing import Literal, NamedTuple, NotRequired, Optional, TypedDict
 from urllib.parse import quote, urlencode
 from uuid import uuid4
 
@@ -31,7 +31,10 @@ from bkapi_client_core.exceptions import HTTPResponseError
 from requests import HTTPError as RequestsHTTPError
 
 from aidev_agent.core.tools.runtime_tools.paas_backend import PaasSandboxBackend
-from aidev_agent.packages.resource_manager.registry import ResourceManagerProtocol
+from aidev_agent.packages.resource_manager.registry import (
+    SANDBOX_PV_PROPERTY_KEYS,
+    ResourceManagerProtocol,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +77,26 @@ PV_LIST_PAGE_SLEEP_SECONDS = 0.5  # 翻页前预防性等待，避免打爆 PaaS
 SESSION_VOLUME_PATH = "$STORAGE_PATH/session"
 SESSION_FILES_DIR = "files"
 TEMP_UPLOAD_VOLUME_MOUNT_PATH = "/app/.storage/session"
+# 草稿卷只挂给临时上传 sandbox，不写入 agent 运行时的 volume_mounts，
+# 因此运行中的 agent 在物理上读不到用户尚未发送的附件。
+TEMP_DRAFT_VOLUME_MOUNT_PATH = "/app/.storage/draft"
+
+
+PvScope = Literal["session", "draft"]
+
+
+class _PvScopeSpec(NamedTuple):
+    """一种 PV 作用域的差异项：会话属性字段、卷名前缀、临时 sandbox 挂载点。"""
+
+    property_key: str
+    volume_name_prefix: str
+    mount_path: str
+
+
+PV_SCOPE_SPECS: dict[PvScope, _PvScopeSpec] = {
+    "session": _PvScopeSpec(SANDBOX_PV_PROPERTY_KEYS["session"], "session-pv", TEMP_UPLOAD_VOLUME_MOUNT_PATH),
+    "draft": _PvScopeSpec(SANDBOX_PV_PROPERTY_KEYS["draft"], "session-draft-pv", TEMP_DRAFT_VOLUME_MOUNT_PATH),
+}
 # 临时上传 sandbox 的 PaaS 存活时长，同时作为进程内复用缓存的过期阈值：
 # 复用期内不再建/销毁，到期由 PaaS 自动回收；临界点若命中已回收 sandbox，由 fallback 重建兜底
 # PaaS sandbox ttl_seconds 上限为 30 分钟（1800s）
@@ -179,9 +202,13 @@ def _get_session_op_lock(session_code: str) -> threading.Lock:
         return lock
 
 
-def _get_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str) -> str:
-    """返回未过期的缓存 sandbox_id，无则空串。"""
-    cache_key = (app_code, session_code, volume_id)
+def _get_cached_upload_sandbox(app_code: str, session_code: str, volume_key: str) -> str:
+    """返回未过期的缓存 sandbox_id，无则空串。
+
+    `volume_key` 标识该 sandbox 实际挂载的卷组合（见 `_build_volume_cache_key`），
+    挂载组合变化时不得复用旧容器。
+    """
+    cache_key = (app_code, session_code, volume_key)
     with _UPLOAD_SANDBOX_CACHE_LOCK:
         entry = _UPLOAD_SANDBOX_CACHE.get(cache_key)
         if not entry:
@@ -196,14 +223,19 @@ def _get_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str)
         return sandbox_id
 
 
+def _build_volume_cache_key(draft_volume_id: str, session_volume_id: str) -> str:
+    """临时上传 sandbox 的挂载指纹：草稿卷与会话卷任一变化都不复用旧容器。"""
+    return f"{draft_volume_id}|{session_volume_id}"
+
+
 def _set_cached_upload_sandbox(
     app_code: str,
     session_code: str,
-    volume_id: str,
+    volume_key: str,
     sandbox_id: str,
     created_at: float | None = None,
 ) -> None:
-    cache_key = (app_code, session_code, volume_id)
+    cache_key = (app_code, session_code, volume_key)
     with _UPLOAD_SANDBOX_CACHE_LOCK:
         if created_at is None:
             existing = _UPLOAD_SANDBOX_CACHE.get(cache_key)
@@ -213,8 +245,8 @@ def _set_cached_upload_sandbox(
         _UPLOAD_SANDBOX_CACHE[cache_key] = (sandbox_id, created_at)
 
 
-def _invalidate_cached_upload_sandbox(app_code: str, session_code: str, volume_id: str) -> None:
-    cache_key = (app_code, session_code, volume_id)
+def _invalidate_cached_upload_sandbox(app_code: str, session_code: str, volume_key: str) -> None:
+    cache_key = (app_code, session_code, volume_key)
     with _UPLOAD_SANDBOX_CACHE_LOCK:
         _UPLOAD_SANDBOX_CACHE.pop(cache_key, None)
     # 显式失效时一并清理会话锁，避免锁对象持续累积
@@ -311,16 +343,21 @@ class SandboxPvFileService:
     # 反查 & Client 构造
     # ------------------------------------------------------------------
 
-    def _get_volume_id(self, session_code: str) -> str:
-        """从 `ChatSession.session_property.sandbox_pv_id` 读取 volume_id，缺失即报错。"""
+    def _resolve_volume_id(self, session_code: str, scope: PvScope = "session") -> str:
+        """从会话属性读取指定作用域的 volume_id，缺失即报错。"""
+        spec = PV_SCOPE_SPECS[scope]
         session = self._rm.retrieve_chat_session(session_code) or {}
         session_property = session.get("session_property") or {}
-        volume_id = session_property.get("sandbox_pv_id")
+        volume_id = session_property.get(spec.property_key)
         if not volume_id:
             raise SandboxFileNotFoundError(
-                f"session {session_code} 未初始化沙箱 PersistentVolume（sandbox_pv_id 缺失）"
+                f"session {session_code} 未初始化沙箱 PersistentVolume（{spec.property_key} 缺失）"
             )
         return volume_id
+
+    def _get_volume_id(self, session_code: str) -> str:
+        """从 `ChatSession.session_property.sandbox_pv_id` 读取 volume_id，缺失即报错。"""
+        return self._resolve_volume_id(session_code, "session")
 
     def _get_client(self):
         return self._rm.get_paas_sbx_client(self._executor_info)
@@ -330,8 +367,9 @@ class SandboxPvFileService:
         return {"app_code": app_code, "volume_id": volume_id}
 
     @staticmethod
-    def _extract_volume_id(session: dict) -> str:
-        volume_id = ((session or {}).get("session_property") or {}).get("sandbox_pv_id")
+    def _extract_volume_id(session: dict, scope: PvScope = "session") -> str:
+        property_key = PV_SCOPE_SPECS[scope].property_key
+        volume_id = ((session or {}).get("session_property") or {}).get(property_key)
         return str(volume_id) if volume_id else ""
 
     @staticmethod
@@ -357,8 +395,20 @@ class SandboxPvFileService:
 
     def ensure_volume(self, session_code: str) -> str:
         """幂等获取会话 PV；不存在时创建并写回会话。"""
+        return self._ensure_volume(session_code, "session")
+
+    def ensure_draft_volume(self, session_code: str) -> str:
+        """幂等获取会话草稿 PV；不存在时创建并写回会话。
+
+        草稿卷只挂给临时上传 sandbox，不进入 agent 运行时挂载，
+        用户尚未发送的附件因此对运行中的 agent 不可见。
+        """
+        return self._ensure_volume(session_code, "draft")
+
+    def _ensure_volume(self, session_code: str, scope: PvScope) -> str:
+        spec = PV_SCOPE_SPECS[scope]
         try:
-            return self._get_volume_id(session_code)
+            return self._resolve_volume_id(session_code, scope)
         except SandboxFileNotFoundError:
             pass
 
@@ -366,7 +416,7 @@ class SandboxPvFileService:
         app_code = self._executor_info.get("app_code") or ""
         created_volume_id = ""
         try:
-            volume_name = f"session-pv-{session_code}-{uuid4().hex[:8]}"
+            volume_name = f"{spec.volume_name_prefix}-{session_code}-{uuid4().hex[:8]}"
             response = client.create_agent_sandbox_volume.request(
                 json={"name": volume_name},
                 path_params={"app_code": app_code},
@@ -398,15 +448,14 @@ class SandboxPvFileService:
                     paas_message = str(create_payload.get("message") or "")
                 raise SandboxFileServerError(paas_message or "创建 sandbox PV 返回格式异常")
 
-            updated_session = self._rm.update_chat_session_sandbox_pv_id(
-                session_code,
-                created_volume_id,
-            )
-            persisted_volume_id = self._extract_volume_id(updated_session)
+            updated_session = self._update_session_volume_id(session_code, created_volume_id, scope)
+            persisted_volume_id = self._extract_volume_id(updated_session, scope)
             if not persisted_volume_id:
-                persisted_volume_id = self._extract_volume_id(self._rm.retrieve_chat_session(session_code))
+                persisted_volume_id = self._extract_volume_id(
+                    self._rm.retrieve_chat_session(session_code), scope
+                )
             if not persisted_volume_id:
-                raise SandboxFileServerError(f"会话 {session_code} 的 sandbox PV 写回失败")
+                raise SandboxFileServerError(f"会话 {session_code} 的 {spec.property_key} 写回失败")
 
             if persisted_volume_id != created_volume_id:
                 self._delete_volume_quietly(client, app_code, created_volume_id)
@@ -423,6 +472,16 @@ class SandboxPvFileService:
             if created_volume_id:
                 self._delete_volume_quietly(client, app_code, created_volume_id)
             raise SandboxFileServerError(f"创建会话 sandbox PV 失败: {exc}") from exc
+
+    def _update_session_volume_id(self, session_code: str, volume_id: str, scope: PvScope) -> dict:
+        """把新建卷写回会话属性。
+
+        session 作用域保持原有位置调用，未升级的 ResourceManager 实现同样可用；
+        草稿作用域才附加 `scope`，老实现会因缺少该参数报错并触发上传侧降级。
+        """
+        if scope == "session":
+            return self._rm.update_chat_session_sandbox_pv_id(session_code, volume_id)
+        return self._rm.update_chat_session_sandbox_pv_id(session_code, volume_id, scope=scope)
 
     # ------------------------------------------------------------------
     # 错误映射
@@ -509,14 +568,23 @@ class SandboxPvFileService:
             raise SandboxFileInvalidArgumentError("since/until 必须是 tz-aware datetime（含时区信息）")
         return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
-    def _call_single(self, action: str, session_code: str, params: dict, *, volume_id=None, client=None):
+    def _call_single(
+        self,
+        action: str,
+        session_code: str,
+        params: dict,
+        *,
+        scope: PvScope = "session",
+        volume_id=None,
+        client=None,
+    ):
         """调用 PaaS 单个操作（非分页），返回原始 Response。
 
         `action` 同时用作 Client 属性名与错误日志 tag（当前所有单请求方法都对齐）。
         `volume_id` / `client` 可选：调用方已算好的可传入，避免分页等循环场景重复
         `_get_volume_id`（一次会话 HTTP 查询）与 `_get_client` 构造。
         """
-        volume_id = volume_id or self._get_volume_id(session_code)
+        volume_id = volume_id or self._resolve_volume_id(session_code, scope)
         client = client or self._get_client()
         try:
             resp = getattr(client, action).request(
@@ -552,10 +620,18 @@ class SandboxPvFileService:
             return snapshot
         raise SandboxFileInvalidArgumentError("创建临时 sandbox 需要 file-kit Skill 的已构建镜像")
 
+    @staticmethod
+    def _build_upload_volume_mounts(draft_volume_id: str, session_volume_id: str) -> list[dict[str, str]]:
+        """临时上传 sandbox 的挂载：会话卷用于 promote 落地，草稿卷用于承接未发送附件。"""
+        mounts = [{"volume_id": session_volume_id, "mount_path": TEMP_UPLOAD_VOLUME_MOUNT_PATH}]
+        if draft_volume_id:
+            mounts.append({"volume_id": draft_volume_id, "mount_path": TEMP_DRAFT_VOLUME_MOUNT_PATH})
+        return mounts
+
     def _create_upload_sandbox(
         self,
         session_code: str,
-        volume_id: str,
+        volume_mounts: list[dict[str, str]],
         snapshot: str,
         backend: PaasSandboxBackend,
     ) -> tuple[str, float]:
@@ -566,7 +642,7 @@ class SandboxPvFileService:
             ttl_seconds=TEMP_UPLOAD_SANDBOX_TTL_SECONDS,
             snapshot=snapshot,
             snapshot_entrypoint=[],
-            volume_mounts=[{"volume_id": volume_id, "mount_path": TEMP_UPLOAD_VOLUME_MOUNT_PATH}],
+            volume_mounts=volume_mounts,
         )
         created_at = time.monotonic()
         logger.info(
@@ -608,7 +684,7 @@ class SandboxPvFileService:
                 file_name = f"{stem}-{uuid4().hex[:8]}{suffix}"
             used_names.add(file_name)
             relative_path = posixpath.join(files_dir, file_name)
-            absolute_path = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, relative_path)
+            absolute_path = posixpath.join(absolute_files_dir, file_name)
             result = {
                 "type": "file",
                 "id": relative_path,
@@ -651,6 +727,10 @@ class SandboxPvFileService:
         同一进程的复用期内不再 create/destroy，到期由 PaaS 自动回收；复用失败（容器已被回收）
         时 fallback 重建一次。同一进程内的会话操作加锁串行化，避免单容器并发冲突。
 
+        文件先落到会话草稿卷，`promote_files` 之后才移入会话卷；草稿卷不挂载给 agent 运行时，
+        因此运行中的 agent 读不到用户尚未发送的附件。ResourceManager 不支持草稿卷写回时
+        （老平台）自动降级为直接写会话卷，保持既有行为。
+
         同名文件直接覆盖会话 PV 中已有文件的内容，路径（``files/<filename>``）保持不变；
         同一请求内若出现多个同名文件，后者追加短 hash 后缀（``files/<stem>-<hash><suffix>``）
         以避免互相覆盖，跨请求的同名文件不做去重、按原路径覆盖。
@@ -658,7 +738,11 @@ class SandboxPvFileService:
         validate_session_upload_files(files)
 
         snapshot = self._resolve_upload_snapshot()
-        volume_id = self.ensure_volume(session_code)
+        session_volume_id = self.ensure_volume(session_code)
+        draft_volume_id = self._ensure_draft_volume_or_degrade(session_code)
+        upload_scope: PvScope = "draft" if draft_volume_id else "session"
+        volume_mounts = self._build_upload_volume_mounts(draft_volume_id, session_volume_id)
+        volume_key = _build_volume_cache_key(draft_volume_id, session_volume_id)
         client = self._get_client()
         backend = PaasSandboxBackend(
             app_code=self._executor_info.get("app_code") or "",
@@ -669,15 +753,17 @@ class SandboxPvFileService:
             env_vars={},
         )
         files_dir = SESSION_FILES_DIR
-        absolute_files_dir = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, files_dir)
+        absolute_files_dir = posixpath.join(PV_SCOPE_SPECS[upload_scope].mount_path, files_dir)
 
         # 进程内会话锁：串行化同一进程内的 sandbox exec/upload，避免单容器并发冲突
         with _get_session_op_lock(session_code):
             app_code = self._executor_info.get("app_code") or ""
-            sandbox_id = _get_cached_upload_sandbox(app_code, session_code, volume_id)
+            sandbox_id = _get_cached_upload_sandbox(app_code, session_code, volume_key)
             sandbox_created_at: float | None = None
             if not sandbox_id:
-                sandbox_id, sandbox_created_at = self._create_upload_sandbox(session_code, volume_id, snapshot, backend)
+                sandbox_id, sandbox_created_at = self._create_upload_sandbox(
+                    session_code, volume_mounts, snapshot, backend
+                )
 
             gone_signal: dict[str, bool] = {}
             try:
@@ -693,9 +779,9 @@ class SandboxPvFileService:
                         session_code,
                         sandbox_id,
                     )
-                    _invalidate_cached_upload_sandbox(app_code, session_code, volume_id)
+                    _invalidate_cached_upload_sandbox(app_code, session_code, volume_key)
                     sandbox_id, sandbox_created_at = self._create_upload_sandbox(
-                        session_code, volume_id, snapshot, backend
+                        session_code, volume_mounts, snapshot, backend
                     )
                     try:
                         results = self._write_files_to_sandbox(
@@ -718,9 +804,9 @@ class SandboxPvFileService:
                     session_code,
                     sandbox_id,
                 )
-                _invalidate_cached_upload_sandbox(app_code, session_code, volume_id)
+                _invalidate_cached_upload_sandbox(app_code, session_code, volume_key)
                 sandbox_id, sandbox_created_at = self._create_upload_sandbox(
-                    session_code, volume_id, snapshot, backend
+                    session_code, volume_mounts, snapshot, backend
                 )
                 results = self._write_files_to_sandbox(
                     session_code, sandbox_id, backend, files_dir, absolute_files_dir, files
@@ -728,12 +814,12 @@ class SandboxPvFileService:
             _set_cached_upload_sandbox(
                 app_code,
                 session_code,
-                volume_id,
+                volume_key,
                 sandbox_id,
                 created_at=sandbox_created_at,
             )
 
-        self._attach_image_download_urls(session_code, results)
+        self._attach_image_download_urls(session_code, results, upload_scope)
         succeeded = sum(item["status"] == "success" for item in results)
         return {
             "count": len(results),
@@ -742,7 +828,147 @@ class SandboxPvFileService:
             "results": results,
         }
 
-    def _attach_image_download_urls(self, session_code: str, results: list[dict]) -> None:
+    @staticmethod
+    def _normalize_draft_path(path: str) -> str:
+        """校验草稿相对路径，只接受 `files/<filename>` 这一层，拒绝穿越与绝对路径。"""
+        raw = str(path or "").strip()
+        if not raw:
+            raise SandboxFileInvalidArgumentError("待提交的草稿路径不能为空")
+        normalized = posixpath.normpath(raw)
+        if normalized != raw or normalized.startswith(("/", "..")):
+            raise SandboxFileInvalidArgumentError(f"非法的草稿路径: {path}")
+        if posixpath.dirname(normalized) != SESSION_FILES_DIR:
+            raise SandboxFileInvalidArgumentError(f"草稿路径必须位于 {SESSION_FILES_DIR}/ 下: {path}")
+        return normalized
+
+    @staticmethod
+    def _build_promote_result(moved: list[tuple[str, str]]) -> dict:
+        results = []
+        for path, error in moved:
+            item = {"path": path, "status": "failed" if error else "success"}
+            if error:
+                item["error"] = error
+            results.append(item)
+        succeeded = sum(item["status"] == "success" for item in results)
+        return {
+            "count": len(results),
+            "succeeded": succeeded,
+            "failed": len(results) - succeeded,
+            "results": results,
+        }
+
+    def _move_drafts_into_session(
+        self,
+        sandbox_id: str,
+        backend: PaasSandboxBackend,
+        target_dir: str,
+        paths: list[str],
+    ) -> list[tuple[str, str]]:
+        """在同时挂载草稿卷与会话卷的 sandbox 内逐个搬运，返回 (path, error) 列表。"""
+        mkdir_result = backend.exec_command(sandbox_id, ["mkdir", "-p", target_dir])
+        if mkdir_result.exit_code not in (0, None):
+            raise SandboxFileServerError(
+                f"创建会话文件目录失败: exit_code={mkdir_result.exit_code}, stderr={mkdir_result.stderr}"
+            )
+
+        moved: list[tuple[str, str]] = []
+        for path in paths:
+            source = posixpath.join(TEMP_DRAFT_VOLUME_MOUNT_PATH, path)
+            destination = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, path)
+            # argv 直传，文件名中的引号、空格等字符不经 shell 解析
+            result = backend.exec_command(sandbox_id, ["mv", "-f", source, destination])
+            if result.exit_code in (0, None):
+                moved.append((path, ""))
+                continue
+            error = result.stderr or f"exit_code={result.exit_code}"
+            logger.warning("[pv_files] 草稿搬运失败 path=%s error=%s", path, error)
+            moved.append((path, error))
+        return moved
+
+    def promote_files(self, session_code: str, paths: list[str]) -> dict:
+        """把草稿卷内的附件移入会话卷，使其对后续 agent 可见。
+
+        发送消息前调用：上传阶段文件只落在草稿卷，运行中的 agent 物理上读不到；
+        本方法把本轮真正要发送的附件搬进会话卷，相对路径 ``files/<filename>`` 保持不变。
+        草稿卷不存在说明上传已降级直写会话卷，无需搬运，按成功返回。
+        """
+        if not paths:
+            raise SandboxFileInvalidArgumentError("待提交的草稿路径不能为空")
+        if len(paths) > MAX_SESSION_UPLOAD_FILES:
+            raise SandboxFileInvalidArgumentError(f"单次提交文件不能超过 {MAX_SESSION_UPLOAD_FILES} 个")
+        normalized_paths = [self._normalize_draft_path(path) for path in paths]
+
+        try:
+            draft_volume_id = self._resolve_volume_id(session_code, "draft")
+        except SandboxFileNotFoundError:
+            return self._build_promote_result([(path, "") for path in normalized_paths])
+
+        snapshot = self._resolve_upload_snapshot()
+        session_volume_id = self.ensure_volume(session_code)
+        backend = PaasSandboxBackend(
+            app_code=self._executor_info.get("app_code") or "",
+            bk_username=self._executor_info.get("executor") or "",
+            client=self._get_client(),
+            snapshot=snapshot,
+            snapshot_entrypoint=[],
+            env_vars={},
+        )
+        volume_mounts = self._build_upload_volume_mounts(draft_volume_id, session_volume_id)
+        volume_key = _build_volume_cache_key(draft_volume_id, session_volume_id)
+        target_dir = posixpath.join(TEMP_UPLOAD_VOLUME_MOUNT_PATH, SESSION_FILES_DIR)
+        app_code = self._executor_info.get("app_code") or ""
+
+        # 与上传共用会话锁和 sandbox 复用缓存，避免同一容器上并发 exec
+        with _get_session_op_lock(session_code):
+            sandbox_id = _get_cached_upload_sandbox(app_code, session_code, volume_key)
+            sandbox_created_at: float | None = None
+            if not sandbox_id:
+                sandbox_id, sandbox_created_at = self._create_upload_sandbox(
+                    session_code, volume_mounts, snapshot, backend
+                )
+            try:
+                moved = self._move_drafts_into_session(sandbox_id, backend, target_dir, normalized_paths)
+            except HTTPResponseError as exc:
+                if not self._is_sandbox_gone(exc):
+                    self._raise_mapped_paas_error("promote_files", exc)
+                logger.warning(
+                    "[pv_files] sandbox 疑似已回收，重建重试 session=%s sandbox_id=%s",
+                    session_code,
+                    sandbox_id,
+                )
+                _invalidate_cached_upload_sandbox(app_code, session_code, volume_key)
+                sandbox_id, sandbox_created_at = self._create_upload_sandbox(
+                    session_code, volume_mounts, snapshot, backend
+                )
+                try:
+                    moved = self._move_drafts_into_session(sandbox_id, backend, target_dir, normalized_paths)
+                except HTTPResponseError as exc2:
+                    self._raise_mapped_paas_error("promote_files", exc2)
+            _set_cached_upload_sandbox(
+                app_code,
+                session_code,
+                volume_key,
+                sandbox_id,
+                created_at=sandbox_created_at,
+            )
+
+        return self._build_promote_result(moved)
+
+    def _ensure_draft_volume_or_degrade(self, session_code: str) -> str:
+        """获取草稿卷；ResourceManager 或平台不支持时返回空串，由调用方退回会话卷。"""
+        try:
+            return self.ensure_draft_volume(session_code)
+        except SandboxFileError:
+            logger.warning(
+                "[pv_files] 草稿 PV 不可用，本次上传直接落会话卷 session=%s",
+                session_code,
+                exc_info=True,
+            )
+            return ""
+
+    def _attach_image_download_urls(
+        self, session_code: str, results: list[dict], scope: PvScope = "session"
+    ) -> None:
         """给成功上传的图片签发 download_url，供输入框和首条 user 消息展示。
 
         签发失败不得打垮整批：该文件改为 failed 并写入原因，其它已成功文件不受影响。
@@ -757,7 +983,7 @@ class SandboxPvFileService:
                 continue
             try:
                 url_data = self.get_download_url(
-                    session_code, path, expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN
+                    session_code, path, expires_in=IMAGE_DOWNLOAD_URL_EXPIRES_IN, scope=scope
                 )
             except (SandboxFileError, HTTPResponseError, RequestsHTTPError) as exc:
                 # 文件已成功写入 PV，失败的只是「签发展示用临时 URL」；保留 status=success，
@@ -843,26 +1069,28 @@ class SandboxPvFileService:
             result["truncated"] = True
         return result
 
-    def delete_file(self, session_code: str, path: str) -> None:
+    def delete_file(self, session_code: str, path: str, scope: PvScope = "session") -> None:
         """删除 PV 内指定文件（幂等）。"""
-        self._call_single("delete_file", session_code, {"path": path})
+        self._call_single("delete_file", session_code, {"path": path}, scope=scope)
 
-    def stat_file(self, session_code: str, path: str) -> dict:
+    def stat_file(self, session_code: str, path: str, scope: PvScope = "session") -> dict:
         """查询文件/目录元数据（不存在时 PaaS 返回 `exists=false`，透传）。"""
-        resp = self._call_single("stat_file", session_code, {"path": path})
+        resp = self._call_single("stat_file", session_code, {"path": path}, scope=scope)
         return resp.json() or {}
 
-    def preview_file(self, session_code: str, path: str, max_bytes: int = 65536) -> tuple[bytes, bool]:
+    def preview_file(
+        self, session_code: str, path: str, max_bytes: int = 65536, scope: PvScope = "session"
+    ) -> tuple[bytes, bool]:
         """返回文件前 max_bytes 字节纯文本内容，及是否被截断（`X-Truncated` header）。"""
-        resp = self._call_single(
-            "preview_file", session_code, {"path": path, "max_bytes": max_bytes}
-        )
+        resp = self._call_single("preview_file", session_code, {"path": path, "max_bytes": max_bytes}, scope=scope)
         truncated = str(resp.headers.get("X-Truncated", "false")).lower() == "true"
         return resp.content, truncated
 
-    def get_download_url(self, session_code: str, path: str, expires_in: int = 600) -> dict:
+    def get_download_url(
+        self, session_code: str, path: str, expires_in: int = 600, scope: PvScope = "session"
+    ) -> dict:
         """签发临时 download_url / preview_url。"""
         resp = self._call_single(
-            "get_download_url", session_code, {"path": path, "expires_in": expires_in}
+            "get_download_url", session_code, {"path": path, "expires_in": expires_in}, scope=scope
         )
         return resp.json() or {}

--- a/src/agent/tests/services/test_sandbox_pv_files.py
+++ b/src/agent/tests/services/test_sandbox_pv_files.py
@@ -856,3 +856,226 @@ class TestFillUserImageUrls:
         fill_user_image_urls(file_service, payload)
 
         assert "url" not in payload["content"][0]
+
+
+# ---------------------------------------------------------------------------
+# 草稿卷：上传隔离 + promote 搬运
+# ---------------------------------------------------------------------------
+
+
+SESSION_MOUNT = {"volume_id": "vol-abc", "mount_path": "/app/.storage/session"}
+DRAFT_MOUNT = {"volume_id": "vol-draft", "mount_path": "/app/.storage/draft"}
+
+
+@pytest.fixture
+def draft_service(mock_client):
+    """会话卷与草稿卷都已初始化的 service。"""
+    rm = MagicMock()
+    rm.retrieve_chat_session.return_value = {
+        "session_property": {"sandbox_pv_id": "vol-abc", "sandbox_draft_pv_id": "vol-draft"}
+    }
+    rm.get_paas_sbx_client.return_value = mock_client
+    return SandboxPvFileService(
+        resource_manager=rm,
+        executor_info={
+            "app_code": "test-app",
+            "app_secret": "test-secret",
+            "snapshot": DEFAULT_UPLOAD_SNAPSHOT,
+        },
+    )
+
+
+class TestEnsureDraftVolume:
+    def test_creates_draft_volume_with_scope_kwarg(self, service, resource_manager, mock_client):
+        resource_manager.update_chat_session_sandbox_pv_id.return_value = {
+            "session_property": {"sandbox_draft_pv_id": "vol-draft-new"}
+        }
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-draft-new"})
+
+        assert service.ensure_draft_volume("s1") == "vol-draft-new"
+
+        resource_manager.update_chat_session_sandbox_pv_id.assert_called_once_with(
+            "s1", "vol-draft-new", scope="draft"
+        )
+        create_kwargs = mock_client.create_agent_sandbox_volume.request.call_args.kwargs
+        assert create_kwargs["json"]["name"].startswith("session-draft-pv-s1-")
+
+    def test_reuses_persisted_draft_volume(self, draft_service, mock_client):
+        assert draft_service.ensure_draft_volume("s1") == "vol-draft"
+        mock_client.create_agent_sandbox_volume.request.assert_not_called()
+
+
+class TestDraftUpload:
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_writes_into_draft_volume_and_mounts_both(self, mock_backend_cls, draft_service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        result = draft_service.upload_files("s1", [{"name": "a.txt", "content": b"a"}])
+
+        assert result["succeeded"] == 1
+        # 相对路径不变，变的只是它当前所在的卷
+        assert result["results"][0]["path"] == "files/a.txt"
+        assert backend.upload_file.call_args.args[1] == "/app/.storage/draft/files/a.txt"
+        assert backend.create_sandbox.call_args.kwargs["volume_mounts"] == [SESSION_MOUNT, DRAFT_MOUNT]
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_degrades_to_session_volume_when_manager_lacks_scope(
+        self, mock_backend_cls, service, resource_manager, mock_client
+    ):
+        """老平台的 ResourceManager 不认 scope：上传退回直写会话卷，不整体失败。"""
+
+        def _update(session_code, volume_id, **kwargs):
+            if kwargs.get("scope"):
+                raise TypeError("unexpected keyword argument 'scope'")
+            return {"session_property": {"sandbox_pv_id": volume_id}}
+
+        resource_manager.update_chat_session_sandbox_pv_id.side_effect = _update
+        mock_client.create_agent_sandbox_volume.request.return_value = _mock_paas_response({"uuid": "vol-new"})
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        result = service.upload_files("s1", [{"name": "a.txt", "content": b"a"}])
+
+        assert result["succeeded"] == 1
+        assert backend.upload_file.call_args.args[1] == "/app/.storage/session/files/a.txt"
+        assert backend.create_sandbox.call_args.kwargs["volume_mounts"] == [SESSION_MOUNT]
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_image_download_url_is_signed_against_draft_volume(self, mock_backend_cls, draft_service, mock_client):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+        mock_client.get_download_url.request.return_value = _mock_paas_response({"download_url": "https://img"})
+
+        result = draft_service.upload_files("s1", [{"name": "a.png", "content": b"p", "mime_type": "image/png"}])
+
+        assert result["results"][0]["download_url"] == "https://img"
+        assert mock_client.get_download_url.request.call_args.kwargs["path_params"]["volume_id"] == "vol-draft"
+
+
+class TestPromoteFiles:
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_moves_drafts_into_session_volume(self, mock_backend_cls, draft_service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        result = draft_service.promote_files("s1", ["files/a.txt", "files/b.png"])
+
+        assert result == {
+            "count": 2,
+            "succeeded": 2,
+            "failed": 0,
+            "results": [
+                {"path": "files/a.txt", "status": "success"},
+                {"path": "files/b.png", "status": "success"},
+            ],
+        }
+        commands = [call.args[1] for call in backend.exec_command.call_args_list]
+        assert commands == [
+            ["mkdir", "-p", "/app/.storage/session/files"],
+            ["mv", "-f", "/app/.storage/draft/files/a.txt", "/app/.storage/session/files/a.txt"],
+            ["mv", "-f", "/app/.storage/draft/files/b.png", "/app/.storage/session/files/b.png"],
+        ]
+        assert backend.create_sandbox.call_args.kwargs["volume_mounts"] == [SESSION_MOUNT, DRAFT_MOUNT]
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_reuses_upload_sandbox(self, mock_backend_cls, draft_service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.return_value = SimpleNamespace(stdout="", stderr="", exit_code=0)
+
+        draft_service.upload_files("s1", [{"name": "a.txt", "content": b"a"}])
+        draft_service.promote_files("s1", ["files/a.txt"])
+
+        assert backend.create_sandbox.call_count == 1
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_per_file_failure_is_reported(self, mock_backend_cls, draft_service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.return_value = "sandbox-upload"
+        backend.exec_command.side_effect = [
+            SimpleNamespace(stdout="", stderr="", exit_code=0),
+            SimpleNamespace(stdout="", stderr="No such file or directory", exit_code=1),
+            SimpleNamespace(stdout="", stderr="", exit_code=0),
+        ]
+
+        result = draft_service.promote_files("s1", ["files/gone.txt", "files/ok.txt"])
+
+        assert result["succeeded"] == 1
+        assert result["failed"] == 1
+        assert result["results"][0] == {
+            "path": "files/gone.txt",
+            "status": "failed",
+            "error": "No such file or directory",
+        }
+
+    @patch("aidev_agent.services.sandbox_pv_files.PaasSandboxBackend")
+    def test_rebuilds_sandbox_when_gone(self, mock_backend_cls, draft_service):
+        backend = mock_backend_cls.return_value
+        backend.create_sandbox.side_effect = ["sandbox-upload", "sandbox-upload-2"]
+        backend.exec_command.side_effect = [
+            _mock_http_error(404, "AGENT_SANDBOX_NOT_FOUND"),
+            SimpleNamespace(stdout="", stderr="", exit_code=0),
+            SimpleNamespace(stdout="", stderr="", exit_code=0),
+        ]
+
+        result = draft_service.promote_files("s1", ["files/a.txt"])
+
+        assert result["succeeded"] == 1
+        assert backend.create_sandbox.call_count == 2
+
+    def test_returns_success_when_draft_volume_missing(self, service, mock_client):
+        """上传已降级直写会话卷时无需搬运，按成功返回且不触碰 sandbox。"""
+        result = service.promote_files("s1", ["files/a.txt"])
+
+        assert result == {
+            "count": 1,
+            "succeeded": 1,
+            "failed": 0,
+            "results": [{"path": "files/a.txt", "status": "success"}],
+        }
+        mock_client.create_agent_sandbox_volume.request.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "../../etc/passwd",
+            "files/../../etc/passwd",
+            "/etc/passwd",
+            "files/./a.txt",
+            "files/sub/a.txt",
+            "a.txt",
+            "",
+        ],
+    )
+    def test_rejects_illegal_path(self, draft_service, path):
+        with pytest.raises(SandboxFileInvalidArgumentError):
+            draft_service.promote_files("s1", [path])
+
+    def test_rejects_empty_and_oversized_batch(self, draft_service):
+        with pytest.raises(SandboxFileInvalidArgumentError):
+            draft_service.promote_files("s1", [])
+        with pytest.raises(SandboxFileInvalidArgumentError):
+            draft_service.promote_files("s1", [f"files/{i}.txt" for i in range(MAX_SESSION_UPLOAD_FILES + 1)])
+
+
+class TestScopedSingleFileCalls:
+    def test_delete_file_targets_draft_volume(self, draft_service, mock_client):
+        mock_client.delete_file.request.return_value = _mock_paas_response()
+
+        draft_service.delete_file("s1", "files/a.txt", scope="draft")
+
+        call_kwargs = mock_client.delete_file.request.call_args.kwargs
+        assert call_kwargs["path_params"]["volume_id"] == "vol-draft"
+
+    def test_delete_file_defaults_to_session_volume(self, draft_service, mock_client):
+        mock_client.delete_file.request.return_value = _mock_paas_response()
+
+        draft_service.delete_file("s1", "files/a.txt")
+
+        call_kwargs = mock_client.delete_file.request.call_args.kwargs
+        assert call_kwargs["path_params"]["volume_id"] == "vol-abc"

--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/views/session.py
@@ -325,6 +325,24 @@ class ChatSessionViewSet(PluginViewSet):
             self._raise_pv_exc(exc)
         return Response(data=data)
 
+    @action(["POST"], url_path="pv_files/promote", detail=True)
+    def pv_files_promote(self, request, pk, **kwargs):
+        """把草稿卷内的附件搬进会话 PV，发送消息前调用。"""
+        self._check_session_owner(request, pk, require_access=True)
+        paths = request.data.get("paths")
+        if not isinstance(paths, list) or not paths:
+            raise ClientBlueException(message="paths is required")
+
+        svc = self._make_pv_file_service(request)
+        snapshot = self._resolve_upload_snapshot(PluginResourceManager(username=request.user.username))
+        if snapshot:
+            svc._executor_info["snapshot"] = snapshot
+        try:
+            data = svc.promote_files(session_code=pk, paths=paths)
+        except SandboxFileError as exc:
+            self._raise_pv_exc(exc)
+        return Response(data=data)
+
 
 def _copy_session_content_payload(data):
     """复制写消息 payload，避免改写原始 request.data。"""

--- a/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
+++ b/src/plugins/aidev_bkplugin/tests/views/test_session_pv_files_views.py
@@ -3,7 +3,7 @@
 
 覆盖点：
 - 构造沙箱文件 Service 时正确注入 PluginResourceManager + executor_info
-- 5 个 action 参数透传（GET list / stat / preview / download_url / upload）
+- 6 个 action 参数透传（GET list / stat / preview / download_url / upload / promote）
 - 上传会话归属校验与沙箱文件异常映射
 - 沙箱文件异常 → blueapps 异常映射（404 / 400 / 500）
 - preview 返回 HttpResponse(text/plain) + X-Truncated 头透传
@@ -72,6 +72,7 @@ def _request(
     meta=None,
     path="/pv-files",
     files=None,
+    data=None,
 ):
     return SimpleNamespace(
         query_params=query_params or {},
@@ -80,6 +81,7 @@ def _request(
         COOKIES=cookies or {},
         META=meta or {},
         path=path,
+        data=data or {},
         FILES=SimpleNamespace(getlist=lambda field_name: files or [] if field_name == "files" else []),
     )
 
@@ -431,6 +433,46 @@ class TestPvFilesUpload:
         assert excinfo.value.STATUS_CODE == 400
         instance.upload_files.assert_not_called()
         session_mod.PluginResourceManager.return_value.get_client.return_value.api.retrieve_latest_skill_version_image.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# pv_files_promote
+# ---------------------------------------------------------------------------
+
+
+class TestPvFilesPromote:
+    def test_promote_forwards_paths(self, view, mock_svc):
+        instance, _ = mock_svc
+        promote_result = {
+            "count": 1,
+            "succeeded": 1,
+            "failed": 0,
+            "results": [{"path": "files/a.txt", "status": "success"}],
+        }
+        instance.promote_files.return_value = promote_result
+
+        response = view.pv_files_promote(_request(method="POST", data={"paths": ["files/a.txt"]}), pk="s1")
+
+        assert response.data == promote_result
+        instance.promote_files.assert_called_once_with(session_code="s1", paths=["files/a.txt"])
+
+    @pytest.mark.parametrize("data", [{}, {"paths": []}, {"paths": "files/a.txt"}])
+    def test_promote_rejects_missing_paths(self, view, mock_svc, data):
+        from blueapps.core.exceptions import ClientBlueException
+
+        instance, _ = mock_svc
+        with pytest.raises(ClientBlueException):
+            view.pv_files_promote(_request(method="POST", data=data), pk="s1")
+        instance.promote_files.assert_not_called()
+
+    def test_promote_maps_invalid_argument_to_400(self, view, mock_svc):
+        from blueapps.core.exceptions import ClientBlueException
+
+        instance, _ = mock_svc
+        instance.promote_files.side_effect = SandboxFileInvalidArgumentError("非法的草稿路径")
+        with pytest.raises(ClientBlueException) as excinfo:
+            view.pv_files_promote(_request(method="POST", data={"paths": ["../etc"]}), pk="s1")
+        assert excinfo.value.STATUS_CODE == 400
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## 背景

TAPD [#138056758](https://tapd.woa.com/tapd_fe/70093903/story/detail/1070093903138056758)：用户在输入框选了附件但**还没点发送**，正在运行的 agent 已经能读到它。

根因 / 现状：

- `upload_files` 上传即写会话 PV 的 `files/`，落在 `session_property.sandbox_pv_id` 指向的那一块卷上
- agent 运行时通过 `volume_mounts` 把**整块**会话卷挂到 `$STORAGE_PATH/session`，卷内没有任何目录级隔离手段
- 因此同卷内换目录、加命名前缀、改属性都挡不住 `ls`；要做到"未发送即不可见"，只能让草稿根本不在 agent 挂载的那块卷里
- 定性：不是存量数据问题，是上传链路的设计缺口，每次上传都会复现；不需要刷库

参考 Codex 的做法：附件即时上传到独立草稿区，发送消息时才提交到工作区。本次比 Codex 更严格 —— Codex 的 `$CODEX_HOME/uploads` 对 agent 仍可读，这里的草稿卷根本不进 agent 运行时的 `volume_mounts`。

## 改动

**改动一：卷作用域抽象（`sandbox_pv_files.py`）**

- 新增 `PvScope = Literal["session", "draft"]` 与 `PV_SCOPE_SPECS`，把「property 字段名 / 卷名前缀 / 挂载路径」三元组按 scope 收敛到一处；草稿卷挂载点为 `TEMP_DRAFT_VOLUME_MOUNT_PATH`，与会话卷 `TEMP_UPLOAD_VOLUME_MOUNT_PATH` 并列
- 卷解析与 ensure 统一走 `_resolve_volume_id(session_code, scope)` / `_ensure_volume(session_code, scope)`；对外仍保留 `ensure_volume` / `_get_volume_id` 两个会话语义的薄包装，既有调用方零改动
- `_call_single` 增加 keyword-only 的 `scope`，`delete_file` / `stat_file` / `preview_file` / `get_download_url` 随之支持按卷寻址。取消未发送附件时删的是草稿卷副本，不会误删已发送的同名文件

**改动二：上传落草稿 + 降级**

- `upload_files` 先经 `_ensure_draft_volume_or_degrade` 拿草稿卷；拿不到（RM 不支持 / 平台未升级）时返回空串并**退回直写会话卷**，只记 warning。老环境不会因为缺草稿卷而上传失败，这是本次唯一容许"隔离性降级"的路径
- 临时上传 sandbox 同时挂两块卷（`_build_upload_volume_mounts`），为后续 promote 的同容器搬运做准备
- sandbox 复用缓存键从单个 `volume_id` 换成 `_build_volume_cache_key(draft, session)` 的组合键。不这么做的话，挂着不同卷组合的 sandbox 会被错误复用，promote 时会找不到源文件

**改动三：`promote_files` 提交语义**

- 新增 `promote_files(session_code, paths)`：把草稿卷内附件搬进会话卷的 `files/`，相对路径不变，搬完对 agent 才可见
- 跨卷 `mv` 在 PaaS 侧不可用，改为在同时挂载两卷的临时 sandbox 内 `exec_command(["mv", "-f", src, dst])`；argv 直传不经 shell，文件名里的引号和空格不会被解析
- `_normalize_draft_path` 只接受 `files/<filename>` 这一层，`posixpath.normpath` 后与原串比对，拒绝 `../`、绝对路径、`./` 与多级子目录
- 逐文件搬运，单个失败不影响其余，结果按 `{count, succeeded, failed, results[]}` 返回；sandbox 被回收时（`_is_sandbox_gone`）失效缓存后重建重试一次
- 草稿卷不存在时直接按全成功返回 —— 那说明上传已降级直写会话卷，本来就无需搬运

**改动四：ResourceManager 契约**

- `SANDBOX_PV_PROPERTY_KEYS` 把 scope 映射到 `sandbox_pv_id` / `sandbox_draft_pv_id`，Protocol 与 Base 的 `update_chat_session_sandbox_pv_id` 增加 keyword-only 的 `scope`，默认 `session` 保持既有调用方兼容

**改动五：插件 HTTP 入口**

- `aidev_bkplugin` 暴露 `POST pv_files/promote`，复用 upload 的归属校验与 snapshot 解析路径

被否方案：曾考虑在同一块卷内用 `drafts/` 子目录或命名前缀区分。放弃原因是整卷挂载下这不构成任何隔离，agent 一个 `ls` 就能看到，只是把问题从"可见"降级成"不显眼"。也考虑过按 subpath 挂载卷的一部分，PaaS 侧不支持。

## 性能说明

- promote 与 upload 共用同一把会话锁 `_get_session_op_lock` 和同一套 sandbox 复用缓存，不会额外创建容器；命中缓存时 promote 只有 N 次 `exec_command`
- `_move_drafts_into_session` 先 `mkdir -p` 一次，再逐文件 `mv`，没有循环建目录
- 草稿卷的创建是懒加载：只有真正发生上传时才 ensure，空会话不会多占一块 PV
- 显式声明**故意未做**的部分：草稿卷没有回收 / GC。现有会话卷同样从未回收，本次不扩大范围单独为草稿卷引入清理链路

## 测试

`src/agent`：

- `tests/services/test_sandbox_pv_files.py::TestPromoteFiles` —— 覆盖搬运成功路径、sandbox 复用、单文件失败被单独标记、sandbox 回收后重建重试、草稿卷缺失时按成功返回，以及 7 组非法路径（`../../etc/passwd`、`files/../../etc/passwd`、`/etc/passwd`、`files/./a.txt`、`files/sub/a.txt`、`a.txt`、空串）与空批次 / 超量批次
- `tests/services/test_sandbox_pv_files.py::TestScopedSingleFileCalls` —— 断言 `delete_file` 传 `scope="draft"` 时命中草稿卷 id、不传时命中会话卷 id
- `tests/services/test_sandbox_pv_files.py::TestUploadFiles` —— 断言上传默认落草稿卷，草稿卷不可用时降级写会话卷

`src/plugins/aidev_bkplugin`：

- `tests/views/test_session_pv_files_views.py::TestPvFilesPromote` —— 断言 paths 透传给 service、缺失 / 空数组 / 非列表三种入参被拒、`SandboxFileInvalidArgumentError` 映射为 400

执行结果：

- `uv run pytest tests/services/test_sandbox_pv_files.py` 通过（92 passed）
- `uv run pytest tests/views/test_session_pv_files_views.py` 通过（38 passed）

无预存在失败项。

## 兼容性

- 非 breaking：`scope` 与 `promote_files` 全部是新增；所有既有方法签名的默认值保持 `session`，未传 scope 的调用方行为与改动前完全一致
- `session_property` 新增 `sandbox_draft_pv_id`，读取侧缺字段时走 `SandboxFileNotFoundError` 分支并降级，不影响存量会话
- DB 副作用：只在首次创建草稿卷时写一次 `session_property`，与既有 `sandbox_pv_id` 的写回路径同源，未额外触碰 `auto_now` 字段
- 显式声明未改动的相邻链路：`pv_files` 的 DELETE 路由不在本次范围（属于「取消未发送附件」事项），因此 `scope` 参数目前只在 SDK service 层可用，尚无 HTTP 出口；前端接入（发送前调 promote）同样另开事项

## 关联

tapd: #138056758

发起人：
- @Vellun7
