### PR TITLE
refactor: MESSAGES_SNAPSHOT 快照改原样透传账本 dict，类型放宽为 list[dict] --story=1…

### DIFF
--- a/src/agent/aidev_agent/core/ag_ui/types.py
+++ b/src/agent/aidev_agent/core/ag_ui/types.py
@@ -274,7 +274,7 @@ ExtendMessage = Annotated[
 
 
 class MessageSnapshotEventExtend(MessagesSnapshotEvent):
-    messages: list[ExtendMessage]
+    messages: list[dict]
 
 
 class ResumeItem(ConfiguredBaseModel):
@@ -290,7 +290,7 @@ class AgentInput(RunAgentInput):
 
     thread_id: str
     run_id: str | None = None
-    messages: list[ExtendMessage]
+    messages: list[dict]
     tools: list[Tool] = Field(default_factory=list)
     context: list[Context] = Field(default_factory=list)
     forwarded_props: Any = Field(default_factory=dict)

--- a/src/agent/aidev_agent/services/agent/chat.py
+++ b/src/agent/aidev_agent/services/agent/chat.py
@@ -27,13 +27,11 @@ from aidev_agent.core.ag_ui.aidev_agent import ASK_USER_QUESTION_TOOL_NAME, Aide
 from aidev_agent.core.ag_ui.events import ExtendToolCallResultEvent
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
-    ExtendMessage,
     ReasoningLangChainMessage,
     SchemaKeys,
     SessionPersistenceEventNames,
 )
 from aidev_agent.core.ag_ui.utils import (
-    contents_to_agui_messages,
     get_schema_keys,
     get_stream_payload_input,
 )
@@ -97,7 +95,7 @@ def _to_ledger_dict(record: Any) -> dict:
     """把 chat_history 账本记录归一为 dict 形态。
 
     账本记录以 ChatPrompt 对象为主（build 期 model_validate 承接 + 本轮 patch append）；
-    快照转换器（contents_to_agui_messages）按 dict 消费，这里统一把 ChatPrompt 对象
+    快照下发与消费方均按 dict 形态处理，这里统一把 ChatPrompt 对象
     model_dump 为 dict（role/content 顶层、status/created_at 透传顶层、builtin_property/extra 保留）。
     """
     if isinstance(record, dict):
@@ -1117,19 +1115,19 @@ class ChatCompletionAgent(BaseModel):
             async_finalizer=self._aclose_chat_models,
         )
 
-    def _build_snapshot_agui_messages(self) -> list[ExtendMessage]:
-        """构建首帧 MESSAGES_SNAPSHOT 的 AG-UI 消息列表。
+    def _build_snapshot_agui_messages(self) -> list[dict]:
+        """构建首帧 MESSAGES_SNAPSHOT 的消息列表（前端历史接口原始返回形态）。
 
         数据源为 lossless chat_history 账本（由 build_chat_history 无损承接 session_context_data 而来，
         与前端历史消息接口同源，含 system 展示类记录）；resume 命中的 interrupt 记录已被
         _prepare_pre_run_history 就地改写为终态（原 id 不变），本轮 user/tool 记录也已直接并入账本，
-        快照对账本全量转换。
+        快照对账本全量下发。
 
-        账本记录统一经 model_dump 归一为 dict 后交由快照转换器消费（role/content 顶层、
-        status/created_at 透传顶层、builtin_property/extra 保留）。
+        下发布局即账本原样：账本记录统一经 model_dump 归一为 dict（role/content 顶层、
+        builtin_property/extra 保留、字段名保持后端原样），不经 AG-UI 消息转换器，
+        不做 role 归一 / camelCase 改名 / status 映射 / multimodal 重排。
         """
-        base = [_to_ledger_dict(rec) for rec in (self.chat_history or [])]
-        return contents_to_agui_messages(base)
+        return [_to_ledger_dict(rec) for rec in (self.chat_history or [])]
 
     def _stream(
         self,

--- a/src/agent/tests/core/ag_ui/test_messages_snapshot.py
+++ b/src/agent/tests/core/ag_ui/test_messages_snapshot.py
@@ -3,12 +3,13 @@
 
 覆盖四类场景：
 - fail/error 消息的还原（含用户取消）；
-- 多模态 user content 的结构化数组编码；
+- 多模态 user content 的原样保留；
 - reasoning 消息的还原（LLM 入口排除）；
-- createdAt 全量回传（且不进入模型 payload）。
+- createdAt 位于 builtin_property 内回传（且不进入模型 payload）。
 
-快照数据源为 lossless ChatPrompt 单账本（chat_history），经
-``contents_to_agui_messages`` 编码；LLM 入口沿用 convert 链（chat_history）。
+快照数据源为 lossless ChatPrompt 单账本（chat_history），**原样透传**（经
+``_to_ledger_dict`` 归一为 dict）而不经 AG-UI 消息转换器：不做 role 归一 /
+camelCase 改名 / status 映射 / multimodal 重排。LLM 入口沿用 convert 链。
 """
 
 import json
@@ -31,7 +32,7 @@ from langchain_openai.chat_models.base import _convert_message_to_dict
 
 
 def _build_messages_snapshot(agent: ChatCompletionAgent):
-    """与 chat._stream 中 body['messages'] 组装一致（读单账本编码）。"""
+    """与 chat._stream 中 body['messages'] 组装一致（读单账本原样透传）。"""
     return agent._build_snapshot_agui_messages()
 
 
@@ -57,53 +58,58 @@ def _failed_ledger(status: str = "error", content: str = RunId.CANCELLED_MESSAGE
 def test_messages_snapshot_entry_includes_user_cancelled():
     agent = ChatCompletionAgent(chat_history=_failed_ledger())
     snapshot = _build_messages_snapshot(agent)
-    assert [each.role for each in snapshot] == ["user", "assistant"]
-    assert snapshot[-1].content == RunId.CANCELLED_MESSAGE
-    assert snapshot[-1].status == "error"
+    assert [each["role"] for each in snapshot] == ["user", "assistant"]
+    assert snapshot[-1]["content"] == RunId.CANCELLED_MESSAGE
+    assert snapshot[-1]["builtin_property"]["status"] == "error"
 
 
-def test_messages_snapshot_entry_includes_fail_status():
-    agent = ChatCompletionAgent(chat_history=_failed_ledger(status="fail", content="模型调用失败"))
+@pytest.mark.parametrize(
+    "status, content",
+    [
+        ("error", RunId.CANCELLED_MESSAGE),
+        ("fail", "模型调用失败"),
+    ],
+)
+def test_messages_snapshot_entry_keeps_platform_status(status, content):
+    """原始平台域 status 原样透传，不做归一。"""
+    agent = ChatCompletionAgent(chat_history=_failed_ledger(status=status, content=content))
     snapshot = _build_messages_snapshot(agent)
-    assert [each.role for each in snapshot] == ["user", "assistant"]
-    assert snapshot[-1].content == "模型调用失败"
-    assert snapshot[-1].status == "error"
+    assert [each["role"] for each in snapshot] == ["user", "assistant"]
+    assert snapshot[-1]["content"] == content
+    assert snapshot[-1]["builtin_property"]["status"] == status
+
+
+def _llm_contents(agent: ChatCompletionAgent):
+    """把账本经 convert 链送入 LLM 入口视图，返回各条 content。"""
+    return [
+        each.content
+        for each in agent._filter_messages_for_llm(
+            convert_chat_history_to_messages(
+                agent.chat_history,
+                model_context_options=agent.model_context_options,
+                support_vision=agent.support_vision,
+                model_name=agent.model_name,
+                agent_info=agent.agent_info,
+                generating_keyword=agent.generating_keyword,
+                files=agent.files,
+            )
+        )
+    ]
 
 
 def test_llm_entry_keeps_cancelled_and_orphan_user_messages():
     """取消轮与连续 user 均保留入模，不再整轮剔除。"""
     cancelled_history = _failed_ledger() + [ChatPrompt(id="3", role="user", content="换个问题")]
-    agent = ChatCompletionAgent(chat_history=cancelled_history)
-    llm_messages = agent._filter_messages_for_llm(
-        convert_chat_history_to_messages(
-            agent.chat_history,
-            model_context_options=agent.model_context_options,
-            support_vision=agent.support_vision,
-            model_name=agent.model_name,
-            agent_info=agent.agent_info,
-            generating_keyword=agent.generating_keyword,
-            files=agent.files,
-        )
-    )
-    assert [each.content for each in llm_messages] == ["分析图片", RunId.CANCELLED_MESSAGE, "换个问题"]
+    cancelled_agent = ChatCompletionAgent(chat_history=cancelled_history)
+    assert _llm_contents(cancelled_agent) == ["分析图片", RunId.CANCELLED_MESSAGE, "换个问题"]
 
-    orphan_history = [
-        ChatPrompt(id="1", role="user", content="孤立提问"),
-        ChatPrompt(id="2", role="user", content="新问题"),
-    ]
-    agent = ChatCompletionAgent(chat_history=orphan_history)
-    llm_messages = agent._filter_messages_for_llm(
-        convert_chat_history_to_messages(
-            agent.chat_history,
-            model_context_options=agent.model_context_options,
-            support_vision=agent.support_vision,
-            model_name=agent.model_name,
-            agent_info=agent.agent_info,
-            generating_keyword=agent.generating_keyword,
-            files=agent.files,
-        )
+    orphan_agent = ChatCompletionAgent(
+        chat_history=[
+            ChatPrompt(id="1", role="user", content="孤立提问"),
+            ChatPrompt(id="2", role="user", content="新问题"),
+        ]
     )
-    assert [each.content for each in llm_messages] == ["孤立提问", "新问题"]
+    assert _llm_contents(orphan_agent) == ["孤立提问", "新问题"]
 
 
 def test_messages_snapshot_sse_includes_user_cancelled():
@@ -111,11 +117,11 @@ def test_messages_snapshot_sse_includes_user_cancelled():
     payload = _encode_snapshot_payload(_build_messages_snapshot(agent))
     assert payload["messages"][-1]["role"] == "assistant"
     assert payload["messages"][-1]["content"] == RunId.CANCELLED_MESSAGE
-    assert payload["messages"][-1]["status"] == "error"
+    assert payload["messages"][-1]["builtin_property"]["status"] == "error"
 
 
 # ---------------------------------------------------------------------------
-# 多模态 content 格式
+# 多模态 content 原样保留
 # ---------------------------------------------------------------------------
 
 MULTIMODAL_CONTENT = [
@@ -134,38 +140,26 @@ def _multimodal_ledger(raw_content):
     return [{"id": "user-1", "role": "user", "content": raw_content, "status": "complete"}]
 
 
-@pytest.mark.parametrize(
-    "raw_content",
-    [
-        MULTIMODAL_CONTENT,
-        json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False),
-    ],
-    ids=["list", "json_string"],
-)
-def test_messages_snapshot_keeps_multimodal_array(raw_content):
-    """历史多模态消息转换后 content 必须为数组，不能是 JSON 字符串。"""
-    agent = ChatCompletionAgent(chat_history=_multimodal_ledger(raw_content))
-    agui_message = agent._build_snapshot_agui_messages()[0]
+def test_messages_snapshot_keeps_multimodal_list_as_is():
+    """列表形态多模态 content 原样透传，mime_type 不会被改名为 mimeType。"""
+    agent = ChatCompletionAgent(chat_history=_multimodal_ledger(MULTIMODAL_CONTENT))
+    message = agent._build_snapshot_agui_messages()[0]
 
-    assert isinstance(agui_message.content, list)
-    assert agui_message.content[0].type == "binary"
-    assert agui_message.content[0].filename == "upload_file_1785756353687_fjdwe7.jpeg"
-    assert agui_message.content[0].mime_type == "image/jpeg"
-    assert agui_message.content[1].type == "text"
-    assert agui_message.content[1].text == "图片内容是啥"
+    assert message["content"] == MULTIMODAL_CONTENT
+    assert message["content"][0]["mime_type"] == "image/jpeg"
+    assert "mimeType" not in message["content"][0]
 
 
-def test_messages_snapshot_sse_encodes_multimodal_as_array():
-    """MESSAGES_SNAPSHOT SSE 载荷中 user content 应为结构化数组。"""
-    agent = ChatCompletionAgent(chat_history=_multimodal_ledger(json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False)))
+def test_messages_snapshot_keeps_multimodal_json_string_as_is():
+    """JSON 字符串形态多模态 content 不解析为数组，原样透传给前端。"""
+    raw = json.dumps(MULTIMODAL_CONTENT, ensure_ascii=False)
+    agent = ChatCompletionAgent(chat_history=_multimodal_ledger(raw))
     payload = _encode_snapshot_payload(agent._build_snapshot_agui_messages())
 
     user_message = payload["messages"][0]
     assert user_message["role"] == "user"
-    assert isinstance(user_message["content"], list)
-    assert user_message["content"][0]["type"] == "binary"
-    assert user_message["content"][0]["filename"] == "upload_file_1785756353687_fjdwe7.jpeg"
-    assert user_message["content"][1]["type"] == "text"
+    assert user_message["content"] == raw
+    assert isinstance(user_message["content"], str)
 
 
 def test_chat_history_to_langchain_parses_json_string_multimodal():
@@ -214,10 +208,11 @@ def test_parse_reasoning_content_normalizes_types():
 def test_messages_snapshot_includes_reasoning_with_duration():
     agent = ChatCompletionAgent(chat_history=_reasoning_ledger())
     snapshot = _build_messages_snapshot(agent)
-    assert [each.role for each in snapshot] == ["user", "reasoning", "assistant"]
+    assert [each["role"] for each in snapshot] == ["user", "reasoning", "assistant"]
     reasoning = snapshot[1]
-    assert reasoning.content == ["先分析用户意图", "再选择工具"]
-    assert reasoning.duration == 2.5
+    assert reasoning["content"] == ["先分析用户意图", "再选择工具"]
+    assert reasoning["builtin_property"]["duration"] == 2.5
+    assert "duration" not in reasoning
 
 
 def test_llm_entry_excludes_reasoning():
@@ -243,7 +238,7 @@ def test_messages_snapshot_sse_reasoning_payload():
     reasoning = payload["messages"][1]
     assert reasoning["role"] == "reasoning"
     assert reasoning["content"] == ["先分析用户意图", "再选择工具"]
-    assert reasoning["duration"] == 2.5
+    assert reasoning["builtin_property"]["duration"] == 2.5
 
 
 # ---------------------------------------------------------------------------
@@ -252,34 +247,32 @@ def test_messages_snapshot_sse_reasoning_payload():
 
 
 def test_messages_snapshot_includes_created_at_for_all_roles():
+    created_at_values = [
+        "2026-08-13T10:00:00+00:00",
+        "2026-08-13T10:01:00+00:00",
+        "2026-08-13T10:05:00+00:00",
+    ]
     agent = ChatCompletionAgent(
         chat_history=[
             ChatPrompt(
-                id="user-1",
-                role="user",
-                content="第一轮提问",
-                builtin_property={"created_at": "2026-08-13T10:00:00+00:00"},
+                id="user-1", role="user", content="第一轮提问", builtin_property={"created_at": created_at_values[0]}
             ),
             ChatPrompt(
                 id="assistant-1",
                 role="assistant",
                 content="第一轮回答",
-                builtin_property={"created_at": "2026-08-13T10:01:00+00:00"},
+                builtin_property={"created_at": created_at_values[1]},
             ),
             ChatPrompt(
-                id="user-2",
-                role="user",
-                content="本轮提问",
-                builtin_property={"created_at": "2026-08-13T10:05:00+00:00"},
+                id="user-2", role="user", content="本轮提问", builtin_property={"created_at": created_at_values[2]}
             ),
         ]
     )
 
     payload = _encode_snapshot_payload(agent._build_snapshot_agui_messages())
 
-    assert payload["messages"][0]["createdAt"] == "2026-08-13T10:00:00+00:00"
-    assert payload["messages"][1]["createdAt"] == "2026-08-13T10:01:00+00:00"
-    assert payload["messages"][2]["createdAt"] == "2026-08-13T10:05:00+00:00"
+    assert [each["builtin_property"]["created_at"] for each in payload["messages"]] == created_at_values
+    assert all("createdAt" not in each for each in payload["messages"])
 
 
 def test_created_at_is_not_sent_to_openai_payload():

--- a/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
+++ b/src/agent/tests/core/interrupt/test_ag_ui_interrupt_protocol.py
@@ -8,7 +8,6 @@ from aidev_agent.core.ag_ui.aidev_agent import AidevAGUIAgent
 from aidev_agent.core.ag_ui.events import ExtendToolCallStartEvent
 from aidev_agent.core.ag_ui.types import (
     AgentInput,
-    ExtendAssistantMessage,
     MessageSnapshotEventExtend,
     ResumeItem,
     RunFinishedInterruptOutcome,
@@ -25,7 +24,7 @@ async def test_aidev_agent_run_exposes_messages_snapshot(monkeypatch):
         yield RunStartedEvent(type=EventType.RUN_STARTED, thread_id="thread-3", run_id="run-3")
         yield MessageSnapshotEventExtend(
             type=EventType.MESSAGES_SNAPSHOT,
-            messages=[ExtendAssistantMessage(id="assistant-3", role="assistant", content="snapshot message")],
+            messages=[{"id": "assistant-3", "role": "assistant", "content": "snapshot message"}],
         )
         yield RunFinishedEvent(
             type=EventType.RUN_FINISHED,

--- a/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
+++ b/src/agent/tests/core/interrupt/test_ask_user_question_frontend_resume_e2e.py
@@ -829,26 +829,34 @@ async def test_ask_user_resume_snapshot_matches_contents():
         m.get("role") == PromptRole.USER.value and m.get("content") == "我喜欢瑜伽" for m in snapshot_messages
     ), "快照应含本轮 user 消息"
 
-    # 硬性断言：多模态 binary 项 type=="binary" 且 mimeType 键存在
+    # 硬性断言：多模态 binary 项原样透传（落库 JSON 字符串不解析，内含 type=="binary" 且 mime_type 非空）
     binary_found = False
     for m in snapshot_messages:
-        if m.get("role") != PromptRole.USER.value or not isinstance(m.get("content"), list):
+        if m.get("role") != PromptRole.USER.value:
             continue
-        for item in m["content"]:
-            if isinstance(item, dict) and item.get("type") == "binary" and item.get("mimeType"):
+        content = m.get("content")
+        if isinstance(content, str):
+            try:
+                content = json.loads(content)
+            except (json.JSONDecodeError, TypeError):
+                continue
+        if not isinstance(content, list):
+            continue
+        for item in content:
+            if isinstance(item, dict) and item.get("type") == "binary" and item.get("mime_type"):
                 binary_found = True
-    assert binary_found, "快照应含 type==binary 且 mimeType 键非空的多模态项"
+    assert binary_found, "快照应含 type==binary 且 mime_type 键非空的多模态项"
 
-    # 硬性断言：activity 消息 content 含嵌套 referenceDocument 且引用项 originFileUrl 存在
+    # 硬性断言：activity 消息 content 原样透传（嵌套 reference_document 引用项 origin_file_url 存在）
     rag_found = False
     for m in snapshot_messages:
         if m.get("role") != PromptRole.ACTIVITY.value:
             continue
         content = m.get("content") or {}
-        ref_docs = content.get("referenceDocument") if isinstance(content, dict) else None
-        if isinstance(ref_docs, list) and any(isinstance(d, dict) and d.get("originFileUrl") for d in ref_docs):
+        ref_docs = content.get("reference_document") if isinstance(content, dict) else None
+        if isinstance(ref_docs, list) and any(isinstance(d, dict) and d.get("origin_file_url") for d in ref_docs):
             rag_found = True
-    assert rag_found, "快照应含 referenceDocument 且引用项 originFileUrl 存在的知识库召回"
+    assert rag_found, "快照应含 reference_document 且引用项 origin_file_url 存在的知识库召回"
 
 
 @pytest.mark.asyncio
@@ -856,7 +864,7 @@ async def test_ask_user_skip_snapshot_includes_tool_and_cancelled():
     """问答中断 skip 续流：首帧快照含 skip tool 记录 + CANCELLED 终态 interrupt（原 id），无 pending 残留。
 
     skip 路径改写后：interrupt 记录就地升级为 CANCELLED 终态（原 id 不变），
-    另补 skip tool 记录（content==SKIPPED、toolCallId 非空），顺序为 [..., interrupt(升级), tool]。
+    另补 skip tool 记录（content==SKIPPED、tool_call_id 非空），顺序为 [..., interrupt(升级), tool]。
     """
     mock_client = _MockBKAidevClient()
     _seed_mock_record(mock_client, role=PromptRole.USER.value, content="问我问题")
@@ -889,14 +897,16 @@ async def test_ask_user_skip_snapshot_includes_tool_and_cancelled():
     )
     snapshot_messages = _first_snapshot_messages(agent)
 
-    # skip tool 记录并入：content==SKIPPED、toolCallId 非空
+    # skip tool 记录并入：content==SKIPPED、tool_call_id 非空（账本原样键）
     skip_tools = [
         m
         for m in snapshot_messages
         if m.get("role") == PromptRole.TOOL.value and m.get("content") == ASK_USER_QUESTION_SKIPPED_CONTENT
     ]
     assert skip_tools, "快照应含 skip 路径的 tool 记录"
-    assert skip_tools[0].get("toolCallId"), f"skip tool 记录 toolCallId 应为非空: {skip_tools[0].get('toolCallId')}"
+    assert skip_tools[0].get("tool_call_id"), (
+        f"skip tool 记录 tool_call_id 应为非空: {skip_tools[0].get('tool_call_id')}"
+    )
 
     # CANCELLED 终态 interrupt 就地改写（原 id 不变）
     assert _terminal_snapshot_by_status(snapshot_messages, "cancelled"), "快照应含 CANCELLED 终态 interrupt"


### PR DESCRIPTION
…36417903

- _build_snapshot_agui_messages 直接返回 _to_ledger_dict 归一后的 ChatPrompt 账本列表，不再经 contents_to_agui_messages 转换