### PR TITLE
feat: 恢复默认 LangChain Instrumentor 注册 --story=1070093903136959970

### DIFF
--- a/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
+++ b/src/plugins/aidev_bkplugin/aidev_bkplugin/settings.py
@@ -31,6 +31,16 @@ CHAT_GROUP_TYPE = os.environ.get("CHAT_GROUP_TYPE", "qyweixin_chat_group")
 ENABLE_OTEL_TRACE = os.getenv("BKAPP_ENABLE_OTEL_TRACE", "1") == "1"
 BK_APP_OTEL_INSTRUMENT_DB_API = os.getenv("BKAPP_OTEL_INSTRUMENT_DB_API", "1") == "1"
 
+# OpenTelemetry 是可选 extras，未安装时不注册任何额外 instrumentor。
+# 安装方式：pip install aidev-bkplugin[opentelemetry]
+BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS: list = []
+try:
+    from opentelemetry.instrumentation.langchain import LangchainInstrumentor
+
+    BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS = [LangchainInstrumentor()]
+except ImportError:
+    pass
+
 # SaaS运行版本
 RUN_VER = "ieod" if os.environ.get("BKPAAS_ENGINE_REGION", "default") == "ieod" else "open"
 


### PR DESCRIPTION
## 背景

移除默认 LangChain Instrumentor 注册后出现 `agent.execution` Span 缺失。用户确认仅恢复该注册并重启服务后，Span 恢复正常。本次先恢复既有配置，后续继续定位具体的回调和上下文影响。

## 原因

`700059ad9909c5a44b1759671d387432e89c58dd`（#888）删除了默认注册。第三方 Instrumentor 会全局包装 LangChain 回调管理器，不能仅根据 Agent 专用插桩入口保留就排除运行影响。

## 改动内容

恢复 #888 删除的 10 行：可选导入 `LangchainInstrumentor` 并注册到 `BK_APP_OTEL_ADDTIONAL_INSTRUMENTORS`；未安装可选依赖时保留空列表。其余配置与 Span 生命周期实现不变。

## 收益

恢复已由用户回加验证有效的配置，先缓解执行根 Span 缺失。

## 测试验证

- settings 文件语法检查通过。
- 使用导入替身验证可选依赖存在时注册一个 Instrumentor、缺失时保留空列表，两项通过。
- 用户反馈的回加与重启已恢复根 Span，监控页面核实为 completed/OK；这不是本 PR 的新部署验证。
- 完整 pre-commit 已执行，未通过：develop 既有 Ruff 与格式问题位于本次改动之外；自动产生的无关修改已撤回。仓库规则排除了 settings.py，因此另外执行了上述针对性检查。
- 补丁仅恢复一个文件的 10 行，diff 检查通过；未执行完整 SDK 测试或重新部署。
