### PR TITLE
feat: 完善 chat-x 文件上传与引用并调整消息回填字段

### DIFF
--- a/src/frontend/ai-blueking/packages/chat-x/CHANGELOG.md
+++ b/src/frontend/ai-blueking/packages/chat-x/CHANGELOG.md
@@ -4,7 +4,26 @@
 
 ### Breaking Changes
 
+- 用户消息的富文本文档从 `property.extra.docSchema` 移至 `property.docSchema`，与 `extra` 同级；发送、编辑回填及编辑确认后的持久化需使用新字段位置。
+
 - + 号「添加」分组只保留内置「文件」项；移除「图片」项、`MenuItemType` 的 `'image'`，以及导出常量 `IMAGE_UPLOAD_ACCEPT`。图片与其它允许类型都通过「文件」入口（`accept` / `DEFAULT_UPLOAD_ACCEPT`）选择。
+
+### Added
+
+- `ChatInput` / `ChatContainer` 新增 `deleteFile(file: Partial<UploadFile>)` 事件（模板监听 `@delete-file`）：取消输入框附件时携带 `id` 等文件信息，供业务方调用删除接口；UI 立即移除附件，不等待接口结果，成功或失败均不恢复附件。
+- Playground 新增上传、删除及本地文件下载 mock，上传响应包含 `id` / `path`；补充已上传文件和无 `outputId` 的历史附件示例，支持验证引用、预览及菜单过滤行为。
+
+### Changed
+
+- `@` / `+` 的会话文件只收集具有 `outputId` 的条目，不再回退到 URL 或文件名；手动传入的 `artifact.id` 必须使用文件 `outputId`。
+- 上传响应 `path` 映射为附件 `outputId`，上传成功后即可引用、预览；发送时保留该身份，待发送附件、用户消息附件与助手产物共用侧栏预览和下载流程。
+
+- 单文件上传大小限制放宽为严格小于 45 MB（`45 * 1024 * 1024` 字节），文件选择、拖拽、粘贴及 `FileUploadBtn` 共用此限制，大小提示同步更新。
+
+### Fixed
+
+- 修复仅含 `id` 的回填附件无法取消的问题，删除时优先按文件 `id` 匹配。
+- 带 `outputId` 的图片附件在缩略图失效后仍可打开产物预览；取消或发送附件后，同步清理待发送文件的菜单与预览数据。
 
 ## 0.0.52-beta.1 (2026-09-03)
 

--- a/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/chat-bot-new.vue
@@ -47,6 +47,7 @@
       :timezone="timezone"
       :update-tools="customUpdateTools"
       @confirm-share="handleConfirmShare"
+      @delete-file="handleDeleteFile"
       @delete-shortcut="handleDeleteShortcut"
       @model-change="handleModelChange"
       @select-shortcut="handleSelectShortcut"
@@ -204,9 +205,9 @@
     MOCK_TOOLCALL_STATUS_MESSAGES,
     mockArtifactClick,
   } from './mock';
-  import { mockUploadFileToSession } from './upload-file';
+  import { mockDeleteUploadedFile, mockUploadFileToSession } from './upload-file';
 
-  import type { CustomTab, IInputMenuItem, Shortcut, TagSchema } from '../src/types';
+  import type { CustomTab, IInputMenuItem, Shortcut, TagSchema, UploadFile } from '../src/types';
   import type { IToolBtn } from '../src/types/tool';
 
   import '../src/styles/global.scss';
@@ -951,7 +952,7 @@
       messageId: `user_${Date.now()}`,
       status: MessageStatus.Complete,
       // content 仍是纯文本；docSchema 让用户消息把 @ 选中的资源原样还原成标签
-      property: { extra: { docSchema } },
+      property: { docSchema },
     } as UserMessage);
     await new Promise(resolve => setTimeout(resolve, 5000));
   };
@@ -970,6 +971,12 @@
 
   // playground 走本地 mock，不依赖后端网关与 access_token；
   // 真实接入示例见 ./upload-file 的 uploadFileToSession
+  const handleDeleteFile = async (file: Partial<UploadFile>) => {
+    const outputId = file.outputId || file.id;
+    if (outputId) await mockDeleteUploadedFile(outputId);
+    console.log('delete file:', outputId);
+  };
+
   const handleUpload = async (files: File[]) => {
     const responses = await Promise.all(
       files.map(async file => {
@@ -987,7 +994,7 @@
     const target = messages.value.find(item => item.id === message.id);
     if (target) {
       target.content = content as Message['content'];
-      target.property = { ...target.property, extra: { ...target.property?.extra, docSchema } };
+      target.property = { ...target.property, docSchema };
     }
   };
 

--- a/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/mock.ts
@@ -39,11 +39,13 @@ import {
   // CopyIcon,
   DeleteIcon,
   InterruptReason,
+  MessageContentType,
   MessageRole,
   MessageStatus,
   ShareIcon,
   t,
 } from '../src';
+import { createMockUploadedFile, getMockUploadedFileUrls } from './upload-file';
 
 // 模型图标示例：图标为图片地址（string），贴合后端返回的 icon 字段
 const DEEPSEEK_ICON =
@@ -756,6 +758,8 @@ export const MOCK_ARTIFACT_URL_MAP: Record<string, MockArtifactUrl> = MOCK_ARTIF
 export const mockArtifactClick = async (file: AIFileInfo): Promise<MockArtifactUrl> => {
   console.info('mockArtifactClick', file);
   await new Promise(resolve => setTimeout(resolve, 600));
+  const uploadedUrls = getMockUploadedFileUrls(file.outputId);
+  if (uploadedUrls) return uploadedUrls;
   const staticUrls = MOCK_ARTIFACT_STATIC_URL[file.outputId] ?? {};
   const textDownloadUrl = getMockTextDownloadUrl(file.outputId);
   return {
@@ -808,12 +812,30 @@ const mockCreatedAt = (dayOffset: number, hours: number, minutes: number, yearOf
   return date.toISOString();
 };
 
+// 已上传文件样例：可在 @ / + 中引用，也可点击附件在侧栏预览与下载。
+const MOCK_UPLOADED_FILES = [
+  new File(['# 上传文件接入说明\n\n上传响应的 `path` 会保存为 `outputId`。\n\n- 在 @ 或 + 中引用文件\n- 点击附件或标签打开侧栏\n- 在侧栏下载原文件\n'], '上传文件接入说明.md', { type: 'text/markdown' }),
+  new File(['{\n  "service": "chat-x",\n  "uploadLimitMB": 45,\n  "previewEnabled": true\n}'], '上传配置示例.json', { type: 'application/json' }),
+].map(createMockUploadedFile);
+
 // 带文件产物的会话消息，用于 playground 调试 artifacts 展示与 outputId 去重
 export const MOCK_ARTIFACTS_MESSAGES = [
   {
     id: 'mock-artifacts-user',
     role: MessageRole.User,
-    content: '帮我把本周监控方案相关的产出文件都整理出来，方便评审。',
+    content: [
+      { type: MessageContentType.Text, text: '帮我检查上传的接入说明和配置。旧版附件没有 outputId，只展示在消息中，不进入 @ / + 菜单。' },
+      ...MOCK_UPLOADED_FILES.map(file => ({
+        type: MessageContentType.Binary,
+        id: file.id,
+        outputId: file.path,
+        filename: file.name,
+        mimeType: file.mime_type,
+        size: file.size,
+        url: file.download_url,
+      })),
+      { type: MessageContentType.Binary, id: 'legacy-file', filename: '旧版附件（无outputId）.txt', mimeType: 'text/plain', size: 128 },
+    ],
     name: 'user',
     status: MessageStatus.Complete,
     messageId: 'mock-artifacts-user',

--- a/src/frontend/ai-blueking/packages/chat-x/playground/upload-file.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/playground/upload-file.ts
@@ -44,21 +44,52 @@ export interface UploadFileResponse {
 /** mock 上传延时区间（毫秒）：模拟网络往返，便于观察附件从 pending 到 success */
 const MOCK_UPLOAD_DELAY_RANGE = [300, 800] as const;
 
-/**
- * 本地 mock 上传：不依赖后端网关与 access_token，playground 开箱即用。
- *
- * 返回原文件的 blob URL 作为 download_url —— 发送后的消息里附件只剩
- * `url / filename / mimeType / size`（没有 File 引用），只有 url 真实可达
- * 才能看到图片缩略图与全屏预览的实际效果。
- *
- * blob URL 在页面存活期内一直有效，playground 不做回收。
- */
-export async function mockUploadFileToSession(file: File): Promise<{ download_url: string }> {
+/** 本地上传文件按永久 path 保存；预览、下载和删除共用同一份数据。 */
+const mockUploadedFiles = new Map<string, { file: File; url: string }>();
+
+/** 注册预置样例或用户选中的文件，响应结构与上传 API 一致。 */
+export const createMockUploadedFile = (file: File) => {
+  const path = `files/${crypto.randomUUID()}-${file.name}`;
+  const url = URL.createObjectURL(file);
+  mockUploadedFiles.set(path, { file, url });
+  return {
+    type: 'file' as const,
+    id: path,
+    path,
+    name: file.name,
+    mime_type: file.type,
+    size: file.size,
+    status: 'success' as const,
+    download_url: url,
+  };
+};
+
+/** 文本、代码使用 download_url；图片和 PDF 可直接预览，其他二进制格式需后端转码。 */
+export const getMockUploadedFileUrls = (outputId: string) => {
+  const item = mockUploadedFiles.get(outputId);
+  if (!item) return undefined;
+  return {
+    download_url: item.url,
+    preview_url: item.file.type.startsWith('image/') || item.file.name.toLowerCase().endsWith('.pdf')
+      ? item.url
+      : undefined,
+  };
+};
+
+/** 本地 mock 上传保留延时，便于观察 pending → success → 可引用和预览。 */
+export async function mockUploadFileToSession(file: File) {
   const [minDelay, maxDelay] = MOCK_UPLOAD_DELAY_RANGE;
   await new Promise(resolve => setTimeout(resolve, minDelay + Math.random() * (maxDelay - minDelay)));
-
-  return { download_url: URL.createObjectURL(file) };
+  return createMockUploadedFile(file);
 }
+
+export const mockDeleteUploadedFile = async (outputId: string) => {
+  await new Promise(resolve => setTimeout(resolve, 300));
+  const item = mockUploadedFiles.get(outputId);
+  if (!item) return;
+  mockUploadedFiles.delete(outputId);
+  URL.revokeObjectURL(item.url);
+};
 
 /**
  * 批量上传文件

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-container.md
@@ -242,7 +242,7 @@ ai-chat-container（:data-ai-size="size"）
 
 ### 内置「文件产物」Tab
 
-除「执行情况」外，容器内置一个常驻固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话所有 `AssistantMessage.property.artifacts`（按 `outputId` 去重）：
+除「执行情况」外，容器内置一个常驻固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话具有 `outputId` 的助手产物、用户消息附件及输入框中上传成功的待发送附件（按 `outputId` 去重）：
 
 - **常驻挂载 / 默认选中**：容器初始化即通过 `ensureCustomTab` 挂上该 Tab（不展开侧栏）；因 `order: -1` 排在 Tab 栏首位，在用户未主动切换过 Tab 时它就是侧栏的默认面板。不随产物有无增删，无产物时由面板展示整块空态
 - **默认图标**：`ArtifactTabIcon`，16×16 线性折角文档，`fill` 走 `currentColor` 以继承 Tab 选中/默认色
@@ -620,7 +620,7 @@ ai-chat-container（:data-ai-size="size"）
 
 `menuSources` 继承自 [ChatInput](/components/input/chat-input)，一份数组按 `type` 分发到 `/`、`@`、`\` 与左下角 + 号。容器在此之上做了三件事：
 
-**1. 会话产物自动收集**：`menuSources` 中没有 `artifact` 条目时，容器用 [`collectMessageArtifacts`](/utils/#会话产物收集) 从 `messages` 里收集产物补进去——来源是助手消息的 `property.artifacts` 与用户消息里的二进制附件。业务方自己传了 `artifact` 条目时以传入的为准，容器不再自动补。没有产物时 `@` / + 号菜单不会出现「会话产物」分组。
+**1. 会话产物自动收集**：`menuSources` 中没有 `artifact` 条目时，容器用 [`collectMessageArtifacts`](/utils/#会话产物收集) 从 `messages` 里收集产物补进去——来源是具有 `outputId` 的助手消息 `property.artifacts` 与用户消息二进制附件，不再回退到 URL 或文件名。上传响应的 `path` 由输入框映射为 `outputId`，尚未发送的成功附件也会追加到菜单。手动传入的 `artifact.id` 必须是对应文件的 `outputId`。业务方自己传了 `artifact` 条目时以传入的为准，容器不再自动补。没有产物时 `@` / + 号菜单不会出现「会话产物」分组。
 
 **2. 资源引用入口**：容器通过 [useInputMention](/composables/use-input-mention) 提供 `insertMention`，消息区的文件卡片与侧栏产物面板因此能直接把文件「@ 进输入框」，无需逐层透传输入框实例。没有输入框的场景（`Share` 只读态）自动不显示引用按钮。
 
@@ -651,7 +651,7 @@ ai-chat-container（:data-ai-size="size"）
 </script>
 ```
 
-> 用户消息要把 `@` 选中的资源以标签形态回显，需要业务侧把 `onSendMessage` 的 `docSchema` 存进 `message.property.extra.docSchema`，详见 [MentionText](/components/rendering/mention-text)。
+> 用户消息要把 `@` 选中的资源以标签形态回显，需要业务侧把 `onSendMessage` 的 `docSchema` 存进 `message.property.docSchema`，详见 [MentionText](/components/rendering/mention-text)。
 
 ## 模型选择
 
@@ -776,6 +776,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | update:asideCollapsed | `(collapsed: boolean)`          | 折叠态变更请求（`v-model:asideCollapsed`）；受控时是否真的展开取决于外部是否更新该值 |
 | selectShortcut | `(shortcut: Shortcut)`                 | 选择快捷指令（继承自 ChatInput）     |
 | deleteShortcut | —                                      | 删除已选快捷指令（继承自 ChatInput） |
+| deleteFile     | `(file: Partial<UploadFile>)`          | 取消输入框附件（继承自 ChatInput）；业务方根据 `file.id` 调用删除接口，UI 立即移除，不等待结果 |
 | modelChange    | `(model: IModelOption)`                | 切换模型（继承自 ChatInput）         |
 
 ### Slots

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/chat-input.md
@@ -286,8 +286,10 @@ const handleSendMessage = async (
 
 选中「文件」后唤起隐藏 `input[type=file]`，与拖拽 / 粘贴共用同一套 `handleUpload` / `onUpload`。系统选择器与入队校验都走 `accept` prop（默认 `DEFAULT_UPLOAD_ACCEPT`，含图片 / 文档 / 文本 / 代码扩展名）。
 
-- `onUpload` 一次选择传入**全部** `File[]`，返回同序的结果数组（也可对单文件返回单个对象）；元素为 `{ download_url?: string; id?: string; status?: 'failed' | 'success' }`
+- `onUpload` 一次选择传入**全部** `File[]`，返回同序的结果数组（也可对单文件返回单个对象）；元素为 `{ download_url?: string; id?: string; path?: string; status?: 'failed' | 'success' }`
 - 文件自动去重（基于 `name + size + lastModified` 复合键），不会重复上传
+- 上传成功后将响应 `path` 保存为附件的 `outputId`（`id` 缺省时也以 `path` 回填）。具有 `outputId` 的文件立即进入 `@` / `+` 的「会话产物」菜单和容器预览侧栏；发送时保留 `outputId`，已发送附件与助手产物共用引用、预览和下载能力。仅有 `id`、URL 或文件名的旧附件不作为会话产物收集。
+- 取消附件时立即从 UI 移除，并触发 `deleteFile` 事件（模板使用 `@delete-file`），参数为 `Partial<UploadFile>`。业务方可根据 `file.id` 调用删除接口；组件不等待接口结果，成功或失败均不恢复附件。上传中 / 上传失败的附件也会触发事件，此时 `id` 可能为空，由业务方决定是否调用接口。发送后清空列表不会触发此事件。
 - **上传中或存在失败附件时禁止发送**（点击、Enter、`triggerSendMessage` 均拦截）。失败附件需用户删除后才能再发；不要把附件 Pending 映射成 `MessageStatus.Pending`
 - 拖拽只响应从系统拖入的文件（编辑器内部标签拖动不会误触发），悬停时框体切换为蓝色描边 + 浅蓝底
 - 发送成功后待发送列表自动清空；文件加入列表后光标自动回到输入区
@@ -295,7 +297,7 @@ const handleSendMessage = async (
 **个数、大小与格式校验**：
 
 - 列表最多保留 **`MAX_UPLOAD_FILES`（9）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
-- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）** 会被跳过并弹出超大小/个数提示。与已有文件重复的项只去重、不弹这条误导文案。
+- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（45MB，即 `45 * 1024 * 1024` 字节）** 会被跳过并弹出超大小/个数提示。与已有文件重复的项只去重、不弹这条误导文案。
 - **文件类型**：默认使用 `DEFAULT_UPLOAD_ACCEPT`（图片 / 文档 / 文本 / 代码扩展名列表）。系统文件选择框带 `accept` 过滤；选择后、拖拽、粘贴仍会再按扩展名校验，不支持的格式弹出「因格式不支持未添加」并不会入队。可通过 `accept` prop 覆盖（空字符串表示不限制）。
 - 个数上限、重复、大小与类型校验都在 `ChatInput` 的 `handleUpload` 中统一处理（含 + 号菜单唤起的系统文件选择器、拖拽和粘贴）。
 
@@ -505,6 +507,7 @@ const defaultFiles: UploadFile[] = [
 | modelChange       | `(model: IModelOption)`                                               | 用户切换模型                                                 |
 | selectShortcut    | `(shortcut: Shortcut)`                                                | 点击底部快捷指令按钮                                         |
 | deleteShortcut    | -                                                                     | 点击已选快捷指令旁的关闭按钮                                 |
+| deleteFile        | `(file: Partial<UploadFile>)`                                         | 用户取消附件；携带文件 `id`、状态等信息，UI 立即移除，不等待删除接口 |
 
 ### Slots
 
@@ -519,6 +522,8 @@ const defaultFiles: UploadFile[] = [
 | send-icon      | -                                                                | 发送按钮内图标，点击逻辑与样式仍由组件控制               |
 
 ### Expose
+
+`uploadedArtifacts`：只读 `AIFileInfo[]`，包含输入框中已上传且具有 `outputId` 的附件；供容器合并到侧栏预览列表，取消或发送后同步更新。
 
 | 方法名             | 类型                              | 说明                                             |
 | ------------------ | --------------------------------- | ------------------------------------------------ |

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-content.md
@@ -218,6 +218,10 @@ MIME 为 `image/*` 时渲染为图片缩略图（`cursor: zoom-in`）。点击�
 </template>
 ```
 
+## 上传文件预览
+
+具有 `outputId` 且不处于上传中 / 失败态的附件，在 `ChatContainer` 内点击会通过统一的文件产物侧栏预览，使用 `onArtifactClick` 获取预览和下载链接。图片缩略图链接失效时仍可按 `outputId` 重新取链；无 `outputId` 的图片继续使用原有图片预览。
+
 ## API
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/file-upload-btn.md
@@ -42,7 +42,7 @@
 ```
 用户选择文件
   │
-  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（约 2.4MB）→ 加入 toEmit
+  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（45MB）→ 加入 toEmit
   │       size 为 0 或 ≥ 上限 → sizeRejected += 1
   │
   ├─ sizeRejected > 0 → bkui-vue Message.error（formatUploadNotAddedMessage，说明可能超大或超出个数等）
@@ -60,7 +60,7 @@
 | 部分文件因空文件或单文件超大被过滤                           | 弹出错误 toast；若仍有合法文件，**仍触发** `upload`（payload 为合法子集） |
 | 全部被过滤（均为空或超大）                                   | 仅 toast，**不触发** `upload`                                        |
 | `file.size === 0`                                          | 计入未添加提示，不进入 `upload` payload                              |
-| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，约 2.4MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
+| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，45MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
 | 选择后取消                                                   | `files.length === 0`，不触发 `upload`                                |
 
 > `multiple` prop 声明存在但当前模板中 `input` 的 `multiple` 属性为**硬编码**（非 `:multiple="multiple"` 绑定），始终允许多选，该 prop 暂时无实际效果。
@@ -135,7 +135,7 @@
 
 | 事件名 | 参数              | 说明                                                                                      |
 | ------ | ----------------- | ----------------------------------------------------------------------------------------- |
-| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，约 2.4MB）后的数组；个数截断不在此组件内完成 |
+| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，45MB）后的数组；个数截断不在此组件内完成 |
 
 ### Slots
 

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/mention-text.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/mention-text.md
@@ -2,7 +2,7 @@
 
 > 能力域：内容渲染 ｜ 未从包入口导出：内部组件，请通过上层组件使用 ｜ since 0.0.51
 
-MentionText 接收一份 TagSchema 文档（二维数组：行 → 节点），逐行渲染：text 节点输出文本、 tag 节点交给 MentionTag；行间用 <br> 分隔，空白以 pre-wrap 保留。 UserMessage 在 property.extra.docSchema 含标签时用它替代 TextContent。 源码位置：src/components/mention/mention-text.vue。
+MentionText 接收一份 TagSchema 文档（二维数组：行 → 节点），逐行渲染：text 节点输出文本、 tag 节点交给 MentionTag；行间用 <br> 分隔，空白以 pre-wrap 保留。 UserMessage 在 property.docSchema 含标签时用它替代 TextContent。 源码位置：src/components/mention/mention-text.vue。
 
 **关联**：mention-tag（tag 节点的实际渲染者）、user-message（用户消息在文档含标签时改用本组件回显）、text-content（纯文本消息仍走 TextContent）
 
@@ -23,7 +23,7 @@ MentionText 接收一份 TagSchema 文档（二维数组：行 → 节点），�
 ```
 用户在输入框选中资源
   → onSendMessage(content, docSchema)   content 仍是纯文本，不改后端契约
-  → 业务侧把 docSchema 存进 message.property.extra.docSchema
+  → 业务侧把 docSchema 存进 message.property.docSchema
   → UserMessage 检测到文档中存在 tag 节点
   → 用 MentionText 渲染（否则回退 TextContent）
 ```
@@ -35,14 +35,14 @@ MentionText 接收一份 TagSchema 文档（二维数组：行 → 节点），�
 const handleSendMessage = async (content: UserMessage['content'], docSchema: TagSchema) => {
   messages.value.push({
     id, messageId: id, role: MessageRole.User, content,
-    property: { extra: { docSchema } },
+    property: { docSchema },
   });
 };
 
 // 编辑确认
 const handleUserInputConfirm = async (message: Message, content: UserMessage['content'], docSchema: TagSchema) => {
   target.content = content;
-  target.property = { ...target.property, extra: { ...target.property?.extra, docSchema } };
+  target.property = { ...target.property, docSchema };
 };
 ```
 

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/components/user-message.md
@@ -2,7 +2,7 @@
 
 > 能力域：消息系统 ｜ 未从包入口导出：内部组件（入口的同名导出是 TS 类型，不是组件） ｜ since 0.0.20
 
-渲染用户消息：纯文本（非 Markdown）、键值引用、二进制附件与编辑态 ChatInput / ShortcutRender； 正文经 CollapsibleContent 限高 200px，property.extra.docSchema 含标签时改用 MentionText 还原资源标签； 工具栏含 copy / edit / delete。源码位置：src/components/chat-message/user-message/user-message.vue。
+渲染用户消息：纯文本（非 Markdown）、键值引用、二进制附件与编辑态 ChatInput / ShortcutRender； 正文经 CollapsibleContent 限高 200px，property.docSchema 含标签时改用 MentionText 还原资源标签； 工具栏含 copy / edit / delete。源码位置：src/components/chat-message/user-message/user-message.vue。
 
 **关联**：mention-text（文档含标签时用它还原已选资源）、collapsible-content（正文超过 200px 时折叠）、message-render（由 MessageRender 在 role 为 user 时创建）、message-tools（消息工具栏交互与状态由 MessageTools 体系承载）、message-time（createdAt 经工具栏 prepend 插槽展示）、message-container（嵌入列表时由 MessageContainer 管理分组与多选）、chat-input（编辑态普通消息使用 ChatInput）
 
@@ -71,7 +71,7 @@
 
 ## 资源标签回显与正文折叠
 
-**标签回显**：`property.extra.docSchema` 是发送时输入框的富文本文档。**只有文档里真的含标签节点时**才走 [MentionText](/components/rendering/mention-text) 结构化渲染，纯文本文档仍走 `TextContent`——历史消息与第三方消息的表现因此保持不变。`content` 始终是纯文本，后端契约不变。
+**标签回显**：`property.docSchema` 是发送时输入框的富文本文档。**只有文档里真的含标签节点时**才走 [MentionText](/components/rendering/mention-text) 结构化渲染，纯文本文档仍走 `TextContent`——历史消息与第三方消息的表现因此保持不变。`content` 始终是纯文本，后端契约不变。
 
 编辑态同样以 `docSchema` 回填，否则改完这条消息已选资源会退化成纯文本；因此业务侧在 `onInputConfirm` 里要把新的 `docSchema` 一起写回。
 
@@ -260,7 +260,7 @@
 **`editContent` 的初始化逻辑**（仅文本部分，二进制文件通过 `defaultUploadFiles` 恢复）：
 
 ```
-文档含标签      → editContent = property.extra.docSchema（保留已选资源）
+文档含标签      → editContent = property.docSchema（保留已选资源）
 否则 textParts 有值 → editContent = textParts[0]（取第一个文本片段）
 binaryFiles 有值   → 进入编辑模式（editContent 可为空）
 进入编辑态后       → nextTick 后自动 focus，光标落在内容末尾
@@ -374,7 +374,7 @@ binaryFiles 有值   → 进入编辑模式（editContent 可为空）
 | ------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
 | content            | `string \| InputContent[]`                                                                 | 消息内容，字符串或含 text/binary 的数组                                   |
 | createdAt          | `number \| string`                                                                         | 消息创建时间，经 `MessageTools` 的 `#prepend` 插槽交给 `MessageTime` 渲染在工具图标左侧；无值时不展示 |
-| property           | `{ extra?: MessageExtra; artifacts?: AIFileInfo[] }`                                       | 附加属性；本组件消费 `extra.cite` / `shortcut` / `context` / `docSchema`  |
+| property           | `{ docSchema?: TagSchema; extra?: MessageExtra; artifacts?: AIFileInfo[] }`                                       | 附加属性；本组件消费 `docSchema` 与 `extra.cite` / `extra.shortcut` / `extra.context`  |
 | messageTools       | `IToolBtn[]`                                                                               | 自定义用户消息工具组；按 id 与 `CONST_USER_MESSAGE_TOOLS` 合并，`{ id, hidden: true }` 可隐藏 |
 | messageToolsStatus | `MessageToolsStatus`                                                                       | 工具按钮状态，`disabled` 禁用、`hidden` 从 DOM 移除                       |
 | onAction           | `MessageToolsProps['onAction']`                                                            | 工具回调；`copy`/`edit` 有内置行为，`delete` 需外部处理                   |
@@ -422,8 +422,6 @@ type MessageExtra = {
   command?: string;
   pause?: boolean;
   shortcut?: Partial<Shortcut>;
-  /** 发送时输入框的富文本文档；有标签时用于回显与编辑回填 */
-  docSchema?: TagSchema;
   context?: Array<{
     __key: string;
     __label: string;

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/composables/use-message-group.md
@@ -119,17 +119,14 @@ const isExecutionMessage = (m: Message): boolean => {
 
 ## sessionArtifacts 会话级文件产物
 
-`sessionArtifacts` 拍平当前会话所有 `AssistantMessage.property.artifacts`，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。以 **`outputId`** 为会话内唯一键去重（同 `outputId` 视为同一文件），保留最后一次出现的文件信息，列表顺序与「最后一次出现」的相对顺序一致：
+`sessionArtifacts` 收集当前会话具有 `outputId` 的助手产物与用户上传附件，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。以 **`outputId`** 为会话内唯一键去重（同 `outputId` 视为同一文件），保留最后一次出现的文件信息，列表顺序与「最后一次出现」的相对顺序一致：
 
 ```typescript
 const sessionArtifacts = computed(() => {
   // delete + set：同 key 覆盖内容，并把该项挪到 Map 末尾，保证「最后出现」顺序
   const byOutputId = new Map();
   for (const message of messages.value) {
-    if (message.role !== MessageRole.Assistant) continue;
-    const artifacts = message.property?.artifacts;
-    if (!artifacts?.length) continue;
-    for (const file of artifacts) {
+    for (const file of getMessageArtifacts(message)) {
       if (byOutputId.has(file.outputId)) {
         byOutputId.delete(file.outputId);
       }
@@ -214,7 +211,7 @@ const {
 | ---------------- | ----------------------------- | --------------------------------------------------------------------------- |
 | messageGroups    | `Ref<MessageGroup[]>`         | 完整消息分组列表                                                            |
 | executionGroups  | `ComputedRef<MessageGroup[]>` | 仅包含执行类消息的分组（工具调用 + FlowAgent），自动提取 `userMessageTitle` |
-| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 拍平会话所有 AssistantMessage 文件产物，按 `outputId` 去重（保留最后一次） |
+| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 收集助手产物与具有 `outputId` 的上传附件，按 `outputId` 去重（保留最后一次） |
 | pendingApprovalCount | `ComputedRef<number>`      | 当前消息中待审批 AI Dev 审批中断的数量                                      |
 | pendingApprovalTipText | `ComputedRef<string>`    | 待审批阻塞发送提示文案；无待审批时为空字符串                                |
 | isShareMode      | `ShallowRef<boolean>`         | 是否处于分享模式                                                            |

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/types/messages.md
@@ -57,6 +57,9 @@ interface BaseMessage<T extends MessageType, C = string> {
 
   // 消息属性（可选）
   property?: {
+    // 发送时输入框的富文本文档；content 仍是纯文本（不改后端契约），
+    // 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签
+    docSchema?: TagSchema;
     extra?: {
       // 引用内容
       cite:
@@ -74,9 +77,6 @@ interface BaseMessage<T extends MessageType, C = string> {
       shortcut?: Shortcut;
       // 暂停标记：为 true 时该消息所在消息组不显示 MessageTools 工具栏
       pause?: boolean;
-      // 发送时输入框的富文本文档；content 仍是纯文本（不改后端契约），
-      // 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签
-      docSchema?: TagSchema;
     };
   };
 }

--- a/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/utils/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/skills/blueking-chat-x/references/utils/index.md
@@ -85,10 +85,10 @@ const tools = mergeToolsById(
 
 | 来源                            | id 取值                                          | 名称                   |
 | ------------------------------- | ------------------------------------------------ | ---------------------- |
-| 助手消息的 `property.artifacts` | `file.outputId \|\| file.name`                   | `file.name`            |
-| 用户消息里的二进制附件          | `content.id \|\| content.url \|\| content.filename` | `content.filename` 或 id |
+| 助手消息的 `property.artifacts` | `file.outputId`                   | `file.name`            |
+| 用户消息里的二进制附件          | `content.outputId` | `content.filename` 或 id |
 
-同一 id 多次出现时取最后一次的名称（文件可能被后续轮次更新），位置保持首次出现的顺序。
+缺少 `outputId` 的文件会被跳过；上传响应中的 `path` 由 `ChatInput` 映射为 `outputId`。同一 id 多次出现时取最后一次的名称（文件可能被后续轮次更新），位置保持首次出现的顺序。
 
 ```typescript
 import { collectMessageArtifacts } from '@blueking/chat-x';

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/contents.ts
@@ -32,6 +32,8 @@ export interface BinaryInputContent {
   filename?: string;
   id?: string;
   mimeType: string;
+  /** 上传接口返回的 path，用于文件引用、下载与预览 */
+  outputId?: string;
   /** 文件字节数；发送时由原始 File 写入，用于消息态附件卡片展示大小 */
   size?: number;
   type: MessageContentType.Binary;

--- a/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/messages.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/ag-ui/types/messages.ts
@@ -66,6 +66,11 @@ export interface BaseMessage<T extends MessageType, C = string> {
   property?: {
     /* 附件 */
     artifacts?: AIFileInfo[];
+    /**
+     * 发送时输入框的富文本文档。content 仍是纯文本（不改后端契约），
+     * 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签。
+     */
+    docSchema?: TagSchema;
     extra?: {
       cite:
         | {
@@ -87,11 +92,6 @@ export interface BaseMessage<T extends MessageType, C = string> {
           context_type: 'checkbox' | 'input' | 'number' | 'radioGroup' | 'select' | 'switcher' | 'text' | 'textarea'; // 快捷指令 components type 类型
         } & Partial<OldShortcut>
       >[];
-      /**
-       * 发送时输入框的富文本文档。content 仍是纯文本（不改后端契约），
-       * 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签。
-       */
-      docSchema?: TagSchema;
       pause?: boolean; // 用于判断是否显示 message tools
       shortcut?: Partial<Shortcut>; // 用于 UserMessage 的快捷指令
     };

--- a/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/common/constants.ts
@@ -130,7 +130,7 @@ export const CONST_UPDATE_TOOLS = [
 
 export const MAX_UPLOAD_FILES = 9; // 最大上传文件数量
 
-export const MAX_UPLOAD_FILE_SIZE = 2.4 * 1024 * 1024; // 最大上传文件大小 2.5MB
+export const MAX_UPLOAD_FILE_SIZE = 45 * 1024 * 1024; // 单文件大小须严格小于 45MB
 
 export { ALLOWED_UPLOAD_EXTENSIONS, DEFAULT_UPLOAD_ACCEPT } from '../utils/upload-accept';
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/ai-buttons/file-upload-btn/file-upload-btn.spec.ts
@@ -62,7 +62,6 @@ vi.mock('../../../common', async importOriginal => {
   return {
     ...actual,
     isEn: false,
-    MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
     MAX_UPLOAD_FILES: 9,
   };
 });
@@ -329,7 +328,7 @@ describe('FileUploadBtn', () => {
       await triggerFileChange(wrapper, [validFile, emptyFile]);
 
       expect(mockMessage).toHaveBeenCalledWith({
-        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        message: '有 1 个文件未上传，可能文件超过 45.0 MB或超出上传个数',
         theme: 'error',
       });
       const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
@@ -341,11 +340,11 @@ describe('FileUploadBtn', () => {
       wrapper = mount(FileUploadBtn);
 
       const validFile = createFile('small.png', 1024);
-      const oversizedFile = createFile('huge.png', 3 * 1024 * 1024);
+      const oversizedFile = createFile('huge.png', 46 * 1024 * 1024);
       await triggerFileChange(wrapper, [validFile, oversizedFile]);
 
       expect(mockMessage).toHaveBeenCalledWith({
-        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        message: '有 1 个文件未上传，可能文件超过 45.0 MB或超出上传个数',
         theme: 'error',
       });
       const emittedFiles = wrapper.emitted('upload')?.[0]?.[0] as File[];
@@ -406,20 +405,29 @@ describe('FileUploadBtn', () => {
 
       expect(wrapper.emitted('upload')).toBeFalsy();
       expect(mockMessage).toHaveBeenCalledWith({
-        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        message: '有 1 个文件未上传，可能文件超过 45.0 MB或超出上传个数',
         theme: 'error',
       });
+    });
+
+    it('小于 45 MB 一个字节的文件应允许上传', async () => {
+      wrapper = mount(FileUploadBtn);
+      const file = createFile('valid.png', 45 * 1024 * 1024 - 1);
+      await triggerFileChange(wrapper, [file]);
+
+      expect(wrapper.emitted('upload')).toEqual([[[file]]]);
+      expect(mockMessage).not.toHaveBeenCalled();
     });
 
     it('刚好等于最大尺寸的文件应该被过滤', async () => {
       wrapper = mount(FileUploadBtn);
 
-      const maxSizeFile = createFile('max.png', 2.5 * 1024 * 1024);
+      const maxSizeFile = createFile('max.png', 45 * 1024 * 1024);
       await triggerFileChange(wrapper, [maxSizeFile]);
 
       expect(wrapper.emitted('upload')).toBeFalsy();
       expect(mockMessage).toHaveBeenCalledWith({
-        message: '有 1 个文件未上传，可能文件超过 2.5 MB或超出上传个数',
+        message: '有 1 个文件未上传，可能文件超过 45.0 MB或超出上传个数',
         theme: 'error',
       });
     });

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.spec.ts
@@ -84,6 +84,10 @@ const mockSessionArtifactsRef = vi.hoisted(() => {
   const { ref: vueRef } = require('vue');
   return vueRef([]) as Ref<Array<{ name: string; outputId: string; size: number; type: string }>>;
 });
+const mockUploadedArtifactsRef = vi.hoisted(() => {
+  const { ref: vueRef } = require('vue');
+  return vueRef([]) as Ref<Array<{ name: string; outputId: string; size: number; type: string }>>;
+});
 const mockUseMessageGroup = vi.hoisted(() => vi.fn());
 const mockUseRenderModeProvider = vi.hoisted(() => vi.fn());
 
@@ -428,9 +432,11 @@ vi.mock('../chat-input/chat-input.vue', () => ({
       'update:selectedModel',
       'selectShortcut',
       'deleteShortcut',
+      'deleteFile',
       'modelChange',
     ],
-    setup(_, { slots }) {
+    setup(_, { slots, expose }) {
+      expose({ uploadedArtifacts: mockUploadedArtifactsRef });
       return () => h('div', { class: 'mock-chat-input' }, [slots.top?.(), slots.interrupt?.()]);
     },
   }),
@@ -644,6 +650,7 @@ describe('ChatContainer', () => {
     mockMessageGroupsRef.value = [];
     mockExecutionGroupsRef.value = [];
     mockSessionArtifactsRef.value = [];
+    mockUploadedArtifactsRef.value = [];
   });
 
   afterEach(() => {
@@ -942,6 +949,14 @@ describe('ChatContainer', () => {
       const ci = wrapper.findComponent({ name: 'ChatInput' });
       expect(ci.props('models')).toEqual(models);
       expect(ci.props('selectedModel')).toBe('GPT-4');
+    });
+
+    it('ChatInput 取消附件时应向上透传 deleteFile 及完整附件信息', async () => {
+      wrapper = mount(ChatContainer, { props: defaultProps });
+      const file = { id: 'files/report.pdf', filename: 'report.pdf', status: 'success' };
+      await wrapper.findComponent({ name: 'ChatInput' }).vm.$emit('deleteFile', file);
+
+      expect(wrapper.emitted('deleteFile')).toEqual([[file]]);
     });
 
     it('ChatInput 触发 modelChange 时应向上冒泡', async () => {
@@ -1490,6 +1505,7 @@ describe('ChatContainer', () => {
     it('无 executionGroups、无产物时 asideCollapsed 为 false 仍应展开并渲染 Tab', async () => {
       mockExecutionGroupsRef.value = [];
       mockSessionArtifactsRef.value = [];
+    mockUploadedArtifactsRef.value = [];
 
       wrapper = mount(ChatContainer, {
         props: { ...defaultProps, asideCollapsed: false },
@@ -1563,6 +1579,31 @@ describe('ChatContainer', () => {
 
       expect(getSideTabRenderComponent).toHaveBeenCalled();
       expect(wrapper.find('.custom-tab-label').exists()).toBe(true);
+    });
+
+    it('待发送的上传文件应进入预览侧栏，发送入消息后去重，取消后移除', async () => {
+      const file = { name: 'report.pdf', outputId: 'files/report.pdf', size: 3, type: 'pdf' };
+      wrapper = mount(ChatContainer, {
+        props: { ...defaultProps, asideCollapsed: false },
+        global: { stubs: { FileArtifactPanel: defineComponent({
+          name: 'FileArtifactPanel', props: ['artifacts', 'activeId'], render: () => h('div'),
+        }) } },
+      });
+      getChatContainerExposed(wrapper).selectCustomTab({ name: 'file-artifact', label: '文件产物' });
+      mockUploadedArtifactsRef.value = [file];
+      await nextTick();
+      const panel = wrapper.findComponent({ name: 'FileArtifactPanel' });
+      expect(panel.props('artifacts')).toEqual([file]);
+
+      mockSessionArtifactsRef.value = [file];
+      await nextTick();
+      expect(panel.props('artifacts')).toEqual([file]);
+      mockUploadedArtifactsRef.value = [];
+      await nextTick();
+      expect(panel.props('artifacts')).toEqual([file]);
+      mockSessionArtifactsRef.value = [];
+      await nextTick();
+      expect(panel.props('artifacts')).toEqual([]);
     });
 
     it('无文件产物时也应常驻挂上文件产物 Tab', async () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-container/chat-container.vue
@@ -256,6 +256,7 @@
               :shortcuts="shortcuts"
               :support-upload="supportUpload"
               :tippy-options="commonTippyOptions"
+              @delete-file="emits('deleteFile', $event)"
               @delete-shortcut="handleCloseShortcut"
               @model-change="emits('modelChange', $event)"
               @select-shortcut="handleSelectShortcut"
@@ -594,7 +595,7 @@
   const {
     messageGroups,
     executionGroups,
-    sessionArtifacts,
+    sessionArtifacts: messageArtifacts,
     isShareMode,
     isAllSelected,
     onToggleShareAll,
@@ -607,6 +608,15 @@
     messages: computed(() => props.messages),
     renderMode: computed(() => renderMode.value),
     selectedUserMessages,
+  });
+
+  // 输入框里上传成功但尚未发送的文件也可立即预览，移除附件后同步移出侧栏。
+  const sessionArtifacts = computed(() => {
+    const files = new Map(messageArtifacts.value.map(file => [file.outputId, file]));
+    for (const file of chatInputRef.value?.uploadedArtifacts ?? []) {
+      files.set(file.outputId, file);
+    }
+    return [...files.values()];
   });
 
   // 文件卡片点击 → 命中文件并展开侧栏、切到「文件产物」Tab

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.spec.ts
@@ -30,6 +30,7 @@ import { type VueWrapper, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import FileContent from './file-content.vue';
+import { ARTIFACT_PREVIEW_TOKEN } from '../../../composables/use-artifact-preview';
 
 import type { UploadFile } from '../../../types';
 import { UploadStatus } from '../../../types';
@@ -92,6 +93,35 @@ describe('FileContent', () => {
 
   afterEach(() => {
     wrapper?.unmount();
+  });
+
+  describe('上传文件产物预览', () => {
+    it.each(['pdf', 'png'])('具有 outputId 的 %s 附件应通过统一侧栏预览', async extension => {
+      const openPreview = vi.fn();
+      const file = { outputId: `files/a.${extension}`, filename: `a.${extension}`, mimeType: extension === 'png' ? 'image/png' : 'application/pdf', size: 1 };
+      wrapper = mount(FileContent, {
+        props: { files: [file] },
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: { openPreview } } },
+      });
+      if (extension === 'png') await wrapper.find(IMAGE_SELECTOR).trigger('error');
+      await wrapper.find(extension === 'png' ? IMAGE_SELECTOR : FILE_SELECTOR).trigger('click');
+      expect(openPreview).toHaveBeenCalledExactlyOnceWith({ file: {
+        outputId: file.outputId, name: file.filename, size: 1, type: extension,
+      } });
+      expect(wrapper.findComponent({ name: 'ImagePreview' }).props('visible')).toBe(false);
+    });
+
+    it.each([UploadStatus.Pending, UploadStatus.Error])('%s 附件不能预览，删除按钮也不触发预览', async status => {
+      const openPreview = vi.fn();
+      wrapper = mount(FileContent, {
+        props: { files: [{ outputId: 'files/a.pdf', filename: 'a.pdf', status }] },
+        global: { provide: { [ARTIFACT_PREVIEW_TOKEN]: { openPreview } } },
+      });
+      await wrapper.find(FILE_SELECTOR).trigger('click');
+      await wrapper.find(DELETE_SELECTOR).trigger('click');
+      expect(openPreview).not.toHaveBeenCalled();
+      expect(wrapper.emitted('deleteFile')).toHaveLength(1);
+    });
   });
 
   describe('渲染测试', () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/file-content.vue
@@ -12,6 +12,7 @@
         v-for="item in imageItems"
         :key="item.key"
         :has-error="item.hasError"
+        :previewable="canPreviewArtifact(item.file)"
         :name="item.name"
         :readonly="readonly"
         :src="item.src"
@@ -30,8 +31,10 @@
         v-for="item in fileItems"
         :key="item.key"
         :file="item.file"
+        :previewable="canPreviewArtifact(item.file)"
         :readonly="readonly"
         @delete="handleDeleteFile(item.file)"
+        @preview="handleArtifactPreview(item.file)"
       />
     </div>
     <ImagePreview
@@ -45,8 +48,9 @@
 <script lang="ts" setup>
   import { computed, onBeforeUnmount, shallowReactive, shallowRef, watch } from 'vue';
 
+  import { useArtifactPreviewConsumer } from '../../../composables/use-artifact-preview';
   import { type UploadFile, type UploadFileVariant, UploadStatus } from '../../../types';
-  import { getUploadFileKey, getUploadFileName, splitUploadFiles } from '../../../utils';
+  import { getUploadFileKey, getUploadFileName, splitUploadFiles, toUploadArtifact } from '../../../utils';
   import ImagePreview from '../../image-preview/image-preview.vue';
   import UploadFileItem from './upload-file-item.vue';
   import UploadImageItem from './upload-image-item.vue';
@@ -66,6 +70,13 @@
       variant: 'input',
     },
   );
+
+  const artifactPreview = useArtifactPreviewConsumer();
+  const canPreviewArtifact = (file: Partial<UploadFile>) => !!artifactPreview && !!toUploadArtifact(file);
+  const handleArtifactPreview = (file: Partial<UploadFile>) => {
+    const artifact = toUploadArtifact(file);
+    if (artifact) artifactPreview?.openPreview({ file: artifact });
+  };
 
   // 图片加载失败：key -> true，失败项降级为错误占位且不进入预览列表
   const imageErrorMap = shallowReactive<Record<string, boolean>>({});
@@ -141,6 +152,11 @@
     emit('deleteFile', file);
   };
   const handlePreview = (key: string) => {
+    const item = imageItems.value.find(item => item.key === key);
+    if (item && canPreviewArtifact(item.file)) {
+      handleArtifactPreview(item.file);
+      return;
+    }
     const index = previewItems.value.findIndex(item => item.key === key);
     if (index < 0) return;
     previewIndex.value = index;

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/upload-file-item.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/upload-file-item.vue
@@ -5,7 +5,9 @@
       'is-readonly': readonly,
       'is-pending': isPending,
       'is-error': isError,
+      'is-previewable': previewable,
     }"
+    @click="previewable && emit('preview')"
   >
     <span class="ai-upload-file-item-icon">
       <!-- 与文件产物侧栏共用一套扩展名 → 图标映射，解除类型限制后各类文件都有对应图标 -->
@@ -64,9 +66,10 @@
   const props = defineProps<{
     file: Partial<UploadFile>;
     readonly?: boolean;
+    previewable?: boolean;
   }>();
   const emit = defineEmits<{
-    (e: 'delete'): void;
+    (e: 'delete' | 'preview'): void;
   }>();
 
   const commonTippyOptions = useCommonTippyInject();
@@ -99,6 +102,10 @@
 
     &:not(.is-readonly):not(.is-pending):not(.is-error):hover {
       background: variables.$color-border;
+    }
+
+    &.is-previewable {
+      cursor: pointer;
     }
 
     &.is-error {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/upload-image-item.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-content/file-content/upload-image-item.vue
@@ -1,7 +1,8 @@
 <template>
   <div
     class="ai-upload-image-item"
-    :class="{ 'is-pending': isPending }"
+    :class="{ 'is-pending': isPending, 'is-previewable': previewable }"
+    @click="handlePreview"
   >
     <img
       v-if="!showError"
@@ -9,7 +10,6 @@
       class="ai-upload-image-item-thumb"
       :class="`is-${variant}`"
       :src="src"
-      @click="handlePreview"
       @error="emit('error')"
     />
     <div
@@ -51,6 +51,7 @@
       hasError?: boolean;
       name?: string;
       readonly?: boolean;
+      previewable?: boolean;
       src?: string;
       status?: UploadStatus;
       variant?: UploadFileVariant;
@@ -67,7 +68,7 @@
   const showError = computed(() => !!props.hasError || props.status === UploadStatus.Error);
 
   const handlePreview = () => {
-    if (isPending.value) {
+    if (isPending.value || (showError.value && !props.previewable)) {
       return;
     }
     emit('preview');
@@ -123,6 +124,10 @@
       pointer-events: none;
       background: rgb(0 0 0 / 50%);
       border-radius: 8px;
+    }
+
+    &.is-previewable &-thumb {
+      cursor: pointer;
     }
 
     &-error-icon {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.spec.ts
@@ -26,7 +26,7 @@
 
 import { defineComponent, h, nextTick } from 'vue';
 
-import { type VueWrapper, mount } from '@vue/test-utils';
+import { type VueWrapper, flushPromises, mount } from '@vue/test-utils';
 import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -63,7 +63,6 @@ vi.mock('../../common', async importOriginal => {
     CHAT_Z_INDEX: 1000,
     isEn: false,
     MAX_UPLOAD_FILES: 9,
-    MAX_UPLOAD_FILE_SIZE: 2.5 * 1024 * 1024,
     commonSVGProps: {
       class: 'mock-svg-icon',
       xmlns: 'http://www.w3.org/2000/svg',
@@ -1143,6 +1142,130 @@ describe('ChatInput', () => {
   });
 
   describe('文件上传功能测试', () => {
+    it.each(['@', 'plus'] as const)('上传 path 应立即加入 %s 菜单并在发送内容中保留 outputId', async trigger => {
+      const onSendMessage = vi.fn();
+      wrapper = mount(ChatInput, {
+        props: {
+          modelValue: '', onSendMessage,
+          onUpload: vi.fn().mockResolvedValue({ id: 'upload-id', path: 'files/report.pdf', status: 'success' }),
+        },
+      });
+      await emitUpload(wrapper, [new File(['pdf'], 'report.pdf', { type: 'application/pdf' })]);
+      await flushPromises();
+      await emitMenuChange(wrapper, trigger);
+      const groups = wrapper.findComponent({ name: 'InputMenuPanel' }).props('groups');
+      expect(groups.flatMap((group: { items: IInputMenuItem[] }) => group.items)).toContainEqual({
+        id: 'files/report.pdf', type: 'artifact', name: 'report.pdf',
+      });
+      expect((wrapper.vm as unknown as { uploadedArtifacts: unknown[] }).uploadedArtifacts).toEqual([
+        { outputId: 'files/report.pdf', name: 'report.pdf', size: 3, type: 'pdf' },
+      ]);
+      await emitMenuChange(wrapper, null);
+      await waitUntilSendEnabled(wrapper);
+      await wrapper.find('.send-btn').trigger('click');
+      expect(onSendMessage.mock.calls[0][0][0]).toMatchObject({ id: 'upload-id', outputId: 'files/report.pdf' });
+      expect((wrapper.vm as unknown as { uploadedArtifacts: unknown[] }).uploadedArtifacts).toEqual([]);
+    });
+
+    it('取消上传附件后应从菜单和暴露的预览数据移除', async () => {
+      wrapper = mount(ChatInput, {
+        props: { modelValue: '', onUpload: vi.fn().mockResolvedValue({ path: 'files/a.pdf' }) },
+      });
+      await emitUpload(wrapper, [new File(['a'], 'a.pdf', { type: 'application/pdf' })]);
+      await flushPromises();
+      await wrapper.find('.mock-file-item').trigger('click');
+      await emitMenuChange(wrapper, '@');
+      expect(wrapper.find('.mock-input-menu-panel').exists()).toBe(false);
+      expect((wrapper.vm as unknown as { uploadedArtifacts: unknown[] }).uploadedArtifacts).toEqual([]);
+    });
+
+    it.each([
+      { id: 'legacy-id', download_url: 'https://example.com/a.pdf' },
+      { path: 'files/a.pdf', status: 'failed' },
+    ])('没有有效 outputId 的上传结果不能加入菜单：%j', async result => {
+      wrapper = mount(ChatInput, { props: { modelValue: '', onUpload: vi.fn().mockResolvedValue(result) } });
+      await emitUpload(wrapper, [new File(['a'], 'a.pdf', { type: 'application/pdf' })]);
+      await flushPromises();
+      await emitMenuChange(wrapper, '@');
+      expect(wrapper.find('.mock-input-menu-panel').exists()).toBe(false);
+    });
+
+    it.each(['选择', '拖拽', '粘贴'])('%s 文件时仅允许非空且严格小于 45 MB 的文件', async entry => {
+      const onUpload = vi.fn().mockResolvedValue({ id: 'files/valid.pdf', status: 'success' });
+      const files = [45 * 1024 * 1024 - 1, 45 * 1024 * 1024, 45 * 1024 * 1024 + 1, 0].map((size, index) => {
+        const file = new File(['pdf'], `${index}.pdf`, { type: 'application/pdf' });
+        Object.defineProperty(file, 'size', { value: size });
+        return file;
+      });
+      wrapper = mount(ChatInput, { props: { modelValue: '', onUpload } });
+
+      if (entry === '选择') {
+        const input = wrapper.find('.chat-input-file-input');
+        Object.defineProperty(input.element, 'files', { value: files });
+        await input.trigger('change');
+      } else if (entry === '拖拽') {
+        await wrapper.find('.chat-input').trigger('drop', {
+          dataTransfer: { types: ['Files'], files },
+        });
+      } else {
+        await emitUpload(wrapper, files);
+      }
+
+      expect(onUpload).toHaveBeenCalledExactlyOnceWith([files[0]]);
+      expect(wrapper.findAll('.mock-file-item')).toHaveLength(1);
+      expect(mockBkMessage).toHaveBeenCalledWith(expect.objectContaining({
+        message: '有 3 个文件未上传，可能文件超过 45.0 MB或超出上传个数',
+      }));
+    });
+
+    it.each(['成功', '失败'])('删除接口%s时都应立即移除附件并抛出完整文件信息', async result => {
+      let resolveDelete!: () => void;
+      let rejectDelete!: (error: Error) => void;
+      const request = new Promise<void>((resolve, reject) => {
+        resolveDelete = resolve;
+        rejectDelete = reject;
+      });
+      const onDeleteFile = vi.fn(() => request);
+      const errorHandler = vi.fn();
+      const file = new File(['pdf'], 'report.pdf', { type: 'application/pdf' });
+      wrapper = mount(ChatInput, {
+        props: {
+          modelValue: '',
+          onUpload: vi.fn().mockResolvedValue({ id: 'files/report.pdf', status: 'success' }),
+          onDeleteFile,
+        },
+        global: { config: { errorHandler } },
+      });
+      await emitUpload(wrapper, [file]);
+      await flushPromises();
+      await wrapper.find('.mock-file-item').trigger('click');
+
+      expect(wrapper.find('.mock-file-content').exists()).toBe(false);
+      expect(wrapper.emitted('deleteFile')).toEqual([[expect.objectContaining({
+        id: 'files/report.pdf', file, status: 'success',
+      })]]);
+      expect(onDeleteFile).toHaveBeenCalledTimes(1);
+
+      const error = new Error('删除失败');
+      if (result === '成功') resolveDelete();
+      else rejectDelete(error);
+      await flushPromises();
+      expect(wrapper.find('.mock-file-content').exists()).toBe(false);
+      expect(errorHandler).toHaveBeenCalledTimes(result === '成功' ? 0 : 1);
+    });
+
+    it('删除仅含 id 的回填附件时应移除对应文件并发出事件', async () => {
+      const files = [
+        { type: 'binary', id: 'files/a.pdf', mimeType: 'application/pdf' },
+        { type: 'binary', id: 'files/b.pdf', mimeType: 'application/pdf' },
+      ] as UploadFile[];
+      wrapper = mount(ChatInput, { props: { modelValue: '', defaultUploadFiles: files } });
+      await wrapper.find('.mock-file-item').trigger('click');
+
+      expect(wrapper.findComponent({ name: 'FileContent' }).props('files')).toEqual([files[1]]);
+      expect(wrapper.emitted('deleteFile')).toEqual([[files[0]]]);
+    });
+
     it('supportUpload 默认为 true 时应该渲染 + 号按钮', () => {
       wrapper = mount(ChatInput, {
         props: {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/chat-input.vue
@@ -170,6 +170,8 @@
     getUploadFileName,
     getUploadFileSize,
     isFileAcceptedByAccept,
+    toArtifactMenuItem,
+    toUploadArtifact,
   } from '../../utils';
   import AddMenuBtn from '../ai-buttons/add-menu-btn/add-menu-btn.vue';
   import ShortcutBtn from '../ai-shortcut/shortcut-btn/shortcut-btn.vue';
@@ -183,6 +185,7 @@
   import { DEFAULT_GROUP_ITEM_LIMIT, InputMenuPanel, useInputMenu } from './input-menu';
   import { ModelSelector } from './model-selector';
 
+  import type { AIFileInfo } from '../../ag-ui/types/file';
   import type { MenuGroupKey } from './input-menu';
   import type { IModelOption } from './model-selector';
 
@@ -202,6 +205,7 @@
   export type ChatInputEmits = {
     (e: 'selectShortcut', shortcut: Shortcut): void;
     (e: 'deleteShortcut'): void;
+    (e: 'deleteFile', file: Partial<UploadFile>): void;
     (e: 'update:modelValue', value: string | TagSchema, selectedResourceList: IInputMenuItem[]): void;
     (e: 'modelChange', model: IModelOption): void;
   };
@@ -234,6 +238,7 @@
     download_url?: string;
     error?: string;
     id?: string;
+    path?: string;
     status?: 'failed' | 'success';
   };
   const props = withDefaults(defineProps<ChatInputProps>(), {
@@ -245,7 +250,7 @@
   });
   const emit = defineEmits<ChatInputEmits>();
   /** 数据源里存在的菜单类型，用于决定 placeholder 展示哪几行提示 */
-  const sourceTypes = computed(() => new Set(props.menuSources.map(item => item.type)));
+  const sourceTypes = computed(() => new Set(resolvedMenuSources.value.map(item => item.type)));
   const resolvedPlaceholder = computed(() => {
     if (props.placeholder !== undefined) {
       return props.placeholder;
@@ -260,6 +265,16 @@
     });
   });
   const uploadFiles = deepRef<Partial<UploadFile>[]>(props.defaultUploadFiles || []);
+  const uploadedArtifacts = computed(() =>
+    uploadFiles.value.map(toUploadArtifact).filter((file): file is AIFileInfo => !!file),
+  );
+  const resolvedMenuSources = computed(() => {
+    const sources = new Map(props.menuSources.map(item => [`${item.type}:${item.id}`, item]));
+    for (const file of uploadedArtifacts.value) {
+      sources.set(`artifact:${file.outputId}`, toArtifactMenuItem(file));
+    }
+    return [...sources.values()];
+  });
   const selectedShortcut = computed(() => {
     return props.shortcuts?.find(shortcut => shortcut.id === props.shortcutId);
   });
@@ -280,7 +295,7 @@
     );
   });
   const availableSources = computed<IInputMenuItem[]>(() => {
-    const list = props.menuSources.filter(item => !insertedTagKeys.value.has(`${item.type}:${item.id}`));
+    const list = resolvedMenuSources.value.filter(item => !insertedTagKeys.value.has(`${item.type}:${item.id}`));
     // 「文件」是组件内置的上传入口，只在 + 号聚合菜单的「添加」分组里出现
     return props.supportUpload ? [{ id: '__built_in_file__', type: 'file', name: t('文件') }, ...list] : list;
   });
@@ -396,6 +411,7 @@
         content = uploadFiles.value?.slice().map(file => ({
           type: MessageContentType.Binary,
           id: file.id,
+          outputId: file.outputId,
           url: file.url,
           mimeType: file.mimeType || file.file?.type || '',
           filename: getUploadFileName(file),
@@ -462,9 +478,10 @@
   const maxUploadMb = (MAX_UPLOAD_FILE_SIZE / (1024 * 1024)).toFixed(1);
   const applyUploadResult = (fileItem: Partial<UploadFile>, res?: ChatInputUploadResult) => {
     const failed = res?.status === 'failed';
-    const succeeded = !failed && (!!res?.id || !!res?.download_url || res?.status === 'success');
+    const succeeded = !failed && (!!res?.id || !!res?.path || !!res?.download_url || res?.status === 'success');
     if (succeeded) {
-      fileItem.id = res.id;
+      fileItem.id = res.id || res.path;
+      fileItem.outputId = res.path;
       fileItem.url = res.download_url;
       fileItem.status = UploadStatus.Success;
       return;
@@ -579,6 +596,9 @@
   };
   const handleDeleteFile = (file: Partial<UploadFile>) => {
     uploadFiles.value = uploadFiles.value.filter(item => {
+      if (item.id && file.id) {
+        return item.id !== file.id;
+      }
       if (item.file) {
         return item.file !== file.file;
       }
@@ -590,13 +610,15 @@
       }
       return true;
     });
+    // 仅通知业务方删除远端文件，UI 不等待接口结果。
+    emit('deleteFile', file);
   };
   /** 把文档里的标签还原成菜单选项，作为 update:modelValue 的第二个参数交给业务方 */
   const handleUpdateModelValue = (value: TagSchema) => {
     const selectedResourceList = value
       .flat()
       .filter(node => node.type === 'tag')
-      .map(node => props.menuSources.find(item => item.id === node.data.value && item.type === node.data.type))
+      .map(node => resolvedMenuSources.value.find(item => item.id === node.data.value && item.type === node.data.type))
       .filter((item): item is IInputMenuItem => Boolean(item));
     emit('update:modelValue', value, selectedResourceList);
   };
@@ -639,6 +661,7 @@
     focus,
     insertMention,
     triggerSendMessage: handleSendMessage,
+    uploadedArtifacts,
   });
 </script>
 <style lang="scss">

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-menu/use-input-menu.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-menu/use-input-menu.spec.ts
@@ -55,6 +55,17 @@ const setup = (trigger: MenuTrigger | null, keyword = '', groupItemLimit = 4) =>
   });
 
 describe('useInputMenu', () => {
+  it.each(['@', 'plus'] as const)('%s 不展示缺少 outputId 的文件条目', trigger => {
+    const { flatItems } = useInputMenu({
+      sources: shallowRef<IInputMenuItem[]>([
+        { id: '', name: 'invalid.pdf', type: 'artifact' },
+        { id: 'files/valid.pdf', name: 'valid.pdf', type: 'artifact' },
+      ]),
+      keyword: shallowRef(''), trigger: shallowRef(trigger), groupItemLimit: shallowRef(4),
+    });
+    expect(flatItems.value).toEqual([{ id: 'files/valid.pdf', name: 'valid.pdf', type: 'artifact' }]);
+  });
+
   it('trigger 为空时不产出任何分组', () => {
     const { groups, hasContent } = setup(null);
     expect(groups.value).toEqual([]);

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-menu/use-input-menu.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-input/input-menu/use-input-menu.ts
@@ -65,6 +65,7 @@ export const useInputMenu = (params: {
       const def = MENU_GROUP_DEFS[key];
       const matched = params.sources.value.filter(
         item =>
+          (item.type !== 'artifact' || !!item.id) &&
           (def.types as MenuItemType[]).includes(item.type) && (!keyword || item.name.toLowerCase().includes(keyword)),
       );
       // 初始化与搜索过滤后，组内没有条目就不渲染该分组

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/artifact-file-card.vue
@@ -29,7 +29,7 @@
     <!-- 右侧操作区：hover 显示，设计稿中引用在下载左侧 -->
     <div class="ai-artifact-file-card-actions">
       <div
-        v-if="inputMention"
+        v-if="inputMention && file.outputId"
         v-tippy="citeTippy"
         class="ai-artifact-file-card-action ai-artifact-file-card-cite"
         @click.stop="handleCite"
@@ -122,7 +122,7 @@
   }));
 
   const handleCite = () => {
-    inputMention?.insertMention(toArtifactMenuItem(props.file));
+    if (props.file.outputId) inputMention?.insertMention(toArtifactMenuItem(props.file));
   };
 
   const handleCardClick = () => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/assistant-message/message-artifacts/file-artifact-panel.vue
@@ -73,7 +73,7 @@
             </span>
             <!-- 设计稿：引用位于下载左侧，点击后该文件以标签形式进入输入框 -->
             <span
-              v-if="inputMention"
+              v-if="inputMention && activeArtifact.outputId"
               v-tippy="citeTippy"
               class="ai-file-artifact-panel-preview-header-action"
               @click="handleCite(activeArtifact)"
@@ -187,7 +187,7 @@
   }));
 
   const handleCite = (file: SessionArtifact) => {
-    inputMention?.insertMention(toArtifactMenuItem(file));
+    if (file.outputId) inputMention?.insertMention(toArtifactMenuItem(file));
   };
 
   const filteredArtifacts = computed(() => {

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.spec.ts
@@ -644,11 +644,11 @@ describe('UserMessage', () => {
       ],
     ];
 
-    it('property.extra.docSchema 含标签时按结构渲染而不是纯文本', () => {
+    it('property.docSchema 含标签时按结构渲染而不是纯文本', () => {
       wrapper = mount(UserMessage, {
         props: {
           content: '帮我查一下 @知识库01 的内容',
-          property: { extra: { docSchema: docWithTag } },
+          property: { docSchema: docWithTag },
         } as never,
       });
 
@@ -657,12 +657,25 @@ describe('UserMessage', () => {
       expect(wrapper.find('.mock-text-content').exists()).toBe(false);
     });
 
+    it('编辑时从 property.docSchema 回填标签，并保留同级 extra 的引用展示', async () => {
+      wrapper = mount(UserMessage, {
+        props: {
+          content: '帮我查一下 @知识库01 的内容',
+          property: { docSchema: docWithTag, extra: { cite: '原引用内容' } },
+        } as never,
+      });
+      expect(wrapper.find('.mock-cite-content').text()).toContain('原引用内容');
+      await wrapper.findComponent({ name: 'MessageTools' }).props('onAction')({ id: 'edit' });
+      expect(wrapper.findComponent({ name: 'ChatInput' }).props('modelValue')).toEqual(docWithTag);
+      expect(mockChatInputFocus).toHaveBeenCalled();
+    });
+
     it('标签携带的 icon 直接用于渲染', () => {
       const doc = [
         [{ type: 'tag', data: { label: '知识库01', value: 'kb_01', type: 'knowledgebase', icon: 'https://x/kb.png' } }],
       ];
       wrapper = mount(UserMessage, {
-        props: { content: '@知识库01', property: { extra: { docSchema: doc } } } as never,
+        props: { content: '@知识库01', property: { docSchema: doc } } as never,
       });
 
       expect(wrapper.find('.ai-resource-icon img').attributes('src')).toBe('https://x/kb.png');
@@ -672,7 +685,7 @@ describe('UserMessage', () => {
       wrapper = mount(UserMessage, {
         props: {
           content: '普通消息',
-          property: { extra: { docSchema: [[{ type: 'text', text: '普通消息' }]] } },
+          property: { docSchema: [[{ type: 'text', text: '普通消息' }]] },
         } as never,
       });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
+++ b/src/frontend/ai-blueking/packages/chat-x/src/components/chat-message/user-message/user-message.vue
@@ -206,7 +206,7 @@
    * 纯文本走原有 TextContent，保持历史消息与第三方消息的表现不变。
    */
   const mentionDoc = computed(() => {
-    const doc = props.property?.extra?.docSchema;
+    const doc = props.property?.docSchema;
     return doc?.some(line => line.some(node => node.type === 'tag')) ? doc : undefined;
   });
 

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.spec.ts
@@ -359,6 +359,22 @@ describe('useMessageGroup', () => {
   });
 
   describe('sessionArtifacts', () => {
+    it('用户上传文件与助手产物共用 outputId 去重，并忽略缺少 outputId 的文件', async () => {
+      const messages = [
+        createAssistantMessage('a1', '', { property: { artifacts: [
+          createFile({ outputId: 'files/report.pdf', name: 'old.pdf' }),
+          createFile({ outputId: '', name: 'invalid.pdf' }),
+        ] } }),
+        { ...createUserMessage('u1'), content: [
+          { type: MessageContentType.Binary, id: 'upload-id', outputId: 'files/report.pdf', filename: 'report.pdf', size: 5, mimeType: 'application/pdf' },
+          { type: MessageContentType.Binary, id: 'legacy-id', filename: 'legacy.pdf', mimeType: 'application/pdf' },
+        ] },
+      ] as Message[];
+      const { sessionArtifacts } = setupMessageGroup(messages);
+      await nextTick();
+      expect(sessionArtifacts.value).toEqual([{ outputId: 'files/report.pdf', name: 'report.pdf', size: 5, type: 'pdf' }]);
+    });
+
     it('无文件产物时应返回空数组', async () => {
       const { sessionArtifacts } = setupMessageGroup([createAssistantMessage('1', 'plain')]);
       await nextTick();

--- a/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/composables/use-message-group.ts
@@ -38,7 +38,7 @@ import {
 } from '../ag-ui/types';
 import { LOADING_MESSAGE_ID, RenderMode } from '../common/constants';
 import { t } from '../lang/lang';
-import { generateUUID } from '../utils';
+import { generateUUID, getMessageArtifacts } from '../utils';
 
 import type { BkFlowMessageContent } from '../ag-ui/types/contents';
 import type { InterruptMessage, UserQuestionInterrupt } from '../ag-ui/types/interrupt';
@@ -265,21 +265,14 @@ export const useMessageGroup = (options: {
       }));
   });
   /**
-   * 会话级文件产物：拍平所有 AssistantMessage 的 property.artifacts，
+   * 会话级文件产物：收集助手产物与具有 outputId 的上传附件，
    * 以 outputId 为唯一键去重，保留最后一次出现（列表顺序同最后一次出现的相对顺序）。
    */
   const sessionArtifacts = computed<SessionArtifact[]>(() => {
     // delete + set：同 key 覆盖内容，并把该项挪到 Map 末尾，保证「最后出现」顺序
     const byOutputId = new Map<string, SessionArtifact>();
     for (const message of options.messages.value) {
-      if (message.role !== MessageRole.Assistant) {
-        continue;
-      }
-      const artifacts = (message as AssistantMessage).property?.artifacts;
-      if (!artifacts?.length) {
-        continue;
-      }
-      for (const file of artifacts) {
+      for (const file of getMessageArtifacts(message)) {
         if (byOutputId.has(file.outputId)) {
           byOutputId.delete(file.outputId);
         }

--- a/src/frontend/ai-blueking/packages/chat-x/src/types/input-menu.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/types/input-menu.ts
@@ -33,16 +33,7 @@ import type { lang } from '../lang/lang';
  *
  * `file` 是组件内置的动作项（触发本地文件上传），不由业务方通过 `menuSources` 提供。
  */
-export const MENU_ITEM_TYPES = [
-  'file',
-  'skill',
-  'mcp',
-  'tool',
-  'knowledgebase',
-  'doc',
-  'artifact',
-  'prompt',
-] as const;
+export const MENU_ITEM_TYPES = ['file', 'skill', 'mcp', 'tool', 'knowledgebase', 'doc', 'artifact', 'prompt'] as const;
 
 /** 面板渲染用的分组（已应用关键字过滤与折叠阈值） */
 export interface IInputMenuGroup {
@@ -73,6 +64,7 @@ export interface IInputMenuItem {
    * 因此只有字符串形式能被保留，传组件时标签内会回退为类型默认图标。
    */
   icon?: Component | string;
+  /** artifact 类型必须使用文件的 outputId，不能用 URL 或文件名代替 */
   id: string;
   name: string;
   type: MenuItemType;

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/collect-message-artifacts.spec.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/collect-message-artifacts.spec.ts
@@ -39,8 +39,8 @@ describe('toArtifactMenuItem', () => {
     });
   });
 
-  it('缺少 outputId 时回退到文件名作为 id', () => {
-    expect(toArtifactMenuItem({ name: 'a.md', outputId: '', size: 1, type: 'md' }).id).toBe('a.md');
+  it('缺少 outputId 时不再回退到文件名作为 id', () => {
+    expect(toArtifactMenuItem({ name: 'a.md', outputId: '', size: 1, type: 'md' }).id).toBe('');
   });
 
   it('与消息收集产出的条目完全一致，保证去重可用', () => {
@@ -52,6 +52,14 @@ describe('toArtifactMenuItem', () => {
 });
 
 describe('collectMessageArtifacts', () => {
+  it('缺少 outputId 的助手文件不会成为菜单条目', () => {
+    const messages = [{ content: '', property: { artifacts: [
+      { name: 'missing.pdf', outputId: '', size: 1, type: 'pdf' },
+      { name: 'valid.pdf', outputId: 'output-1', size: 1, type: 'pdf' },
+    ] } }] as unknown as Message[];
+    expect(collectMessageArtifacts(messages)).toEqual([{ id: 'output-1', name: 'valid.pdf', type: 'artifact' }]);
+  });
+
   it('没有消息时返回空数组', () => {
     expect(collectMessageArtifacts()).toEqual([]);
     expect(collectMessageArtifacts([])).toEqual([]);
@@ -71,7 +79,7 @@ describe('collectMessageArtifacts', () => {
     const messages = [
       {
         content: [
-          { type: MessageContentType.Binary, id: 'b1', filename: '人员名单.xlsx', mimeType: 'xlsx' },
+          { type: MessageContentType.Binary, id: 'upload-1', outputId: 'b1', filename: '人员名单.xlsx', mimeType: 'xlsx' },
           { type: MessageContentType.Text, text: '看看这个' },
         ],
       },
@@ -96,19 +104,17 @@ describe('collectMessageArtifacts', () => {
     expect(collectMessageArtifacts(messages).map(item => item.id)).toEqual(['a', 'b']);
   });
 
-  it('二进制附件缺少 id 时按 url、filename 依次回退', () => {
+  it('二进制附件缺少 outputId 时不能用 id、url 或 filename 替代', () => {
     const messages = [
       {
         content: [
           { type: MessageContentType.Binary, url: 'http://example.com/a.png', filename: 'a.png' },
           { type: MessageContentType.Binary, filename: 'b.pdf' },
+          { type: MessageContentType.Binary, id: 'legacy-id', filename: 'c.pdf' },
         ],
       },
     ] as unknown as Message[];
-    expect(collectMessageArtifacts(messages)).toEqual([
-      { id: 'http://example.com/a.png', type: 'artifact', name: 'a.png' },
-      { id: 'b.pdf', type: 'artifact', name: 'b.pdf' },
-    ]);
+    expect(collectMessageArtifacts(messages)).toEqual([]);
   });
 
   it('id / url / filename 都缺失的二进制附件会被跳过', () => {
@@ -119,7 +125,7 @@ describe('collectMessageArtifacts', () => {
   it('助手产物与用户附件一起收集，同一 id 仍去重', () => {
     const messages = [
       { content: '', property: { artifacts: [{ name: 'a.md', outputId: 'o1', size: 1, type: 'md' }] } },
-      { content: [{ type: MessageContentType.Binary, id: 'o1', filename: 'a-v2.md' }] },
+      { content: [{ type: MessageContentType.Binary, id: 'upload-1', outputId: 'o1', filename: 'a-v2.md' }] },
     ] as unknown as Message[];
     expect(collectMessageArtifacts(messages)).toEqual([{ id: 'o1', type: 'artifact', name: 'a-v2.md' }]);
   });

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/collect-message-artifacts.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/collect-message-artifacts.ts
@@ -24,6 +24,7 @@
  * IN THE SOFTWARE.
  */
 import { MessageContentType } from '../ag-ui/types/constants';
+import { toUploadArtifact } from './upload-file';
 
 import type { BinaryInputContent } from '../ag-ui/types/contents';
 import type { AIFileInfo } from '../ag-ui/types/file';
@@ -37,40 +38,31 @@ import type { IInputMenuItem } from '../types/input-menu';
  * `@` 菜单的去重、以及已插入标签的匹配全部失效。
  */
 export const toArtifactMenuItem = (file: AIFileInfo): IInputMenuItem => ({
-  id: file.outputId || file.name,
+  id: file.outputId,
   type: 'artifact',
   name: file.name,
 });
 
-/**
- * 从会话消息里收集「会话产物」，作为输入框 `@` 菜单的 artifact 选项。
- *
- * 两个来源：助手消息的文件产物 `property.artifacts`，以及用户消息里已上传的二进制附件。
- * 同一 id 多次出现时取最后一次的名称（文件可能被后续轮次更新），位置保持首次出现的顺序。
- */
-export const collectMessageArtifacts = (messages: Message[] = []): IInputMenuItem[] => {
-  const collected = new Map<string, IInputMenuItem>();
-
-  for (const message of messages) {
-    for (const artifact of message.property?.artifacts ?? []) {
-      const item = toArtifactMenuItem(artifact);
-      if (item.id) {
-        collected.set(item.id, item);
-      }
-    }
-    if (!Array.isArray(message.content)) {
-      continue;
-    }
+/** 从同一条消息提取具有 outputId 的助手产物与上传附件，供菜单、侧栏共用。 */
+export const getMessageArtifacts = (message: Message): AIFileInfo[] => {
+  const files = (message.property?.artifacts ?? []).filter(file => !!file.outputId);
+  if (Array.isArray(message.content)) {
     for (const content of message.content as BinaryInputContent[]) {
-      if (content?.type !== MessageContentType.Binary) {
-        continue;
-      }
-      const id = content.id || content.url || content.filename || '';
-      if (id) {
-        collected.set(id, { id, type: 'artifact', name: content.filename || id });
-      }
+      if (content?.type !== MessageContentType.Binary) continue;
+      const file = toUploadArtifact(content);
+      if (file) files.push(file);
     }
   }
+  return files;
+};
 
+/** 同一 outputId 取最后一次名称，菜单位置保持首次出现的顺序。 */
+export const collectMessageArtifacts = (messages: Message[] = []): IInputMenuItem[] => {
+  const collected = new Map<string, IInputMenuItem>();
+  for (const message of messages) {
+    for (const file of getMessageArtifacts(message)) {
+      collected.set(file.outputId, toArtifactMenuItem(file));
+    }
+  }
   return [...collected.values()];
 };

--- a/src/frontend/ai-blueking/packages/chat-x/src/utils/upload-file.ts
+++ b/src/frontend/ai-blueking/packages/chat-x/src/utils/upload-file.ts
@@ -32,13 +32,18 @@
  * 结构化入参而非直接依赖 `UploadFile`，让 utils 层不反向依赖 components / types。
  */
 import { formatBytes, isImageFile } from './file';
+import { normalizeFileExtension } from './file-type';
+
+import type { AIFileInfo } from '../ag-ui/types/file';
 
 /** 附件的结构化最小契约，`Partial<UploadFile>` 可直接传入 */
 export type UploadFileLike = {
   file?: File;
   filename?: string;
   mimeType?: string;
+  outputId?: string;
   size?: number;
+  status?: string;
   url?: string;
 };
 
@@ -47,10 +52,10 @@ export const getFileIdentity = (file: File): string => `${file.name}_${file.size
 
 /**
  * 附件的稳定 key：待发送态用 `File` 身份（上传成功回填 url 后不变），
- * 已发送态退回 url / 文件名。
+ * 已发送态优先用 outputId，旧附件退回 url / 文件名。
  */
 export const getUploadFileKey = (item: UploadFileLike): string =>
-  item.file ? getFileIdentity(item.file) : item.url || item.filename || '';
+  item.file ? getFileIdentity(item.file) : item.outputId || item.url || item.filename || '';
 
 /**
  * 是否按图片渲染缩略图。
@@ -79,4 +84,18 @@ export const splitUploadFiles = <T extends UploadFileLike>(items: T[]): { imageF
     (isUploadImageFile(item) ? imageFiles : otherFiles).push(item);
   }
   return { imageFiles, otherFiles };
+};
+
+/** 已上传附件按 path 映射出的 outputId 进入与助手产物相同的引用、预览流程。 */
+export const toUploadArtifact = (item: UploadFileLike): AIFileInfo | undefined => {
+  if (!item.outputId || item.status === 'pending' || item.status === 'error') {
+    return undefined;
+  }
+  const name = getUploadFileName(item) || item.outputId.split('/').pop() || item.outputId;
+  return {
+    outputId: item.outputId,
+    name,
+    size: getUploadFileSize(item) ?? 0,
+    type: normalizeFileExtension(undefined, name),
+  };
 };

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/chat-input.md
@@ -434,8 +434,10 @@ const handleSendMessage = async (
 
 选中「文件」后唤起隐藏 `input[type=file]`，与拖拽 / 粘贴共用同一套 `handleUpload` / `onUpload`。系统选择器与入队校验都走 `accept` prop（默认 `DEFAULT_UPLOAD_ACCEPT`，含图片 / 文档 / 文本 / 代码扩展名）。
 
-- `onUpload` 一次选择传入**全部** `File[]`，返回同序的结果数组（也可对单文件返回单个对象）；元素为 `{ download_url?: string; id?: string; status?: 'failed' | 'success' }`
+- `onUpload` 一次选择传入**全部** `File[]`，返回同序的结果数组（也可对单文件返回单个对象）；元素为 `{ download_url?: string; id?: string; path?: string; status?: 'failed' | 'success' }`
 - 文件自动去重（基于 `name + size + lastModified` 复合键），不会重复上传
+- 上传成功后将响应 `path` 保存为附件的 `outputId`（`id` 缺省时也以 `path` 回填）。具有 `outputId` 的文件立即进入 `@` / `+` 的「会话产物」菜单和容器预览侧栏；发送时保留 `outputId`，已发送附件与助手产物共用引用、预览和下载能力。仅有 `id`、URL 或文件名的旧附件不作为会话产物收集。
+- 取消附件时立即从 UI 移除，并触发 `deleteFile` 事件（模板使用 `@delete-file`），参数为 `Partial<UploadFile>`。业务方可根据 `file.id` 调用删除接口；组件不等待接口结果，成功或失败均不恢复附件。上传中 / 上传失败的附件也会触发事件，此时 `id` 可能为空，由业务方决定是否调用接口。发送后清空列表不会触发此事件。
 - **上传中或存在失败附件时禁止发送**（点击、Enter、`triggerSendMessage` 均拦截）。失败附件需用户删除后才能再发；不要把附件 Pending 映射成 `MessageStatus.Pending`
 - 拖拽只响应从系统拖入的文件（编辑器内部标签拖动不会误触发），悬停时框体切换为蓝色描边 + 浅蓝底
 - 发送成功后待发送列表自动清空；文件加入列表后光标自动回到输入区
@@ -443,7 +445,7 @@ const handleSendMessage = async (
 **个数、大小与格式校验**：
 
 - 列表最多保留 **`MAX_UPLOAD_FILES`（9）** 个待发送附件；已满时再次选择/拖入/粘贴文件会弹出 **bkui-vue `Message` 错误提示**（`formatUploadNotAddedMessage`），且不会继续入队。
-- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（约 2.4MB）** 会被跳过并弹出超大小/个数提示。与已有文件重复的项只去重、不弹这条误导文案。
+- 在未满的前提下：空文件、单文件大小 **`>= MAX_UPLOAD_FILE_SIZE`（45MB，即 `45 * 1024 * 1024` 字节）** 会被跳过并弹出超大小/个数提示。与已有文件重复的项只去重、不弹这条误导文案。
 - **文件类型**：默认使用 `DEFAULT_UPLOAD_ACCEPT`（图片 / 文档 / 文本 / 代码扩展名列表）。系统文件选择框带 `accept` 过滤；选择后、拖拽、粘贴仍会再按扩展名校验，不支持的格式弹出「因格式不支持未添加」并不会入队。可通过 `accept` prop 覆盖（空字符串表示不限制）。
 - 个数上限、重复、大小与类型校验都在 `ChatInput` 的 `handleUpload` 中统一处理（含 + 号菜单唤起的系统文件选择器、拖拽和粘贴）。
 
@@ -694,6 +696,7 @@ const defaultFiles: UploadFile[] = [
 | modelChange       | `(model: IModelOption)`                                               | 用户切换模型                                                 |
 | selectShortcut    | `(shortcut: Shortcut)`                                                | 点击底部快捷指令按钮                                         |
 | deleteShortcut    | -                                                                     | 点击已选快捷指令旁的关闭按钮                                 |
+| deleteFile        | `(file: Partial<UploadFile>)`                                         | 用户取消附件；携带文件 `id`、状态等信息，UI 立即移除，不等待删除接口 |
 
 ### Slots
 
@@ -708,6 +711,8 @@ const defaultFiles: UploadFile[] = [
 | send-icon      | -                                                                | 发送按钮内图标，点击逻辑与样式仍由组件控制               |
 
 ### Expose
+
+`uploadedArtifacts`：只读 `AIFileInfo[]`，包含输入框中已上传且具有 `outputId` 的附件；供容器合并到侧栏预览列表，取消或发送后同步更新。
 
 | 方法名             | 类型                              | 说明                                             |
 | ------------------ | --------------------------------- | ------------------------------------------------ |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/input/file-upload-btn.md
@@ -61,7 +61,7 @@ sinceVersion: 1.0.0
 ```
 用户选择文件
   │
-  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（约 2.4MB）→ 加入 toEmit
+  ├─ 遍历所选文件：size > 0 且 size < MAX_UPLOAD_FILE_SIZE（45MB）→ 加入 toEmit
   │       size 为 0 或 ≥ 上限 → sizeRejected += 1
   │
   ├─ sizeRejected > 0 → bkui-vue Message.error（formatUploadNotAddedMessage，说明可能超大或超出个数等）
@@ -79,7 +79,7 @@ sinceVersion: 1.0.0
 | 部分文件因空文件或单文件超大被过滤                           | 弹出错误 toast；若仍有合法文件，**仍触发** `upload`（payload 为合法子集） |
 | 全部被过滤（均为空或超大）                                   | 仅 toast，**不触发** `upload`                                        |
 | `file.size === 0`                                          | 计入未添加提示，不进入 `upload` payload                              |
-| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，约 2.4MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
+| `file.size >= MAX_UPLOAD_FILE_SIZE`（与全局常量一致，45MB） | 计入未添加提示，不进入 `upload` payload（比较为严格 `<`）           |
 | 选择后取消                                                   | `files.length === 0`，不触发 `upload`                                |
 
 > `multiple` prop 声明存在但当前模板中 `input` 的 `multiple` 属性为**硬编码**（非 `:multiple="multiple"` 绑定），始终允许多选，该 prop 暂时无实际效果。
@@ -170,7 +170,7 @@ sinceVersion: 1.0.0
 
 | 事件名 | 参数              | 说明                                                                                      |
 | ------ | ----------------- | ----------------------------------------------------------------------------------------- |
-| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，约 2.4MB）后的数组；个数截断不在此组件内完成 |
+| upload | `(files: File[])` | 当存在至少一个合法文件时触发；`files` 为过滤掉空文件与单文件超大（`size >= MAX_UPLOAD_FILE_SIZE`，45MB）后的数组；个数截断不在此组件内完成 |
 
 ### Slots
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/file-content.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/medias/file-content.md
@@ -317,6 +317,10 @@ MIME 为 `image/*` 时渲染为图片缩略图（`cursor: zoom-in`）。点击�
 </template>
 ```
 
+## 上传文件预览
+
+具有 `outputId` 且不处于上传中 / 失败态的附件，在 `ChatContainer` 内点击会通过统一的文件产物侧栏预览，使用 `onArtifactClick` 获取预览和下载链接。图片缩略图链接失效时仍可按 `outputId` 重新取链；无 `outputId` 的图片继续使用原有图片预览。
+
 ## API
 
 ### Props

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/message/user-message.md
@@ -6,7 +6,7 @@ domain: message
 description: 渲染用户消息，支持纯文本、键值引用、文件附件和编辑态输入。
 aiSummary: >
   渲染用户消息：纯文本（非 Markdown）、键值引用、二进制附件与编辑态 ChatInput / ShortcutRender；
-  正文经 CollapsibleContent 限高 200px，property.extra.docSchema 含标签时改用 MentionText 还原资源标签；
+  正文经 CollapsibleContent 限高 200px，property.docSchema 含标签时改用 MentionText 还原资源标签；
   工具栏含 copy / edit / delete。源码位置：src/components/chat-message/user-message/user-message.vue。
 relatedComponents:
   - slug: mention-text
@@ -177,7 +177,7 @@ sinceVersion: 0.0.20
 
 ## 资源标签回显与正文折叠
 
-**标签回显**：`property.extra.docSchema` 是发送时输入框的富文本文档。**只有文档里真的含标签节点时**才走 [MentionText](/components/rendering/mention-text) 结构化渲染，纯文本文档仍走 `TextContent`——历史消息与第三方消息的表现因此保持不变。`content` 始终是纯文本，后端契约不变。
+**标签回显**：`property.docSchema` 是发送时输入框的富文本文档。**只有文档里真的含标签节点时**才走 [MentionText](/components/rendering/mention-text) 结构化渲染，纯文本文档仍走 `TextContent`——历史消息与第三方消息的表现因此保持不变。`content` 始终是纯文本，后端契约不变。
 
 编辑态同样以 `docSchema` 回填，否则改完这条消息已选资源会退化成纯文本；因此业务侧在 `onInputConfirm` 里要把新的 `docSchema` 一起写回。
 
@@ -399,7 +399,7 @@ sinceVersion: 0.0.20
 **`editContent` 的初始化逻辑**（仅文本部分，二进制文件通过 `defaultUploadFiles` 恢复）：
 
 ```
-文档含标签      → editContent = property.extra.docSchema（保留已选资源）
+文档含标签      → editContent = property.docSchema（保留已选资源）
 否则 textParts 有值 → editContent = textParts[0]（取第一个文本片段）
 binaryFiles 有值   → 进入编辑模式（editContent 可为空）
 进入编辑态后       → nextTick 后自动 focus，光标落在内容末尾
@@ -513,7 +513,7 @@ binaryFiles 有值   → 进入编辑模式（editContent 可为空）
 | ------------------ | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
 | content            | `string \| InputContent[]`                                                                 | 消息内容，字符串或含 text/binary 的数组                                   |
 | createdAt          | `number \| string`                                                                         | 消息创建时间，经 `MessageTools` 的 `#prepend` 插槽交给 `MessageTime` 渲染在工具图标左侧；无值时不展示 |
-| property           | `{ extra?: MessageExtra; artifacts?: AIFileInfo[] }`                                       | 附加属性；本组件消费 `extra.cite` / `shortcut` / `context` / `docSchema`  |
+| property           | `{ docSchema?: TagSchema; extra?: MessageExtra; artifacts?: AIFileInfo[] }`                                       | 附加属性；本组件消费 `docSchema` 与 `extra.cite` / `extra.shortcut` / `extra.context`  |
 | messageTools       | `IToolBtn[]`                                                                               | 自定义用户消息工具组；按 id 与 `CONST_USER_MESSAGE_TOOLS` 合并，`{ id, hidden: true }` 可隐藏 |
 | messageToolsStatus | `MessageToolsStatus`                                                                       | 工具按钮状态，`disabled` 禁用、`hidden` 从 DOM 移除                       |
 | onAction           | `MessageToolsProps['onAction']`                                                            | 工具回调；`copy`/`edit` 有内置行为，`delete` 需外部处理                   |
@@ -561,8 +561,6 @@ type MessageExtra = {
   command?: string;
   pause?: boolean;
   shortcut?: Partial<Shortcut>;
-  /** 发送时输入框的富文本文档；有标签时用于回显与编辑回填 */
-  docSchema?: TagSchema;
   context?: Array<{
     __key: string;
     __label: string;

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/mention-text.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/rendering/mention-text.md
@@ -7,7 +7,7 @@ description: 把发送时保留的富文本文档还原成「文本 + 资源标�
 aiSummary: >
   MentionText 接收一份 TagSchema 文档（二维数组：行 → 节点），逐行渲染：text 节点输出文本、
   tag 节点交给 MentionTag；行间用 <br> 分隔，空白以 pre-wrap 保留。
-  UserMessage 在 property.extra.docSchema 含标签时用它替代 TextContent。
+  UserMessage 在 property.docSchema 含标签时用它替代 TextContent。
   源码位置：src/components/mention/mention-text.vue。
 relatedComponents:
   - slug: mention-tag
@@ -61,7 +61,7 @@ sinceVersion: 0.0.51
 ```
 用户在输入框选中资源
   → onSendMessage(content, docSchema)   content 仍是纯文本，不改后端契约
-  → 业务侧把 docSchema 存进 message.property.extra.docSchema
+  → 业务侧把 docSchema 存进 message.property.docSchema
   → UserMessage 检测到文档中存在 tag 节点
   → 用 MentionText 渲染（否则回退 TextContent）
 ```
@@ -73,14 +73,14 @@ sinceVersion: 0.0.51
 const handleSendMessage = async (content: UserMessage['content'], docSchema: TagSchema) => {
   messages.value.push({
     id, messageId: id, role: MessageRole.User, content,
-    property: { extra: { docSchema } },
+    property: { docSchema },
   });
 };
 
 // 编辑确认
 const handleUserInputConfirm = async (message: Message, content: UserMessage['content'], docSchema: TagSchema) => {
   target.content = content;
-  target.property = { ...target.property, extra: { ...target.property?.extra, docSchema } };
+  target.property = { ...target.property, docSchema };
 };
 ```
 

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/components/setup/chat-container.md
@@ -531,7 +531,7 @@ ai-chat-container（:data-ai-size="size"）
 
 ### 内置「文件产物」Tab
 
-除「执行情况」外，容器内置一个常驻固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话所有 `AssistantMessage.property.artifacts`（按 `outputId` 去重）：
+除「执行情况」外，容器内置一个常驻固定 Tab —— **「文件产物」**（`name: 'file-artifact'`），用于聚合预览当前会话具有 `outputId` 的助手产物、用户消息附件及输入框中上传成功的待发送附件（按 `outputId` 去重）：
 
 - **常驻挂载 / 默认选中**：容器初始化即通过 `ensureCustomTab` 挂上该 Tab（不展开侧栏）；因 `order: -1` 排在 Tab 栏首位，在用户未主动切换过 Tab 时它就是侧栏的默认面板。不随产物有无增删，无产物时由面板展示整块空态
 - **默认图标**：`ArtifactTabIcon`，16×16 线性折角文档，`fill` 走 `currentColor` 以继承 Tab 选中/默认色
@@ -1008,7 +1008,7 @@ ai-chat-container（:data-ai-size="size"）
 
 `menuSources` 继承自 [ChatInput](/components/input/chat-input)，一份数组按 `type` 分发到 `/`、`@`、`\` 与左下角 + 号。容器在此之上做了三件事：
 
-**1. 会话产物自动收集**：`menuSources` 中没有 `artifact` 条目时，容器用 [`collectMessageArtifacts`](/utils/#会话产物收集) 从 `messages` 里收集产物补进去——来源是助手消息的 `property.artifacts` 与用户消息里的二进制附件。业务方自己传了 `artifact` 条目时以传入的为准，容器不再自动补。没有产物时 `@` / + 号菜单不会出现「会话产物」分组。
+**1. 会话产物自动收集**：`menuSources` 中没有 `artifact` 条目时，容器用 [`collectMessageArtifacts`](/utils/#会话产物收集) 从 `messages` 里收集产物补进去——来源是具有 `outputId` 的助手消息 `property.artifacts` 与用户消息二进制附件，不再回退到 URL 或文件名。上传响应的 `path` 由输入框映射为 `outputId`，尚未发送的成功附件也会追加到菜单。手动传入的 `artifact.id` 必须是对应文件的 `outputId`。业务方自己传了 `artifact` 条目时以传入的为准，容器不再自动补。没有产物时 `@` / + 号菜单不会出现「会话产物」分组。
 
 **2. 资源引用入口**：容器通过 [useInputMention](/composables/use-input-mention) 提供 `insertMention`，消息区的文件卡片与侧栏产物面板因此能直接把文件「@ 进输入框」，无需逐层透传输入框实例。没有输入框的场景（`Share` 只读态）自动不显示引用按钮。
 
@@ -1039,7 +1039,7 @@ ai-chat-container（:data-ai-size="size"）
 </script>
 ```
 
-> 用户消息要把 `@` 选中的资源以标签形态回显，需要业务侧把 `onSendMessage` 的 `docSchema` 存进 `message.property.extra.docSchema`，详见 [MentionText](/components/rendering/mention-text)。
+> 用户消息要把 `@` 选中的资源以标签形态回显，需要业务侧把 `onSendMessage` 的 `docSchema` 存进 `message.property.docSchema`，详见 [MentionText](/components/rendering/mention-text)。
 
 ## 模型选择
 
@@ -1183,6 +1183,7 @@ ChatContainer 的 Props 继承自 `ChatInputProps` 和 `MessageContainerProps`�
 | update:asideCollapsed | `(collapsed: boolean)`          | 折叠态变更请求（`v-model:asideCollapsed`）；受控时是否真的展开取决于外部是否更新该值 |
 | selectShortcut | `(shortcut: Shortcut)`                 | 选择快捷指令（继承自 ChatInput）     |
 | deleteShortcut | —                                      | 删除已选快捷指令（继承自 ChatInput） |
+| deleteFile     | `(file: Partial<UploadFile>)`          | 取消输入框附件（继承自 ChatInput）；业务方根据 `file.id` 调用删除接口，UI 立即移除，不等待结果 |
 | modelChange    | `(model: IModelOption)`                | 切换模型（继承自 ChatInput）         |
 
 ### Slots

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/composables/use-message-group.md
@@ -130,17 +130,14 @@ const isExecutionMessage = (m: Message): boolean => {
 
 ## sessionArtifacts 会话级文件产物
 
-`sessionArtifacts` 拍平当前会话所有 `AssistantMessage.property.artifacts`，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。以 **`outputId`** 为会话内唯一键去重（同 `outputId` 视为同一文件），保留最后一次出现的文件信息，列表顺序与「最后一次出现」的相对顺序一致：
+`sessionArtifacts` 收集当前会话具有 `outputId` 的助手产物与用户上传附件，供 `ChatContainer` 侧栏「文件产物」Tab 聚合预览。以 **`outputId`** 为会话内唯一键去重（同 `outputId` 视为同一文件），保留最后一次出现的文件信息，列表顺序与「最后一次出现」的相对顺序一致：
 
 ```typescript
 const sessionArtifacts = computed(() => {
   // delete + set：同 key 覆盖内容，并把该项挪到 Map 末尾，保证「最后出现」顺序
   const byOutputId = new Map();
   for (const message of messages.value) {
-    if (message.role !== MessageRole.Assistant) continue;
-    const artifacts = message.property?.artifacts;
-    if (!artifacts?.length) continue;
-    for (const file of artifacts) {
+    for (const file of getMessageArtifacts(message)) {
       if (byOutputId.has(file.outputId)) {
         byOutputId.delete(file.outputId);
       }
@@ -225,7 +222,7 @@ const {
 | ---------------- | ----------------------------- | --------------------------------------------------------------------------- |
 | messageGroups    | `Ref<MessageGroup[]>`         | 完整消息分组列表                                                            |
 | executionGroups  | `ComputedRef<MessageGroup[]>` | 仅包含执行类消息的分组（工具调用 + FlowAgent），自动提取 `userMessageTitle` |
-| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 拍平会话所有 AssistantMessage 文件产物，按 `outputId` 去重（保留最后一次） |
+| sessionArtifacts | `ComputedRef<SessionArtifact[]>` | 收集助手产物与具有 `outputId` 的上传附件，按 `outputId` 去重（保留最后一次） |
 | pendingApprovalCount | `ComputedRef<number>`      | 当前消息中待审批 AI Dev 审批中断的数量                                      |
 | pendingApprovalTipText | `ComputedRef<string>`    | 待审批阻塞发送提示文案；无待审批时为空字符串                                |
 | isShareMode      | `ShallowRef<boolean>`         | 是否处于分享模式                                                            |

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/types/messages.md
@@ -65,6 +65,9 @@ interface BaseMessage<T extends MessageType, C = string> {
 
   // 消息属性（可选）
   property?: {
+    // 发送时输入框的富文本文档；content 仍是纯文本（不改后端契约），
+    // 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签
+    docSchema?: TagSchema;
     extra?: {
       // 引用内容
       cite:
@@ -82,9 +85,6 @@ interface BaseMessage<T extends MessageType, C = string> {
       shortcut?: Shortcut;
       // 暂停标记：为 true 时该消息所在消息组不显示 MessageTools 工具栏
       pause?: boolean;
-      // 发送时输入框的富文本文档；content 仍是纯文本（不改后端契约），
-      // 有这份文档时用户消息会把 @ 选中的资源原样还原成标签，编辑回填也不会丢标签
-      docSchema?: TagSchema;
     };
   };
 }

--- a/src/frontend/ai-blueking/packages/chat-x/wikis/utils/index.md
+++ b/src/frontend/ai-blueking/packages/chat-x/wikis/utils/index.md
@@ -79,10 +79,10 @@ const tools = mergeToolsById(
 
 | 来源                            | id 取值                                          | 名称                   |
 | ------------------------------- | ------------------------------------------------ | ---------------------- |
-| 助手消息的 `property.artifacts` | `file.outputId \|\| file.name`                   | `file.name`            |
-| 用户消息里的二进制附件          | `content.id \|\| content.url \|\| content.filename` | `content.filename` 或 id |
+| 助手消息的 `property.artifacts` | `file.outputId`                   | `file.name`            |
+| 用户消息里的二进制附件          | `content.outputId` | `content.filename` 或 id |
 
-同一 id 多次出现时取最后一次的名称（文件可能被后续轮次更新），位置保持首次出现的顺序。
+缺少 `outputId` 的文件会被跳过；上传响应中的 `path` 由 `ChatInput` 映射为 `outputId`。同一 id 多次出现时取最后一次的名称（文件可能被后续轮次更新），位置保持首次出现的顺序。
 
 ```typescript
 import { collectMessageArtifacts } from '@blueking/chat-x';


### PR DESCRIPTION
## 背景
本次完善 chat-x 文件上传、附件取消、资源引用和用户消息富文本回填行为。

- TAPD: [【chat-x】单文件上传限制放宽至小于 45 MB]（ID: 1070093903138078046）
- TAPD: [【chat-x】取消输入框附件时抛出删除文件事件]（ID: 1070093903138078047）
- TAPD: [【chat-x】按 outputId 统一上传文件引用、预览与下载]（ID: 1070093903138078048）
- TAPD: [【chat-x】用户消息 docSchema 调整为与 extra 同级]（ID: 1070093903138078051）

## 改动
- 上传入口：单文件限制统一为严格小于 45 MB；取消附件立即移除 UI 并抛出 deleteFile 事件，由业务方调用删除接口。
- 文件引用与预览：上传响应 path 映射为 outputId；待发送文件、用户附件和助手产物统一进入引用、预览和下载流程；过滤无 outputId 条目，图片缩略图失效后仍可打开产物预览。
- 用户消息：富文本文档从 property.extra.docSchema 移至 property.docSchema，同步发送、编辑回填和持久化。
- Playground：补充上传、删除、本地下载 mock 和历史附件样例；同步组件文档、技能参考文档与 CHANGELOG。

## 影响面
- 消费方需将 docSchema 持久化和回填字段迁移到 property.docSchema。
- 手动菜单 artifact.id 须使用文件 outputId；上传回调需返回 path 才能参与引用和统一预览。
- 业务方可监听 @delete-file 调用删除接口；UI 不等待结果，删除失败也不恢复附件。
- Mock 图片/PDF 可使用本地预览地址，其他文件格式的转换预览仍依赖真实后端。

## 测试
- [ ] 单元测试：本次代码已执行，100 个测试文件、1526 项测试通过。
- [ ] Mock 冒烟：已验证上传响应、原文件下载、同名文件独立标识、PDF 预览地址、历史附件过滤和删除清理。
- [ ] 类型检查：已执行，未通过；现有 chat-input.vue 的国际化文案“有 {count} 个文件因格式不支持未添加”缺少类型 key（TS2345），本次未改动该问题。
- [ ] 浏览器与真实后端联调：未执行。

