### PR TITLE
feat: 过滤 Agent Trace 配置中的提示词正文 --story=1070093903136959970

### DIFF
--- a/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
+++ b/src/agent/aidev_agent/packages/opentelemetry/callback_handler.py
@@ -144,7 +144,14 @@ class BkAidevAgentInjector:
         start_time_unix_nano = int(now.timestamp() * 1_000_000_000)
 
         # Agent 配置信息
-        agent_info = agent_info or {}
+        agent_info = dict(agent_info or {})
+        # 仅裁剪上报副本，避免提示词正文撑大属性或影响 Agent 运行配置。
+        if isinstance(prompt_setting := agent_info.get("prompt_setting"), dict):
+            agent_info["prompt_setting"] = {
+                key: value
+                for key, value in prompt_setting.items()
+                if key not in {"collection_content", "prompt_content"}
+            }
         agent_id = agent_info.get("agent_id", "unknown")
         agent_code = agent_info.get("agent_code", "unknown")
         agent_name = agent_info.get("agent_name", "unknown")

--- a/src/agent/tests/packages/opentelemetry/test_callback_handler.py
+++ b/src/agent/tests/packages/opentelemetry/test_callback_handler.py
@@ -17,9 +17,11 @@ to the current version of the project delivered to anyone in the future.
 """
 
 import asyncio
+from copy import deepcopy
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import orjson
 import pytest
 from aidev_agent.packages.opentelemetry.callback_handler import (
     BkAidevAgentCallbackHandler,
@@ -63,6 +65,43 @@ def tracer_and_exporter():
 
 class TestBkAidevAgentInjector:
     """测试 BkAidevAgentInjector 类"""
+
+    def test_on_bk_agent_start_filters_prompt_bodies(self, tracer_and_exporter):
+        tracer, exporter = tracer_and_exporter
+        agent_info = {
+            "agent_code": "test_agent",
+            "prompt_setting": {
+                "collection_content": "知识" * 20000,
+                "prompt_content": "提示词" * 20000,
+                "temperature": 0.5,
+            },
+            "other_setting": {"prompt_content": "keep"},
+        }
+        original = deepcopy(agent_info)
+        injector = BkAidevAgentInjector(tracer=tracer)
+        injector.on_bk_agent_start(inputs={}, execute_kwargs=MagicMock(), agent_info=agent_info)
+        injector.on_bk_agent_end()
+
+        (span,) = exporter.get_finished_spans()
+        payload = span.attributes["agent.info.agent_info"]
+        assert orjson.loads(payload) == {
+            "agent_code": "test_agent",
+            "prompt_setting": {"temperature": 0.5},
+            "other_setting": {"prompt_content": "keep"},
+        }
+        assert len(payload.encode("utf-8")) < 1024
+        assert agent_info == original
+        assert span.name == "agent.execution"
+
+    @pytest.mark.parametrize("agent_info", [{}, {"prompt_setting": None}, {"prompt_setting": {}}])
+    def test_on_bk_agent_start_preserves_empty_prompt_settings(self, tracer_and_exporter, agent_info):
+        tracer, exporter = tracer_and_exporter
+        injector = BkAidevAgentInjector(tracer=tracer)
+        injector.on_bk_agent_start(inputs={}, execute_kwargs=MagicMock(), agent_info=agent_info)
+        injector.on_bk_agent_end()
+
+        (span,) = exporter.get_finished_spans()
+        assert orjson.loads(span.attributes["agent.info.agent_info"]) == agent_info
 
     def test_on_bk_agent_start_span_attributes(self, tracer_and_exporter):
         """测试 on_bk_agent_start 创建的 span 包含所有必需的属性"""


### PR DESCRIPTION
## 背景与原因

`agent.info.agent_info` 包含完整提示词及知识正文，可能使根 Span 属性过长，影响 Trace 展示。

## 改动与收益

在序列化上报配置前过滤 `prompt_setting.collection_content` 和 `prompt_setting.prompt_content`，减小属性体积。仅复制并裁剪上报数据，保留其他字段和业务运行使用的原始配置。

## 测试验证

- 通过 SDK `make test path=tests/packages/opentelemetry/test_callback_handler.py`：33 项通过，覆盖超长内容过滤、原输入不变、其他路径同名字段保留、字段缺失或为空及根 Span 正常导出。
- 变更文件的 Ruff、格式和冲突检查通过。
- 完整 pre-commit 受基线既有问题阻挡：5 项 Ruff 问题及其他文件格式差异。检查产生的无关修改已撤回。
- 尚未部署或进行生产复验。
